### PR TITLE
feat: Sprints 1-4 — IaC coverage, cleanup, consolidation, and security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Project Lenie: Personal AI Assistant
 
-Project Lenie, named after the enigmatic protagonist from Peter Watts' novel "Starfish,"
-offers advanced solutions for collecting, managing, and searching data using
-Large Language Models (LLMs).
+Project Lenie is named after Lenie Clarke — the protagonist of Peter Watts' novel "Starfish,"
+who ultimately becomes an agent of extinction for the world as we know it. The name is
+a deliberate nod: I'm not convinced that AI won't end up doing the same to our civilization.
+That said, Lenie offers advanced solutions for collecting, managing, and searching data
+using Large Language Models (LLMs).
 
 Lenie enables users to:
 * collect and manage links, allowing easy searching of accumulated references using LLM,

--- a/_bmad-output/implementation-artifacts/14-1-remove-elastic-ip-from-ec2-instance.md
+++ b/_bmad-output/implementation-artifacts/14-1-remove-elastic-ip-from-ec2-instance.md
@@ -1,6 +1,6 @@
 # Story 14.1: Remove Elastic IP from EC2 Instance
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -190,8 +190,34 @@ Removal-only change following CloudFormation Resource Removal Pattern from Sprin
 |------|--------|-------------|
 | `infra/aws/cloudformation/templates/ec2-lenie.yaml` | MOD | Removed ElasticIP, EIPAssociation resources and PublicIP output |
 
+## Senior Developer Review (AI)
+
+**Reviewer:** Claude Opus 4.6 | **Date:** 2026-02-20 | **Outcome:** Changes Requested → Fixed
+
+### Findings
+
+| # | Severity | Issue | Resolution |
+|---|----------|-------|------------|
+| H1 | HIGH | Template Description still says "assign an Elastic IP" after EIP removal (line 2) | FIXED: Updated to "Template to create an EC2 instance with Amazon Linux 2023" |
+| M1 | MEDIUM | `infra/aws/cloudformation/CLAUDE.md` ec2-lenie.yaml entry still listed "EIP" and "Elastic IP" | FIXED: Updated to "SG, IAM" and "dynamic public IP" |
+| M2 | MEDIUM | `infra/aws/README.md` section 5.1 still listed ElasticIP and EIPAssociation resource rows | FIXED: Removed both rows |
+| L1 | LOW | `aws_ec2_route53.py` `get_instance_public_ip()` has unbounded recursion (no max retry) | NOTED: Pre-existing, out of scope — added to backlog as B-22 |
+
+### AC Verification
+
+All 6 Acceptance Criteria verified as correctly implemented. cfn-lint zero errors. All tasks confirmed done.
+
+### Review File List
+
+| File | Action | Description |
+|------|--------|-------------|
+| `infra/aws/cloudformation/templates/ec2-lenie.yaml` | MOD | Removed "and assign an Elastic IP" from Description |
+| `infra/aws/cloudformation/CLAUDE.md` | MOD | Removed EIP references from ec2-lenie.yaml entry |
+| `infra/aws/README.md` | MOD | Removed ElasticIP and EIPAssociation resource rows |
+
 ## Change Log
 
 | Date | Change | Story |
 |------|--------|-------|
 | 2026-02-20 | Removed Elastic IP and EIP Association resources from EC2 CloudFormation template to eliminate ~$3.65/month idle charges; verified Route53 DNS update script and VPC subnet config support dynamic public IP | 14-1 |
+| 2026-02-20 | Code review fixes: removed stale EIP references from template Description, CLAUDE.md, and README.md | 14-1-review |

--- a/_bmad-output/implementation-artifacts/14-2-fix-redundant-lambda-function-name-in-lambda-rds-start.md
+++ b/_bmad-output/implementation-artifacts/14-2-fix-redundant-lambda-function-name-in-lambda-rds-start.md
@@ -1,0 +1,255 @@
+# Story 14.2: Fix Redundant Lambda Function Name in lambda-rds-start
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer**,
+I want to fix the Lambda function name in `lambda-rds-start.yaml` from the redundant `${AWS::StackName}-rds-start-function` to the clean `${ProjectCode}-${Environment}-rds-start` pattern,
+so that all Lambda functions follow a consistent, non-redundant naming convention.
+
+## Acceptance Criteria
+
+1. **Given** `infra/aws/cloudformation/templates/lambda-rds-start.yaml` uses `FunctionName: !Sub '${AWS::StackName}-rds-start-function'`, **When** the developer changes it to `FunctionName: !Sub '${ProjectCode}-${Environment}-rds-start'`, **Then** the template produces the clean name `lenie-dev-rds-start` instead of `lenie-dev-lambda-rds-start-rds-start-function`.
+
+2. **Given** the FunctionName is changed, **When** the developer runs cfn-lint validation, **Then** the template passes with zero errors.
+
+3. **Given** all other Lambda templates exist in `infra/aws/cloudformation/templates/`, **When** the developer audits their `FunctionName` properties, **Then** zero templates use `${AWS::StackName}` in FunctionName (all use `${ProjectCode}-${Environment}-<description>`).
+
+4. **Given** `infra/aws/cloudformation/parameters/dev/lambda-rds-start.json` exists, **When** the developer reviews its contents, **Then** the parameter file is confirmed clean (only contains ProjectCode and Environment — no function name references).
+
+5. **Given** `infra/aws/cloudformation/parameters/dev/sqs-to-rds-step-function.json` contains `SqsToRdsLambdaFunctionName`, **When** the developer verifies it, **Then** the value references `lenie-dev-sqs-to-rds-lambda` (not the renamed rds-start function) — no change needed.
+
+6. **Given** `infra/aws/cloudformation/templates/api-gw-infra.yaml` references Lambda functions, **When** the developer verifies the rds-start reference, **Then** it already uses `${ProjectCode}-${Environment}-rds-start` pattern — no change needed (confirmed from architecture analysis).
+
+7. **Given** `infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml` defines a Step Function, **When** the developer verifies Lambda invocation references, **Then** the Step Function does not reference the rds-start Lambda directly (uses sqs-to-rds-lambda) — no change needed.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Verify no naming conflict with api-gw-infra.yaml (AC: #6) — CRITICAL PRE-CHECK
+  - [x] Read `infra/aws/cloudformation/templates/api-gw-infra.yaml` completely
+  - [x] Check if it CREATES a Lambda function with `FunctionName: !Sub ${ProjectCode}-${Environment}-rds-start` (reported at line 78)
+  - [x] If yes: determine if lambda-rds-start.yaml and api-gw-infra.yaml create the SAME or DIFFERENT functions
+  - [x] If CONFLICT: the same function name cannot exist in two stacks — determine which template is the source of truth and document the resolution approach
+  - ~~If NO CONFLICT (api-gw-infra only references, doesn't create): proceed to Task 2~~ — N/A, CONFLICT found
+  - **Resolution:** CONFLICT confirmed — `api-gw-infra.yaml` CREATES `RdsStartFunction` (line 75-99) with FunctionName `${ProjectCode}-${Environment}-rds-start`. User decision: `api-gw-infra.yaml` is the source of truth for infra Lambda functions. `lambda-rds-start.yaml` is redundant. Additionally, `api-gw-infra.yaml`'s shared `LambdaExecutionRole` lacked RDS/SSM permissions needed by rds-start/stop/status functions.
+- [x] Task 2: Consolidate rds-start Lambda into api-gw-infra.yaml (AC: #1 — adapted)
+  - [x] Added RDS permissions (`rds:StartDBInstance`, `rds:StopDBInstance`, `rds:DescribeDBInstances`) to `LambdaExecutionRole` in `api-gw-infra.yaml`
+  - [x] Added scoped SSM permission (`ssm:GetParameter`) for database name parameter
+  - [x] Increased `RdsStartFunction` timeout from 30s to 60s (matching original `lambda-rds-start.yaml`)
+  - [x] Commented out `lambda-rds-start.yaml` in `deploy.ini` with note to manually delete stack `lenie-dev-lambda-rds-start`
+- [x] Task 3: Validate modified template (AC: #2)
+  - [x] Run `cfn-lint infra/aws/cloudformation/templates/api-gw-infra.yaml` — zero errors
+  - [x] Run `cfn-lint infra/aws/cloudformation/templates/*.yaml` — zero errors, no regressions (only pre-existing W8001/W2001 warnings)
+- [x] Task 4: Audit all other Lambda templates for ${AWS::StackName} usage (AC: #3)
+  - [x] Searched all `.yaml` files in `infra/aws/cloudformation/templates/` for `${AWS::StackName}` in FunctionName
+  - [x] Only match: `lambda-rds-start.yaml:55` — now decommissioned (commented out in deploy.ini). All active templates use `${ProjectCode}-${Environment}` pattern.
+- [x] Task 5: Verify parameter file is clean (AC: #4)
+  - [x] Read `infra/aws/cloudformation/parameters/dev/lambda-rds-start.json`
+  - [x] Confirmed: only contains ProjectCode and Environment parameters (no function name references)
+- [x] Task 6: Verify Step Function parameter (AC: #5)
+  - [x] Read `infra/aws/cloudformation/parameters/dev/sqs-to-rds-step-function.json`
+  - [x] Confirmed: `SqsToRdsLambdaFunctionName` = `lenie-dev-sqs-to-rds-lambda` (not rds-start)
+- [x] Task 7: Verify Step Function template (AC: #7)
+  - [x] Read `infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml`
+  - [x] Confirmed: no reference to rds-start Lambda — uses `SqsToRdsLambdaFunctionName` parameter only
+
+## Dev Notes
+
+### Architecture Compliance
+
+**Lambda Function Naming Convention (from Sprint 4 Architecture):**
+- Pattern: `${ProjectCode}-${Environment}-<description>`
+- All Lambda templates MUST use this pattern — zero `${AWS::StackName}` usage in FunctionName
+- Current violation: `lambda-rds-start.yaml` line 55 uses `${AWS::StackName}-rds-start-function`
+- After fix: produces `lenie-dev-rds-start` (consistent with all other Lambdas)
+
+**CloudFormation Update Behavior:**
+- Changing `FunctionName` triggers a **replacement** (CloudFormation deletes old function, creates new one)
+- Brief unavailability is acceptable — this is an on-demand function (starts RDS, used infrequently)
+- After stack update, code must be re-uploaded via `zip_to_s3.sh` (the S3 key `${ProjectCode}-${Environment}-rds-start.zip` remains unchanged)
+
+**Anti-patterns (NEVER do):**
+- Do NOT change the FunctionName to any other pattern (e.g., `lenie-rds-start`, `rds-start-function`)
+- Do NOT modify the RoleName in the same change (line 21 uses `${AWS::StackName}` but is outside FR scope)
+- Do NOT modify Outputs section (Exports use `${AWS::StackName}` prefix, which is standard for CF Exports)
+- Do NOT modify any other resource or property in the template
+
+### Critical Technical Context
+
+**CRITICAL PRE-CHECK: Potential naming conflict with api-gw-infra.yaml**
+
+Analysis revealed that `api-gw-infra.yaml` (line 78) appears to CREATE a Lambda function named `lenie-dev-rds-start`:
+```yaml
+RdsStartFunction:
+  Type: 'AWS::Lambda::Function'
+  Properties:
+    FunctionName: !Sub ${ProjectCode}-${Environment}-rds-start
+```
+
+After the fix, `lambda-rds-start.yaml` would ALSO create a function with name `lenie-dev-rds-start`. Two CloudFormation stacks CANNOT create the same Lambda function name — this would cause a deployment failure.
+
+**Resolution approach (Task 1 must determine):**
+- If api-gw-infra.yaml creates a SEPARATE inline Lambda for API Gateway: the two functions serve different purposes and the naming fix needs a DIFFERENT target name, or the api-gw-infra.yaml function should reference lambda-rds-start.yaml's function instead
+- If api-gw-infra.yaml only REFERENCES the function (via API Gateway integration URI) but doesn't create it: no conflict, proceed with fix
+
+**Current file state (line 55):**
+```yaml
+FunctionName: !Sub '${AWS::StackName}-rds-start-function'
+```
+With stack name `lenie-dev-lambda-rds-start`, this produces: `lenie-dev-lambda-rds-start-rds-start-function` (redundant)
+
+**Target state (line 55):**
+```yaml
+FunctionName: !Sub '${ProjectCode}-${Environment}-rds-start'
+```
+This produces: `lenie-dev-rds-start` (clean, consistent)
+
+**Lambda template current structure:**
+- Parameters: `ProjectCode` (default: lenie), `Environment` (default: dev)
+- Resources:
+  - `RDSStartLambdaRole` (IAM Role) — RoleName: `${AWS::StackName}-rds-start-lambda-role` (NOT in scope)
+  - `RDSStartLambdaFunction` (Lambda) — FunctionName: `${AWS::StackName}-rds-start-function` (FIX THIS)
+- Outputs:
+  - `LambdaFunctionArn` — Export: `${AWS::StackName}-lambda-arn` (NOT in scope)
+  - `LambdaRoleArn` — Export: `${AWS::StackName}-lambda-role-arn` (NOT in scope)
+
+### Lambda FunctionName Audit Results (Pre-verified)
+
+| Template | FunctionName Pattern | Status |
+|----------|---------------------|--------|
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-sqs-size` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-rds-start` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-rds-stop` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-rds-status` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-ec2-status` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-ec2-start` | COMPLIANT |
+| `api-gw-infra.yaml` | `${ProjectCode}-${Environment}-ec2-stop` | COMPLIANT |
+| `sqs-to-rds-lambda.yaml` | `${ProjectCode}-${Environment}-sqs-to-rds-lambda` | COMPLIANT |
+| `lambda-weblink-put-into-sqs.yaml` | `${ProjectCode}-${Environment}-weblink-put-into-sqs` | COMPLIANT |
+| `url-add.yaml` | `${ProjectCode}-${Environment}-url-add` | COMPLIANT |
+| **`lambda-rds-start.yaml`** | **`${AWS::StackName}-rds-start-function`** | **NON-COMPLIANT** |
+
+### Consumer Verification (Pre-verified)
+
+| Consumer | Reference | Conflict Risk | Action |
+|----------|-----------|---------------|--------|
+| `api-gw-infra.yaml` (API GW integration URI, line 445) | `${ProjectCode}-${Environment}-rds-start` | NONE — already uses correct pattern | Verify only |
+| `sqs-to-rds-step-function.json` (parameter) | `lenie-dev-sqs-to-rds-lambda` | NONE — references different Lambda | Verify only |
+| `sqs-to-rds-step-function.yaml` (Step Function definition) | `${SqsToRdsLambdaFunctionName}` parameter | NONE — does not reference rds-start | Verify only |
+| `lambda-rds-start.json` (parameter file) | ProjectCode + Environment only | NONE — no function name references | Verify only |
+
+### What NOT to Change
+
+- Do NOT modify `infra/aws/cloudformation/templates/api-gw-infra.yaml` — it already uses the correct naming pattern
+- Do NOT modify `infra/aws/cloudformation/parameters/dev/lambda-rds-start.json` — it's clean
+- Do NOT modify `infra/aws/cloudformation/parameters/dev/sqs-to-rds-step-function.json` — it references a different Lambda
+- Do NOT modify `infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml` — it doesn't reference rds-start
+- Do NOT change the RoleName (line 21) — it's outside the FR scope for this story
+- Do NOT change the Outputs section — Export names using `${AWS::StackName}` are standard for CF Exports
+
+### File Structure
+
+Only one file modified:
+
+| File | Action | Description |
+|------|--------|-------------|
+| `infra/aws/cloudformation/templates/lambda-rds-start.yaml` | MOD | Line 55: Change FunctionName from `${AWS::StackName}-rds-start-function` to `${ProjectCode}-${Environment}-rds-start` |
+
+Verification-only files (read, no changes):
+
+| File | Verification |
+|------|-------------|
+| `infra/aws/cloudformation/templates/api-gw-infra.yaml` | Uses `${ProjectCode}-${Environment}-rds-start` in API GW integration; **check if it also CREATES a function with this name** |
+| `infra/aws/cloudformation/parameters/dev/lambda-rds-start.json` | Only ProjectCode + Environment params, no function name refs |
+| `infra/aws/cloudformation/parameters/dev/sqs-to-rds-step-function.json` | SqsToRdsLambdaFunctionName = `lenie-dev-sqs-to-rds-lambda` |
+| `infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml` | Uses parameter for Lambda name, not rds-start |
+| All other Lambda templates | Audit confirms all use `${ProjectCode}-${Environment}` pattern |
+
+### Testing Requirements
+
+1. **cfn-lint validation:** `cfn-lint infra/aws/cloudformation/templates/lambda-rds-start.yaml` — zero errors
+2. **Template validation:** `aws cloudformation validate-template --template-body file://infra/aws/cloudformation/templates/lambda-rds-start.yaml` — valid
+3. **Manual verification:** Confirm template still has all original resources intact (only FunctionName value changed)
+4. **Naming conflict check:** Verify no other CloudFormation stack creates a function named `lenie-dev-rds-start` in the same account/region
+
+### Previous Story Intelligence (Story 14.1)
+
+**From Story 14.1 (Remove Elastic IP):**
+- Removal-only change pattern: delete blocks entirely, no remnants, no placeholder comments
+- cfn-lint validation as standard quality gate
+- Verification-driven tasks: read files, confirm behavior, no unnecessary code changes
+- Template retains all other resources unchanged — minimal blast radius
+- Git history shows recent Sprint 4 planning and Epic 13/14 stories
+
+**From Sprint 4 Git History (last 10 commits):**
+- `e69d399` — fix: update pypdf dependency
+- `bed69fe` — fix: remove Elastic IP from EC2 CloudFormation template (Story 14-1)
+- `69f640b` — docs: update Sprint 4 planning artifacts
+- `bea7f95` — docs: verify CRLF git config (Story 13-2)
+- `ff47d84` — fix: extend env var validation (Story 13-1 review)
+- Pattern: commit messages use conventional commits (fix:, feat:, docs:) with story references
+
+### Project Structure Notes
+
+- `infra/aws/cloudformation/templates/lambda-rds-start.yaml` is in Layer 5 (Compute) of deploy.ini
+- Sprint 4 architecture confirms B-5 (this story) is independent of B-4 (EIP removal, Story 14.1) — can be done in parallel
+- Sprint 4 architecture specifies implementation order: B-5 before B-14 (API GW consolidation) for clean Lambda naming context
+- Gen 2+ canonical template pattern remains in effect for all CF modifications
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md — Epic 14, Story 14.2]
+- [Source: _bmad-output/planning-artifacts/architecture.md — Sprint 4, Lambda Function Rename Strategy]
+- [Source: _bmad-output/planning-artifacts/architecture.md — Sprint 4, Implementation Patterns — Lambda Naming]
+- [Source: _bmad-output/planning-artifacts/architecture.md — Sprint 1, Enforcement Guidelines — NFR7]
+- [Source: infra/aws/cloudformation/templates/lambda-rds-start.yaml — line 55 FunctionName]
+- [Source: infra/aws/cloudformation/templates/api-gw-infra.yaml — line 78 RdsStartFunction, line 445 integration URI]
+- [Source: infra/aws/cloudformation/parameters/dev/sqs-to-rds-step-function.json — SqsToRdsLambdaFunctionName]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+- Task 1 pre-check discovered CONFLICT: `api-gw-infra.yaml` (line 75-99) CREATES `RdsStartFunction` with `FunctionName: ${ProjectCode}-${Environment}-rds-start`. Renaming `lambda-rds-start.yaml` to the same name would cause CloudFormation deployment failure (duplicate function name across stacks).
+- Additional finding: `api-gw-infra.yaml`'s shared `LambdaExecutionRole` had ONLY CloudWatch Logs permissions — missing RDS and SSM permissions required by rds-start/stop/status functions.
+- User decision: `api-gw-infra.yaml` is the source of truth for infrastructure Lambda functions. `lambda-rds-start.yaml` is redundant and decommissioned.
+
+### Completion Notes List
+
+- ✅ CONFLICT resolved: `api-gw-infra.yaml` designated as source of truth for rds-start Lambda (user decision)
+- ✅ Added RDS permissions (StartDBInstance, StopDBInstance, DescribeDBInstances) to `LambdaExecutionRole` in `api-gw-infra.yaml`
+- ✅ Added scoped SSM permission for database name parameter
+- ✅ Increased RdsStartFunction timeout from 30s to 60s (matching original standalone template)
+- ✅ Decommissioned `lambda-rds-start.yaml` by commenting out in `deploy.ini`
+- ✅ All verifications passed: cfn-lint zero errors, no regressions, all consumer references verified
+- ✅ No cross-stack imports of `lambda-rds-start` exports found — safe to remove stack
+- ⚠️ Manual AWS action required: delete stack `lenie-dev-lambda-rds-start` and its Lambda function `lenie-dev-lambda-rds-start-rds-start-function` from AWS account
+- ✅ Removed `/infra/git-webhooks` endpoint and `LambdaInvokePermissionGitWebhooks` from `api-gw-infra.yaml` — Lambda `git-webhooks` doesn't exist (archived: tag `archive/git-webhooks`), was blocking all stack updates
+- ✅ Updated documentation (6 files) to reflect 7 endpoints in api-gw-infra (was 8)
+
+### File List
+
+| File | Action | Description |
+|------|--------|-------------|
+| `infra/aws/cloudformation/templates/api-gw-infra.yaml` | MOD | Added RDS + SSM permissions to LambdaExecutionRole; increased RdsStartFunction timeout from 30s to 60s |
+| `infra/aws/cloudformation/deploy.ini` | MOD | Commented out `lambda-rds-start.yaml` with decommission note |
+| `infra/aws/cloudformation/CLAUDE.md` | MOD | Updated template tables and deploy order to reflect decommissioned lambda-rds-start.yaml and api-gw-infra.yaml IAM changes |
+| `infra/aws/cloudformation/templates/api-gw-infra.yaml` | MOD | Removed `/infra/git-webhooks` endpoint and `LambdaInvokePermissionGitWebhooks` (Lambda doesn't exist, blocked stack updates) |
+| `infra/aws/CLAUDE.md` | MOD | Updated api-gw-infra endpoint count: 8 → 7 |
+| `infra/aws/README.md` | MOD | Removed git-webhooks row from API endpoints table, updated LambdaExecutionRole description |
+| `docs/architecture-decisions.md` | MOD | Updated api-gw-infra endpoint list (removed git-webhooks) |
+| `docs/Jenkins.md` | MOD | Added note that git-webhooks endpoint was removed |
+
+## Change Log
+
+| Date | Change | Story |
+|------|--------|-------|
+| 2026-02-20 | Consolidated rds-start Lambda management into api-gw-infra.yaml: added RDS/SSM IAM permissions, increased timeout, decommissioned redundant lambda-rds-start.yaml in deploy.ini | 14.2 |
+| 2026-02-20 | Removed `/infra/git-webhooks` endpoint from api-gw-infra.yaml (Lambda `git-webhooks` archived, blocked stack updates). Updated 6 documentation files: endpoint count 8→7. | 14.2 |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -145,7 +145,7 @@ development_status:
   # --- Epic 14: Infrastructure Cost & Naming Cleanup ---
   epic-14: in-progress
   14-1-remove-elastic-ip-from-ec2-instance: review
-  14-2-fix-redundant-lambda-function-name-in-lambda-rds-start: backlog
+  14-2-fix-redundant-lambda-function-name-in-lambda-rds-start: review
   epic-14-retrospective: optional
 
   # --- Epic 15: API Gateway Consolidation ---

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -143,8 +143,8 @@ development_status:
   epic-13-retrospective: optional
 
   # --- Epic 14: Infrastructure Cost & Naming Cleanup ---
-  epic-14: in-progress
-  14-1-remove-elastic-ip-from-ec2-instance: review
+  epic-14: done
+  14-1-remove-elastic-ip-from-ec2-instance: done
   14-2-fix-redundant-lambda-function-name-in-lambda-rds-start: done
   epic-14-retrospective: optional
 
@@ -176,6 +176,8 @@ development_status:
   B-10-create-apigw-cloudwatch-iam-role-in-cloudformation: backlog
   B-16-migrate-web-interface-react-from-cra-to-vite: backlog
   B-17-migrate-web-add-url-react-from-cra-to-vite: backlog
+
+  B-22-add-max-retry-limit-to-aws-ec2-route53-script: backlog
 
   # --- Low Priority / Ideas ---
   B-8-manage-acm-certificates-via-cloudformation-and-ssm: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -145,7 +145,7 @@ development_status:
   # --- Epic 14: Infrastructure Cost & Naming Cleanup ---
   epic-14: in-progress
   14-1-remove-elastic-ip-from-ec2-instance: review
-  14-2-fix-redundant-lambda-function-name-in-lambda-rds-start: review
+  14-2-fix-redundant-lambda-function-name-in-lambda-rds-start: done
   epic-14-retrospective: optional
 
   # --- Epic 15: API Gateway Consolidation ---
@@ -169,6 +169,7 @@ development_status:
   B-3-rename-legacy-lambda-lenie-2-internet-and-db: backlog
 
   # --- Medium Priority ---
+  B-21-split-shared-lambda-execution-role-into-per-function-roles: backlog
   B-1-analyze-ec2-lambda-consolidation: backlog
   B-2-analyze-rds-lambda-consolidation: backlog
   B-6-migrate-api-gw-app-stage-to-separate-resource: backlog

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.1.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
@@ -628,9 +628,9 @@ dependencies = [
     { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -2850,14 +2850,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/f1/ee81806690a87dab5f5653c1f146c92bc066d7f4cebc603ef88eb9e13957/werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25", size = 864736, upload-time = "2026-02-19T15:17:18.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131", size = 225166, upload-time = "2026-02-19T15:17:17.475Z" },
 ]
 
 [[package]]

--- a/docs/Jenkins.md
+++ b/docs/Jenkins.md
@@ -130,14 +130,7 @@ keytool -importkeystore \
 
 ## GitHub Webhooks
 
-Testing GitHub webhooks:
-
-```bash
-curl -X POST \
-    -H "Content-Type: application/json" \
-    -d '{"key1":"value1", "key2":"value2"}' \
-    https://your-api-gateway.execute-api.us-east-1.amazonaws.com/v1/infra/git-webhooks
-```
+> **Note:** The `/infra/git-webhooks` API Gateway endpoint and its `git-webhooks` Lambda function have been removed (Sprint 4, Story 14.2). The Lambda is archived under git tag `archive/git-webhooks`. Jenkins is no longer in use, so the webhook integration is not needed.
 
 ## Code Checkout
 

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -205,7 +205,7 @@ Problems: (A) infrastructure endpoints were duplicated across `api-gw-app` and `
 ### Related Artifacts
 
 - `infra/aws/cloudformation/templates/api-gw-app.yaml` — 10 app endpoints only
-- `infra/aws/cloudformation/templates/api-gw-infra.yaml` — 8 infra endpoints (database, vpn, sqs, git-webhooks)
+- `infra/aws/cloudformation/templates/api-gw-infra.yaml` — 7 infra endpoints (database start/stop/status, vpn start/stop/status, sqs size)
 - `web_interface_react/src/modules/shared/context/authorizationContext.js` — `infraApiUrl` state
 - `web_interface_react/src/modules/shared/hooks/useDatabase.js` — uses `infraApiUrl` for AWS mode
 - `web_interface_react/src/modules/shared/hooks/useVpnServer.js` — uses `infraApiUrl` for AWS mode

--- a/infra/aws/CLAUDE.md
+++ b/infra/aws/CLAUDE.md
@@ -46,7 +46,7 @@ aws/
 ## Subdirectories
 
 ### cloudformation/
-Primary IaC approach. Custom `deploy.sh` script manages stack lifecycle (create/update/delete) across environments. Covers 34 templates organized by layer: networking (VPC), database (RDS, DynamoDB), queues (SQS, SNS), storage (S3), compute (EC2, Lambda), API Gateway (2 active REST APIs: app 10 + infra 8 endpoints, plus Chrome ext API), orchestration (Step Functions), organization (SCPs, Identity Store), and monitoring (budgets). See `cloudformation/CLAUDE.md` for details.
+Primary IaC approach. Custom `deploy.sh` script manages stack lifecycle (create/update/delete) across environments. Covers 34 templates organized by layer: networking (VPC), database (RDS, DynamoDB), queues (SQS, SNS), storage (S3), compute (EC2, Lambda), API Gateway (2 active REST APIs: app 10 + infra 7 endpoints, plus Chrome ext API), orchestration (Step Functions), organization (SCPs, Identity Store), and monitoring (budgets). See `cloudformation/CLAUDE.md` for details.
 
 ### serverless/
 Lambda function source code (11 functions) and Lambda layer build scripts (psycopg2, lenie_all, openai). Two function categories: simple infrastructure Lambdas (RDS/EC2/SQS management) and app Lambdas that bundle `backend/library/` for document processing and AI operations. Includes packaging scripts (`zip_to_s3.sh`, `create_empty_lambdas.sh`). See `serverless/CLAUDE.md` for details.
@@ -85,7 +85,7 @@ Jenkins target (`aws-start-jenkins`) was removed since Jenkins is not currently 
 | SNS | Error notifications via email |
 | S3 | Lambda code artifacts, video transcriptions, web content |
 | Lambda | 11 functions for infra management and app logic |
-| API Gateway | 2 active REST APIs (app: 10 endpoints, infra: 8 endpoints) + 1 Chrome extension API (url-add.yaml) |
+| API Gateway | 2 active REST APIs (app: 10 endpoints, infra: 7 endpoints) + 1 Chrome extension API (url-add.yaml) |
 | Step Functions | SQS-to-RDS workflow with auto DB start/stop |
 | EC2 | Application server, bastion host, Jenkins, OpenVPN |
 | EKS | Kubernetes cluster (alternative deployment target) |

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -195,12 +195,14 @@ infra/aws/
 
 ## 6. Compute - Lambda Functions
 
-### 6.1 RDS Start (`lambda-rds-start.yaml`)
+### 6.1 RDS Start (`lambda-rds-start.yaml`) — REDUNDANT
+
+> **Decommissioned:** Commented out in `deploy.ini`. The rds-start Lambda is now managed by `api-gw-infra.yaml`. Delete stack `lenie-dev-lambda-rds-start` manually.
 
 | Resource                 | Type                     | Details                                        |
 |--------------------------|--------------------------|------------------------------------------------|
-| RDSStartLambdaFunction   | AWS::Lambda::Function    | RDS start/stop, timeout: 60s                   |
-| RDSStartLambdaRole       | AWS::IAM::Role           | rds:Start/Stop/Describe, ssm:GetParameter      |
+| RDSStartLambdaFunction   | AWS::Lambda::Function    | REDUNDANT — managed by api-gw-infra.yaml       |
+| RDSStartLambdaRole       | AWS::IAM::Role           | REDUNDANT — permissions moved to shared role   |
 
 ### 6.2 URL Add to SQS (`lambda-weblink-put-into-sqs.yaml`)
 
@@ -265,7 +267,7 @@ infra/aws/
 
 | Resource              | Type                        | Details                                     |
 |-----------------------|-----------------------------|---------------------------------------------|
-| LambdaExecutionRole   | AWS::IAM::Role              | logs:*, rds:Start/Stop/Describe, ssm:GetParameter |
+| LambdaExecutionRole   | AWS::IAM::Role              | logs:*, rds:Start/Stop/Describe, ec2:Start/Stop/Describe, sqs:GetQueueAttributes, ssm:GetParameter |
 | SqsSizeFunction       | AWS::Lambda::Function       | `lenie-dev-sqs-size`, timeout: 30s          |
 | RdsStartFunction      | AWS::Lambda::Function       | `lenie-dev-rds-start`                       |
 | RdsStopFunction       | AWS::Lambda::Function       | `lenie-dev-rds-stop`                        |

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -178,8 +178,6 @@ infra/aws/
 |-------------------------|-------------------------------|--------------------------------------------|
 | EC2Instance             | AWS::EC2::Instance            | t4g.micro (ARM64), Amazon Linux 2023       |
 | InstanceSecurityGroup   | AWS::EC2::SecurityGroup       | SSH (22), HTTP (80), HTTPS (443)           |
-| ElasticIP               | AWS::EC2::EIP                 | Static public IP                           |
-| EIPAssociation          | AWS::EC2::EIPAssociation      | -                                          |
 | InstanceRole            | AWS::IAM::Role                | AmazonSSMManagedInstanceCore               |
 | InstanceProfile         | AWS::IAM::InstanceProfile     | -                                          |
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -265,7 +265,7 @@ infra/aws/
 
 | Resource              | Type                        | Details                                     |
 |-----------------------|-----------------------------|---------------------------------------------|
-| LambdaExecutionRole   | AWS::IAM::Role              | logs:*                                      |
+| LambdaExecutionRole   | AWS::IAM::Role              | logs:*, rds:Start/Stop/Describe, ssm:GetParameter |
 | SqsSizeFunction       | AWS::Lambda::Function       | `lenie-dev-sqs-size`, timeout: 30s          |
 | RdsStartFunction      | AWS::Lambda::Function       | `lenie-dev-rds-start`                       |
 | RdsStopFunction       | AWS::Lambda::Function       | `lenie-dev-rds-stop`                        |
@@ -288,7 +288,6 @@ infra/aws/
 | `/infra/vpn_server/start`     | POST, OPTIONS  | Start EC2 (VPN)       |
 | `/infra/vpn_server/stop`      | POST, OPTIONS  | Stop EC2 (VPN)        |
 | `/infra/vpn_server/status`    | POST, OPTIONS  | Get EC2 status        |
-| `/infra/git-webhooks`         | POST, OPTIONS  | Git webhook handler   |
 
 ---
 

--- a/infra/aws/cloudformation/CLAUDE.md
+++ b/infra/aws/cloudformation/CLAUDE.md
@@ -142,7 +142,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 
 | Template | Resources | Description |
 |----------|-----------|-------------|
-| `ec2-lenie.yaml` | EC2 (t4g.micro ARM64), EIP, SG, IAM | Instance with Elastic IP and SSM |
+| `ec2-lenie.yaml` | EC2 (t4g.micro ARM64), SG, IAM | Instance with dynamic public IP and SSM |
 | `lenie-launch-template.yaml` | Launch Template | EC2 launch template |
 | `lambda-rds-start.yaml` | Lambda, IAM Role | REDUNDANT — commented out in deploy.ini; rds-start Lambda is managed by api-gw-infra.yaml. Delete stack `lenie-dev-lambda-rds-start` manually. |
 | `lambda-weblink-put-into-sqs.yaml` | Lambda | Function to put web links into SQS |

--- a/infra/aws/cloudformation/CLAUDE.md
+++ b/infra/aws/cloudformation/CLAUDE.md
@@ -153,7 +153,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 
 | Template | Resources | Description |
 |----------|-----------|-------------|
-| `api-gw-infra.yaml` | REST API, 7 Lambdas, IAM Role | Infrastructure management API (7 endpoints: RDS start/stop/status, EC2/VPN start/stop/status, SQS size). Shared IAM role includes RDS + SSM permissions for rds-start/stop/status functions. |
+| `api-gw-infra.yaml` | REST API, 7 Lambdas, IAM Role | Infrastructure management API (7 endpoints: RDS start/stop/status, EC2/VPN start/stop/status, SQS size). Shared IAM role includes RDS, EC2, SQS, and SSM permissions for all functions. |
 | `api-gw-app.yaml` | REST API, 2 Lambdas | Main application API (10 endpoints, x-api-key) |
 | `api-gw-url-add.yaml` | REST API, API Key, Usage Plan | UNUSED — commented out in deploy.ini (duplicate of url-add.yaml) |
 

--- a/infra/aws/cloudformation/CLAUDE.md
+++ b/infra/aws/cloudformation/CLAUDE.md
@@ -144,7 +144,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 |----------|-----------|-------------|
 | `ec2-lenie.yaml` | EC2 (t4g.micro ARM64), EIP, SG, IAM | Instance with Elastic IP and SSM |
 | `lenie-launch-template.yaml` | Launch Template | EC2 launch template |
-| `lambda-rds-start.yaml` | Lambda, IAM Role | Function to start RDS |
+| `lambda-rds-start.yaml` | Lambda, IAM Role | REDUNDANT — commented out in deploy.ini; rds-start Lambda is managed by api-gw-infra.yaml. Delete stack `lenie-dev-lambda-rds-start` manually. |
 | `lambda-weblink-put-into-sqs.yaml` | Lambda | Function to put web links into SQS |
 | `sqs-to-rds-lambda.yaml` | Lambda, IAM Role | Transfer messages from SQS to RDS (VPC, layers) |
 | `url-add.yaml` | Lambda, API GW, API Key, IAM, Logs | URL addition (standalone with its own API Gateway) |
@@ -153,7 +153,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 
 | Template | Resources | Description |
 |----------|-----------|-------------|
-| `api-gw-infra.yaml` | REST API, 8 Lambdas | Infrastructure management API (8 endpoints: RDS, EC2/VPN, SQS, git-webhooks) |
+| `api-gw-infra.yaml` | REST API, 7 Lambdas, IAM Role | Infrastructure management API (7 endpoints: RDS start/stop/status, EC2/VPN start/stop/status, SQS size). Shared IAM role includes RDS + SSM permissions for rds-start/stop/status functions. |
 | `api-gw-app.yaml` | REST API, 2 Lambdas | Main application API (10 endpoints, x-api-key) |
 | `api-gw-url-add.yaml` | REST API, API Key, Usage Plan | UNUSED — commented out in deploy.ini (duplicate of url-add.yaml) |
 
@@ -232,7 +232,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 - `lambda-layer-psycopg2.yaml` - PostgreSQL driver layer
 - `ec2-lenie.yaml` - application server
 - `lenie-launch-template.yaml` - EC2 launch template
-- `lambda-rds-start.yaml` - Lambda for DB start
+- ~~`lambda-rds-start.yaml`~~ - REDUNDANT, commented out (rds-start Lambda managed by api-gw-infra.yaml)
 - `lambda-weblink-put-into-sqs.yaml` - Lambda for SQS ingestion
 - `sqs-to-rds-lambda.yaml` - SQS to RDS transfer Lambda
 - `url-add.yaml` - URL addition Lambda with API Gateway

--- a/infra/aws/cloudformation/deploy.ini
+++ b/infra/aws/cloudformation/deploy.ini
@@ -33,7 +33,7 @@ templates/lambda-layer-openai.yaml
 templates/lambda-layer-psycopg2.yaml
 templates/ec2-lenie.yaml
 templates/lenie-launch-template.yaml
-templates/lambda-rds-start.yaml
+; templates/lambda-rds-start.yaml  ; REDUNDANT — rds-start Lambda is managed by api-gw-infra.yaml. Delete stack lenie-dev-lambda-rds-start manually.
 templates/lambda-weblink-put-into-sqs.yaml
 templates/sqs-to-rds-lambda.yaml
 templates/url-add.yaml

--- a/infra/aws/cloudformation/parameters/dev/url-add.json
+++ b/infra/aws/cloudformation/parameters/dev/url-add.json
@@ -17,6 +17,6 @@
   },
   {
     "ParameterKey": "timestamp",
-    "ParameterValue": "1771367260"
+    "ParameterValue": "1771566241"
   }
 ]

--- a/infra/aws/cloudformation/templates/api-gw-infra.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-infra.yaml
@@ -39,6 +39,16 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: "*"
+              - Effect: Allow
+                Action:
+                  - rds:StartDBInstance
+                  - rds:StopDBInstance
+                  - rds:DescribeDBInstances
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectCode}/${Environment}/database/name'
       Tags:
         - Key: Environment
           Value: !Ref Environment
@@ -86,7 +96,7 @@ Resources:
         S3Bucket: !Sub '{{resolve:ssm:/${ProjectCode}/${Environment}/s3/cloudformation/name}}'
         S3Key: !Sub ${ProjectCode}-${Environment}-rds-start.zip
       Runtime: !Sub '{{resolve:ssm:/${ProjectCode}/${Environment}/python/lambda-runtime-version}}'
-      Timeout: 30
+      Timeout: 60
       MemorySize: 128
       Environment:
         Variables:
@@ -563,49 +573,6 @@ Resources:
                 requestTemplates:
                   application/json: '{"statusCode": 200}'
                 passthroughBehavior: "when_no_match"
-          /infra/git-webhooks:
-            post:
-              responses:
-                "200":
-                  description: "200 response"
-                  content:
-                    application/json:
-                      schema:
-                        $ref: "#/components/schemas/Empty"
-              x-amazon-apigateway-integration:
-                type: "aws_proxy"
-                httpMethod: "POST"
-                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:git-webhooks/invocations"
-                passthroughBehavior: "when_no_match"
-                timeoutInMillis: 29000
-                contentHandling: "CONVERT_TO_TEXT"
-            options:
-              responses:
-                "200":
-                  description: "200 response"
-                  headers:
-                    Access-Control-Allow-Origin:
-                      schema:
-                        type: "string"
-                    Access-Control-Allow-Methods:
-                      schema:
-                        type: "string"
-                    Access-Control-Allow-Headers:
-                      schema:
-                        type: "string"
-                  content: {}
-              x-amazon-apigateway-integration:
-                type: "mock"
-                responses:
-                  default:
-                    statusCode: "200"
-                    responseParameters:
-                      method.response.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
-                      method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
-                      method.response.header.Access-Control-Allow-Origin: "'*'"
-                requestTemplates:
-                  application/json: '{"statusCode": 200}'
-                passthroughBehavior: "when_no_match"
         components:
           schemas:
             Empty:
@@ -689,10 +656,3 @@ Resources:
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${LenieApi}/*/*"
 
-  LambdaInvokePermissionGitWebhooks:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: git-webhooks
-      Action: lambda:InvokeFunction
-      Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${LenieApi}/*/*"

--- a/infra/aws/cloudformation/templates/api-gw-infra.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-infra.yaml
@@ -44,11 +44,21 @@ Resources:
                   - rds:StartDBInstance
                   - rds:StopDBInstance
                   - rds:DescribeDBInstances
+                Resource: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:*'
+              - Effect: Allow
+                Action:
+                  - ec2:StartInstances
+                  - ec2:StopInstances
+                  - ec2:DescribeInstances
                 Resource: '*'
               - Effect: Allow
                 Action:
+                  - sqs:GetQueueAttributes
+                Resource: !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*'
+              - Effect: Allow
+                Action:
                   - ssm:GetParameter
-                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectCode}/${Environment}/database/name'
+                Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectCode}/${Environment}/*'
       Tags:
         - Key: Environment
           Value: !Ref Environment

--- a/infra/aws/cloudformation/templates/ec2-lenie.yaml
+++ b/infra/aws/cloudformation/templates/ec2-lenie.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Template to create an EC2 instance with Amazon Linux 2023 and assign an Elastic IP
+Description: Template to create an EC2 instance with Amazon Linux 2023
 
 Parameters:
   ProjectCode:

--- a/infra/aws/cloudformation/templates/lambda-rds-start.yaml
+++ b/infra/aws/cloudformation/templates/lambda-rds-start.yaml
@@ -71,7 +71,7 @@ Resources:
 
 Outputs:
   LambdaFunctionArn:
-    Description: 'ARN of the RDS Stop Lambda function'
+    Description: 'ARN of the RDS Start Lambda function'
     Value: !GetAtt RDSStartLambdaFunction.Arn
     Export:
       Name: !Sub '${AWS::StackName}-lambda-arn'


### PR DESCRIPTION
## Summary

Comprehensive infrastructure modernization across 4 sprints (195 commits), covering:

- **Sprint 1 — IaC Coverage & Migration**: CloudFormation templates for DynamoDB, S3 buckets, Lambda layers; S3 data migration; CloudFront distribution; API Gateway consolidation
- **Sprint 2 — Cleanup & Vision**: Step Function timezone fix, DynamoDB cache table removal, README vision update, documentation overhaul
- **Sprint 3 — Code Cleanup**: Removed dead endpoints (/ai_ask, /translate, /infra_ip_allow, ai_describe_image), CloudFormation template improvements (tags, SSM patterns, API deployment fixes, parameterization), cross-cutting verification
- **Sprint 4 — Consolidation & Tooling**: Deployment safety (zip_to_s3.sh), CRLF verification, Elastic IP removal (~$3.65/month savings), rds-start Lambda consolidation into api-gw-infra.yaml, git-webhooks cleanup
- **Code Reviews**: Adversarial reviews for Stories 14-1 and 14-2 — fixed missing EC2/SQS IAM permissions, stale documentation, template description errors
- **Security**: Upgraded flask 3.1.2→3.1.3, werkzeug 3.1.5→3.1.6, pypdf 6.7.1; resolved ~70 npm vulnerabilities (Sprint 3)
- **Backlog items added**: B-21 (per-Lambda IAM role separation), B-22 (aws_ec2_route53.py retry limit)

### Key infrastructure changes
- 34 CloudFormation templates managed via deploy.sh
- api-gw-infra.yaml: 7 endpoints with full IAM permissions (RDS, EC2, SQS, SSM)
- Decommissioned: lambda-rds-start.yaml, api-gw-url-add.yaml, SES, DynamoDB cache tables
- Epic 14 completed — all stories reviewed and done

## Test plan

- [x] cfn-lint validation: zero errors on all modified templates
- [x] Adversarial code reviews for Sprint 4 stories (14-1, 14-2)
- [x] All Acceptance Criteria verified for each story
- [ ] Deploy CloudFormation stacks to dev (`./deploy.sh -p lenie -s dev`)
- [ ] Delete orphaned stack `lenie-dev-lambda-rds-start` manually
- [ ] Verify EC2/VPN and SQS endpoints work with new IAM permissions
- [ ] Run `aws_ec2_route53.py` to confirm dynamic IP DNS update

> **Note:** `main` is 9 commits ahead — may require merge conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)