### PR TITLE
fix: CORS, API URL cleanup, DB-aware UI

### DIFF
--- a/infra/aws/cloudformation/templates/api-gw-infra.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-infra.yaml
@@ -491,6 +491,26 @@ Resources:
               in: "header"
 
 
+  GatewayResponseDefault4XX:
+    Type: 'AWS::ApiGateway::GatewayResponse'
+    Properties:
+      RestApiId: !Ref LenieApi
+      ResponseType: DEFAULT_4XX
+      ResponseParameters:
+        gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+        gatewayresponse.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+        gatewayresponse.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
+
+  GatewayResponseDefault5XX:
+    Type: 'AWS::ApiGateway::GatewayResponse'
+    Properties:
+      RestApiId: !Ref LenieApi
+      ResponseType: DEFAULT_5XX
+      ResponseParameters:
+        gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+        gatewayresponse.header.Access-Control-Allow-Headers: "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+        gatewayresponse.header.Access-Control-Allow-Methods: "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'"
+
   ApiStage:
     Type: 'AWS::ApiGateway::Stage'
     Properties:

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -95,7 +95,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 
 ### Global State (`authorizationContext.tsx`)
 
-- **API config** (persisted to localStorage): `apiUrl`, `apiKey`, `apiType` (AWS Serverless / Docker), `infraApiUrl`
+- **API config** (persisted to localStorage): `apiUrl`, `apiKey`, `apiType` (AWS Serverless / Docker)
 - **Infrastructure status**: `databaseStatus`, `vpnServerStatus`, `sqsLength`
 - **Document filters**: `selectedDocumentType`, `selectedDocumentState`, `searchInDocument`, `searchType`
 
@@ -104,8 +104,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 | Key | Value |
 |-----|-------|
 | `lenie_apiType` | "AWS Serverless" or "Docker" |
-| `lenie_apiUrl` | Server API URL |
-| `lenie_infraApiUrl` | Infrastructure API URL |
+| `lenie_apiUrl` | API URL (single URL for both app and infra endpoints) |
 | `lenie_apiKey` | API authentication key |
 
 ### Custom Hooks
@@ -129,10 +128,12 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 
 ### Default URLs
 
-| API Type | Server URL | Infra URL |
-|----------|-----------|-----------|
-| AWS Serverless | `https://api.dev.lenie-ai.eu` | `https://api.dev.lenie-ai.eu` |
-| Docker | `http://localhost:5000` | `http://localhost:5000` |
+| API Type | API URL |
+|----------|---------|
+| AWS Serverless | `https://api.dev.lenie-ai.eu` |
+| Docker | `http://localhost:5000` |
+
+App endpoints use the base URL (e.g., `/website_list`), infra endpoints use `/infra` prefix (e.g., `/infra/database/status`). Both share the same domain via API Gateway custom domain base path mappings.
 
 ## TypeScript
 

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -131,7 +131,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 
 | API Type | Server URL | Infra URL |
 |----------|-----------|-----------|
-| AWS Serverless | `https://api.dev.lenie-ai.eu` | `https://api.dev.lenie-ai.eu/infra` |
+| AWS Serverless | `https://api.dev.lenie-ai.eu` | `https://api.dev.lenie-ai.eu` |
 | Docker | `http://localhost:5000` | `http://localhost:5000` |
 
 ## TypeScript

--- a/web_interface_react/src/modules/shared/components/Authorization/authorization.tsx
+++ b/web_interface_react/src/modules/shared/components/Authorization/authorization.tsx
@@ -20,6 +20,14 @@ const Authorization = () => {
   const { fetchSqsSize } = useSqs();
   const navigate = useNavigate();
 
+  // Auto-check infrastructure status on mount
+  React.useEffect(() => {
+    handleDBStatusGet();
+    handleVPNServerStatusGet();
+    fetchSqsSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const generateClass = (): string => {
     switch (databaseStatus) {
       case "unknown":

--- a/web_interface_react/src/modules/shared/context/authorizationContext.tsx
+++ b/web_interface_react/src/modules/shared/context/authorizationContext.tsx
@@ -11,8 +11,6 @@ export const AuthorizationContext = createContext<AuthorizationState>({
   setApiKey: () => {},
   apiUrl: "",
   setApiUrl: () => {},
-  infraApiUrl: "",
-  setInfraApiUrl: () => {},
   apiType: "AWS Serverless",
   setApiType: () => {},
   sqsLength: -1,
@@ -37,7 +35,6 @@ const AuthorizationProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [apiKey, setApiKey] = React.useState<string | undefined>(saved.apiKey);
   const [apiType, setApiType] = React.useState<ApiType>(saved.apiType);
   const [apiUrl, setApiUrl] = React.useState(saved.apiUrl);
-  const [infraApiUrl, setInfraApiUrl] = React.useState(saved.infraApiUrl);
   const [selectedDocumentType, setSelectedDocumentType] = React.useState("link");
   const [selectedDocumentState, setSelectedDocumentState] = React.useState("NEED_MANUAL_REVIEW");
   const [searchInDocument, setSearchInDocument] = React.useState("");
@@ -49,11 +46,10 @@ const AuthorizationProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       saveConnectionConfig({
         apiType,
         apiUrl,
-        infraApiUrl,
         apiKey,
       });
     }
-  }, [apiType, apiUrl, infraApiUrl, apiKey]);
+  }, [apiType, apiUrl, apiKey]);
 
   return (
     <AuthorizationContext.Provider
@@ -66,8 +62,6 @@ const AuthorizationProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setApiKey,
         apiUrl,
         setApiUrl,
-        infraApiUrl,
-        setInfraApiUrl,
         apiType,
         setApiType,
         sqsLength,

--- a/web_interface_react/src/modules/shared/hooks/useDatabase.ts
+++ b/web_interface_react/src/modules/shared/hooks/useDatabase.ts
@@ -6,15 +6,14 @@ export const useDatabase = () => {
   const [message, setMessage] = React.useState<string | false>(false);
   const [isLoading, setIsLoading] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
-  const { apiKey, apiUrl, infraApiUrl, apiType, setDatabaseStatus } =
+  const { apiKey, apiUrl, setDatabaseStatus } =
     React.useContext(AuthorizationContext);
-  const baseUrl = apiType === "AWS Serverless" ? infraApiUrl : apiUrl;
 
   const handleDBStatusGet = async () => {
     setDatabaseStatus("unknown");
     setIsLoading(true);
     try {
-      const response = await axios.get(`${baseUrl}/infra/database/status`, {
+      const response = await axios.get(`${apiUrl}/infra/database/status`, {
         headers: {
           "Content-Type": "application/json",
           "x-api-key": `${apiKey}`,
@@ -47,7 +46,7 @@ export const useDatabase = () => {
     setIsLoading(true);
     try {
       const response = await axios.post(
-        `${baseUrl}/infra/database/start`,
+        `${apiUrl}/infra/database/start`,
         {},
         {
           headers: {
@@ -82,7 +81,7 @@ export const useDatabase = () => {
     setIsLoading(true);
     try {
       const response = await axios.post(
-        `${baseUrl}/infra/database/stop`,
+        `${apiUrl}/infra/database/stop`,
         {},
         {
           headers: {

--- a/web_interface_react/src/modules/shared/hooks/useList.ts
+++ b/web_interface_react/src/modules/shared/hooks/useList.ts
@@ -8,13 +8,15 @@ export const useList = () => {
   const [message, setMessage] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
-  const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
+  const { apiKey, apiUrl, databaseStatus } = React.useContext(AuthorizationContext);
   const { selectedDocumentType, selectedDocumentState} = React.useContext(AuthorizationContext);
 
   React.useEffect(() => {
-    handleGetList(selectedDocumentType, selectedDocumentState).then(() => null);  // Domyślne wartości na start
+    if (databaseStatus === "available") {
+      handleGetList(selectedDocumentType, selectedDocumentState).then(() => null);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [databaseStatus]);
 
   const handleGetList = async (type: string, documentState: string, searchInDocument?: string) => {
     setIsLoading(true);

--- a/web_interface_react/src/modules/shared/hooks/useSqs.ts
+++ b/web_interface_react/src/modules/shared/hooks/useSqs.ts
@@ -5,13 +5,12 @@ import { AuthorizationContext } from "../context/authorizationContext";
 export const useSqs = () => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
-  const { apiKey, apiUrl, infraApiUrl, apiType, setSqsLength } = React.useContext(AuthorizationContext);
-  const baseUrl = apiType === "AWS Serverless" ? infraApiUrl : apiUrl;
+  const { apiKey, apiUrl, setSqsLength } = React.useContext(AuthorizationContext);
 
   const fetchSqsSize = async () => {
     setIsLoading(true);
     try {
-      const response = await axios.get(`${baseUrl}/infra/sqs/size`, {
+      const response = await axios.get(`${apiUrl}/infra/sqs/size`, {
         headers: {
           "Content-Type": "application/json",
           "x-api-key": `${apiKey}`,

--- a/web_interface_react/src/modules/shared/hooks/useVpnServer.ts
+++ b/web_interface_react/src/modules/shared/hooks/useVpnServer.ts
@@ -6,14 +6,13 @@ export const useVpnServer = () => {
     const [message, setMessage] = React.useState("");
     const [isLoading, setIsLoading] = React.useState(false);
     const [isError, setIsError] = React.useState(false);
-    const { apiKey, apiUrl, infraApiUrl, apiType, setVpnServerStatus } = React.useContext(AuthorizationContext);
-    const baseUrl = apiType === "AWS Serverless" ? infraApiUrl : apiUrl;
+    const { apiKey, apiUrl, setVpnServerStatus } = React.useContext(AuthorizationContext);
 
     const handleVPNServerStatusGet = async () => {
         setVpnServerStatus("unknown");
         setIsLoading(true);
         try {
-            const response = await axios.get(`${baseUrl}/infra/vpn_server/status`, {
+            const response = await axios.get(`${apiUrl}/infra/vpn_server/status`, {
                 headers: {
                     "Content-Type": "application/json",
                     "x-api-key": `${apiKey}`,
@@ -42,7 +41,7 @@ export const useVpnServer = () => {
         setIsLoading(true);
         try {
             const response = await axios.post(
-                `${baseUrl}/infra/vpn_server/start`,
+                `${apiUrl}/infra/vpn_server/start`,
                 {},
                 {
                     headers: {
@@ -73,7 +72,7 @@ export const useVpnServer = () => {
         setIsLoading(true);
         try {
             const response = await axios.post(
-                `${baseUrl}/infra/vpn_server/stop`,
+                `${apiUrl}/infra/vpn_server/stop`,
                 {},
                 {
                     headers: {

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -7,23 +7,19 @@ import type { ApiType } from "../../../types";
 
 const Connect: React.FC = () => {
   const navigate = useNavigate();
-  const { setApiKey, setApiUrl, setInfraApiUrl, setApiType } =
+  const { setApiKey, setApiUrl, setApiType, setDatabaseStatus } =
     React.useContext(AuthorizationContext);
 
   const [formApiType, setFormApiType] = useState<ApiType>("AWS Serverless");
-  const [formApiUrl, setFormApiUrl] = useState(DEFAULT_URLS["AWS Serverless"].apiUrl);
-  const [formInfraApiUrl, setFormInfraApiUrl] = useState(DEFAULT_URLS["AWS Serverless"].infraApiUrl);
+  const [formApiUrl, setFormApiUrl] = useState(DEFAULT_URLS["AWS Serverless"]);
   const [formApiKey, setFormApiKey] = useState("");
   const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState("");
-  const [skipValidation, setSkipValidation] = useState(false);
 
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newType = e.target.value as ApiType;
     setFormApiType(newType);
-    const defaults = DEFAULT_URLS[newType];
-    setFormApiUrl(defaults.apiUrl);
-    setFormInfraApiUrl(defaults.infraApiUrl);
+    setFormApiUrl(DEFAULT_URLS[newType]);
   };
 
   const handleConnect = async () => {
@@ -34,42 +30,65 @@ const Connect: React.FC = () => {
       return;
     }
 
-    if (skipValidation) {
-      applyAndRedirect();
-      return;
-    }
-
     setIsValidating(true);
+    const headers = { "x-api-key": formApiKey };
+    const timeout = 10000;
+
+    // Step 1: Check infra API — validates key + returns DB status
+    let dbStatus = "unknown";
     try {
-      await axios.get(`${formApiUrl}/website_list`, {
-        params: { type: "link", limit: 1 },
-        headers: { "x-api-key": formApiKey },
-        timeout: 10000,
+      const response = await axios.get(`${formApiUrl}/infra/database/status`, {
+        headers,
+        timeout,
       });
-      applyAndRedirect();
+      dbStatus = response.data;
     } catch (err: any) {
+      setIsValidating(false);
       if (err.response?.status === 403 || err.response?.status === 401) {
         setError("Invalid API key. Check the key and try again.");
       } else if (err.code === "ECONNABORTED") {
-        setError("Connection timed out. Check the server URL or skip validation.");
+        setError("Connection timed out. Check the API URL.");
       } else {
-        setError(`Connection failed: ${err.message}. You can skip validation if the backend is down.`);
+        setError(`Connection failed: ${err.message}`);
       }
-    } finally {
-      setIsValidating(false);
+      return;
     }
+
+    // Step 2: If DB is up, also validate app API key
+    if (dbStatus === "available") {
+      try {
+        await axios.get(`${formApiUrl}/website_list`, {
+          params: { type: "link", limit: 1 },
+          headers,
+          timeout,
+        });
+      } catch (err: any) {
+        setIsValidating(false);
+        if (err.response?.status === 403 || err.response?.status === 401) {
+          setError("Database is up, but App API rejected the key (403). Check your API key.");
+        } else if (err.code === "ECONNABORTED") {
+          setError("Database is up, but App API timed out.");
+        } else {
+          setError(`Database is up, but App API failed: ${err.message}`);
+        }
+        return;
+      }
+    }
+
+    // All checks passed — save DB status and enter the app
+    setIsValidating(false);
+    setDatabaseStatus(dbStatus);
+    applyAndRedirect();
   };
 
   const applyAndRedirect = () => {
     saveConnectionConfig({
       apiType: formApiType,
       apiUrl: formApiUrl,
-      infraApiUrl: formInfraApiUrl,
       apiKey: formApiKey,
     });
     setApiType(formApiType);
     setApiUrl(formApiUrl);
-    setInfraApiUrl(formInfraApiUrl);
     setApiKey(formApiKey);
     navigate("/list");
   };
@@ -95,7 +114,7 @@ const Connect: React.FC = () => {
 
       <div style={{ marginBottom: "15px" }}>
         <label htmlFor="connect-api-url" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
-          Server API URL
+          API URL
         </label>
         <input
           id="connect-api-url"
@@ -105,21 +124,6 @@ const Connect: React.FC = () => {
           style={{ width: "100%", padding: "8px", fontSize: "14px" }}
         />
       </div>
-
-      {formApiType === "AWS Serverless" && (
-        <div style={{ marginBottom: "15px" }}>
-          <label htmlFor="connect-infra-url" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
-            Infra API URL
-          </label>
-          <input
-            id="connect-infra-url"
-            type="text"
-            value={formInfraApiUrl}
-            onChange={(e) => setFormInfraApiUrl(e.target.value)}
-            style={{ width: "100%", padding: "8px", fontSize: "14px" }}
-          />
-        </div>
-      )}
 
       <div style={{ marginBottom: "15px" }}>
         <label htmlFor="connect-api-key" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
@@ -133,17 +137,6 @@ const Connect: React.FC = () => {
           placeholder="Enter your API key"
           style={{ width: "100%", padding: "8px", fontSize: "14px" }}
         />
-      </div>
-
-      <div style={{ marginBottom: "15px" }}>
-        <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer" }}>
-          <input
-            type="checkbox"
-            checked={skipValidation}
-            onChange={(e) => setSkipValidation(e.target.checked)}
-          />
-          Skip validation (use when backend is down)
-        </label>
       </div>
 
       {error && (

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -16,7 +16,7 @@ const List = () => {
     onSubmit: () => {},
   });
 
-  const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState} = React.useContext(AuthorizationContext);
+  const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState, databaseStatus } = React.useContext(AuthorizationContext);
   const { searchInDocument, setSearchInDocument} = React.useContext(AuthorizationContext);
   const { searchType, setSearchType} = React.useContext(AuthorizationContext);
 
@@ -38,11 +38,19 @@ const List = () => {
     handleGetList(selectedDocumentType, selectedDocumentState);
   };
 
+  const dbDown = databaseStatus !== "available";
+
   return (
     <div>
       <h2 style={{ marginBottom: "20px" }}>
         Lista Zapisanych Stron i linków {!!data && `(${data?.length} z ${dataAllLength})`}
       </h2>
+
+      {dbDown && (
+        <p style={{ padding: "15px", background: "#fff3cd", border: "1px solid #ffc107", borderRadius: "4px", marginBottom: "15px" }}>
+          Baza danych jest niedostępna (status: {databaseStatus}). Uruchom bazę danych w panelu po lewej stronie, aby przeglądać dokumenty.
+        </p>
+      )}
 
       <select value={selectedDocumentType} onChange={handleTypeChange}>
         <option value="ALL">ALL</option>
@@ -93,7 +101,7 @@ const List = () => {
         />
         <label htmlFor="similar">Similar</label>
       <button
-        disabled={isLoading}
+        disabled={isLoading || dbDown}
         className={"button"}
         type={"button"}
         onClick={() => handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument)}

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -3,33 +3,23 @@ import type { ApiType } from "../../../types";
 const KEYS = {
   apiType: "lenie_apiType",
   apiUrl: "lenie_apiUrl",
-  infraApiUrl: "lenie_infraApiUrl",
   apiKey: "lenie_apiKey",
 } as const;
 
-export const DEFAULT_URLS: Record<ApiType, { apiUrl: string; infraApiUrl: string }> = {
-  "AWS Serverless": {
-    apiUrl: "https://api.dev.lenie-ai.eu",
-    infraApiUrl: "https://api.dev.lenie-ai.eu",
-  },
-  Docker: {
-    apiUrl: "http://localhost:5000",
-    infraApiUrl: "http://localhost:5000",
-  },
+export const DEFAULT_URLS: Record<ApiType, string> = {
+  "AWS Serverless": "https://api.dev.lenie-ai.eu",
+  Docker: "http://localhost:5000",
 };
 
 export function loadConnectionConfig(): {
   apiType: ApiType;
   apiUrl: string;
-  infraApiUrl: string;
   apiKey: string | undefined;
 } {
   const apiType = (localStorage.getItem(KEYS.apiType) as ApiType) || "AWS Serverless";
-  const defaults = DEFAULT_URLS[apiType];
   return {
     apiType,
-    apiUrl: localStorage.getItem(KEYS.apiUrl) || defaults.apiUrl,
-    infraApiUrl: localStorage.getItem(KEYS.infraApiUrl) || defaults.infraApiUrl,
+    apiUrl: localStorage.getItem(KEYS.apiUrl) || DEFAULT_URLS[apiType],
     apiKey: localStorage.getItem(KEYS.apiKey) || undefined,
   };
 }
@@ -37,19 +27,16 @@ export function loadConnectionConfig(): {
 export function saveConnectionConfig(config: {
   apiType: ApiType;
   apiUrl: string;
-  infraApiUrl: string;
   apiKey: string;
 }): void {
   localStorage.setItem(KEYS.apiType, config.apiType);
   localStorage.setItem(KEYS.apiUrl, config.apiUrl);
-  localStorage.setItem(KEYS.infraApiUrl, config.infraApiUrl);
   localStorage.setItem(KEYS.apiKey, config.apiKey);
 }
 
 export function clearConnectionConfig(): void {
   localStorage.removeItem(KEYS.apiType);
   localStorage.removeItem(KEYS.apiUrl);
-  localStorage.removeItem(KEYS.infraApiUrl);
   localStorage.removeItem(KEYS.apiKey);
 }
 

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -10,7 +10,7 @@ const KEYS = {
 export const DEFAULT_URLS: Record<ApiType, { apiUrl: string; infraApiUrl: string }> = {
   "AWS Serverless": {
     apiUrl: "https://api.dev.lenie-ai.eu",
-    infraApiUrl: "https://api.dev.lenie-ai.eu/infra",
+    infraApiUrl: "https://api.dev.lenie-ai.eu",
   },
   Docker: {
     apiUrl: "http://localhost:5000",

--- a/web_interface_react/src/types/index.ts
+++ b/web_interface_react/src/types/index.ts
@@ -32,8 +32,6 @@ export interface AuthorizationState {
   setApiKey: React.Dispatch<React.SetStateAction<string | undefined>>;
   apiUrl: string;
   setApiUrl: React.Dispatch<React.SetStateAction<string>>;
-  infraApiUrl: string;
-  setInfraApiUrl: React.Dispatch<React.SetStateAction<string>>;
   apiType: ApiType;
   setApiType: React.Dispatch<React.SetStateAction<ApiType>>;
   sqsLength: number;


### PR DESCRIPTION
## Summary

- **CORS fix**: Add `GatewayResponse` DEFAULT_4XX/5XX with CORS headers to `api-gw-infra.yaml` — fixes browser-blocked 403 responses
- **Remove infraApiUrl**: Single API URL for both app and infra endpoints (custom domain handles routing via base path mappings)
- **Connect validation**: Check infra API first (validates key + DB status), then app API only if DB is up
- **DB-aware list page**: Skip document fetch when DB is down, show warning banner, auto-fetch when DB starts

## Commits

- `37d45b9` fix: CORS and infra API connectivity
- `93f4032` refactor: remove infraApiUrl
- `aed94dd` fix: skip document list fetch when database is down

## Test plan

- [ ] Connect with invalid key → error message shown, no access
- [ ] Connect with valid key + DB down → enters panel, shows "Baza danych jest niedostępna" on list page
- [ ] Start DB from panel → list auto-fetches documents
- [ ] Connect with valid key + DB up → validates both APIs, enters panel with document list

🤖 Generated with [Claude Code](https://claude.com/claude-code)