### PR TITLE
feat: host landing page on S3 + CloudFront (www.lenie-ai.eu)

### DIFF
--- a/infra/aws/CLAUDE.md
+++ b/infra/aws/CLAUDE.md
@@ -48,7 +48,7 @@ aws/
 ## Subdirectories
 
 ### cloudformation/
-Primary IaC approach. Custom `deploy.sh` script manages stack lifecycle (create/update/delete) across environments. 27 templates in deploy.ini [dev] (34 total .yaml files) organized by layer: networking (VPC), database (RDS, DynamoDB), queues (SQS, SNS), storage (S3), compute (EC2, Lambda), API Gateway (2 REST APIs: app 11 + infra 7 endpoints, custom domain with base path mappings), orchestration (Step Functions), organization (SCPs, Identity Store), and monitoring (budgets). See `cloudformation/CLAUDE.md` for details and `docs/infrastructure-metrics.md` for authoritative counts.
+Primary IaC approach. Custom `deploy.sh` script manages stack lifecycle (create/update/delete) across environments. 29 templates in deploy.ini [dev] (36 total .yaml files) organized by layer: networking (VPC), database (RDS, DynamoDB), queues (SQS, SNS), storage (S3), compute (EC2, Lambda), API Gateway (2 REST APIs: app 11 + infra 7 endpoints, custom domain with base path mappings), orchestration (Step Functions), CDN (CloudFront for app + landing page), organization (SCPs, Identity Store), and monitoring (budgets). See `cloudformation/CLAUDE.md` for details and `docs/infrastructure-metrics.md` for authoritative counts.
 
 ### serverless/
 Lambda function source code and Lambda layer build scripts (psycopg2, lenie_all, openai). 8 Lambda functions total: 6 CF-managed (3 simple infrastructure in api-gw-infra.yaml + 3 S3-packaged app functions) and 2 non-CF-managed (`lenie-dev-app-server-db`, `lenie-dev-app-server-internet`). Includes packaging script (`zip_to_s3.sh`). See `serverless/CLAUDE.md` for details and `docs/infrastructure-metrics.md` for full inventory.
@@ -97,8 +97,14 @@ Jenkins target (`aws-start-jenkins`) was removed since Jenkins is not currently 
 | CloudWatch | Logging, Step Function execution monitoring |
 | Budgets | Cost alerts ($8/month threshold) |
 | Organizations + SCPs | Multi-account governance, region restrictions |
-| Amplify | Frontend hosting (React SPA) with auto-deploy from GitHub |
+| CloudFront | CDN for frontend app (`app.dev.lenie-ai.eu`) and landing page (`www.lenie-ai.eu`) |
 
-## Frontend Hosting (Historical Context)
+## Frontend Hosting
 
-The React frontend was originally deployed via a **GitLab CI pipeline** that synced built static files to S3 and invalidated a CloudFront distribution. This has been replaced by **AWS Amplify**, which provides managed hosting, CI/CD, HTTPS, and custom domains out of the box. See `docs/AWS_Amplify_Deployment.md` for details. The archived pipeline is in `infra/archive/gitlab-ci-frontend.yml`.
+Two web frontends are hosted via S3 + CloudFront:
+- **React app** (`web_interface_react/`) — `app.dev.lenie-ai.eu` via `s3-app-web` + `cloudfront-app` stacks
+- **Landing page** (`web_landing_page/`, Next.js static export) — `www.lenie-ai.eu` via `s3-landing-web` + `cloudfront-landing` stacks
+
+### Historical Context
+
+The React frontend was originally deployed via a **GitLab CI pipeline** that synced built static files to S3 and invalidated a CloudFront distribution. This was later replaced by AWS Amplify (now removed), then migrated back to S3 + CloudFront. The archived pipeline is in `infra/archive/gitlab-ci-frontend.yml`.

--- a/infra/aws/cloudformation/CLAUDE.md
+++ b/infra/aws/cloudformation/CLAUDE.md
@@ -102,7 +102,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 |----------|-----------|-------------|
 | `env-setup.yaml` | SSM Parameter | Runtime version configuration (python3.11) |
 | `vpc.yaml` | VPC, 6 Subnets, IGW, Route Table, SSM | Multi-AZ network (public, private, DB subnets) |
-| `1-domain-route53.yaml` | Route53 Hosted Zone | Domain `lenie-ai.eu` |
+| `1-domain-route53.yaml` | Route53 Hosted Zone | DISABLED — creates duplicate zone. Domain `lenie-ai.eu` hosted zone is managed by legacy stack `lenie-domain-route53-definition` (with SSM exports for all environments). |
 | `security-groups.yaml` | Security Group | SSH access from specific IPs |
 | `secrets.yaml` | Secrets Manager, SSM Parameter | Database credentials (auto-generated password, username in `GenerateSecretString`). Exports secret ARN to SSM at `/${ProjectCode}/${Environment}/rds/secret-arn` |
 
@@ -128,6 +128,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 | `s3-cloudformation.yaml` | S3 Bucket, SSM | Lambda code and CF artifacts bucket |
 | `s3-website-content.yaml` | S3 Bucket, Bucket Policy, SSM | Website content storage (`lenie-{stage}-website-content`, AES256) |
 | `s3-app-web.yaml` | S3 Bucket, Bucket Policy, SSM | Frontend hosting bucket (`lenie-{stage}-app-web`, CloudFront OAC) |
+| `s3-landing-web.yaml` | S3 Bucket, Bucket Policy, SSM | Landing page hosting bucket (`lenie-{stage}-landing-web`, CloudFront OAC) |
 | `helm.yaml` | S3 Bucket, Bucket Policy, CloudFront OAI, CloudFront Distribution | Helm chart repository and CDN (`helm.{env}.lenie-ai.eu`) |
 
 ### Lambda Layers
@@ -179,6 +180,7 @@ These settings apply to all methods/resources via wildcard `MethodSettings` (`Ht
 | Template | Resources | Description |
 |----------|-----------|-------------|
 | `cloudfront-app.yaml` | CloudFront Distribution, OAC, Route53 A-Record, SSM | CDN for frontend application (`app.{env}.lenie-ai.eu`) with SPA error responses (403/404 → index.html) and Route53 alias record |
+| `cloudfront-landing.yaml` | CloudFront Distribution, OAC, Route53 A-Record, SSM | CDN for landing page (`www.lenie-ai.eu`) with static 404 error page and Route53 alias record |
 
 ### Email
 
@@ -207,7 +209,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 ### Layer 1: Foundation
 - `env-setup.yaml` - base configuration (SSM parameters)
 - `budget.yaml` - cost alerts
-- `1-domain-route53.yaml` - domain
+- ~~`1-domain-route53.yaml`~~ - DISABLED (duplicate zone; managed by legacy stack `lenie-domain-route53-definition`)
 
 ### Layer 2: Networking
 - `vpc.yaml` - VPC, subnets, IGW
@@ -222,6 +224,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 - `dynamodb-documents.yaml` - documents table
 - `s3-website-content.yaml` - website content storage
 - `s3-app-web.yaml` - frontend hosting bucket
+- `s3-landing-web.yaml` - landing page hosting bucket
 - `sqs-documents.yaml` - document processing queue
 - `sqs-application-errors.yaml` - DLQ with email notification
 - `rds.yaml` - database (commented out; deployed separately, managed lifecycle via Step Functions)
@@ -247,6 +250,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 
 ### Layer 8: CDN
 - `cloudfront-app.yaml` - CDN for frontend application
+- `cloudfront-landing.yaml` - CDN for landing page (`www.lenie-ai.eu`)
 - `helm.yaml` - Helm chart repository and CDN
 
 This order is reflected in the `deploy.ini` file under the `[dev]` section. Run `./deploy.sh -p lenie -s dev` to deploy all templates in order.

--- a/infra/aws/cloudformation/deploy.ini
+++ b/infra/aws/cloudformation/deploy.ini
@@ -7,7 +7,7 @@
 ; --- Layer 1: Foundation ---
 templates/env-setup.yaml
 templates/budget.yaml
-templates/1-domain-route53.yaml
+; templates/1-domain-route53.yaml  ; DUPLICATE — hosted zone managed by legacy stack lenie-domain-route53-definition (with SSM exports). This template creates a second empty zone.
 
 ; --- Layer 2: Networking ---
 templates/vpc.yaml
@@ -22,6 +22,7 @@ templates/s3-cloudformation.yaml
 templates/dynamodb-documents.yaml
 templates/s3-website-content.yaml
 templates/s3-app-web.yaml
+templates/s3-landing-web.yaml
 templates/sqs-documents.yaml
 templates/sqs-application-errors.yaml
 ; rds.yaml - deployed separately, managed lifecycle via Step Functions
@@ -48,4 +49,5 @@ templates/sqs-to-rds-step-function.yaml
 
 ; --- Layer 8: CDN ---
 templates/cloudfront-app.yaml
+templates/cloudfront-landing.yaml
 templates/helm.yaml

--- a/infra/aws/cloudformation/parameters/dev/cloudfront-landing.json
+++ b/infra/aws/cloudformation/parameters/dev/cloudfront-landing.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "ProjectCode",
+    "ParameterValue": "lenie"
+  },
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "AcmCertificateArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:008971653395:certificate/086deba9-90e6-454a-b9d7-e2111542f150"
+  },
+  {
+    "ParameterKey": "HostedZoneId",
+    "ParameterValue": "Z07906713RCJHAZLQEP4C"
+  }
+]

--- a/infra/aws/cloudformation/parameters/dev/s3-landing-web.json
+++ b/infra/aws/cloudformation/parameters/dev/s3-landing-web.json
@@ -1,0 +1,14 @@
+[
+  {
+    "ParameterKey": "ProjectCode",
+    "ParameterValue": "lenie"
+  },
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "CloudFrontDistributionId",
+    "ParameterValue": "E3604IQH1WCL5D"
+  }
+]

--- a/infra/aws/cloudformation/templates/cloudfront-landing.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-landing.yaml
@@ -1,0 +1,127 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFront distribution for landing page hosting for Project Lenie'
+
+Parameters:
+  ProjectCode:
+    Type: String
+    Default: lenie
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      # Post-MVP: add prod, qa as needed
+    Description: Environment name
+  AcmCertificateArn:
+    Type: String
+    Description: ACM certificate ARN for custom domain (must be in us-east-1)
+  HostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route53 hosted zone ID for lenie-ai.eu
+
+Resources:
+  # Origin Access Control for S3 origin (sigv4 signing)
+  LandingOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub '${ProjectCode}-${Environment}-landing-web.s3.us-east-1.amazonaws.com'
+        SigningProtocol: sigv4
+        SigningBehavior: always
+        OriginAccessControlOriginType: s3
+        Description: 'OAC for landing page S3 bucket'
+
+  # CloudFront distribution for landing page
+  LandingDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub '${Environment} landing page for lenie'
+        DefaultRootObject: index.html
+        PriceClass: PriceClass_100
+        HttpVersion: http2
+        IPV6Enabled: true
+        Aliases:
+          - www.lenie-ai.eu
+        Origins:
+          - Id: !Sub '${ProjectCode}-${Environment}-landing-web.s3.us-east-1.amazonaws.com'
+            DomainName: !Sub '${ProjectCode}-${Environment}-landing-web.s3.us-east-1.amazonaws.com'
+            OriginAccessControlId: !GetAtt LandingOriginAccessControl.Id
+            S3OriginConfig:
+              OriginAccessIdentity: ''
+        DefaultCacheBehavior:
+          TargetOriginId: !Sub '${ProjectCode}-${Environment}-landing-web.s3.us-east-1.amazonaws.com'
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          # AWS managed CachingOptimized policy
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+        ViewerCertificate:
+          AcmCertificateArn: !Ref AcmCertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404/index.html
+            ErrorCachingMinTTL: 10
+          - ErrorCode: 404
+            ResponseCode: 404
+            ResponsePagePath: /404/index.html
+            ErrorCachingMinTTL: 10
+        Restrictions:
+          GeoRestriction:
+            RestrictionType: none
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Project
+          Value: !Ref ProjectCode
+
+  # Route53 A-record alias pointing to CloudFront distribution
+  LandingDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: www.lenie-ai.eu
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt LandingDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2  # CloudFront global hosted zone ID
+
+  # SSM Parameter exports
+  LandingDistributionIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${ProjectCode}/${Environment}/cloudfront/landing/id'
+      Type: String
+      Value: !Ref LandingDistribution
+      Description: 'CloudFront landing distribution ID for Project Lenie'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode
+
+  LandingDistributionDomainNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${ProjectCode}/${Environment}/cloudfront/landing/domain-name'
+      Type: String
+      Value: !GetAtt LandingDistribution.DomainName
+      Description: 'CloudFront landing distribution domain name for Project Lenie'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode
+
+Outputs:
+  DistributionId:
+    Description: CloudFront Distribution ID (use in s3-landing-web parameters)
+    Value: !Ref LandingDistribution
+  DistributionDomainName:
+    Description: CloudFront Distribution Domain Name
+    Value: !GetAtt LandingDistribution.DomainName

--- a/infra/aws/cloudformation/templates/s3-landing-web.yaml
+++ b/infra/aws/cloudformation/templates/s3-landing-web.yaml
@@ -1,0 +1,103 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'S3 bucket for landing page hosting for Project Lenie'
+
+Parameters:
+  ProjectCode:
+    Type: String
+    Default: lenie
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      # Post-MVP: add prod, qa as needed
+    Description: Environment name
+  CloudFrontDistributionId:
+    Type: String
+    Description: CloudFront distribution ID for OAC bucket policy
+
+Resources:
+  LandingWebBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub '${ProjectCode}-${Environment}-landing-web'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: true
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Project
+          Value: !Ref ProjectCode
+
+  LandingWebBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LandingWebBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: PolicyForCloudFrontPrivateContent
+        Statement:
+          - Sid: AllowCloudFrontServicePrincipal
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub '${LandingWebBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistributionId}'
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !GetAtt LandingWebBucket.Arn
+              - !Sub '${LandingWebBucket.Arn}/*'
+            Condition:
+              Bool:
+                aws:SecureTransport: 'false'
+
+  # SSM Parameter exports
+  LandingWebBucketNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${ProjectCode}/${Environment}/s3/landing-web/name'
+      Type: String
+      Value: !Ref LandingWebBucket
+      Description: 'S3 landing-web bucket name for Project Lenie'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode
+
+  LandingWebBucketArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${ProjectCode}/${Environment}/s3/landing-web/arn'
+      Type: String
+      Value: !GetAtt LandingWebBucket.Arn
+      Description: 'S3 landing-web bucket ARN for Project Lenie'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode
+
+  LandingWebBucketDomainNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub '/${ProjectCode}/${Environment}/s3/landing-web/domain-name'
+      Type: String
+      Value: !GetAtt LandingWebBucket.DomainName
+      Description: 'S3 landing-web bucket domain name for Project Lenie'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode

--- a/web_landing_page/next.config.mjs
+++ b/web_landing_page/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  images: {
+    unoptimized: true,
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Configure Next.js 14 landing page for static export (`output: 'export'`, `images: { unoptimized: true }`)
- Add CloudFormation templates for S3 bucket (`s3-landing-web.yaml`) and CloudFront distribution (`cloudfront-landing.yaml`) with Route53 A-record alias
- Clean up stale Amplify DNS records (app, app2, www CNAMEs) from Route53
- Deploy and verify: `www.lenie-ai.eu` serves landing page via CloudFront with HTTPS

## Infrastructure created
- **S3 bucket**: `lenie-dev-landing-web` (stack `lenie-dev-s3-landing-web`)
- **CloudFront**: `E3604IQH1WCL5D` / `d2g7lv13o176od.cloudfront.net` (stack `lenie-dev-cloudfront-landing`)
- **DNS**: `www.lenie-ai.eu` → CloudFront A-record alias
- **ACM**: Uses wildcard cert `*.lenie-ai.eu`
- **SSM Parameters**: `/lenie/dev/cloudfront/landing/*`, `/lenie/dev/s3/landing-web/*`

## Test plan
- [x] `npm run build` generates static `out/` directory (25 pages)
- [x] `curl -I https://www.lenie-ai.eu` returns HTTP 200
- [x] Images load correctly (no `/_next/image/` optimization endpoint needed)
- [x] Both CF stacks in `CREATE_COMPLETE` state
- [x] 309 objects uploaded to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)