### PR TITLE
feat: Advanced Settings toggle + frontend deploy scripts with SSM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,22 @@ Some endpoints exist only in `server.py` (not in Lambda): `/url_add` (replaced b
 
 See `infra/aws/serverless/CLAUDE.md` for detailed comparison and known differences.
 
+### Frontend Deployment (AWS)
+
+All three frontends are deployed to S3 + CloudFront. Deploy scripts resolve bucket names and distribution IDs from SSM Parameter Store (exported by CloudFormation). See `docs/frontend-deployment.md` for full details.
+
+```bash
+# React app (app.dev.lenie-ai.eu)
+cd web_interface_react && ./deploy.sh
+
+# Admin panel (app2.dev.lenie-ai.eu)
+cd web_interface_app2 && ./deploy.sh
+
+# Common options
+./deploy.sh --skip-build         # Deploy existing build/ only
+./deploy.sh --skip-invalidation  # Skip CloudFront cache invalidation
+```
+
 ### CI/CD
 - CircleCI (`.circleci/config.yml`) - EC2-based testing
 - GitLab CI (`.gitlab-ci.yml`) - Qodana security scanning

--- a/docs/frontend-deployment.md
+++ b/docs/frontend-deployment.md
@@ -1,0 +1,85 @@
+# Frontend Deployment
+
+Manual deployment guide for Lenie AI frontend applications to AWS (S3 + CloudFront).
+
+## Overview
+
+Three web frontends are hosted via S3 + CloudFront:
+
+| App | URL | Deploy Script | S3 Bucket |
+|-----|-----|---------------|-----------|
+| React app | `app.dev.lenie-ai.eu` | `web_interface_react/deploy.sh` | `lenie-dev-app-web` |
+| Admin panel | `app2.dev.lenie-ai.eu` | `web_interface_app2/deploy.sh` | `lenie-dev-app2-web` |
+| Landing page | `www.lenie-ai.eu` | *(no script yet)* | `lenie-prod-landing-web` |
+
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- Node.js and npm installed
+- SSM Parameter Store populated by CloudFormation stacks (`s3-app-web`, `s3-app2-web`, `cloudfront-app`, `cloudfront-app2`)
+
+## Deploy Scripts
+
+Both `web_interface_react` and `web_interface_app2` have identical deploy script interfaces. The scripts resolve infrastructure configuration (S3 bucket name, CloudFront distribution ID) from AWS SSM Parameter Store — no hardcoded values.
+
+### Usage
+
+```bash
+cd web_interface_react   # or web_interface_app2
+./deploy.sh                      # Full: npm install + build + S3 sync + CF invalidation
+./deploy.sh --skip-build         # Skip npm install and build (use existing build/)
+./deploy.sh --skip-invalidation  # Skip CloudFront cache invalidation
+./deploy.sh --help               # Show usage
+```
+
+### What the Script Does
+
+1. **Resolves config from SSM** — reads S3 bucket name and CloudFront distribution ID
+2. **Installs dependencies** — `npm install` (skippable with `--skip-build`)
+3. **Builds production bundle** — `npm run build` (output: `build/`)
+4. **Syncs to S3** — `aws s3 sync build/ s3://<bucket> --delete`
+5. **Invalidates CloudFront cache** — `aws cloudfront create-invalidation --paths "/*"` (skippable)
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROJECT_CODE` | `lenie` | Project code used in SSM parameter paths |
+| `ENVIRONMENT` | `dev` | Environment name (`dev`, future: `prod`, `qa`) |
+| `AWS_REGION` | `us-east-1` | AWS region |
+
+### SSM Parameters
+
+The deploy scripts read the following SSM parameters (exported by CloudFormation):
+
+**React app (`web_interface_react`):**
+- `/${PROJECT_CODE}/${ENVIRONMENT}/s3/app-web/name` — S3 bucket name
+- `/${PROJECT_CODE}/${ENVIRONMENT}/cloudfront/app/id` — CloudFront distribution ID
+
+**Admin panel (`web_interface_app2`):**
+- `/${PROJECT_CODE}/${ENVIRONMENT}/s3/app2-web/name` — S3 bucket name
+- `/${PROJECT_CODE}/${ENVIRONMENT}/cloudfront/app2/id` — CloudFront distribution ID
+
+These parameters are created by CloudFormation templates:
+- `s3-app-web.yaml` / `s3-app2-web.yaml` — bucket name, ARN, domain name
+- `cloudfront-app.yaml` / `cloudfront-app2.yaml` — distribution ID, domain name
+
+### Git Bash Compatibility
+
+The scripts include `MSYS_NO_PATHCONV=1` for AWS CLI calls that use SSM paths starting with `/`. This prevents Git Bash (MSYS) from incorrectly converting these paths to Windows paths. The scripts work in both Git Bash and WSL.
+
+## CloudFront Cache Invalidation
+
+After deploying, CloudFront cache invalidation takes 1-5 minutes to propagate globally. Use `--skip-invalidation` if deploying multiple times in quick succession (invalidate only on the final deploy).
+
+To check invalidation status:
+
+```bash
+aws cloudfront get-invalidation \
+  --distribution-id <DISTRIBUTION_ID> \
+  --id <INVALIDATION_ID>
+```
+
+## Historical Context
+
+The React frontend was originally deployed via a GitLab CI pipeline (archived at `infra/archive/gitlab-ci-frontend.yml`), then migrated to AWS Amplify (now removed), and finally back to S3 + CloudFront with manual deploy scripts.

--- a/web_interface_app2/CLAUDE.md
+++ b/web_interface_app2/CLAUDE.md
@@ -27,13 +27,19 @@ Uses the existing backend API key as password — no backend changes needed.
 
 ## Deployment
 
+Deploy to S3 + CloudFront (`app2.dev.lenie-ai.eu`). The script resolves S3 bucket and CloudFront distribution ID from SSM Parameter Store.
+
 ```bash
-./deploy.sh                    # Full build + deploy to S3 + CF invalidation
-./deploy.sh --skip-build       # Deploy existing build/ only
+./deploy.sh                      # Full build + deploy to S3 + CF invalidation
+./deploy.sh --skip-build         # Deploy existing build/ only
 ./deploy.sh --skip-invalidation  # Skip CF cache invalidation
 ```
 
-Target: S3 bucket `lenie-dev-app2-web` + CloudFront distribution `E1NHFTM571WQ7L`.
+SSM parameters used:
+- `/${PROJECT_CODE}/${ENVIRONMENT}/s3/app2-web/name` — S3 bucket name
+- `/${PROJECT_CODE}/${ENVIRONMENT}/cloudfront/app2/id` — CloudFront distribution ID
+
+Environment variables: `PROJECT_CODE` (default: `lenie`), `ENVIRONMENT` (default: `dev`), `AWS_REGION` (default: `us-east-1`).
 
 ## Project Structure
 

--- a/web_interface_app2/src/pages/LoginPage.tsx
+++ b/web_interface_app2/src/pages/LoginPage.tsx
@@ -80,7 +80,25 @@ const LoginPage: React.FC = () => {
               />
             </Form.Group>
 
-            {showApiUrl ? (
+            <div className="mb-3">
+              <Button
+                variant="link"
+                size="sm"
+                className="p-0"
+                onClick={() => setShowApiUrl(!showApiUrl)}
+                disabled={isLoading}
+                aria-expanded={showApiUrl}
+              >
+                {showApiUrl ? 'Hide advanced settings' : 'Advanced settings'}
+              </Button>
+              {!showApiUrl && (
+                <div style={{ fontSize: '12px', color: '#6c757d', marginTop: '4px' }}>
+                  API URL: {apiUrl}
+                </div>
+              )}
+            </div>
+
+            {showApiUrl && (
               <Form.Group className="mb-3" controlId="apiUrl">
                 <Form.Label>API URL</Form.Label>
                 <Form.Control
@@ -90,17 +108,6 @@ const LoginPage: React.FC = () => {
                   disabled={isLoading}
                 />
               </Form.Group>
-            ) : (
-              <div className="mb-3">
-                <Button
-                  variant="link"
-                  size="sm"
-                  className="p-0"
-                  onClick={() => setShowApiUrl(true)}
-                >
-                  Advanced settings
-                </Button>
-              </div>
             )}
 
             {error && <Alert variant="danger">{error}</Alert>}

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -169,6 +169,22 @@ npm test          # Run Vitest tests
 npm run lint      # TypeScript type check only
 ```
 
+## AWS Deployment
+
+Deploy to S3 + CloudFront (`app.dev.lenie-ai.eu`). The script resolves S3 bucket and CloudFront distribution ID from SSM Parameter Store.
+
+```bash
+./deploy.sh                      # Full build + deploy to S3 + CF invalidation
+./deploy.sh --skip-build         # Deploy existing build/ only
+./deploy.sh --skip-invalidation  # Skip CF cache invalidation
+```
+
+SSM parameters used:
+- `/${PROJECT_CODE}/${ENVIRONMENT}/s3/app-web/name` — S3 bucket name
+- `/${PROJECT_CODE}/${ENVIRONMENT}/cloudfront/app/id` — CloudFront distribution ID
+
+Environment variables: `PROJECT_CODE` (default: `lenie`), `ENVIRONMENT` (default: `dev`), `AWS_REGION` (default: `us-east-1`).
+
 ## Docker Build
 
 ```

--- a/web_interface_react/deploy.sh
+++ b/web_interface_react/deploy.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Deploy script for web_interface_app2 (app2.dev.lenie-ai.eu)
+# Deploy script for web_interface_react (app.dev.lenie-ai.eu)
 # Usage: ./deploy.sh [--skip-build] [--skip-invalidation]
 #
 # S3 bucket and CloudFront distribution ID are resolved from SSM Parameter Store
-# (exported by CloudFormation templates s3-app2-web.yaml and cloudfront-app2.yaml).
+# (exported by CloudFormation templates s3-app-web.yaml and cloudfront-app.yaml).
 
 PROJECT_CODE="${PROJECT_CODE:-lenie}"
 ENVIRONMENT="${ENVIRONMENT:-dev}"
@@ -45,10 +45,10 @@ done
 # MSYS_NO_PATHCONV prevents Git Bash from mangling SSM paths starting with /
 echo "--- Resolving configuration from SSM ---"
 SSM_PREFIX="/${PROJECT_CODE}/${ENVIRONMENT}"
-S3_BUCKET=$(MSYS_NO_PATHCONV=1 aws ssm get-parameter --name "${SSM_PREFIX}/s3/app2-web/name" --query 'Parameter.Value' --output text --region "$AWS_REGION")
-CLOUDFRONT_DISTRIBUTION_ID=$(MSYS_NO_PATHCONV=1 aws ssm get-parameter --name "${SSM_PREFIX}/cloudfront/app2/id" --query 'Parameter.Value' --output text --region "$AWS_REGION")
+S3_BUCKET=$(MSYS_NO_PATHCONV=1 aws ssm get-parameter --name "${SSM_PREFIX}/s3/app-web/name" --query 'Parameter.Value' --output text --region "$AWS_REGION")
+CLOUDFRONT_DISTRIBUTION_ID=$(MSYS_NO_PATHCONV=1 aws ssm get-parameter --name "${SSM_PREFIX}/cloudfront/app/id" --query 'Parameter.Value' --output text --region "$AWS_REGION")
 
-echo "=== Deploying web_interface_app2 to app2.${ENVIRONMENT}.lenie-ai.eu ==="
+echo "=== Deploying web_interface_react to app.${ENVIRONMENT}.lenie-ai.eu ==="
 echo "S3 bucket:      ${S3_BUCKET}"
 echo "CloudFront ID:  ${CLOUDFRONT_DISTRIBUTION_ID}"
 echo "Region:         ${AWS_REGION}"
@@ -92,4 +92,4 @@ else
 fi
 
 echo ""
-echo "=== Deploy complete: https://app2.${ENVIRONMENT}.lenie-ai.eu ==="
+echo "=== Deploy complete: https://app.${ENVIRONMENT}.lenie-ai.eu ==="

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -13,6 +13,7 @@ const Connect: React.FC = () => {
   const [formApiType, setFormApiType] = useState<ApiType>("AWS Serverless");
   const [formApiUrl, setFormApiUrl] = useState(DEFAULT_URLS["AWS Serverless"]);
   const [formApiKey, setFormApiKey] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState("");
 
@@ -98,34 +99,6 @@ const Connect: React.FC = () => {
       <h2 style={{ marginBottom: "20px" }}>Connect to Lenie Backend</h2>
 
       <div style={{ marginBottom: "15px" }}>
-        <label htmlFor="connect-api-type" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
-          API Type
-        </label>
-        <select
-          id="connect-api-type"
-          value={formApiType}
-          onChange={handleApiTypeChange}
-          style={{ width: "100%", padding: "8px", fontSize: "14px" }}
-        >
-          <option value="AWS Serverless">AWS Serverless</option>
-          <option value="Docker">Docker</option>
-        </select>
-      </div>
-
-      <div style={{ marginBottom: "15px" }}>
-        <label htmlFor="connect-api-url" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
-          API URL
-        </label>
-        <input
-          id="connect-api-url"
-          type="text"
-          value={formApiUrl}
-          onChange={(e) => setFormApiUrl(e.target.value)}
-          style={{ width: "100%", padding: "8px", fontSize: "14px" }}
-        />
-      </div>
-
-      <div style={{ marginBottom: "15px" }}>
         <label htmlFor="connect-api-key" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
           API Key
         </label>
@@ -138,6 +111,63 @@ const Connect: React.FC = () => {
           style={{ width: "100%", padding: "8px", fontSize: "14px" }}
         />
       </div>
+
+      <div style={{ marginBottom: "15px" }}>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          disabled={isValidating}
+          aria-expanded={showAdvanced}
+          style={{
+            background: "none",
+            border: "none",
+            color: "#007bff",
+            cursor: "pointer",
+            padding: 0,
+            fontSize: "14px",
+            textDecoration: "underline",
+          }}
+        >
+          {showAdvanced ? "Hide advanced settings" : "Advanced settings"}
+        </button>
+        {!showAdvanced && (
+          <div style={{ fontSize: "12px", color: "#6c757d", marginTop: "4px" }}>
+            {formApiType} — {formApiUrl}
+          </div>
+        )}
+      </div>
+
+      {showAdvanced && (
+        <>
+          <div style={{ marginBottom: "15px" }}>
+            <label htmlFor="connect-api-type" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              API Type
+            </label>
+            <select
+              id="connect-api-type"
+              value={formApiType}
+              onChange={handleApiTypeChange}
+              style={{ width: "100%", padding: "8px", fontSize: "14px" }}
+            >
+              <option value="AWS Serverless">AWS Serverless</option>
+              <option value="Docker">Docker</option>
+            </select>
+          </div>
+
+          <div style={{ marginBottom: "15px" }}>
+            <label htmlFor="connect-api-url" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              API URL
+            </label>
+            <input
+              id="connect-api-url"
+              type="text"
+              value={formApiUrl}
+              onChange={(e) => setFormApiUrl(e.target.value)}
+              style={{ width: "100%", padding: "8px", fontSize: "14px" }}
+            />
+          </div>
+        </>
+      )}
 
       {error && (
         <p className="errorText" style={{ marginBottom: "15px" }}>{error}</p>


### PR DESCRIPTION
## Summary
- **Advanced Settings toggle** on both login pages (`app` and `app2`) — can now show AND hide API URL/Type fields
- **New deploy script** for `web_interface_react` (`app.dev.lenie-ai.eu`)
- **Refactored both deploy scripts** to resolve S3 bucket and CloudFront distribution ID from SSM Parameter Store (no hardcoded values)
- **Documentation**: new `docs/frontend-deployment.md` + updated CLAUDE.md files

## Changes
- `web_interface_app2/src/pages/LoginPage.tsx` — toggle with hint, aria-expanded, disabled during loading
- `web_interface_react/src/modules/shared/pages/connect.tsx` — toggle with hint, API Type/URL hidden by default
- `web_interface_react/deploy.sh` — new deploy script (SSM-based)
- `web_interface_app2/deploy.sh` — refactored to SSM-based config
- `docs/frontend-deployment.md` — full manual deploy guide
- `CLAUDE.md`, `web_interface_react/CLAUDE.md`, `web_interface_app2/CLAUDE.md` — updated

## Test plan
- [x] TypeScript check passes for both apps
- [x] Both deploy scripts tested with `--skip-build --skip-invalidation` (SSM resolution works)
- [x] Both apps deployed to AWS and CloudFront invalidation triggered
- [ ] Manual verification on https://app.dev.lenie-ai.eu and https://app2.dev.lenie-ai.eu

🤖 Generated with [Claude Code](https://claude.com/claude-code)