### PR TITLE
refactor: extract shared TypeScript types to shared/ package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,11 @@ Key subdirectories: `library/` (core logic & integrations), `database/` (Postgre
 
 See `backend/CLAUDE.md` for full details including endpoints, dependencies, Docker build, and batch processing scripts.
 
+### Shared Types (`shared/`)
+Shared TypeScript type definitions used by both frontend applications. Contains domain types (`WebDocument`, `ApiType`, `SearchResult`, `ListItem`), constants (`DEFAULT_API_URLS`), and factory values (`emptyDocument`). No build step — Vite transpiles directly via esbuild. Both frontends reference it through `@lenie/shared` alias (tsconfig `paths` + Vite `resolve.alias`). See `docs/shared-types.md` for details.
+
 ### Frontend (`web_interface_react/`)
-React 18 SPA (Create React App) for document management and AI processing. 7 pages: document list with filtering, vector similarity search, and per-type editors (link, webpage, youtube, movie) with AI tools (split for embedding, clean text). Formik for form state, axios for API calls, React Router v6. Supports two backend modes: AWS Serverless (Lambda) and Docker (Flask). Includes infrastructure controls (start/stop RDS, VPN, SQS queue status).
+React 18 SPA (Vite) for document management and AI processing. 7 pages: document list with filtering, vector similarity search, and per-type editors (link, webpage, youtube, movie) with AI tools (split for embedding, clean text). Formik for form state, axios for API calls, React Router v6. Supports two backend modes: AWS Serverless (Lambda) and Docker (Flask). Includes infrastructure controls (start/stop RDS, VPN, SQS queue status). Domain types imported from `shared/` via `@lenie/shared` alias.
 
 See `web_interface_react/CLAUDE.md` for details.
 
@@ -86,6 +89,11 @@ See `web_chrome_extension/CLAUDE.md` for details.
 
 ### Landing Page (`web_landing_page/`)
 Next.js 14.2 static export with React 18 + Tailwind 3.4 + TypeScript. Deployed at `www.lenie-ai.eu` via S3 + CloudFront. 25 static pages.
+
+### Admin Panel (`web_interface_app2/`)
+Vite 6 + React 18 + TypeScript admin panel at `app2.dev.lenie-ai.eu`. Uses React Bootstrap, React Router v6. Domain types imported from `shared/` via `@lenie/shared` alias.
+
+See `web_interface_app2/CLAUDE.md` for details.
 
 ### Target Multi-User UI (`web_interface_target/`)
 Build artifacts from a purchased layout (React 18, Redux, React Bootstrap, TypeScript, Sass). Serves as visual/structural reference for the future multi-user admin interface at `app2.dev.lenie-ai.eu`. License restriction prevents direct reuse — new UI to be built from scratch using layout as partial base. Infrastructure ready (S3 + CloudFront templates in deploy.ini). No functionality connected yet.

--- a/docs/api-type-sync-strategy.md
+++ b/docs/api-type-sync-strategy.md
@@ -1,0 +1,282 @@
+# API Type Synchronization Strategy: Pydantic → OpenAPI → TypeScript
+
+## Problem
+
+Frontend (`shared/types/`) and backend (`backend/library/`) define the same data structures independently, leading to drift:
+
+| Issue | Detail |
+|-------|--------|
+| **`id` type mismatch** | TS: `string`, Python: `int` (serial PK) |
+| **`WebDocument` missing fields** | Backend `.dict()` returns 13 fields not in TS interface (paywall, created_at, title_english, project, etc.) |
+| **`ListItem` field count** | TS: 5 fields, backend returns 10 |
+| **`SearchResult` field count** | TS: 5 fields, backend returns 12 |
+| **Enums as plain strings** | Backend has typed enums (`StalkerDocumentStatus`, `StalkerDocumentType`, `StalkerDocumentStatusError`), frontend treats them as `string` |
+| **No contract** | No OpenAPI, JSON Schema, or Pydantic — backend uses custom classes + raw dicts |
+
+## Chosen Approach
+
+**Python Pydantic models → OpenAPI schema → generated TypeScript types**
+
+```
+┌─────────────────────┐     ┌──────────────┐     ┌───────────────────┐
+│  Pydantic models    │────▶│ openapi.json │────▶│ shared/types/*.ts │
+│  (source of truth)  │     │ (generated)  │     │ (generated)       │
+│  backend/library/   │     │ docs/        │     │                   │
+│  models/schemas/    │     └──────────────┘     └───────────────────┘
+└─────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Pydantic Response Models
+
+Create Pydantic v2 models for all API response shapes. These replace the manual `.dict()` methods.
+
+**Files to create:**
+
+```
+backend/library/models/schemas/
+├── __init__.py
+├── documents.py        # WebDocumentResponse, WebDocumentListItem, SearchResultItem
+├── api_responses.py    # ListResponse, SearchResponse, ErrorResponse, SuccessResponse
+└── enums.py            # Re-export existing enums with Pydantic-compatible serialization
+```
+
+**Key models:**
+
+```python
+# backend/library/models/schemas/documents.py
+from pydantic import BaseModel
+from enum import Enum
+
+class DocumentType(str, Enum):
+    movie = "movie"
+    youtube = "youtube"
+    link = "link"
+    webpage = "webpage"
+    text_message = "text_message"
+    text = "text"
+
+class DocumentStatus(str, Enum):
+    ERROR = "ERROR"
+    URL_ADDED = "URL_ADDED"
+    NEED_TRANSCRIPTION = "NEED_TRANSCRIPTION"
+    # ... all 15 values from StalkerDocumentStatus
+
+class DocumentStatusError(str, Enum):
+    NONE = "NONE"
+    ERROR_DOWNLOAD = "ERROR_DOWNLOAD"
+    # ... all 14 values from StalkerDocumentStatusError
+
+class WebDocumentResponse(BaseModel):
+    id: int
+    url: str
+    title: str | None = None
+    author: str | None = None
+    source: str | None = None
+    language: str | None = None
+    tags: str | None = None
+    summary: str | None = None
+    text: str | None = None
+    text_md: str | None = None
+    text_english: str | None = None
+    text_raw: str | None = None
+    document_type: DocumentType
+    document_state: DocumentStatus
+    document_state_error: DocumentStatusError
+    chapter_list: str | None = None
+    note: str | None = None
+    next_id: int | None = None
+    previous_id: int | None = None
+    next_type: str | None = None
+    previous_type: str | None = None
+    paywall: bool | None = None
+    created_at: str | None = None        # formatted "%Y-%m-%d %H:%M:%S"
+    title_english: str | None = None
+    summary_english: str | None = None
+    date_from: str | None = None
+    original_id: str | None = None
+    document_length: int | None = None
+    transcript_job_id: str | None = None
+    ai_summary_needed: bool | None = None
+    s3_uuid: str | None = None
+    project: str | None = None
+
+class WebDocumentListItem(BaseModel):
+    id: int
+    url: str
+    title: str | None = None
+    document_type: str
+    created_at: str
+    document_state: str
+    document_state_error: str | None = None
+    note: str | None = None
+    project: str | None = None
+    s3_uuid: str | None = None
+
+class SearchResultItem(BaseModel):
+    id: int
+    website_id: int
+    text: str
+    similarity: float
+    url: str
+    language: str | None = None
+    text_original: str | None = None
+    websites_text_length: int | None = None
+    embeddings_text_length: int | None = None
+    title: str | None = None
+    document_type: str | None = None
+    project: str | None = None
+```
+
+```python
+# backend/library/models/schemas/api_responses.py
+from pydantic import BaseModel
+
+class ListResponse(BaseModel):
+    status: str
+    message: str
+    encoding: str
+    websites: list[WebDocumentListItem]
+    all_results_count: int
+
+class SearchResponse(BaseModel):
+    status: str
+    message: str
+    encoding: str
+    text: str
+    websites: list[SearchResultItem]
+
+class ErrorResponse(BaseModel):
+    status: str = "error"
+    message: str
+```
+
+### Phase 2: Use Models in Flask Routes
+
+Replace raw dict returns with Pydantic model serialization:
+
+```python
+# Before (current)
+return web_document.dict(), 200
+
+# After
+response = WebDocumentResponse.model_validate(web_document.__dict__)
+return response.model_dump(mode="json"), 200
+```
+
+**Files to modify:**
+- `backend/server.py` — all route handlers that return data
+- `backend/library/stalker_web_document_db.py` — `.dict()` method can delegate to Pydantic
+- Lambda handlers in `infra/aws/serverless/` — same changes for serverless endpoints
+
+### Phase 3: Generate OpenAPI Schema
+
+Option A — manual export script:
+
+```python
+# backend/scripts/generate_openapi.py
+import json
+from library.models.schemas.documents import WebDocumentResponse, WebDocumentListItem, SearchResultItem
+from library.models.schemas.api_responses import ListResponse, SearchResponse
+
+schema = {
+    "openapi": "3.1.0",
+    "info": {"title": "Lenie AI API", "version": "0.3.13.0"},
+    "paths": { ... },  # manually or via flask-smorest
+    "components": {
+        "schemas": {
+            "WebDocumentResponse": WebDocumentResponse.model_json_schema(),
+            "WebDocumentListItem": WebDocumentListItem.model_json_schema(),
+            "SearchResultItem": SearchResultItem.model_json_schema(),
+            "ListResponse": ListResponse.model_json_schema(),
+            "SearchResponse": SearchResponse.model_json_schema(),
+        }
+    }
+}
+
+with open("docs/openapi.json", "w") as f:
+    json.dump(schema, f, indent=2)
+```
+
+Option B — use `flask-smorest` or `apiflask` for automatic OpenAPI generation from decorated routes. This is more work upfront but produces complete path definitions.
+
+### Phase 4: Generate TypeScript from OpenAPI
+
+Install and run `openapi-typescript`:
+
+```bash
+# One-time setup
+cd web_interface_react
+npm install -D openapi-typescript
+
+# Generation (add to package.json scripts or Makefile)
+npx openapi-typescript ../docs/openapi.json -o ../shared/types/generated.ts
+```
+
+Then update `shared/types/index.ts` to re-export from generated types instead of hand-written ones.
+
+### Phase 5: CI Integration
+
+Add to CI pipeline (CircleCI or Jenkins):
+
+```bash
+# 1. Generate OpenAPI from Pydantic
+cd backend && python scripts/generate_openapi.py
+
+# 2. Generate TS from OpenAPI
+cd web_interface_react && npx openapi-typescript ../docs/openapi.json -o ../shared/types/generated.ts
+
+# 3. Verify no diff (types are up to date)
+git diff --exit-code shared/types/generated.ts || (echo "ERROR: Generated types are out of date. Run 'make generate-types'" && exit 1)
+```
+
+## Migration Path (Incremental)
+
+The refactor can be done incrementally — one endpoint at a time:
+
+1. **Start with `/website_get`** — most used, clearest contract
+2. Add `WebDocumentResponse` model, use it in the route
+3. Generate OpenAPI + TS for just this model
+4. Verify frontend still works (TS types become a superset — no breaking changes)
+5. Move to `/website_list`, `/website_similar`, etc.
+
+During migration, hand-written `shared/types/` coexists with generated types. Once all endpoints are covered, remove hand-written types.
+
+## Known Decisions to Make
+
+| Decision | Options | Notes |
+|----------|---------|-------|
+| **`id` type** | Fix frontend to `number` | Backend always sends `int`, frontend incorrectly declares `string` |
+| **Nullable fields** | `T \| null` vs `T \| undefined` | Pydantic uses `None`, TS should use `null` to match JSON |
+| **Enum representation** | String enums vs string literals | `openapi-typescript` generates string literal unions by default — matches current TS approach |
+| **OpenAPI generation tool** | Manual script vs flask-smorest vs apiflask | Manual is simplest for current architecture, flask-smorest for full path coverage |
+| **Pydantic dependency** | Add to base deps vs optional extra | Should be base — it's core to API contract |
+
+## Files Affected (Full List)
+
+### New files
+- `backend/library/models/schemas/__init__.py`
+- `backend/library/models/schemas/documents.py`
+- `backend/library/models/schemas/api_responses.py`
+- `backend/library/models/schemas/enums.py`
+- `backend/scripts/generate_openapi.py`
+- `docs/openapi.json` (generated)
+- `shared/types/generated.ts` (generated)
+
+### Modified files
+- `backend/pyproject.toml` — add `pydantic` dependency
+- `backend/server.py` — use Pydantic models in route handlers
+- `backend/library/stalker_web_document_db.py` — align `.dict()` with Pydantic model
+- `infra/aws/serverless/app-server-db/handler.py` — same changes for Lambda
+- `infra/aws/serverless/app-server-internet/handler.py` — same
+- `shared/types/index.ts` — re-export from generated.ts
+- `web_interface_react/package.json` — add `openapi-typescript` dev dependency
+- `Makefile` — add `generate-types` target
+- CI config — add type generation verification step
+
+## Related Documentation
+
+- [Shared Types](shared-types.md) — current shared TS types setup
+- [API Contracts](api-contracts-backend.md) — existing backend API documentation
+- [Architecture Backend](architecture-backend.md) — backend architecture overview

--- a/docs/shared-types.md
+++ b/docs/shared-types.md
@@ -1,0 +1,122 @@
+# Shared TypeScript Types
+
+Shared domain types used by both frontend applications (`web_interface_react` and `web_interface_app2`).
+
+## Overview
+
+The `shared/` directory at the project root contains TypeScript type definitions and constants that are common across frontend applications. This avoids duplication of domain types like `WebDocument`, `ApiType`, and default API URLs.
+
+**No build step required** — Vite transpiles shared `.ts` files directly via esbuild. TypeScript resolves imports via `tsconfig.json` paths.
+
+## Directory Structure
+
+```
+shared/
+├── tsconfig.json           # Standalone type-check config
+└── types/
+    ├── index.ts            # Barrel re-exports
+    ├── api.ts              # ApiType, DEFAULT_API_URLS
+    └── documents.ts        # WebDocument, emptyDocument, SearchResult, ListItem
+```
+
+## Exported Types and Values
+
+### `api.ts`
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `ApiType` | type | `"AWS Serverless" \| "Docker"` — backend deployment mode |
+| `DEFAULT_API_URLS` | const | Default backend URLs per API type |
+
+### `documents.ts`
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `WebDocument` | interface | Document form fields (id, title, text, metadata, etc.) |
+| `emptyDocument` | const | Factory value with all fields set to empty strings/null |
+| `SearchResult` | interface | Vector similarity search result |
+| `ListItem` | interface | Document list item (id, title, url, state, type) |
+
+## How It Works
+
+Both frontends use the same mechanism to import shared types:
+
+1. **tsconfig.json `paths`** — maps `@lenie/shared/*` to the `shared/` directory (relative to each project)
+2. **Vite `resolve.alias`** — maps `@lenie/shared` at build time so Vite/esbuild can resolve and transpile the `.ts` files
+
+### web_interface_react
+
+```json
+// tsconfig.json
+"baseUrl": ".",
+"paths": {
+  "@lenie/shared/*": ["../shared/*"]
+}
+```
+
+```ts
+// vite.config.ts
+resolve: {
+  alias: {
+    '@lenie/shared': path.resolve(__dirname, '../shared'),
+  },
+},
+```
+
+The local `src/types/index.ts` re-exports all shared types plus defines the app-specific `AuthorizationState` interface (which depends on React's `Dispatch` type).
+
+### web_interface_app2
+
+```json
+// tsconfig.json (baseUrl is ./src, so extra ../)
+"@lenie/shared/*": ["../../shared/*"]
+```
+
+```ts
+// vite.config.ts
+'@lenie/shared': path.resolve(__dirname, '../shared'),
+```
+
+## What Stays App-Specific
+
+Types that depend on framework-specific imports (React) or app-specific auth flows are NOT in shared:
+
+- `AuthorizationState` (`web_interface_react`) — uses `React.Dispatch`
+- `AuthState`, `AuthContextType` (`web_interface_app2`) — specific login flow
+
+## Type-Checking
+
+```bash
+# Check shared types standalone (run from a frontend dir that has TypeScript)
+cd web_interface_react && npx tsc -p ../shared/tsconfig.json --noEmit
+
+# Check each frontend (includes shared types via tsconfig include)
+cd web_interface_react && npm run lint
+cd web_interface_app2 && npm run lint
+```
+
+## Docker Build
+
+The `web_interface_react` Dockerfile expects the build context to be the repository root. It copies `shared/` before building:
+
+```dockerfile
+COPY shared/ ../shared/
+COPY web_interface_react/ .
+RUN npm run build
+```
+
+The `infra/docker/compose.yaml` sets the build context accordingly:
+
+```yaml
+lenie-ai-fronted:
+  build:
+    context: ../..
+    dockerfile: web_interface_react/Dockerfile
+```
+
+## Adding New Shared Types
+
+1. Add the type/value to the appropriate file in `shared/types/` (or create a new file)
+2. Re-export from `shared/types/index.ts`
+3. Import in frontends via `@lenie/shared/types`
+4. If the frontend has a local re-export layer (like `web_interface_react/src/types/index.ts`), add the re-export there too

--- a/infra/docker/compose.yaml
+++ b/infra/docker/compose.yaml
@@ -23,7 +23,9 @@ services:
 #      - ../../backend/database/init:/docker-entrypoint-initdb.d
     restart: unless-stopped
   lenie-ai-fronted:
-    build: ../../web_interface_react
+    build:
+      context: ../..
+      dockerfile: web_interface_react/Dockerfile
     ports:
       - "3000:80"
     restart: no

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["types"]
+}

--- a/shared/types/api.ts
+++ b/shared/types/api.ts
@@ -1,0 +1,6 @@
+export type ApiType = "AWS Serverless" | "Docker";
+
+export const DEFAULT_API_URLS: Record<ApiType, string> = {
+  "AWS Serverless": "https://api.dev.lenie-ai.eu",
+  Docker: "http://localhost:5000",
+};

--- a/shared/types/documents.ts
+++ b/shared/types/documents.ts
@@ -1,0 +1,61 @@
+export interface WebDocument {
+  id: string;
+  author: string;
+  source: string;
+  language: string;
+  url: string;
+  tags: string;
+  title: string;
+  summary: string;
+  text: string;
+  text_md: string;
+  text_english: string;
+  document_type: string;
+  document_state: string;
+  document_state_error: string;
+  chapter_list: string;
+  note: string;
+  next_id: number | null;
+  previous_id: number | null;
+  next_type: string;
+  previous_type: string;
+}
+
+export const emptyDocument: WebDocument = {
+  id: "",
+  author: "",
+  source: "",
+  language: "",
+  url: "",
+  tags: "",
+  title: "",
+  summary: "",
+  text: "",
+  text_md: "",
+  text_english: "",
+  document_type: "",
+  document_state: "",
+  document_state_error: "",
+  chapter_list: "",
+  note: "",
+  next_id: null,
+  previous_id: null,
+  next_type: "",
+  previous_type: "",
+};
+
+export interface SearchResult {
+  id: number;
+  text: string;
+  similarity: number;
+  website_id: number;
+  url: string;
+}
+
+export interface ListItem {
+  id: number;
+  title: string;
+  url: string;
+  document_state: string;
+  document_type: string;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,0 +1,5 @@
+export type { ApiType } from './api';
+export { DEFAULT_API_URLS } from './api';
+
+export type { WebDocument, SearchResult, ListItem } from './documents';
+export { emptyDocument } from './documents';

--- a/web_interface_app2/CLAUDE.md
+++ b/web_interface_app2/CLAUDE.md
@@ -41,6 +41,14 @@ SSM parameters used:
 
 Environment variables: `PROJECT_CODE` (default: `lenie`), `ENVIRONMENT` (default: `dev`), `AWS_REGION` (default: `us-east-1`).
 
+## Shared Types (`@lenie/shared`)
+
+Domain types are imported from the shared `shared/` directory (project root) via `@lenie/shared` alias. Configured in `tsconfig.json` (`paths`) and `vite.config.ts` (`resolve.alias`).
+
+Currently used: `DEFAULT_API_URLS` in `src/services/storage.ts` (replaces hardcoded URL).
+
+See `docs/shared-types.md` for full details.
+
 ## Project Structure
 
 ```

--- a/web_interface_app2/src/services/storage.ts
+++ b/web_interface_app2/src/services/storage.ts
@@ -1,4 +1,5 @@
 import type { AuthState } from '../types';
+import { DEFAULT_API_URLS } from '@lenie/shared/types';
 
 const PREFIX = 'lenie_app2_';
 
@@ -8,7 +9,7 @@ const KEYS = {
   apiUrl: `${PREFIX}apiUrl`,
 } as const;
 
-export const DEFAULT_API_URL = 'https://api.dev.lenie-ai.eu';
+export const DEFAULT_API_URL = DEFAULT_API_URLS["AWS Serverless"];
 
 export function loadAuth(): AuthState | null {
   const apiKey = localStorage.getItem(KEYS.apiKey);

--- a/web_interface_app2/tsconfig.json
+++ b/web_interface_app2/tsconfig.json
@@ -24,8 +24,9 @@
       "Pages/*": ["Pages/*"],
       "Slices/*": ["Slices/*"],
       "ThemeLayout/*": ["ThemeLayout/*"],
-      "Common/*": ["Common/*"]
+      "Common/*": ["Common/*"],
+      "@lenie/shared/*": ["../../shared/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../../shared"]
 }

--- a/web_interface_app2/vite.config.ts
+++ b/web_interface_app2/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      '@lenie/shared': path.resolve(__dirname, '../shared'),
       assets: path.resolve(__dirname, 'src/assets'),
       Pages: path.resolve(__dirname, 'src/pages'),
       Slices: path.resolve(__dirname, 'src/Slices'),

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -16,7 +16,7 @@ web_interface_react/
 │   ├── utils.tsx                       # Utility components
 │   ├── vite-env.d.ts                   # Vite + CSS module type declarations
 │   ├── types/
-│   │   └── index.ts                    # TypeScript interfaces (WebDocument, ApiType, etc.)
+│   │   └── index.ts                    # Re-exports from @lenie/shared + app-specific AuthorizationState
 │   ├── modules/shared/
 │   │   ├── context/
 │   │   │   └── authorizationContext.tsx # Global state: API config (from localStorage), DB/VPN status, filters
@@ -137,13 +137,20 @@ App endpoints use the base URL (e.g., `/website_list`), infra endpoints use `/in
 
 ## TypeScript
 
-All source files are TypeScript (`.ts`/`.tsx`). Key type definitions in `src/types/index.ts`:
+All source files are TypeScript (`.ts`/`.tsx`). Strict mode enabled (`tsconfig.json`: `strict: true`).
+
+### Shared Types (`@lenie/shared`)
+
+Domain types are defined in `shared/` (project root) and imported via `@lenie/shared` alias:
 - `ApiType` — union type for API backend mode
 - `WebDocument` — document form fields interface
-- `AuthorizationState` — global context interface
+- `emptyDocument` — factory constant
+- `DEFAULT_API_URLS` — default backend URLs per API type
 - `SearchResult`, `ListItem` — API response types
 
-Strict mode enabled (`tsconfig.json`: `strict: true`).
+The alias is configured in both `tsconfig.json` (`paths`) and `vite.config.ts` (`resolve.alias`). The local `src/types/index.ts` re-exports shared types and adds app-specific `AuthorizationState`.
+
+See `docs/shared-types.md` for full details.
 
 ## Dependencies
 
@@ -188,10 +195,12 @@ Environment variables: `PROJECT_CODE` (default: `lenie`), `ENVIRONMENT` (default
 ## Docker Build
 
 ```
-Stage 1: node:24 → npm ci && npm run build
+Stage 1: node:24 → npm ci && npm run build (build context is repo root; copies shared/ + web_interface_react/)
 Stage 2: nginx:alpine → serve build/ on port 80
 Config: nginx.conf with SPA routing (all paths → index.html)
 ```
+
+Note: The Dockerfile expects the build context to be the repository root (set in `infra/docker/compose.yaml`). It copies `shared/` into `../shared/` relative to the app workdir so Vite can resolve `@lenie/shared`.
 
 ## i18n
 

--- a/web_interface_react/Dockerfile
+++ b/web_interface_react/Dockerfile
@@ -3,15 +3,16 @@ LABEL authors="ziutus"
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY web_interface_react/package*.json ./
 RUN npm ci
 
-COPY . .
+COPY shared/ ../shared/
+COPY web_interface_react/ .
 RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build-stage /app/build /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build-stage /app/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { AuthorizationContext } from "../context/authorizationContext";
-import { DEFAULT_URLS, saveConnectionConfig } from "../services/storage";
+import { saveConnectionConfig } from "../services/storage";
 import type { ApiType } from "../../../types";
+import { DEFAULT_API_URLS } from "../../../types";
 
 const Connect: React.FC = () => {
   const navigate = useNavigate();
@@ -11,7 +12,7 @@ const Connect: React.FC = () => {
     React.useContext(AuthorizationContext);
 
   const [formApiType, setFormApiType] = useState<ApiType>("AWS Serverless");
-  const [formApiUrl, setFormApiUrl] = useState(DEFAULT_URLS["AWS Serverless"]);
+  const [formApiUrl, setFormApiUrl] = useState(DEFAULT_API_URLS["AWS Serverless"]);
   const [formApiKey, setFormApiKey] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
@@ -20,7 +21,7 @@ const Connect: React.FC = () => {
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newType = e.target.value as ApiType;
     setFormApiType(newType);
-    setFormApiUrl(DEFAULT_URLS[newType]);
+    setFormApiUrl(DEFAULT_API_URLS[newType]);
   };
 
   const handleConnect = async () => {

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -1,15 +1,11 @@
 import type { ApiType } from "../../../types";
+import { DEFAULT_API_URLS } from "../../../types";
 
 const KEYS = {
   apiType: "lenie_apiType",
   apiUrl: "lenie_apiUrl",
   apiKey: "lenie_apiKey",
 } as const;
-
-export const DEFAULT_URLS: Record<ApiType, string> = {
-  "AWS Serverless": "https://api.dev.lenie-ai.eu",
-  Docker: "http://localhost:5000",
-};
 
 export function loadConnectionConfig(): {
   apiType: ApiType;
@@ -19,7 +15,7 @@ export function loadConnectionConfig(): {
   const apiType = (localStorage.getItem(KEYS.apiType) as ApiType) || "AWS Serverless";
   return {
     apiType,
-    apiUrl: localStorage.getItem(KEYS.apiUrl) || DEFAULT_URLS[apiType],
+    apiUrl: localStorage.getItem(KEYS.apiUrl) || DEFAULT_API_URLS[apiType],
     apiKey: localStorage.getItem(KEYS.apiKey) || undefined,
   };
 }

--- a/web_interface_react/src/types/index.ts
+++ b/web_interface_react/src/types/index.ts
@@ -1,27 +1,7 @@
-export type ApiType = "AWS Serverless" | "Docker";
+import type { ApiType } from '@lenie/shared/types';
 
-export interface WebDocument {
-  id: string;
-  author: string;
-  source: string;
-  language: string;
-  url: string;
-  tags: string;
-  title: string;
-  summary: string;
-  text: string;
-  text_md: string;
-  text_english: string;
-  document_type: string;
-  document_state: string;
-  document_state_error: string;
-  chapter_list: string;
-  note: string;
-  next_id: number | null;
-  previous_id: number | null;
-  next_type: string;
-  previous_type: string;
-}
+export type { ApiType, WebDocument, SearchResult, ListItem } from '@lenie/shared/types';
+export { emptyDocument, DEFAULT_API_URLS } from '@lenie/shared/types';
 
 export interface AuthorizationState {
   databaseStatus: string;
@@ -44,43 +24,4 @@ export interface AuthorizationState {
   setSelectedDocumentType: React.Dispatch<React.SetStateAction<string>>;
   selectedDocumentState: string;
   setSelectedDocumentState: React.Dispatch<React.SetStateAction<string>>;
-}
-
-export const emptyDocument: WebDocument = {
-  id: "",
-  author: "",
-  source: "",
-  language: "",
-  url: "",
-  tags: "",
-  title: "",
-  summary: "",
-  text: "",
-  text_md: "",
-  text_english: "",
-  document_type: "",
-  document_state: "",
-  document_state_error: "",
-  chapter_list: "",
-  note: "",
-  next_id: null,
-  previous_id: null,
-  next_type: "",
-  previous_type: "",
-};
-
-export interface SearchResult {
-  id: number;
-  text: string;
-  similarity: number;
-  website_id: number;
-  url: string;
-}
-
-export interface ListItem {
-  id: number;
-  title: string;
-  url: string;
-  document_state: string;
-  document_type: string;
 }

--- a/web_interface_react/tsconfig.json
+++ b/web_interface_react/tsconfig.json
@@ -17,7 +17,11 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@lenie/shared/*": ["../shared/*"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "../shared"]
 }

--- a/web_interface_react/vite.config.ts
+++ b/web_interface_react/vite.config.ts
@@ -1,9 +1,15 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@lenie/shared': path.resolve(__dirname, '../shared'),
+    },
+  },
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary

- Extract shared domain types (`ApiType`, `WebDocument`, `SearchResult`, `ListItem`, `emptyDocument`, `DEFAULT_API_URLS`) from `web_interface_react` into a new `shared/` directory
- Both frontends (`web_interface_react`, `web_interface_app2`) now import via `@lenie/shared` alias (tsconfig paths + Vite resolve.alias)
- Replace hardcoded `DEFAULT_API_URL` in app2 with import from shared
- Update Dockerfile and compose.yaml for new build context (repo root)
- Add `docs/shared-types.md` — full documentation of the shared types mechanism
- Add `docs/api-type-sync-strategy.md` — future plan for Pydantic → OpenAPI → TS pipeline to keep backend/frontend types in sync

## Test plan

- [x] `cd shared && npx tsc --noEmit` — shared types type-check OK
- [x] `cd web_interface_react && npm run lint` — no TS errors
- [x] `cd web_interface_react && npm run build` — production build OK
- [x] `cd web_interface_react && npm test` — 2/2 tests pass
- [x] `cd web_interface_app2 && npm run build` — production build OK
- [ ] Docker build: `cd infra/docker && docker compose build lenie-ai-fronted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)