### PR TITLE
chore: reconcile BMad artifacts with non-sprint changes

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-02-23
+# generated: 2026-02-25
 # project: lenie-server-2025
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-02-23
+generated: 2026-02-25
 project: lenie-server-2025
 project_key: NOKEY
 tracking_system: file-system
@@ -181,52 +181,74 @@ development_status:
   18-consolidation-implementation: done  # Implemented consolidation: 6 Lambdas (ec2-start/stop/status, rds-start/stop/status) → 2 (ec2-manager, rds-manager). CF template api-gw-infra.yaml updated (6→2 Lambda defs, 6→2 permissions). 6 RDS bugs fixed. deploy.sh sponge dependency removed. Deployed & verified via API GW test-invoke-method. Commit 6b458cf.
   epic-18-retrospective: done
 
-  # --- Future Backlog ---
+  # ============================================================
+  # BACKLOG (only items TO DO)
+  # ============================================================
 
-  # --- Frontend ---
-  B-16-migrate-web-interface-react-from-cra-to-vite: done  # Already migrated — Vite 6, vitest, vite.config.ts, no CRA traces
-  # B-17 removed: web_add_url_react archived and deleted from repo. Restore: git checkout archive/web-add-url-react -- _archive/web_add_url_react/
+  # --- Phase 2.5: API Contract & Type Safety ---
+  B-50-api-type-synchronization-pydantic-openapi-ts: backlog  # Pydantic → OpenAPI → generated TS types. Fixes backend-frontend drift: id type mismatch, missing fields (13 in WebDocument, 5 in ListItem, 7 in SearchResult), untyped enums. Strategy: docs/api-type-sync-strategy.md. 5 phases: Pydantic models, Flask route integration, OpenAPI gen, TS gen, CI check.
 
-  # --- Extending Functionality (Phase 7) ---
-  B-41-rss-feed-ingestion-with-llm-filtering: backlog  # RSS feeds (AWS What's New), daily Lambda, LLM relevance scoring, submit to /url_add pipeline
-  B-42-slack-bot-for-user-queries-socket-mode: backlog  # Slack Bot (Socket Mode) — search, status, recent commands. Deploy on lenie-dev-ec2
-  B-44-storytel-audiobook-tracking: backlog  # Track audiobooks listened on storytel.com — scrape/API metadata (title, author, genre, progress), store as content type 'audiobook' in existing pipeline
-  B-45-youtube-movie-description-fetching: backlog  # Fetch and store YouTube video descriptions, metadata (title, channel, duration, tags) for videos in the system
-  B-47-whatsapp-conversation-analysis: backlog  # Import and analyze WhatsApp conversations — extract key topics, contacts, decisions, action items via LLM
-  B-48-google-contacts-integration: backlog  # Integrate with Google Contacts (People API) — sync address book data, link contacts to documents and conversations
-
-  # --- Cleaning AWS Architecture ---
-  B-39-delegate-dns-subzones-per-environment: backlog  # Split lenie-ai.eu into delegated subzones: main zone (root + NS delegations only) + per-env subzones (dev.lenie-ai.eu, prod.lenie-ai.eu). Enables multi-account (049706517731) and multi-cloud (GCP k8s.lenie-ai.eu). Prerequisite for multi-env. Remove 1-domain-route53.yaml, create new templates. $0.50/month per subzone.
-  B-21-split-shared-lambda-execution-role-into-per-function-roles: done  # Tech spec completed 2026-02-24, all 4 steps done
-  B-6-migrate-api-gw-app-stage-to-separate-resource: done
-  B-10-create-apigw-cloudwatch-iam-role-in-cloudformation: review
-  B-22-add-max-retry-limit-to-aws-ec2-route53-script: backlog
-  B-23-consolidate-lambdas-with-vpc-ipv6-dual-stack: backlog  # Enable IPv6 dual-stack + Egress-Only IGW to merge app-server-db + app-server-internet into one Lambda. BLOCKER: OpenAI API has no IPv6 (no AAAA record as of 2026-02). Options: switch to Bedrock, use NAT64, or wait for OpenAI IPv6 support.
-  B-8-manage-acm-certificates-via-cloudformation-and-ssm: done  # ACM certs via CF: wildcard (SSM) + landing inline cert. deploy.sh regex fix. 3 old manual certs deleted. Review: DeletionPolicy added to cert resources, orphaned param file removed.
-  B-9-organize-s3-cloudformation-bucket-directory-structure: done  # Lambda ZIPs moved to lambdas/ prefix, 7 stale ZIPs deleted, CF templates + scripts updated, docs updated. Review: added --profile to s3 cp, fixed AC1 count, documented url-add.json
+  # --- Phase 3: Security Hardening & AWS Cleanup ---
   B-13-parameterize-stage-description-for-multi-environment: backlog
-  B-15-add-custom-domains-for-api-gateways: done  # Realized as story 17-5: api.dev.lenie-ai.eu
   B-19-convert-ec2-to-spot-with-asg-0-1: backlog
-  B-46-define-strict-scp-policies-for-lenie-account: backlog  # Define granular SCPs for the 008971653395 account — restrict unused services, enforce encryption, block public S3, limit regions beyond current SCPs
+  B-22-add-max-retry-limit-to-aws-ec2-route53-script: backlog
+  B-23-consolidate-lambdas-with-vpc-ipv6-dual-stack: backlog  # BLOCKER: OpenAI API has no IPv6 (no AAAA record as of 2026-02). Options: switch to Bedrock, use NAT64, or wait for OpenAI IPv6 support.
+  B-39-delegate-dns-subzones-per-environment: backlog  # Split lenie-ai.eu into delegated subzones (dev, prod). Enables multi-account + multi-cloud. $0.50/month per subzone.
+  B-46-define-strict-scp-policies-for-lenie-account: backlog  # Granular SCPs for 008971653395 — restrict unused services, enforce encryption, block public S3, limit regions.
+  B-52-lambda-layer-security-audit: backlog  # Lambda Layer dependencies ~1.5+ years old. Audit, update, rebuild layer ZIP.
+  B-53-cors-hardening: backlog  # Replace wildcard Access-Control-Allow-Origin: '*' with explicit allowed origins.
+  B-54-lambda-cloudformation-management: backlog  # Replace hardcoded Lambda ARNs with CloudFormation-managed references (SSM/Fn::GetAtt).
+  B-55-remove-stale-api-gateway-deployments: backlog  # Remove 36 stale API Gateway deployments left from manual/ad-hoc deploys.
 
-  # --- LLM Text Analysis (Phase 6 — po MVP) ---
-  # Automatyczna analiza tekstu przez LLM, zwracająca ustrukturyzowany JSON
-  # z metadanymi: autor, temat, państwa, źródło danych, itp.
-  B-29-create-llm-text-analysis-endpoint: backlog
-  B-30-define-analysis-json-schema-and-db-storage: backlog
-  B-31-frontend-ui-for-analysis-results: backlog
-  B-32-batch-analysis-for-existing-documents: backlog
+  # --- Phase 4: MCP Server Foundation ---
+  B-56-database-abstraction-layer: backlog  # Separate raw psycopg2 queries from business logic. Prerequisite for MCP server and testability.
+  B-57-implement-mcp-server-protocol: backlog  # Expose search/retrieve endpoints as MCP tools. Follow MCP specification.
+  B-58-claude-desktop-integration: backlog  # Configure Lenie-AI as MCP server in Claude Desktop. Test search and retrieve workflows.
+  B-59-api-adaptation-for-mcp-tool-consumption: backlog  # Adapt API response formats for MCP tool consumption patterns.
 
-  # --- Multiuser (Phase 7 — na samym końcu) ---
-  # Wsparcie wielu użytkowników na AWS. Realizowane jako ostatnia faza,
-  # po zakończeniu wszystkich pozostałych prac (Security, MCP Server, Obsidian, LLM Analysis).
-  B-33-implement-user-authentication-with-aws-cognito: backlog
-  B-34-add-user-ownership-to-database-schema: backlog
-  B-35-enforce-data-isolation-per-user-in-api-endpoints: backlog
-  B-36-replace-shared-api-key-with-per-user-auth-tokens: backlog
-  B-37-add-login-logout-ui-to-frontend-applications: backlog
-  B-38-add-user-management-admin-panel: backlog
+  # --- Phase 5: RSS & Slack Integration ---
+  B-40-slack-workspace-and-incoming-webhooks: backlog  # Create Slack workspace, configure Incoming Webhook for #notifications, integrate with error handling pipeline (SNS email + Slack). Webhook URL in Secrets Manager.
+  B-41-rss-feed-ingestion-with-llm-filtering: backlog  # RSS feeds (AWS What's New), daily Lambda, LLM relevance scoring, submit to /url_add pipeline.
+  B-42-slack-bot-for-user-queries-socket-mode: backlog  # Slack Bot (Socket Mode) — search, status, recent commands. Deploy on lenie-dev-ec2.
 
-  # --- Done ---
+  # --- Phase 6: Obsidian Integration ---
+  B-60-obsidian-vault-integration: backlog  # Synchronization between Lenie-AI and Obsidian vault — linking, note creation, bidirectional sync.
+  B-61-semantic-search-from-obsidian: backlog  # Semantic search from within Obsidian via Claude Desktop + MCP server (depends on B-57, B-58).
+  B-62-advanced-vector-search-refinements: backlog  # Advanced vector search refinements for personal knowledge management — filtering, ranking, hybrid search.
+
+  # --- Phase 7: Extending Functionality ---
+  B-44-storytel-audiobook-tracking: backlog  # Track audiobooks on storytel.com — scrape/API metadata, store as content type 'audiobook'.
+  B-45-youtube-movie-description-fetching: backlog  # Fetch and store YouTube video descriptions, metadata for videos in the system.
+  B-47-whatsapp-conversation-analysis: backlog  # Import and analyze WhatsApp conversations — extract topics, contacts, decisions via LLM.
+  B-48-google-contacts-integration: backlog  # Google People API — sync address book data, link contacts to documents.
+
+  # --- Phase 8: LLM Text Analysis ---
+  B-29-create-llm-text-analysis-endpoint: backlog  # Nowy endpoint API — LLM zwraca JSON z metadanymi (autor, temat, państwa, źródło).
+  B-30-define-analysis-json-schema-and-db-storage: backlog  # Schemat JSON, kolumna JSONB lub dedykowana tabela, indeksy GIN.
+  B-31-frontend-ui-for-analysis-results: backlog  # Wyświetlanie wyników analizy, ręczna korekta, filtrowanie po metadanych.
+  B-32-batch-analysis-for-existing-documents: backlog  # Batch processing istniejących dokumentów, nowy status ANALYSIS_NEEDED → ANALYSIS_DONE.
+
+  # --- Phase 9: Multiuser ---
+  B-33-implement-user-authentication-with-aws-cognito: backlog  # Cognito User Pool, integracja z API Gateway (Cognito Authorizer).
+  B-34-add-user-ownership-to-database-schema: backlog  # Kolumna user_id w web_documents i websites_embeddings, migracja danych.
+  B-35-enforce-data-isolation-per-user-in-api-endpoints: backlog  # Wszystkie endpointy filtrują po user_id z tokena Cognito.
+  B-36-replace-shared-api-key-with-per-user-auth-tokens: backlog  # JWT z Cognito zamiast x-api-key. Aktualizacja frontendów i Chrome extension.
+  B-37-add-login-logout-ui-to-frontend-applications: backlog  # Ekrany logowania/rejestracji w app2, obsługa sesji i odświeżania tokenów.
+  B-38-add-user-management-admin-panel: backlog  # Zarządzanie użytkownikami — lista, blokowanie, usuwanie, statystyki per user.
+
+  # ============================================================
+  # DONE (completed backlog items — historical record)
+  # ============================================================
+  # B-17 removed: web_add_url_react archived and deleted from repo
+  B-6-migrate-api-gw-app-stage-to-separate-resource: done
   B-7-merge-helm-s3-and-cloudfront-into-single-template: done
-  B-43-fix-app2-domain-to-app2-dev-lenie-ai-eu: done  # Domain moved from app2.lenie-ai.eu to app2.dev.lenie-ai.eu, ACM cert switched to *.dev.lenie-ai.eu, CF stack updated
+  B-8-manage-acm-certificates-via-cloudformation-and-ssm: done  # ACM certs via CF: wildcard (SSM) + landing inline cert. deploy.sh regex fix. 3 old manual certs deleted.
+  B-9-organize-s3-cloudformation-bucket-directory-structure: done  # Lambda ZIPs moved to lambdas/ prefix, 7 stale ZIPs deleted, CF templates + scripts updated.
+  B-10-create-apigw-cloudwatch-iam-role-in-cloudformation: done  # PR #29 merged 2026-02-25
+  B-15-add-custom-domains-for-api-gateways: done  # Realized as story 17-5: api.dev.lenie-ai.eu
+  B-16-migrate-web-interface-react-from-cra-to-vite: done  # Vite 6, vitest, vite.config.ts
+  B-21-split-shared-lambda-execution-role-into-per-function-roles: done  # Tech spec completed 2026-02-24
+  B-43-fix-app2-domain-to-app2-dev-lenie-ai-eu: done  # Domain moved to app2.dev.lenie-ai.eu, ACM cert switched to *.dev.lenie-ai.eu
+  B-49-extract-shared-typescript-types-to-shared-package: done  # shared/ package with @lenie/shared alias. Commit 64e3213.
+  B-51-frontend-deploy-scripts-with-ssm: done  # Deploy scripts for both frontends, SSM integration. Commit f2432ce.
+  epic-19: done  # All 4 stories completed 2026-02-24 (scaffold, login, layout, API)

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -13,7 +13,7 @@ inputDocuments:
 
 ## Overview
 
-This document provides the complete epic and story breakdown for lenie-server-2025. Sprint 4 (Epics 13–16) covers AWS Infrastructure Consolidation & Tooling addressing 6 backlog items: B-4, B-5, B-11, B-12, B-14, B-19. Sprint 5 (Epics 17–18) covers Operational Fixes & Lambda Analysis — deployment safety, bug fixes, database connectivity, API Gateway custom domain (B-15), and Lambda consolidation analysis. Backlog section includes completed non-sprint work (landing page deployment, app2 infrastructure) and Epic 19 (Multi-User Admin Interface).
+This document provides the complete epic and story breakdown for lenie-server-2025. Sprint 4 (Epics 13–16) covers AWS Infrastructure Consolidation & Tooling addressing 6 backlog items: B-4, B-5, B-11, B-12, B-14, B-19. Sprint 5 (Epics 17–18) covers Operational Fixes & Lambda Analysis — deployment safety, bug fixes, database connectivity, API Gateway custom domain (B-15), and Lambda consolidation analysis. Backlog sections include: completed non-sprint work (landing page, app2 infrastructure), Epic 19 (Multi-User Admin Interface — all 4 stories DONE), and Frontend Architecture & API Contract (B-49 shared types DONE, B-50 API type sync pipeline BACKLOG, B-51 deploy scripts DONE).
 
 ## Requirements Inventory
 
@@ -772,22 +772,22 @@ Work completed outside of Sprint 4/5 scope: landing page deployment and app2 (mu
 
 ---
 
-## Epic 19: Multi-User Admin Interface (app2) — PRIORITY
+## Epic 19: Multi-User Admin Interface (app2) — DONE
 
-**URGENT:** app2 is currently publicly accessible at `app2.dev.lenie-ai.eu` without any authentication. Story 19.2 (login) is the highest priority to hide the UI behind credentials.
+All 4 stories completed (2026-02-24). Admin panel at `app2.dev.lenie-ai.eu` is scaffolded, has API key login gate, professional layout, and connected backend API.
 
-Developer has a new admin interface at `app2.dev.lenie-ai.eu` that supports multiple users — scaffolded from a purchased layout (now removed from repo) with added authentication, API integration, and own code in `web_interface_app2/`.
+Developer has a new admin interface at `app2.dev.lenie-ai.eu` — scaffolded from a purchased layout (now removed from repo) with API key authentication, API integration, and own code in `web_interface_app2/`.
 
-**Stories:** 19-1, 19-2, 19-3, 19-4
+**Stories:** 19-1 ✅, 19-2 ✅, 19-3 ✅, 19-4 ✅
 
 Implementation notes:
-- **app2 is LIVE and publicly accessible** — authentication is the most urgent task
-- Infrastructure already provisioned and deployed (S3 + CloudFront stacks)
-- Original purchased layout reference removed from repo (was `web_interface_target/`); design already incorporated into `web_interface_app2/`
+- Authentication uses `x-api-key` (same as backend) instead of originally planned username/password env vars — simpler, sufficient for dev/single-user. AWS Cognito migration planned for Phase 9 (B-33).
+- Infrastructure provisioned and deployed (S3 + CloudFront stacks)
+- Original purchased layout reference removed from repo (commit e8a44fd); design incorporated into `web_interface_app2/`
 - Tech stack: Vite 6, React 18, Redux, React Bootstrap, TypeScript, Sass
 - Current single-user app: `web_interface_react/` at `app.dev.lenie-ai.eu`
-- This epic is a major effort — will likely span multiple sprints
-- Auth approach: simple hardcoded credentials (env vars) as initial solution; AWS Cognito planned for Phase 7
+- Deploy script created with SSM integration (B-51)
+- Domain: `app2.dev.lenie-ai.eu` (fixed from `app2.lenie-ai.eu` in B-43)
 
 ### Story 19.1: Scaffold Multi-User App Project
 
@@ -807,9 +807,10 @@ so that development of the multi-user interface can begin with a clean, properly
 **When** the developer configures the build
 **Then** static export is compatible with S3 + CloudFront SPA hosting (index.html fallback)
 
-**Status:** ready-for-dev
+**Status:** done
+**Completed:** 2026-02-24 (commit 478b62c)
 
-### Story 19.2: Add Login Page and Route Protection — URGENT
+### Story 19.2: Add Login Page and Route Protection
 
 As a **developer**,
 I want app2 to require login before showing any content,
@@ -820,30 +821,23 @@ so that the admin interface is not publicly accessible to unauthorized users.
 **Given** app2 is publicly accessible at `app2.dev.lenie-ai.eu` without authentication
 **When** the developer adds a login page
 **Then** all routes except `/login` redirect to the login page when the user is not authenticated
-**And** the login page has a simple form with username and password fields
+**And** the login page has a simple form with API key field
 
-**Given** the login credentials are stored as environment variables (hardcoded approach)
-**When** the user submits correct credentials
-**Then** the app stores a session token (JWT or simple token) in localStorage
+**Given** the user submits a valid API key
+**When** the login form processes the submission
+**Then** the app stores the API key in localStorage
 **And** the user is redirected to the main dashboard
 **And** all protected routes become accessible
 
-**Given** the user submits incorrect credentials
+**Given** the user submits an incorrect API key
 **When** the login form processes the submission
-**Then** an error message is displayed ("Invalid credentials")
+**Then** an error message is displayed
 **And** the user remains on the login page
 
-**Given** a simple backend auth endpoint is needed
-**When** the developer implements it
-**Then** the endpoint validates credentials against environment variables (`APP2_AUTH_USERNAME`, `APP2_AUTH_PASSWORD`)
-**And** returns a signed token on success (e.g., JWT with expiration)
+**Implementation note:** Original spec called for username/password with env vars (`APP2_AUTH_USERNAME`, `APP2_AUTH_PASSWORD`). Actual implementation uses `x-api-key` authentication — the same API key used by the backend. This is simpler and sufficient for single-user/dev use. Migration to AWS Cognito (B-33) planned for Phase 9.
 
-**Given** the user's session expires or token is invalid
-**When** the user tries to access a protected route
-**Then** the user is redirected to the login page
-
-**Priority:** URGENT — app2 is publicly accessible
-**Status:** ready-for-dev
+**Status:** done
+**Completed:** 2026-02-24 (commits: 478b62c, a5422fc, 9c279e7, 5c57356)
 
 ### Story 19.3: Implement Core Layout and Navigation
 
@@ -866,7 +860,10 @@ so that the application has a professional multi-user admin interface look and f
 **When** the layout is rendered
 **Then** all layout pages are behind the authentication guard
 
-**Status:** ready-for-dev
+**Implementation note:** Layout scaffolded from purchased template. Purchased template reference (`web_interface_target/`) removed from repo (commit e8a44fd) — design already incorporated into app2 codebase.
+
+**Status:** done
+**Completed:** 2026-02-24 (commit 478b62c)
 
 ### Story 19.4: Connect Backend API
 
@@ -885,4 +882,59 @@ so that all current functionality (document CRUD, search, AI operations) works t
 **When** the developer reviews its implementation
 **Then** the API service layer is adapted for the new app (axios, error handling, auth)
 
-**Status:** ready-for-dev
+**Implementation note:** Hardcoded API key removed (commit 5c57356), API key now provided via login page. Redux store manages API server configuration.
+
+**Status:** done
+**Completed:** 2026-02-24 (commits: 478b62c, 5c57356)
+
+---
+
+## Backlog: Frontend Architecture & API Contract
+
+### Overview
+
+Work completed and planned to address frontend-backend type drift and shared code infrastructure. The `shared/` TypeScript package was extracted (B-49) and a strategy document for full API type synchronization was written (`docs/api-type-sync-strategy.md`). The main backlog item (B-50) covers the multi-phase implementation of Pydantic → OpenAPI → generated TypeScript types.
+
+### Completed Work (Non-Sprint)
+
+**B-49: Extract Shared TypeScript Types to shared/ Package** — DONE (2026-02-25)
+- Created `shared/` package with domain types: `WebDocument`, `ApiType`, `SearchResult`, `ListItem`
+- Added constants (`DEFAULT_API_URLS`) and factory values (`emptyDocument`)
+- Both frontends (`web_interface_react/`, `web_interface_app2/`) reference via `@lenie/shared` alias (tsconfig paths + Vite resolve.alias)
+- No build step — Vite transpiles directly via esbuild
+- Commit: 64e3213
+
+**B-51: Frontend Deployment Scripts with SSM** — DONE (2026-02-25)
+- Created `deploy.sh` for `web_interface_react/` and `web_interface_app2/`
+- Scripts resolve S3 bucket name and CloudFront distribution ID from SSM Parameter Store
+- Support `--skip-build` and `--skip-invalidation` flags
+- Commit: f2432ce
+
+### B-50: API Type Synchronization Pipeline (Pydantic → OpenAPI → TypeScript)
+
+**Problem:** Frontend (`shared/types/`) and backend (`backend/library/`) define the same data structures independently, leading to drift. Known issues documented in `docs/api-type-sync-strategy.md`:
+
+| Issue | Detail |
+|-------|--------|
+| `id` type mismatch | TS: `string`, Python: `int` (serial PK) |
+| `WebDocument` missing fields | Backend returns 13 fields not in TS interface |
+| `ListItem` field count | TS: 5 fields, backend: 10 |
+| `SearchResult` field count | TS: 5 fields, backend: 12 |
+| Enums as plain strings | Backend has typed enums, frontend treats as `string` |
+| No contract | No OpenAPI, JSON Schema, or Pydantic — backend uses custom classes + raw dicts |
+
+**Chosen approach:** Python Pydantic models (source of truth) → OpenAPI schema (generated) → TypeScript types (generated)
+
+**Implementation phases (from `docs/api-type-sync-strategy.md`):**
+
+1. **Phase 1: Pydantic Response Models** — Create Pydantic v2 models in `backend/library/models/schemas/` for all API response shapes (WebDocumentResponse, WebDocumentListItem, SearchResultItem, ListResponse, SearchResponse, ErrorResponse)
+2. **Phase 2: Use Models in Flask Routes** — Replace raw dict returns with Pydantic model serialization in `server.py` and Lambda handlers
+3. **Phase 3: Generate OpenAPI Schema** — Manual export script or flask-smorest integration to produce `docs/openapi.json`
+4. **Phase 4: Generate TypeScript from OpenAPI** — Use `openapi-typescript` to generate `shared/types/generated.ts` from OpenAPI schema
+5. **Phase 5: CI Integration** — Add generation + diff check to CI pipeline to prevent future drift
+
+**Migration path:** Incremental, one endpoint at a time. Start with `/website_get`, then `/website_list`, `/website_similar`. Hand-written `shared/types/` coexists with generated types during migration.
+
+**Status:** backlog
+**Strategy document:** `docs/api-type-sync-strategy.md`
+**Depends on:** B-49 (shared types package) — DONE

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -58,6 +58,8 @@ editHistory:
     changes: 'Added landing page (www.lenie-ai.eu) and app2 infrastructure (app2.dev.lenie-ai.eu) to Technical Context. Updated Phase 7 with app2 multi-user UI infrastructure readiness. Updated deploy.ini counts (30 templates in [dev], 3 in [common]). Added web_interface_target reference layout info.'
   - date: '2026-02-23'
     changes: 'Added Phase 5 (RSS & Slack Integration) with 3 backlog items: B-40 (Slack workspace + webhooks for notifications), B-41 (RSS feed ingestion with LLM filtering, starting with AWS Whats New), B-42 (Slack Bot for user queries via Socket Mode). Renumbered Obsidian → Phase 6, LLM Text Analysis → Phase 7, Multiuser → Phase 8.'
+  - date: '2026-02-25'
+    changes: 'Added Phase 2.5 (API Contract & Type Safety) with B-49 (shared TS types — done), B-50 (Pydantic→OpenAPI→TS pipeline — backlog), B-51 (frontend deploy scripts — done). Epic 19 all 4 stories completed. Non-BMad changes reconciled.'
 ---
 
 # Product Requirements Document - lenie-server-2025
@@ -124,20 +126,33 @@ Lenie-server-2025 is a personal AI knowledge management system for collecting, m
 
 6. **B-19: Consolidate duplicated documentation counts** — Same metrics (endpoint counts, template counts, Lambda function counts) are duplicated across 7+ files with known discrepancies: `api-gw-app` documented as "12 endpoints" (actual: 10), `api-gw-infra` as "9 endpoints" (actual: 8), total templates documented as "29" (actual: 34). Affected files: `CLAUDE.md`, `README.md`, `backend/CLAUDE.md`, `docs/index.md`, `docs/api-contracts-backend.md`, `infra/aws/CLAUDE.md`, `infra/aws/cloudformation/CLAUDE.md`. Create single source of truth file. Add automated verification script to catch future drift.
 
-### Phase 3 (Future — Security Hardening)
+### Phase 2.5 (Future — API Contract & Type Safety)
 
-- Lambda Layer security audit (dependencies ~1.5+ years old)
-- CORS hardening (replace wildcard `Access-Control-Allow-Origin: '*'`)
-- Lambda function CloudFormation management (replace hardcoded ARNs)
-- Remove 36 stale API Gateway deployments
-- **B-46: Define strict SCP policies for lenie account** — Define granular Service Control Policies for the 008971653395 account to increase security: restrict unused AWS services, enforce encryption defaults (S3, EBS, RDS), block public S3 buckets, limit IAM actions beyond current region-only SCPs.
+Formalize the API contract between backend and frontend to eliminate type drift and enable safe refactoring.
+
+- ~~**B-49: Extract shared TypeScript types to shared/ package**~~ ✅ DONE (2026-02-25) — `shared/` package with domain types, constants, factory values. Both frontends use `@lenie/shared` alias.
+- **B-50: API type synchronization pipeline (Pydantic → OpenAPI → TS)** — Multi-phase: (1) Pydantic v2 response models in `backend/library/models/schemas/`, (2) integrate into Flask routes, (3) generate `docs/openapi.json`, (4) generate `shared/types/generated.ts` via `openapi-typescript`, (5) CI drift check. Known drift: `id` type mismatch (TS `string` vs Python `int`), 13 missing fields in `WebDocument`, 5 missing in `ListItem`, 7 missing in `SearchResult`, untyped enums. Strategy: `docs/api-type-sync-strategy.md`. Incremental migration — start with `/website_get`.
+- ~~**B-51: Frontend deployment scripts with SSM**~~ ✅ DONE (2026-02-25) — Deploy scripts for both frontends, SSM Parameter Store integration.
+
+### Phase 3 (Future — Security Hardening & AWS Cleanup)
+
+- **B-13: Parameterize stage description for multi-environment** — Enable multi-env support in CloudFormation templates.
+- **B-19: Convert EC2 to Spot with ASG 0-1** — Reduce EC2 costs by switching to Spot instances with Auto Scaling Group (min 0, max 1).
+- **B-22: Add max retry limit to aws_ec2_route53 script** — Prevent infinite loops in Route53 update script.
+- **B-23: Consolidate Lambdas with VPC IPv6 dual-stack** — Merge app-server-db + app-server-internet into one Lambda. ⚠️ BLOCKER: OpenAI API has no IPv6.
+- **B-39: Delegate DNS subzones per environment** — Split lenie-ai.eu into delegated subzones (dev, prod). Enables multi-account + multi-cloud. $0.50/month per subzone.
+- **B-46: Define strict SCP policies for lenie account** — Granular SCPs for 008971653395: restrict unused services, enforce encryption defaults, block public S3, limit regions.
+- **B-52: Lambda Layer security audit** — Lambda Layer dependencies ~1.5+ years old. Audit, update, rebuild layer ZIP.
+- **B-53: CORS hardening** — Replace wildcard `Access-Control-Allow-Origin: '*'` with explicit allowed origins.
+- **B-54: Lambda function CloudFormation management** — Replace hardcoded Lambda ARNs with CloudFormation-managed references (SSM/Fn::GetAtt).
+- **B-55: Remove stale API Gateway deployments** — Remove 36 stale API Gateway deployments left from manual/ad-hoc deploys.
 
 ### Phase 4 (Future — MCP Server Foundation)
 
-- Database abstraction layer (separate raw psycopg2 from business logic)
-- Implement MCP server protocol (expose search/retrieve endpoints as MCP tools)
-- Claude Desktop integration (configure Lenie-AI as MCP server)
-- API adaptation for MCP tool consumption
+- **B-56: Database abstraction layer** — Separate raw psycopg2 queries from business logic. Prerequisite for MCP server and testability.
+- **B-57: Implement MCP server protocol** — Expose search/retrieve endpoints as MCP tools. Follow MCP specification.
+- **B-58: Claude Desktop integration** — Configure Lenie-AI as MCP server in Claude Desktop. Test search and retrieve workflows.
+- **B-59: API adaptation for MCP tool consumption** — Adapt API response formats for MCP tool consumption patterns.
 
 ### Phase 5 (Future — RSS & Slack Integration)
 
@@ -148,9 +163,9 @@ Bidirectional communication channel (Slack) and new automated data source (RSS f
 
 ### Phase 6 (Future — Obsidian Integration)
 
-- Obsidian vault integration (synchronization, linking, note creation)
-- Semantic search from within Obsidian via Claude Desktop + MCP
-- Advanced vector search refinements for personal knowledge management
+- **B-60: Obsidian vault integration** — Synchronization between Lenie-AI and Obsidian vault — linking, note creation, bidirectional sync.
+- **B-61: Semantic search from Obsidian** — Semantic search from within Obsidian via Claude Desktop + MCP server (depends on B-57, B-58).
+- **B-62: Advanced vector search refinements** — Advanced vector search refinements for personal knowledge management — filtering, ranking, hybrid search.
 
 ### Phase 7 (Future — Extending Functionality)
 


### PR DESCRIPTION
## Summary

- Reconcile sprint-status, epics, PRD with work done outside BMad process
- Mark Epic 19 (app2) all 4 stories as done, B-10 as done (PR #29 merged)
- Add completed items: B-49 (shared TS types), B-51 (frontend deploy scripts)
- Add B-50 (API type sync pipeline) to backlog — fixes backend-frontend drift
- Assign B-numbers to all PRD items missing them: B-52–B-62 (Phase 3, 4, 6)
- Assign phases to orphaned backlog items (B-13, B-19, B-22, B-23, B-39 → Phase 3)
- Add missing B-40 (Slack webhooks) to sprint-status
- Separate backlog (TO DO) from done items in sprint-status for clarity
- Add Phase 2.5 (API Contract & Type Safety) to PRD

## Test plan

- [ ] Verify sprint-status.yaml has clean separation: backlog items grouped by phase, done items at bottom
- [ ] Verify PRD phases 3, 4, 6 all have B-numbers
- [ ] Verify epics.md Epic 19 stories marked as done with implementation notes
- [ ] Verify no backlog item is missing a phase assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)