### PR TITLE
feat: add ManagedBy and StackName tags to all CloudFormation resources

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-cf-tagging-managed-by-stack-name.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-cf-tagging-managed-by-stack-name.md
@@ -1,0 +1,312 @@
+---
+title: 'Add ManagedBy and StackName tags to all CloudFormation resources'
+slug: 'cf-tagging-managed-by-stack-name'
+created: '2026-02-25'
+status: 'ready-for-dev'
+stepsCompleted: [1, 2, 3, 4]
+tech_stack: [CloudFormation, YAML]
+files_to_modify:
+  - infra/aws/cloudformation/templates/1-domain-route53.yaml
+  - infra/aws/cloudformation/templates/acm-certificates.yaml
+  - infra/aws/cloudformation/templates/api-gw-account.yaml
+  - infra/aws/cloudformation/templates/api-gw-app.yaml
+  - infra/aws/cloudformation/templates/api-gw-custom-domain.yaml
+  - infra/aws/cloudformation/templates/api-gw-infra.yaml
+  - infra/aws/cloudformation/templates/cloudfront-app.yaml
+  - infra/aws/cloudformation/templates/cloudfront-app2.yaml
+  - infra/aws/cloudformation/templates/cloudfront-landing.yaml
+  - infra/aws/cloudformation/templates/dynamodb-documents.yaml
+  - infra/aws/cloudformation/templates/ec2-lenie.yaml
+  - infra/aws/cloudformation/templates/env-setup.yaml
+  - infra/aws/cloudformation/templates/helm.yaml
+  - infra/aws/cloudformation/templates/lambda-layer-lenie-all.yaml
+  - infra/aws/cloudformation/templates/lambda-layer-openai.yaml
+  - infra/aws/cloudformation/templates/lambda-layer-psycopg2.yaml
+  - infra/aws/cloudformation/templates/lambda-rds-start.yaml
+  - infra/aws/cloudformation/templates/lambda-weblink-put-into-sqs.yaml
+  - infra/aws/cloudformation/templates/lenie-launch-template.yaml
+  - infra/aws/cloudformation/templates/rds.yaml
+  - infra/aws/cloudformation/templates/s3-app-web.yaml
+  - infra/aws/cloudformation/templates/s3-app2-web.yaml
+  - infra/aws/cloudformation/templates/s3-cloudformation.yaml
+  - infra/aws/cloudformation/templates/s3-landing-web.yaml
+  - infra/aws/cloudformation/templates/s3-website-content.yaml
+  - infra/aws/cloudformation/templates/s3.yaml
+  - infra/aws/cloudformation/templates/secrets.yaml
+  - infra/aws/cloudformation/templates/security-groups.yaml
+  - infra/aws/cloudformation/templates/sqs-application-errors.yaml
+  - infra/aws/cloudformation/templates/sqs-documents.yaml
+  - infra/aws/cloudformation/templates/sqs-to-rds-lambda.yaml
+  - infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml
+  - infra/aws/cloudformation/templates/url-add.yaml
+  - infra/aws/cloudformation/templates/vpc.yaml
+code_patterns:
+  - 'List-style tags: - Key: X / Value: Y (all resources except SSM::Parameter)'
+  - 'Map-style tags: Key: Value (SSM::Parameter only)'
+  - 'Environment and Project tags present on ~111 resources (114 total taggable including 3 missing tags)'
+  - 'Tag values use !Ref Environment, !Ref ProjectCode, or literal "lenie"'
+  - '!Ref AWS::StackName pseudo-parameter for dynamic stack name'
+test_patterns:
+  - 'aws cloudformation validate-template for each modified template'
+---
+
+# Tech-Spec: Add ManagedBy and StackName tags to all CloudFormation resources
+
+**Created:** 2026-02-25
+
+## Overview
+
+### Problem Statement
+
+The project uses multiple IaC tools (CloudFormation, Terraform). When viewing resources in the AWS console or via API, there is no way to tell which tool created a resource or which specific CloudFormation stack manages it. This makes auditing, cost allocation, and resource lifecycle management harder.
+
+### Solution
+
+Add two new tags to every taggable resource across all CloudFormation templates:
+- `ManagedBy: CloudFormation` — identifies the IaC tool that created the resource
+- `StackName: !Ref AWS::StackName` — dynamically resolves to the stack name (e.g. `lenie-dev-vpc`)
+
+Also fix 3 resources that support tags but are currently missing them.
+
+### Scope
+
+**In Scope:**
+- Add `ManagedBy` and `StackName` tags to all ~114 taggable resources across 34 CloudFormation templates
+- Fix 3 resources missing tags entirely: CloudWatchRoleArnParameter (SSM), ApiStage (api-gw-app), ApiStage (api-gw-infra)
+
+**Out of Scope:**
+- Resources that don't support tags in CloudFormation (~30 resources including BucketPolicy, Lambda Permission, Route53 RecordSet, OAC, Deployment, BasePathMapping, GatewayResponse, LayerVersion, SecretTargetAttachment, OAI, Budget, InstanceProfile, SNS::Subscription, Scheduler::Schedule, Organizations::*, IdentityStore::*)
+- Templates with zero taggable resources: organization.yaml, scp-block-sso-creation.yaml, scp-only-allowed-reginos.yaml, scp-block-all.yaml, identityStore.yaml, budget.yaml (AWS::Budgets::Budget does not support Tags in CloudFormation)
+- Changing existing tag values or key names
+- Deploying the changes to AWS (separate step after merge)
+
+## Context for Development
+
+### Codebase Patterns
+
+**List-style tags** (all resources except SSM::Parameter):
+```yaml
+Tags:
+  - Key: Environment
+    Value: !Ref Environment
+  - Key: Project
+    Value: !Ref ProjectCode
+```
+Append:
+```yaml
+  - Key: ManagedBy
+    Value: CloudFormation
+  - Key: StackName
+    Value: !Ref 'AWS::StackName'
+```
+
+**HostedZoneTags** (Route53 HostedZone only — uses `HostedZoneTags`, NOT `Tags`):
+```yaml
+HostedZoneTags:
+  - Key: Environment
+    Value: !Ref Environment
+  - Key: Project
+    Value: lenie
+```
+Append:
+```yaml
+  - Key: ManagedBy
+    Value: CloudFormation
+  - Key: StackName
+    Value: !Ref 'AWS::StackName'
+```
+
+**Map-style tags** (SSM::Parameter only):
+```yaml
+Tags:
+  Environment: !Ref Environment
+  Project: !Ref ProjectCode
+```
+Append:
+```yaml
+  ManagedBy: CloudFormation
+  StackName: !Ref 'AWS::StackName'
+```
+
+### Files to Reference
+
+| File | Taggable Resources | Notes |
+| ---- | ------- | ----- |
+| 1-domain-route53.yaml | 1 (HostedZone) | Uses `HostedZoneTags` (NOT `Tags`); DISABLED in deploy.ini |
+| acm-certificates.yaml | 2 (Certificate, SSM) | |
+| api-gw-account.yaml | 2 (IAM Role, SSM) | SSM missing tags — FIX |
+| api-gw-app.yaml | 5 (RestApi, Stage, 3x SSM) | Stage missing tags — FIX |
+| api-gw-custom-domain.yaml | 4 (Certificate, DomainName, 2x SSM) | |
+| api-gw-infra.yaml | 10 (3x IAM, 3x Lambda, RestApi, Stage, 2x SSM) | Stage missing tags — FIX |
+| cloudfront-app.yaml | 3 (Distribution, 2x SSM) | |
+| cloudfront-app2.yaml | 3 (Distribution, 2x SSM) | |
+| cloudfront-landing.yaml | 4 (Certificate, Distribution, 2x SSM) | |
+| dynamodb-documents.yaml | 3 (Table, 2x SSM) | |
+| ec2-lenie.yaml | 3 (Instance, SG, IAM Role) | InstanceProfile not taggable |
+| env-setup.yaml | 1 (SSM) | |
+| helm.yaml | 2 (Bucket, Distribution) | |
+| lambda-layer-lenie-all.yaml | 1 (SSM) | LayerVersion not taggable |
+| lambda-layer-openai.yaml | 1 (SSM) | LayerVersion not taggable |
+| lambda-layer-psycopg2.yaml | 1 (SSM) | LayerVersion not taggable |
+| lambda-rds-start.yaml | 2 (IAM Role, Lambda) | |
+| lambda-weblink-put-into-sqs.yaml | 2 (IAM Role, Lambda) | |
+| lenie-launch-template.yaml | 3 (LaunchTemplate, 2x SSM) | |
+| rds.yaml | 3 (DB, SubnetGroup, SG) | |
+| s3-app-web.yaml | 4 (Bucket, 3x SSM) | |
+| s3-app2-web.yaml | 4 (Bucket, 3x SSM) | |
+| s3-cloudformation.yaml | 2 (Bucket, SSM) | |
+| s3-landing-web.yaml | 4 (Bucket, 3x SSM) | |
+| s3-website-content.yaml | 3 (Bucket, 2x SSM) | |
+| s3.yaml | 1 (Bucket) | |
+| secrets.yaml | 2 (Secret, SSM) | |
+| security-groups.yaml | 1 (SG) | |
+| sqs-application-errors.yaml | 3 (Queue, Topic, SSM) | Subscription not taggable |
+| sqs-documents.yaml | 3 (Queue, 2x SSM) | |
+| sqs-to-rds-lambda.yaml | 2 (Lambda, IAM Role) | |
+| sqs-to-rds-step-function.yaml | 4 (2x IAM, LogGroup, StepFunction) | Scheduler not taggable |
+| url-add.yaml | 3 (Lambda, LogGroup, IAM Role) | |
+| vpc.yaml | 12 (VPC, 6 Subnets, IGW, RouteTable, 3x SSM) | |
+
+### Technical Decisions
+
+- Tag key `ManagedBy` (not `IaC` or `iac:tool`) — clear, human-readable
+- Tag key `StackName` (not `aws:cloudformation:stack-name`) — `aws:` prefix is reserved by AWS
+- `!Ref 'AWS::StackName'` used for StackName value — dynamic, always correct
+- `ManagedBy` value is literal `CloudFormation` (not parameterized) — no reason to make it dynamic
+- 3 resources with missing tags get full 4-tag set (Environment, Project, ManagedBy, StackName)
+- ~15 resource types verified as not supporting tags in CF — no action (see Out of Scope list)
+- Route53 HostedZone uses `HostedZoneTags` property, not `Tags` — different syntax
+- Tag ordering convention: Environment, Project, ManagedBy, StackName (append new tags after existing ones)
+
+## Implementation Plan
+
+### Tasks
+
+- [ ] Task 1: Fix 3 resources with missing tags (add full 4-tag set)
+  - File: `infra/aws/cloudformation/templates/api-gw-account.yaml`
+  - Action: Add `Tags` property to `CloudWatchRoleArnParameter` (SSM map-style) with Environment, Project, ManagedBy, StackName
+  - File: `infra/aws/cloudformation/templates/api-gw-app.yaml`
+  - Action: Add `Tags` property to `ApiStage` (list-style) with Environment, Project, ManagedBy, StackName
+  - File: `infra/aws/cloudformation/templates/api-gw-infra.yaml`
+  - Action: Add `Tags` property to `ApiStage` (list-style) with Environment, Project, ManagedBy, StackName
+
+- [ ] Task 2: Add ManagedBy + StackName to simple templates (1-2 taggable resources each)
+  - File: `infra/aws/cloudformation/templates/1-domain-route53.yaml`
+  - Action: Append ManagedBy + StackName to MyHostedZone using `HostedZoneTags` property (NOT `Tags`). Template is DISABLED in deploy.ini but should still be updated for consistency.
+  - File: `infra/aws/cloudformation/templates/env-setup.yaml`
+  - Action: Append ManagedBy + StackName to CloudFormationSSMParameter (map-style)
+  - File: `infra/aws/cloudformation/templates/s3.yaml`
+  - Action: Append ManagedBy + StackName to MyS3Bucket (list-style)
+  - File: `infra/aws/cloudformation/templates/security-groups.yaml`
+  - Action: Append ManagedBy + StackName to MySecurityGroup (list-style)
+  - File: `infra/aws/cloudformation/templates/helm.yaml`
+  - Action: Append to HelmBucket, HelmDistribution (list-style)
+
+- [ ] Task 3: Add tags to acm-certificates.yaml
+  - Action: Append to CloudFrontCertificate (list-style), CloudFrontCertificateArnParameter (map-style)
+
+- [ ] Task 4: Add tags to api-gw-account.yaml (existing tagged resource)
+  - Action: Append ManagedBy + StackName to ApiGatewayCloudWatchRole (list-style)
+
+- [ ] Task 5: Add tags to api-gw-app.yaml (existing tagged resources)
+  - Action: Append to LenieApi (list-style), ApiGatewayIdParameter, ApiGatewayRootResourceIdParameter, ApiGatewayInvokeUrlParameter (map-style)
+
+- [ ] Task 6: Add tags to api-gw-custom-domain.yaml
+  - Action: Append to ApiCertificate, ApiDomainName (list-style), CustomDomainUrlParameter, CustomDomainCertificateArnParameter (map-style)
+
+- [ ] Task 7: Add tags to api-gw-infra.yaml (existing tagged resources — ApiStage handled in Task 1)
+  - Action: Append to SqsSizeExecutionRole, RdsManagerExecutionRole, Ec2ManagerExecutionRole, SqsSizeFunction, RdsManagerFunction, Ec2ManagerFunction, LenieApi (list-style), ApiGatewayInfraIdParameter, ApiGatewayInfraInvokeUrlParameter (map-style)
+
+- [ ] Task 8: Add tags to cloudfront-app.yaml, cloudfront-app2.yaml, cloudfront-landing.yaml
+  - Action: Append to Distribution resources (list-style), SSM parameters (map-style), Certificate in landing (list-style)
+
+- [ ] Task 9: Add tags to dynamodb-documents.yaml
+  - Action: Append to LenieDocumentsTable (list-style), DocumentsTableNameParameter, DocumentsTableArnParameter (map-style)
+
+- [ ] Task 10: Add tags to ec2-lenie.yaml
+  - Action: Append to EC2Instance, InstanceSecurityGroup, InstanceRole (list-style). Skip InstanceProfile (not taggable).
+
+- [ ] Task 11: Add tags to lambda templates
+  - File: `lambda-layer-lenie-all.yaml` — Append to LenieAllLayerArnParameter (map-style)
+  - File: `lambda-layer-openai.yaml` — Append to LenieOpenaiLayerArnParameter (map-style)
+  - File: `lambda-layer-psycopg2.yaml` — Append to Psycopg2LayerArnParameter (map-style)
+  - File: `lambda-rds-start.yaml` — Append to RDSStartLambdaRole, RDSStartLambdaFunction (list-style)
+  - File: `lambda-weblink-put-into-sqs.yaml` — Append to LambdaExecutionRole, MyLambdaFunction (list-style)
+
+- [ ] Task 12: Add tags to lenie-launch-template.yaml
+  - Action: Append to ApplicationLaunchTemplate (list-style), ApplicationLaunchTemplateParam, ApplicationLaunchTemplateLatestVersionParam (map-style)
+
+- [ ] Task 13: Add tags to rds.yaml
+  - Action: Append to MyDB, DbSubnetGroup, MyDatabaseSecurityGroup (list-style)
+
+- [ ] Task 14: Add tags to S3 templates
+  - File: `s3-app-web.yaml` — Append to AppWebBucket (list-style), 3x SSM (map-style)
+  - File: `s3-app2-web.yaml` — Append to App2WebBucket (list-style), 3x SSM (map-style)
+  - File: `s3-cloudformation.yaml` — Append to MyS3Bucket (list-style), SSM (map-style)
+  - File: `s3-landing-web.yaml` — Append to LandingWebBucket (list-style), 3x SSM (map-style)
+  - File: `s3-website-content.yaml` — Append to WebsiteContentBucket (list-style), 2x SSM (map-style)
+
+- [ ] Task 15: Add tags to secrets.yaml
+  - Action: Append to RDSPasswordSecret (list-style), RDSPasswordSecretArnParameter (map-style)
+
+- [ ] Task 16: Add tags to SQS templates
+  - File: `sqs-application-errors.yaml` — Append to LenieDevProblemsDLQ, LenieDevProblemsTopic (list-style), ProblemsDlqArnParameter (map-style). Skip EmailSubscription (not taggable).
+  - File: `sqs-documents.yaml` — Append to LenieDocumentsSQS (list-style), SQSNameParameter, SQSUrlParameter (map-style)
+
+- [ ] Task 17: Add tags to sqs-to-rds-lambda.yaml
+  - Action: Append to MyLambdaFunction, LambdaExecutionRole (list-style)
+
+- [ ] Task 18: Add tags to sqs-to-rds-step-function.yaml
+  - Action: Append to StateMachineRole, StateMachineLogGroup, MyStateMachine, StepFunctionInvokerRole (list-style). Skip EventBridgeScheduler (not taggable).
+
+- [ ] Task 19: Add tags to url-add.yaml
+  - Action: Append to LenineUrlAddLambdaFunction, LenineUrlAddLogGroup, LambdaExecutionRole (list-style)
+
+- [ ] Task 20: Add tags to vpc.yaml
+  - Action: Append to LenieVPC, PublicSubnet1, PublicSubnet2, PrivateSubnet1, PrivateSubnet2, PrivateDBSubnet1, PrivateDBSubnet2, MyInternetGateway, MyRouteTable (list-style), LenieVPCParam, DataSubnetBIdParam, DataSubnetBIdParam2 (map-style)
+
+- [ ] Task 21: Validate all 34 modified templates
+  - Action: Run `aws cloudformation validate-template --template-body file://templates/<name>.yaml` for each modified template
+  - Full WSL command: `wsl bash -c "cd /mnt/c/Users/ziutus/git/_lenie-all/lenie-server-2025/infra/aws/cloudformation && for f in templates/*.yaml; do echo \"Validating $f...\"; aws cloudformation validate-template --template-body file://$f > /dev/null && echo '  OK' || echo '  FAILED'; done"`
+  - Notes: Must be run via WSL (Git Bash/MSYS breaks `file://` paths)
+
+### Acceptance Criteria
+
+- [ ] AC1: Given any CloudFormation template in `infra/aws/cloudformation/templates/`, when a resource supports the `Tags` property, then it has `ManagedBy: CloudFormation` tag (list-style or map-style as appropriate)
+- [ ] AC2: Given any CloudFormation template in `infra/aws/cloudformation/templates/`, when a resource supports the `Tags` property, then it has `StackName: !Ref 'AWS::StackName'` tag (list-style or map-style as appropriate)
+- [ ] AC3: Given the 3 resources previously missing tags (CloudWatchRoleArnParameter, ApiStage in api-gw-app, ApiStage in api-gw-infra), when modified, then they have all 4 standard tags: Environment, Project, ManagedBy, StackName
+- [ ] AC4: Given all 34 modified templates, when validated with `aws cloudformation validate-template`, then all templates pass validation without errors
+- [ ] AC5: Given all modified templates, when searching for `ManagedBy` with grep, the count of occurrences matches the total number of taggable resources (~114). Verification: `grep -r "ManagedBy" infra/aws/cloudformation/templates/ | wc -l` should equal ~114
+
+## Additional Context
+
+### Dependencies
+
+None — pure template modification, no code changes.
+
+### Testing Strategy
+
+1. Run `aws cloudformation validate-template` on all 34 modified templates via WSL
+2. Visual spot-check of 3-4 templates to verify correct tag format (list vs map vs HostedZoneTags)
+3. Run `grep -c "ManagedBy" infra/aws/cloudformation/templates/*.yaml | grep -v ':0$'` to verify tag presence
+4. Optionally deploy one small stack (e.g. `env-setup.yaml`) to verify tags appear in AWS console
+5. For API Gateway stacks: use change-set mode first (`deploy.sh -p lenie -s dev -t`) to preview changes before applying
+
+### Rollback
+
+- Tag additions are non-destructive in-place updates — rollback by reverting git commit and redeploying
+- For API Gateway Stage: if unexpected replacement detected in change-set, abort and investigate before applying
+
+### Notes
+
+- SSM::Parameter uses map-style tags (`Key: Value`), all other resources use list-style (`- Key: X, Value: Y`)
+- Route53 HostedZone uses `HostedZoneTags` property (NOT `Tags`) — this is a Route53-specific property name
+- Some templates use `!Ref ProjectCode`, others use literal `lenie` for Project tag — this inconsistency is out of scope for this task
+- `aws:cloudformation:stack-name` is automatically added by AWS in some cases, but our explicit `StackName` tag ensures visibility regardless of stack settings
+- Templates with zero taggable resources are not modified: organization.yaml, scp-block-sso-creation.yaml, scp-only-allowed-reginos.yaml, scp-block-all.yaml, identityStore.yaml, budget.yaml
+- Tag updates are in-place modifications (not resource replacements) — safe for all resource types
+- High-risk item: API Gateway Stage resources (`api-gw-app.yaml`, `api-gw-infra.yaml`) — adding tags is a safe update, but use change-set mode (`deploy.sh -t`) for first deployment to verify no replacement
+- `1-domain-route53.yaml` is DISABLED in deploy.ini (zone managed by legacy stack `lenie-domain-route53-definition`) — update template for consistency but no deployment needed
+- `s3-landing-web.yaml` and `cloudfront-landing.yaml` are in `[landing-prod]` section — deployed separately via `deploy.sh -s landing-prod`, not with `-s dev`
+- Tag ordering convention: always append ManagedBy and StackName after existing tags (Environment, Project)
+- Git workflow: create a feature branch (e.g. `feat/cf-tagging-managed-by-stack-name`) before committing changes

--- a/infra/aws/cloudformation/templates/1-domain-route53.yaml
+++ b/infra/aws/cloudformation/templates/1-domain-route53.yaml
@@ -26,3 +26,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/acm-certificates.yaml
+++ b/infra/aws/cloudformation/templates/acm-certificates.yaml
@@ -40,6 +40,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   CloudFrontCertificateArnParameter:
     Type: AWS::SSM::Parameter
@@ -53,3 +57,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/api-gw-account.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-account.yaml
@@ -35,6 +35,10 @@ Resources:
           Value: !Ref ProjectCode
         - Key: Environment
           Value: !Ref Environment
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   ApiGatewayAccount:
     Type: 'AWS::ApiGateway::Account'
@@ -48,6 +52,11 @@ Resources:
       Type: String
       Value: !GetAtt ApiGatewayCloudWatchRole.Arn
       Description: 'API Gateway CloudWatch IAM Role ARN'
+      Tags:
+        Environment: !Ref Environment
+        Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   CloudWatchRoleArn:

--- a/infra/aws/cloudformation/templates/api-gw-app.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-app.yaml
@@ -25,6 +25,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       EndpointConfiguration:
         Types:
           - REGIONAL
@@ -636,6 +640,15 @@ Resources:
       StageName: 'v1'
       Description: 'CF-managed v1 stage'
       TracingEnabled: true
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Project
+          Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       MethodSettings:
         - HttpMethod: '*'
           ResourcePath: '/*'
@@ -664,6 +677,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   ApiGatewayRootResourceIdParameter:
     Type: 'AWS::SSM::Parameter'
@@ -675,6 +690,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   ApiGatewayInvokeUrlParameter:
     Type: 'AWS::SSM::Parameter'
@@ -686,6 +703,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   # Lambda permissions for API Gateway to invoke Lambda functions
   # Wildcard SourceArn (/*) used for app-server-db and app-server-internet because

--- a/infra/aws/cloudformation/templates/api-gw-custom-domain.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-custom-domain.yaml
@@ -45,6 +45,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # API Gateway Custom Domain Name
   ApiDomainName:
@@ -64,6 +68,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Base Path Mapping: root (/) -> app API (lenie_split), stage v1
   AppBasePathMapping:
@@ -110,6 +118,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   CustomDomainCertificateArnParameter:
     Type: 'AWS::SSM::Parameter'
@@ -121,3 +131,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/api-gw-infra.yaml
+++ b/infra/aws/cloudformation/templates/api-gw-infra.yaml
@@ -53,6 +53,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   RdsManagerExecutionRole:
     Type: AWS::IAM::Role
@@ -91,6 +95,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   Ec2ManagerExecutionRole:
     Type: AWS::IAM::Role
@@ -132,6 +140,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   SqsSizeFunction:
     Type: 'AWS::Lambda::Function'
@@ -158,6 +170,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
 
   RdsManagerFunction:
@@ -185,6 +201,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   Ec2ManagerFunction:
     Type: 'AWS::Lambda::Function'
@@ -211,6 +231,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LenieApi:
     Type: 'AWS::ApiGateway::RestApi'
@@ -225,6 +249,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       Body:
         openapi: "3.0.1"
         info:
@@ -587,6 +615,15 @@ Resources:
       DeploymentId: !Ref ApiDeployment
       RestApiId: !Ref LenieApi
       StageName: 'v1'
+      Tags:
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: Project
+          Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   ApiDeployment:
     Type: 'AWS::ApiGateway::Deployment'
@@ -631,6 +668,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   ApiGatewayInfraInvokeUrlParameter:
     Type: 'AWS::SSM::Parameter'
@@ -642,4 +681,6 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 

--- a/infra/aws/cloudformation/templates/cloudfront-app.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-app.yaml
@@ -85,6 +85,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Route53 A-record alias pointing to CloudFront distribution
   AppDnsRecord:
@@ -108,6 +112,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   AppDistributionDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -119,3 +125,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/cloudfront-app2.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-app2.yaml
@@ -80,6 +80,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Route53 A-record alias pointing to CloudFront distribution
   App2DnsRecord:
@@ -103,6 +107,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   App2DistributionDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -114,6 +120,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   DistributionId:

--- a/infra/aws/cloudformation/templates/cloudfront-landing.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-landing.yaml
@@ -37,6 +37,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Origin Access Control for S3 origin (sigv4 signing)
   LandingOriginAccessControl:
@@ -102,6 +106,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Route53 A-record aliases pointing to CloudFront distribution
   LandingDnsRecord:
@@ -135,6 +143,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   LandingDistributionDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -146,6 +156,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   DistributionId:

--- a/infra/aws/cloudformation/templates/dynamodb-documents.yaml
+++ b/infra/aws/cloudformation/templates/dynamodb-documents.yaml
@@ -51,6 +51,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: lenie
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: !If [IsProduction, true, false]
       SSESpecification:
@@ -68,6 +72,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   DocumentsTableArnParameter:
     Type: AWS::SSM::Parameter
@@ -79,6 +85,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   TableName:

--- a/infra/aws/cloudformation/templates/ec2-lenie.yaml
+++ b/infra/aws/cloudformation/templates/ec2-lenie.yaml
@@ -39,6 +39,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       IamInstanceProfile: !Ref InstanceProfile
 
   InstanceSecurityGroup:
@@ -67,6 +71,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   InstanceRole:
     Type: 'AWS::IAM::Role'
@@ -87,6 +95,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'

--- a/infra/aws/cloudformation/templates/env-setup.yaml
+++ b/infra/aws/cloudformation/templates/env-setup.yaml
@@ -25,3 +25,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/helm.yaml
+++ b/infra/aws/cloudformation/templates/helm.yaml
@@ -33,6 +33,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   CloudFrontOAI:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -102,6 +106,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
 Outputs:
   HelmBucketName:

--- a/infra/aws/cloudformation/templates/lambda-layer-lenie-all.yaml
+++ b/infra/aws/cloudformation/templates/lambda-layer-lenie-all.yaml
@@ -55,3 +55,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/lambda-layer-openai.yaml
+++ b/infra/aws/cloudformation/templates/lambda-layer-openai.yaml
@@ -55,3 +55,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/lambda-layer-psycopg2.yaml
+++ b/infra/aws/cloudformation/templates/lambda-layer-psycopg2.yaml
@@ -55,3 +55,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/lambda-rds-start.yaml
+++ b/infra/aws/cloudformation/templates/lambda-rds-start.yaml
@@ -48,6 +48,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   RDSStartLambdaFunction:
     Type: 'AWS::Lambda::Function'
@@ -68,6 +72,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
 Outputs:
   LambdaFunctionArn:

--- a/infra/aws/cloudformation/templates/lambda-weblink-put-into-sqs.yaml
+++ b/infra/aws/cloudformation/templates/lambda-weblink-put-into-sqs.yaml
@@ -75,6 +75,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   MyLambdaFunction:
     Type: AWS::Lambda::Function
@@ -97,3 +101,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/lenie-launch-template.yaml
+++ b/infra/aws/cloudformation/templates/lenie-launch-template.yaml
@@ -44,6 +44,10 @@ Resources:
                 Value: !Ref Environment
               - Key: Project
                 Value: !Ref ProjectCode
+              - Key: ManagedBy
+                Value: CloudFormation
+              - Key: StackName
+                Value: !Ref 'AWS::StackName'
       TagSpecifications:
         - ResourceType: launch-template
           Tags:
@@ -51,6 +55,10 @@ Resources:
               Value: !Ref Environment
             - Key: Project
               Value: !Ref ProjectCode
+            - Key: ManagedBy
+              Value: CloudFormation
+            - Key: StackName
+              Value: !Ref 'AWS::StackName'
 
   ApplicationLaunchTemplateParam:
     Type: AWS::SSM::Parameter
@@ -64,6 +72,8 @@ Resources:
         Name: !Sub ${ProjectCode}-${Environment}-${Component}-application-launch-template-id-param
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   ApplicationLaunchTemplateLatestVersionParam:
     Type: AWS::SSM::Parameter
@@ -77,6 +87,8 @@ Resources:
         Name: !Sub ${ProjectCode}-${Environment}-${Component}-application-launch-template-latest-version-param
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   ApplicationLaunchTemplateId:

--- a/infra/aws/cloudformation/templates/rds.yaml
+++ b/infra/aws/cloudformation/templates/rds.yaml
@@ -61,6 +61,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   DbSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
@@ -74,6 +78,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
 
   SecretTargetAttachment:
@@ -100,3 +108,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3-app-web.yaml
+++ b/infra/aws/cloudformation/templates/s3-app-web.yaml
@@ -53,6 +53,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # CloudFront OAC bucket policy — allows CloudFront to serve frontend content
   AppWebBucketPolicy:
@@ -94,6 +98,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   AppWebBucketArnParameter:
     Type: AWS::SSM::Parameter
@@ -105,6 +111,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   AppWebBucketDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -116,3 +124,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3-app2-web.yaml
+++ b/infra/aws/cloudformation/templates/s3-app2-web.yaml
@@ -39,6 +39,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   App2WebBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -79,6 +83,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   App2WebBucketArnParameter:
     Type: AWS::SSM::Parameter
@@ -90,6 +96,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   App2WebBucketDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -101,3 +109,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3-cloudformation.yaml
+++ b/infra/aws/cloudformation/templates/s3-cloudformation.yaml
@@ -26,6 +26,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   CloudFormationSSMParameter:
     Type: AWS::SSM::Parameter
@@ -37,3 +41,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3-landing-web.yaml
+++ b/infra/aws/cloudformation/templates/s3-landing-web.yaml
@@ -39,6 +39,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LandingWebBucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -79,6 +83,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   LandingWebBucketArnParameter:
     Type: AWS::SSM::Parameter
@@ -90,6 +96,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   LandingWebBucketDomainNameParameter:
     Type: AWS::SSM::Parameter
@@ -101,3 +109,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3-website-content.yaml
+++ b/infra/aws/cloudformation/templates/s3-website-content.yaml
@@ -45,6 +45,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   # Enforce TLS-only access to the bucket
   WebsiteContentBucketPolicy:
@@ -76,6 +80,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   WebsiteContentBucketArnParameter:
     Type: AWS::SSM::Parameter
@@ -87,3 +93,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/s3.yaml
+++ b/infra/aws/cloudformation/templates/s3.yaml
@@ -26,3 +26,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/secrets.yaml
+++ b/infra/aws/cloudformation/templates/secrets.yaml
@@ -30,6 +30,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   RDSPasswordSecretArnParameter:
     Type: 'AWS::SSM::Parameter'
@@ -41,3 +45,5 @@ Resources:
       Tags:
         Project: !Ref ProjectCode
         Environment: !Ref Environment
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/security-groups.yaml
+++ b/infra/aws/cloudformation/templates/security-groups.yaml
@@ -35,3 +35,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/sqs-application-errors.yaml
+++ b/infra/aws/cloudformation/templates/sqs-application-errors.yaml
@@ -29,6 +29,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LenieDevProblemsTopic:
     Type: 'AWS::SNS::Topic'
@@ -39,6 +43,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   EmailSubscription:
     Type: 'AWS::SNS::Subscription'
@@ -57,6 +65,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
 Outputs:
   SqsApplicationErrorsQueueURL:

--- a/infra/aws/cloudformation/templates/sqs-documents.yaml
+++ b/infra/aws/cloudformation/templates/sqs-documents.yaml
@@ -26,6 +26,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   SQSNameParameter:
     Type: AWS::SSM::Parameter
@@ -37,6 +41,8 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   SQSUrlParameter:
     Type: AWS::SSM::Parameter
@@ -48,3 +54,5 @@ Resources:
       Tags:
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/sqs-to-rds-lambda.yaml
+++ b/infra/aws/cloudformation/templates/sqs-to-rds-lambda.yaml
@@ -91,6 +91,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
 
   LambdaExecutionRole:
@@ -127,3 +131,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml
+++ b/infra/aws/cloudformation/templates/sqs-to-rds-step-function.yaml
@@ -51,6 +51,10 @@ Resources:
           Value: !Ref ProjectCode
         - Key: Environment
           Value: !Ref Environment
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       Policies:
         - PolicyName: StateMachinePolicy
           PolicyDocument:
@@ -109,6 +113,10 @@ Resources:
           Value: !Ref ProjectCode
         - Key: Environment
           Value: !Ref Environment
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   MyStateMachine:
     Type: AWS::StepFunctions::StateMachine
@@ -120,6 +128,10 @@ Resources:
           Value: !Ref ProjectCode
         - Key: Environment
           Value: !Ref Environment
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       LoggingConfiguration:
         Level: "ERROR"  # Possible values: ALL, ERROR, FATAL, OFF
         IncludeExecutionData: true
@@ -392,6 +404,10 @@ Resources:
           Value: !Ref ProjectCode
         - Key: Environment
           Value: !Ref Environment
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
       Policies:
         - PolicyName: "StepFunctionInvokePolicy"
           PolicyDocument:

--- a/infra/aws/cloudformation/templates/url-add.yaml
+++ b/infra/aws/cloudformation/templates/url-add.yaml
@@ -65,6 +65,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LenineUrlAddLogGroup:
     Type: 'AWS::Logs::LogGroup'
@@ -76,6 +80,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LambdaExecutionRole:
     Type: 'AWS::IAM::Role'
@@ -134,4 +142,7 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
-
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'

--- a/infra/aws/cloudformation/templates/vpc.yaml
+++ b/infra/aws/cloudformation/templates/vpc.yaml
@@ -60,6 +60,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   LenieVPCParam:
     Type: AWS::SSM::Parameter
@@ -73,6 +77,8 @@ Resources:
         Name: !Sub ${ProjectCode}-${Environment}-vpc-id
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   PublicSubnet1:
     Type: 'AWS::EC2::Subnet'
@@ -88,6 +94,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   PublicSubnet2:
     Type: 'AWS::EC2::Subnet'
@@ -103,6 +113,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   PrivateSubnet1:
     Type: 'AWS::EC2::Subnet'
@@ -118,6 +132,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   PrivateSubnet2:
     Type: 'AWS::EC2::Subnet'
@@ -133,6 +151,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   PrivateDBSubnet1:
     Type: 'AWS::EC2::Subnet'
@@ -148,6 +170,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   DataSubnetBIdParam:
     Type: AWS::SSM::Parameter
@@ -161,6 +187,8 @@ Resources:
         Name: !Sub ${ProjectCode}-${Environment}-data-subnet-a-id-param
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   PrivateDBSubnet2:
     Type: 'AWS::EC2::Subnet'
@@ -176,6 +204,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   DataSubnetBIdParam2:
     Type: AWS::SSM::Parameter
@@ -189,6 +221,8 @@ Resources:
         Name: !Sub ${ProjectCode}-${Environment}-data-subnet-b-id-param
         Environment: !Ref Environment
         Project: !Ref ProjectCode
+        ManagedBy: CloudFormation
+        StackName: !Ref 'AWS::StackName'
 
   MyInternetGateway:
     Type: 'AWS::EC2::InternetGateway'
@@ -200,6 +234,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   AttachGateway:
     Type: 'AWS::EC2::VPCGatewayAttachment'
@@ -218,6 +256,10 @@ Resources:
           Value: !Ref Environment
         - Key: Project
           Value: !Ref ProjectCode
+        - Key: ManagedBy
+          Value: CloudFormation
+        - Key: StackName
+          Value: !Ref 'AWS::StackName'
 
   MyRoute:
     Type: 'AWS::EC2::Route'


### PR DESCRIPTION
## Summary

- Add `ManagedBy: CloudFormation` and `StackName: !Ref AWS::StackName` tags to every taggable resource across all 34 CloudFormation templates (105 tag blocks total)
- Fix 3 resources previously missing tags entirely: CloudWatchRoleArnParameter (SSM), ApiStage (api-gw-app), ApiStage (api-gw-infra)
- Handle Route53 HostedZone `HostedZoneTags` (not `Tags`) and SSM::Parameter map-style tags correctly

## Details

All resources now carry tags identifying which IaC tool created them and which CloudFormation stack manages them. This enables:
- Distinguishing CloudFormation-managed resources from Terraform or manually created ones
- Quick identification of the managing stack for any tagged resource
- Better cost allocation and audit compliance

## Test plan

- [x] All 40 templates pass `aws cloudformation validate-template`
- [x] `grep -c ManagedBy templates/*.yaml` returns 105 total across 34 files
- [x] Verified correct tag format: list-style (most), map-style (SSM), HostedZoneTags (Route53)
- [ ] Deploy one small stack (e.g. env-setup) to verify tags visible in AWS console
- [ ] Use change-set mode (`deploy.sh -t`) for API Gateway stacks before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)