### PR TITLE
feat: standardize CloudFront distribution descriptions

### DIFF
--- a/infra/aws/cloudformation/templates/cloudfront-app.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-app.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudFront distribution for frontend app hosting for Project Lenie'
+Description: 'Lenie App - CloudFront distribution for frontend hosting'
 
 Parameters:
   ProjectCode:
@@ -39,7 +39,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
-        Comment: 'DEV app version of lenie'
+        Comment: !Sub 'Lenie App ${Environment} - frontend hosting'
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
         HttpVersion: http2

--- a/infra/aws/cloudformation/templates/cloudfront-app2.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-app2.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudFront distribution for app2 (target) frontend hosting for Project Lenie'
+Description: 'Lenie App2 - CloudFront distribution for admin panel hosting'
 
 Parameters:
   ProjectCode:
@@ -34,7 +34,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
-        Comment: 'app2 (target) version of lenie'
+        Comment: !Sub 'Lenie App2 ${Environment} - admin panel hosting'
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
         HttpVersion: http2

--- a/infra/aws/cloudformation/templates/cloudfront-landing.yaml
+++ b/infra/aws/cloudformation/templates/cloudfront-landing.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudFront distribution for landing page hosting for Project Lenie'
+Description: 'Lenie Landing - CloudFront distribution for landing page hosting'
 
 Parameters:
   ProjectCode:
@@ -59,7 +59,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
-        Comment: !Sub '${Environment} landing page for lenie'
+        Comment: !Sub 'Lenie Landing ${Environment} - landing page hosting'
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
         HttpVersion: http2

--- a/infra/aws/cloudformation/templates/helm.yaml
+++ b/infra/aws/cloudformation/templates/helm.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'S3 bucket and CloudFront distribution for Helm chart repository for Project Lenie'
+Description: 'Lenie Helm - S3 bucket and CloudFront distribution for Helm chart repository'
 
 Parameters:
   ProjectCode:
@@ -63,7 +63,7 @@ Resources:
     Properties:
       DistributionConfig:
         Enabled: true
-        Comment: !Sub '${ProjectCode}-${Environment} Helm chart repository'
+        Comment: !Sub 'Lenie Helm ${Environment} - chart repository'
         DefaultRootObject: index.html
         PriceClass: PriceClass_100
         HttpVersion: http2


### PR DESCRIPTION
## Summary
- Unified CloudFront Comment/Description pattern: **Lenie [component] [env] - description**
- Fixed `cloudfront-app` hardcoded `DEV` → dynamic `${Environment}`
- Fixed `cloudfront-app2` missing environment in Comment
- All 4 distributions (App, App2, Landing, Helm) now easily identifiable in AWS console

## Test plan
- [ ] Deploy `cloudfront-app` stack (dev)
- [ ] Deploy `cloudfront-app2` stack (dev)
- [ ] Deploy `cloudfront-landing` stack (landing-prod)
- [ ] Deploy `helm` stack (dev)
- [ ] Verify descriptions in AWS CloudFront console

🤖 Generated with [Claude Code](https://claude.com/claude-code)