### PR TITLE
feat: add severity/repo filters to GitGuardian script

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -263,3 +263,4 @@ development_status:
   B-43-fix-app2-domain-to-app2-dev-lenie-ai-eu: done  # Domain moved to app2.dev.lenie-ai.eu, ACM cert switched to *.dev.lenie-ai.eu
   B-49-extract-shared-typescript-types-to-shared-package: done  # shared/ package with @lenie/shared alias. Commit 64e3213.
   B-51-frontend-deploy-scripts-with-ssm: done  # Deploy scripts for both frontends, SSM integration. Commit f2432ce.
+  B-63-gitguardian-incident-management-script: done  # CLI script to review and close GitGuardian incidents. Script uses GitGuardian REST API directly. Token from env var (Vault integration is separate task). Features: list open incidents (with --severity and --repo filters), show details, resolve/ignore with reason.

--- a/scripts/gitguardian_manage_incidents.py
+++ b/scripts/gitguardian_manage_incidents.py
@@ -8,10 +8,15 @@ Wymaga zmiennej środowiskowej GITGUARDIAN_API_KEY (lub pliku .env w katalogu pr
 
 Użycie:
     python scripts/gitguardian_manage_incidents.py list
+    python scripts/gitguardian_manage_incidents.py list --severity high
+    python scripts/gitguardian_manage_incidents.py list --repo lenie-server
+    python scripts/gitguardian_manage_incidents.py list --severity critical --repo lenie
     python scripts/gitguardian_manage_incidents.py resolve <incident_id> [<incident_id> ...]
     python scripts/gitguardian_manage_incidents.py resolve --all
+    python scripts/gitguardian_manage_incidents.py resolve --all --severity high
     python scripts/gitguardian_manage_incidents.py ignore <incident_id> [<incident_id> ...] --reason <reason>
     python scripts/gitguardian_manage_incidents.py ignore --all --reason test_credential
+    python scripts/gitguardian_manage_incidents.py ignore --all --severity low --reason low_risk
 
 Powody ignorowania (--reason):
     test_credential, false_positive, low_risk
@@ -26,6 +31,7 @@ import requests
 from dotenv import load_dotenv
 
 BASE_URL = "https://api.gitguardian.com/v1"
+REQUEST_TIMEOUT = 30
 
 
 def load_api_key() -> str:
@@ -47,19 +53,34 @@ def get_headers(api_key: str) -> dict:
     }
 
 
-def list_open_incidents(api_key: str) -> list[dict]:
-    """Pobiera wszystkie otwarte incydenty (TRIGGERED + ASSIGNED)."""
+def list_open_incidents(
+    api_key: str,
+    severity: str | None = None,
+    repo: str | None = None,
+) -> list[dict]:
+    """Pobiera wszystkie otwarte incydenty (TRIGGERED + ASSIGNED).
+
+    Args:
+        severity: Filtruj po severity (critical, high, medium, low, info, unknown).
+        repo: Filtruj po nazwie repozytorium (substring match, case-insensitive).
+              Wymaga dodatkowych zapytań API (pobranie occurrences per incydent).
+    """
     incidents = []
     page = 1
+    params: dict = {
+        "status": "TRIGGERED,ASSIGNED",
+        "per_page": 100,
+    }
+    if severity:
+        params["severity"] = severity
+
     while True:
+        params["page"] = page
         resp = requests.get(
             f"{BASE_URL}/incidents/secrets",
             headers=get_headers(api_key),
-            params={
-                "status": "TRIGGERED,ASSIGNED",
-                "page": page,
-                "per_page": 100,
-            },
+            params=params,
+            timeout=REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
         data = resp.json()
@@ -69,7 +90,41 @@ def list_open_incidents(api_key: str) -> list[dict]:
         if len(data) < 100:
             break
         page += 1
+
+    if repo:
+        repo_lower = repo.lower()
+        total_before = len(incidents)
+        filtered = []
+        for inc in incidents:
+            if not inc.get("occurrences"):
+                inc["occurrences"] = _fetch_incident_occurrences(api_key, inc["id"])
+            if _incident_matches_repo(inc, repo_lower):
+                filtered.append(inc)
+        incidents = filtered
+        print(f"  Filtr repo '{repo}': {total_before} -> {len(incidents)} incydentów")
+
     return incidents
+
+
+def _fetch_incident_occurrences(api_key: str, incident_id: int) -> list[dict]:
+    """Pobiera occurrences dla incydentu (wymagane do filtrowania po repo)."""
+    resp = requests.get(
+        f"{BASE_URL}/incidents/secrets/{incident_id}/occurrences",
+        headers=get_headers(api_key),
+        params={"per_page": 20},
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _incident_matches_repo(inc: dict, repo_lower: str) -> bool:
+    """Sprawdza czy incydent dotyczy podanego repozytorium."""
+    for occ in inc.get("occurrences") or []:
+        src = occ.get("source", {})
+        if src and repo_lower in str(src.get("display_name", "")).lower():
+            return True
+    return False
 
 
 def resolve_incident(api_key: str, incident_id: int) -> tuple[bool, str]:
@@ -78,6 +133,7 @@ def resolve_incident(api_key: str, incident_id: int) -> tuple[bool, str]:
         f"{BASE_URL}/incidents/secrets/{incident_id}/resolve",
         headers=get_headers(api_key),
         json={"secret_revoked": True},
+        timeout=REQUEST_TIMEOUT,
     )
     if resp.status_code == 200:
         return True, "RESOLVED"
@@ -90,6 +146,7 @@ def ignore_incident(api_key: str, incident_id: int, reason: str) -> tuple[bool, 
         f"{BASE_URL}/incidents/secrets/{incident_id}/ignore",
         headers=get_headers(api_key),
         json={"ignore_reason": reason},
+        timeout=REQUEST_TIMEOUT,
     )
     if resp.status_code == 200:
         return True, "IGNORED"
@@ -123,9 +180,20 @@ def format_incident(inc: dict) -> str:
     )
 
 
-def cmd_list(api_key: str) -> None:
-    print("Pobieram otwarte incydenty...")
-    incidents = list_open_incidents(api_key)
+def cmd_list(
+    api_key: str,
+    severity: str | None = None,
+    repo: str | None = None,
+) -> None:
+    filters = []
+    if severity:
+        filters.append(f"severity={severity}")
+    if repo:
+        filters.append(f"repo={repo}")
+    filter_str = f" (filtry: {', '.join(filters)})" if filters else ""
+    print(f"Pobieram otwarte incydenty{filter_str}...")
+
+    incidents = list_open_incidents(api_key, severity=severity, repo=repo)
     if not incidents:
         print("\nBrak otwartych incydentów!")
         return
@@ -136,10 +204,16 @@ def cmd_list(api_key: str) -> None:
         print()
 
 
-def cmd_resolve(api_key: str, incident_ids: list[int], resolve_all: bool) -> None:
+def cmd_resolve(
+    api_key: str,
+    incident_ids: list[int],
+    resolve_all: bool,
+    severity: str | None = None,
+    repo: str | None = None,
+) -> None:
     if resolve_all:
         print("Pobieram otwarte incydenty...")
-        incidents = list_open_incidents(api_key)
+        incidents = list_open_incidents(api_key, severity=severity, repo=repo)
         if not incidents:
             print("Brak otwartych incydentów.")
             return
@@ -160,10 +234,17 @@ def cmd_resolve(api_key: str, incident_ids: list[int], resolve_all: bool) -> Non
     print(f"\nGotowe: {ok_count} resolved, {fail_count} failed")
 
 
-def cmd_ignore(api_key: str, incident_ids: list[int], reason: str, ignore_all: bool) -> None:
+def cmd_ignore(
+    api_key: str,
+    incident_ids: list[int],
+    reason: str,
+    ignore_all: bool,
+    severity: str | None = None,
+    repo: str | None = None,
+) -> None:
     if ignore_all:
         print("Pobieram otwarte incydenty...")
-        incidents = list_open_incidents(api_key)
+        incidents = list_open_incidents(api_key, severity=severity, repo=repo)
         if not incidents:
             print("Brak otwartych incydentów.")
             return
@@ -184,6 +265,22 @@ def cmd_ignore(api_key: str, incident_ids: list[int], reason: str, ignore_all: b
     print(f"\nGotowe: {ok_count} ignored, {fail_count} failed")
 
 
+_SEVERITY_CHOICES = ["critical", "high", "medium", "low", "info", "unknown"]
+
+
+def _add_filter_args(parser: argparse.ArgumentParser) -> None:
+    """Dodaje wspólne argumenty filtrujące do subparsera."""
+    parser.add_argument(
+        "--severity",
+        choices=_SEVERITY_CHOICES,
+        help="Filtruj po severity",
+    )
+    parser.add_argument(
+        "--repo",
+        help="Filtruj po nazwie repozytorium (dopasowanie fragmentu, case-insensitive)",
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="GitGuardian Incident Manager - zarządzanie incydentami przez API",
@@ -191,19 +288,26 @@ def main() -> None:
         epilog="""
 Przykłady:
   %(prog)s list
+  %(prog)s list --severity high
+  %(prog)s list --repo lenie-server
+  %(prog)s list --severity critical --repo lenie
   %(prog)s resolve 12345 67890
   %(prog)s resolve --all
+  %(prog)s resolve --all --severity high
   %(prog)s ignore 12345 --reason test_credential
   %(prog)s ignore --all --reason false_positive
+  %(prog)s ignore --all --severity low --reason low_risk
         """,
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers.add_parser("list", help="Wyświetl otwarte incydenty")
+    list_parser = subparsers.add_parser("list", help="Wyświetl otwarte incydenty")
+    _add_filter_args(list_parser)
 
     resolve_parser = subparsers.add_parser("resolve", help="Oznacz incydenty jako resolved")
     resolve_parser.add_argument("ids", nargs="*", type=int, help="ID incydentów do zamknięcia")
     resolve_parser.add_argument("--all", action="store_true", help="Zamknij wszystkie otwarte")
+    _add_filter_args(resolve_parser)
 
     ignore_parser = subparsers.add_parser("ignore", help="Oznacz incydenty jako ignored")
     ignore_parser.add_argument("ids", nargs="*", type=int, help="ID incydentów do zignorowania")
@@ -214,20 +318,21 @@ Przykłady:
         choices=["test_credential", "false_positive", "low_risk"],
         help="Powód ignorowania",
     )
+    _add_filter_args(ignore_parser)
 
     args = parser.parse_args()
     api_key = load_api_key()
 
     if args.command == "list":
-        cmd_list(api_key)
+        cmd_list(api_key, severity=args.severity, repo=args.repo)
     elif args.command == "resolve":
         if not args.all and not args.ids:
             resolve_parser.error("Podaj ID incydentów lub użyj --all")
-        cmd_resolve(api_key, args.ids or [], args.all)
+        cmd_resolve(api_key, args.ids or [], args.all, severity=args.severity, repo=args.repo)
     elif args.command == "ignore":
         if not args.all and not args.ids:
             ignore_parser.error("Podaj ID incydentów lub użyj --all")
-        cmd_ignore(api_key, args.ids or [], args.reason, args.all)
+        cmd_ignore(api_key, args.ids or [], args.reason, args.all, severity=args.severity, repo=args.repo)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_gitguardian_manage_incidents.py
+++ b/scripts/tests/test_gitguardian_manage_incidents.py
@@ -1,0 +1,55 @@
+"""Unit tests for gitguardian_manage_incidents helpers."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from gitguardian_manage_incidents import _incident_matches_repo
+
+
+class TestIncidentMatchesRepo:
+    def test_matches_exact_name(self):
+        inc = {"occurrences": [{"source": {"display_name": "lenie-server-2025"}}]}
+        assert _incident_matches_repo(inc, "lenie-server-2025") is True
+
+    def test_matches_substring(self):
+        inc = {"occurrences": [{"source": {"display_name": "lenie-server-2025"}}]}
+        assert _incident_matches_repo(inc, "lenie") is True
+
+    def test_case_insensitive(self):
+        inc = {"occurrences": [{"source": {"display_name": "Lenie-Server-2025"}}]}
+        assert _incident_matches_repo(inc, "lenie-server") is True
+
+    def test_no_match(self):
+        inc = {"occurrences": [{"source": {"display_name": "other-repo"}}]}
+        assert _incident_matches_repo(inc, "lenie") is False
+
+    def test_empty_occurrences(self):
+        inc = {"occurrences": []}
+        assert _incident_matches_repo(inc, "lenie") is False
+
+    def test_none_occurrences(self):
+        inc = {}
+        assert _incident_matches_repo(inc, "lenie") is False
+
+    def test_missing_source(self):
+        inc = {"occurrences": [{}]}
+        assert _incident_matches_repo(inc, "lenie") is False
+
+    def test_missing_display_name(self):
+        inc = {"occurrences": [{"source": {}}]}
+        assert _incident_matches_repo(inc, "lenie") is False
+
+    def test_multiple_occurrences_one_matches(self):
+        inc = {
+            "occurrences": [
+                {"source": {"display_name": "other-repo"}},
+                {"source": {"display_name": "lenie-server-2025"}},
+            ]
+        }
+        assert _incident_matches_repo(inc, "lenie") is True
+
+    def test_source_is_none(self):
+        inc = {"occurrences": [{"source": None}]}
+        assert _incident_matches_repo(inc, "lenie") is False


### PR DESCRIPTION
## Summary
- Add `--severity` and `--repo` filters to all three commands (`list`, `resolve --all`, `ignore --all`)
- Fix repo filtering: fetch occurrences from detail API endpoint instead of relying on list response (which doesn't include them)
- Add `REQUEST_TIMEOUT=30s` to all HTTP requests to prevent hanging
- Extract shared `_add_filter_args()` helper to eliminate argument duplication
- Add 10 unit tests for `_incident_matches_repo` helper
- Move B-63 to DONE section in sprint-status.yaml (was incorrectly left in backlog section)

## Test plan
- [x] `ruff check scripts/` passes
- [x] 10/10 unit tests pass (`uvx --with requests --with python-dotenv pytest scripts/tests/`)
- [x] CLI `--help` works for all three subcommands with new flags
- [ ] Manual: `list --severity high` returns only high-severity incidents
- [ ] Manual: `list --repo <name>` filters by repository name

🤖 Generated with [Claude Code](https://claude.com/claude-code)