### PR TITLE
feat: implement HashiCorp Vault backend (Story 20-2)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -198,9 +198,9 @@ development_status:
   # ============================================================
 
   # --- Epic 20: Secrets Management — Migrate .env to Vault & AWS SSM ---
-  epic-20: backlog
-  20-1-create-unified-config-loader-module: backlog
-  20-2-implement-hashicorp-vault-backend-docker-nas: backlog
+  epic-20: in-progress
+  20-1-create-unified-config-loader-module: done  # Config, EnvBackend, factory, singleton, 19 unit tests. Commits: 4870e16, 084ec14.
+  20-2-implement-hashicorp-vault-backend-docker-nas: review  # VaultBackend implemented: hvac KV v2, token auth, path secret/lenie/{ENV_DATA}, bootstrap vars merge, 6 unit tests. Pending: real Vault integration test on NAS.
   20-3-implement-aws-ssm-secrets-manager-backend: backlog
   20-4-integrate-config-loader-into-server-and-lambda-handlers: backlog
   20-5-update-env-example-and-document-config-flow: backlog

--- a/backend/library/config_loader.py
+++ b/backend/library/config_loader.py
@@ -1,8 +1,8 @@
 """Unified configuration loader with pluggable backends.
 
-Story 20.1 — provides a centralized Config object that replaces scattered
-os.getenv() calls.  Only the ``env`` backend is functional; ``vault`` and
-``aws`` are stubs for Stories 20.2 / 20.3.
+Provides a centralized Config object that replaces scattered os.getenv()
+calls.  Backends: ``env`` (dotenv), ``vault`` (HashiCorp Vault KV v2),
+``aws`` (stub for Story 20.3).
 
 Usage::
 
@@ -65,6 +65,74 @@ class EnvBackend(ConfigBackend):
         return dict(os.environ)
 
 
+# Bootstrap env vars that are always read from the real environment,
+# regardless of which backend is selected.
+_BOOTSTRAP_VARS = frozenset({
+    "SECRETS_BACKEND",
+    "VAULT_ADDR",
+    "VAULT_TOKEN",
+    "ENV_DATA",
+    "AWS_REGION",
+})
+
+
+class VaultBackend(ConfigBackend):
+    """Loads configuration from HashiCorp Vault KV v2.
+
+    Secrets are stored at ``secret/lenie/{ENV_DATA}`` as a single KV v2
+    secret containing all configuration key-value pairs.
+
+    Bootstrap env vars (``VAULT_ADDR``, ``VAULT_TOKEN``, ``ENV_DATA``)
+    must be set in the real environment (e.g. ``.env`` or shell).
+    """
+
+    def load(self) -> dict[str, str]:
+        vault_addr = os.environ.get("VAULT_ADDR")
+        vault_token = os.environ.get("VAULT_TOKEN")
+        env_data = os.environ.get("ENV_DATA", "dev")
+
+        if not vault_addr:
+            logging.error("VAULT_ADDR must be set when using vault backend")
+            sys.exit(1)
+        if not vault_token:
+            logging.error("VAULT_TOKEN must be set when using vault backend")
+            sys.exit(1)
+
+        try:
+            import hvac
+        except ImportError:
+            logging.error("hvac package is required for vault backend: pip install hvac")
+            sys.exit(1)
+
+        try:
+            client = hvac.Client(url=vault_addr, token=vault_token)
+            if not client.is_authenticated():
+                logging.error(
+                    "Vault authentication failed at %s — check VAULT_TOKEN", vault_addr
+                )
+                sys.exit(1)
+
+            secret_path = f"lenie/{env_data}"
+            logging.info("Vault: reading secret at secret/%s", secret_path)
+            response = client.secrets.kv.v2.read_secret_version(
+                path=secret_path,
+                mount_point="secret",
+            )
+            vault_data = response["data"]["data"]
+        except SystemExit:
+            raise
+        except Exception as exc:
+            logging.error(
+                "Failed to load config from Vault at %s: %s", vault_addr, exc
+            )
+            sys.exit(1)
+
+        # Start with bootstrap env vars, overlay with Vault secrets.
+        result = {k: os.environ[k] for k in _BOOTSTRAP_VARS if k in os.environ}
+        result.update(vault_data)
+        return result
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
@@ -77,9 +145,7 @@ def _create_backend(name: str) -> ConfigBackend:
     if name == "env":
         return EnvBackend()
     if name == "vault":
-        raise NotImplementedError(
-            "Vault backend is not yet implemented (see Story 20.2)."
-        )
+        return VaultBackend()
     if name == "aws":
         raise NotImplementedError(
             "AWS backend is not yet implemented (see Story 20.3)."

--- a/backend/library/config_loader.py
+++ b/backend/library/config_loader.py
@@ -71,6 +71,7 @@ _BOOTSTRAP_VARS = frozenset({
     "SECRETS_BACKEND",
     "VAULT_ADDR",
     "VAULT_TOKEN",
+    "VAULT_ENV",
     "ENV_DATA",
     "AWS_REGION",
 })
@@ -79,17 +80,18 @@ _BOOTSTRAP_VARS = frozenset({
 class VaultBackend(ConfigBackend):
     """Loads configuration from HashiCorp Vault KV v2.
 
-    Secrets are stored at ``secret/lenie/{ENV_DATA}`` as a single KV v2
+    Secrets are stored at ``secret/lenie/{VAULT_ENV}`` as a single KV v2
     secret containing all configuration key-value pairs.
 
-    Bootstrap env vars (``VAULT_ADDR``, ``VAULT_TOKEN``, ``ENV_DATA``)
+    Bootstrap env vars (``VAULT_ADDR``, ``VAULT_TOKEN``, ``VAULT_ENV``)
     must be set in the real environment (e.g. ``.env`` or shell).
+    ``VAULT_ENV`` defaults to ``dev`` if not set.
     """
 
     def load(self) -> dict[str, str]:
         vault_addr = os.environ.get("VAULT_ADDR")
         vault_token = os.environ.get("VAULT_TOKEN")
-        env_data = os.environ.get("ENV_DATA", "dev")
+        vault_env = os.environ.get("VAULT_ENV", "dev")
 
         if not vault_addr:
             logging.error("VAULT_ADDR must be set when using vault backend")
@@ -112,7 +114,7 @@ class VaultBackend(ConfigBackend):
                 )
                 sys.exit(1)
 
-            secret_path = f"lenie/{env_data}"
+            secret_path = f"lenie/{vault_env}"
             logging.info("Vault: reading secret at secret/%s", secret_path)
             response = client.secrets.kv.v2.read_secret_version(
                 path=secret_path,

--- a/backend/tests/unit/test_config_loader.py
+++ b/backend/tests/unit/test_config_loader.py
@@ -1,10 +1,11 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from library.config_loader import (
     Config,
     EnvBackend,
+    VaultBackend,
     _create_backend,
     get_config,
     load_config,
@@ -65,10 +66,9 @@ class TestCreateBackend(unittest.TestCase):
         backend = _create_backend("env")
         self.assertIsInstance(backend, EnvBackend)
 
-    def test_vault_not_implemented(self):
-        with self.assertRaises(NotImplementedError) as ctx:
-            _create_backend("vault")
-        self.assertIn("Story 20.2", str(ctx.exception))
+    def test_vault_backend(self):
+        backend = _create_backend("vault")
+        self.assertIsInstance(backend, VaultBackend)
 
     def test_aws_not_implemented(self):
         with self.assertRaises(NotImplementedError) as ctx:
@@ -107,10 +107,13 @@ class TestLoadConfig(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 load_config()
 
-    def test_vault_backend_not_implemented(self):
+    @patch("library.config_loader.VaultBackend.load")
+    def test_vault_backend_loads(self, mock_vault_load):
+        mock_vault_load.return_value = {"DB_HOST": "vault-host", "ENV_DATA": "dev"}
         with patch.dict(os.environ, {"SECRETS_BACKEND": "vault"}, clear=False):
-            with self.assertRaises(NotImplementedError):
-                load_config()
+            cfg = load_config()
+        self.assertEqual(cfg["DB_HOST"], "vault-host")
+        mock_vault_load.assert_called_once()
 
     def test_aws_backend_not_implemented(self):
         with patch.dict(os.environ, {"SECRETS_BACKEND": "aws"}, clear=False):
@@ -140,6 +143,112 @@ class TestLoadConfig(unittest.TestCase):
             reset_config()
             cfg2 = load_config()
         self.assertIsNot(cfg1, cfg2)
+
+
+class TestVaultBackend(unittest.TestCase):
+    """VaultBackend reads secrets from HashiCorp Vault KV v2."""
+
+    def test_missing_vault_addr_exits(self):
+        with patch.dict(os.environ, {"VAULT_TOKEN": "tok"}, clear=True):
+            backend = VaultBackend()
+            with self.assertRaises(SystemExit):
+                backend.load()
+
+    def test_missing_vault_token_exits(self):
+        with patch.dict(os.environ, {"VAULT_ADDR": "http://vault:8200"}, clear=True):
+            backend = VaultBackend()
+            with self.assertRaises(SystemExit):
+                backend.load()
+
+    @patch("library.config_loader.hvac", create=True)
+    def test_auth_failure_exits(self, mock_hvac_module):
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = False
+        mock_hvac_module.Client.return_value = mock_client
+
+        with patch.dict(os.environ, {
+            "VAULT_ADDR": "http://vault:8200",
+            "VAULT_TOKEN": "bad-token",
+            "ENV_DATA": "dev",
+        }, clear=True):
+            # Need to patch hvac import inside VaultBackend.load()
+            with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
+                backend = VaultBackend()
+                with self.assertRaises(SystemExit):
+                    backend.load()
+
+    @patch("library.config_loader.hvac", create=True)
+    def test_successful_load(self, mock_hvac_module):
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {
+                "data": {
+                    "POSTGRESQL_HOST": "db.vault.local",
+                    "OPENAI_API_KEY": "sk-vault-secret",
+                }
+            }
+        }
+        mock_hvac_module.Client.return_value = mock_client
+
+        with patch.dict(os.environ, {
+            "VAULT_ADDR": "http://vault:8200",
+            "VAULT_TOKEN": "test-token",
+            "ENV_DATA": "dev",
+            "SECRETS_BACKEND": "vault",
+        }, clear=True):
+            with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
+                backend = VaultBackend()
+                result = backend.load()
+
+        # Vault secrets present
+        self.assertEqual(result["POSTGRESQL_HOST"], "db.vault.local")
+        self.assertEqual(result["OPENAI_API_KEY"], "sk-vault-secret")
+        # Bootstrap env vars preserved
+        self.assertEqual(result["VAULT_ADDR"], "http://vault:8200")
+        self.assertEqual(result["ENV_DATA"], "dev")
+        self.assertEqual(result["SECRETS_BACKEND"], "vault")
+        # Correct Vault path called
+        mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="lenie/dev",
+            mount_point="secret",
+        )
+
+    @patch("library.config_loader.hvac", create=True)
+    def test_connection_error_exits(self, mock_hvac_module):
+        mock_hvac_module.Client.side_effect = ConnectionError("refused")
+
+        with patch.dict(os.environ, {
+            "VAULT_ADDR": "http://vault:8200",
+            "VAULT_TOKEN": "tok",
+            "ENV_DATA": "dev",
+        }, clear=True):
+            with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
+                backend = VaultBackend()
+                with self.assertRaises(SystemExit):
+                    backend.load()
+
+    @patch("library.config_loader.hvac", create=True)
+    def test_vault_secret_overrides_bootstrap(self, mock_hvac_module):
+        """Vault secrets take precedence over bootstrap env vars."""
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {"data": {"ENV_DATA": "prod"}}
+        }
+        mock_hvac_module.Client.return_value = mock_client
+
+        with patch.dict(os.environ, {
+            "VAULT_ADDR": "http://vault:8200",
+            "VAULT_TOKEN": "tok",
+            "ENV_DATA": "dev",
+        }, clear=True):
+            with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
+                backend = VaultBackend()
+                result = backend.load()
+
+        # Vault value overrides bootstrap
+        self.assertEqual(result["ENV_DATA"], "prod")
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_config_loader.py
+++ b/backend/tests/unit/test_config_loader.py
@@ -169,7 +169,7 @@ class TestVaultBackend(unittest.TestCase):
         with patch.dict(os.environ, {
             "VAULT_ADDR": "http://vault:8200",
             "VAULT_TOKEN": "bad-token",
-            "ENV_DATA": "dev",
+            "VAULT_ENV": "dev",
         }, clear=True):
             # Need to patch hvac import inside VaultBackend.load()
             with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
@@ -194,7 +194,7 @@ class TestVaultBackend(unittest.TestCase):
         with patch.dict(os.environ, {
             "VAULT_ADDR": "http://vault:8200",
             "VAULT_TOKEN": "test-token",
-            "ENV_DATA": "dev",
+            "VAULT_ENV": "dev",
             "SECRETS_BACKEND": "vault",
         }, clear=True):
             with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
@@ -206,7 +206,7 @@ class TestVaultBackend(unittest.TestCase):
         self.assertEqual(result["OPENAI_API_KEY"], "sk-vault-secret")
         # Bootstrap env vars preserved
         self.assertEqual(result["VAULT_ADDR"], "http://vault:8200")
-        self.assertEqual(result["ENV_DATA"], "dev")
+        self.assertEqual(result["VAULT_ENV"], "dev")
         self.assertEqual(result["SECRETS_BACKEND"], "vault")
         # Correct Vault path called
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
@@ -221,7 +221,7 @@ class TestVaultBackend(unittest.TestCase):
         with patch.dict(os.environ, {
             "VAULT_ADDR": "http://vault:8200",
             "VAULT_TOKEN": "tok",
-            "ENV_DATA": "dev",
+            "VAULT_ENV": "dev",
         }, clear=True):
             with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
                 backend = VaultBackend()
@@ -241,7 +241,7 @@ class TestVaultBackend(unittest.TestCase):
         with patch.dict(os.environ, {
             "VAULT_ADDR": "http://vault:8200",
             "VAULT_TOKEN": "tok",
-            "ENV_DATA": "dev",
+            "VAULT_ENV": "dev",
         }, clear=True):
             with patch.dict("sys.modules", {"hvac": mock_hvac_module}):
                 backend = VaultBackend()

--- a/docs/CICD/Vault_Setup.md
+++ b/docs/CICD/Vault_Setup.md
@@ -1,0 +1,198 @@
+# HashiCorp Vault Setup
+
+Vault stores application secrets for Project Lenie. Runs on the NAS as a Docker container with persistent file storage.
+
+> **Related docs:** [NAS_Deployment.md](NAS_Deployment.md) — full NAS stack, [../development-guide.md](../development-guide.md) — dev setup.
+
+## Architecture
+
+```
+secret/lenie/dev     -- development environment secrets (54 keys)
+secret/lenie/prod    -- production (future)
+secret/lenie/qa      -- QA (future)
+```
+
+All configuration keys for a given environment are stored as a single KV v2 secret. The backend reads them via `config_loader.py` using the `hvac` library.
+
+## NAS Installation (Docker)
+
+### 1. Create directories
+
+```bash
+mkdir -p /share/vault/data /share/vault/config
+```
+
+### 2. Copy configuration file
+
+From the developer machine:
+
+```bash
+scp docs/CICD/vault.hcl admin@192.168.200.7:/share/vault/config/vault.hcl
+```
+
+Configuration (`vault.hcl`):
+
+```hcl
+storage "file" {
+  path = "/vault/file"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = 1
+}
+
+ui = true
+api_addr = "http://0.0.0.0:8200"
+```
+
+### 3. Start the container
+
+```bash
+docker run -d \
+  --name vault \
+  --restart=unless-stopped \
+  --cap-add=IPC_LOCK \
+  -p 8210:8200 \
+  -v /share/vault/data:/vault/file \
+  -v /share/vault/config:/vault/config \
+  hashicorp/vault:1.21.3 vault server -config=/vault/config/vault.hcl
+```
+
+### 4. Initialize (one-time)
+
+```bash
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 vault operator init -key-shares=1 -key-threshold=1"
+```
+
+**Save the Unseal Key and Root Token!** They are required for unsealing after restarts and for admin operations.
+
+### 5. Unseal
+
+Required after every container restart:
+
+```bash
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 vault operator unseal <UNSEAL_KEY>"
+```
+
+### 6. Enable KV v2 engine
+
+```bash
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=<ROOT_TOKEN> vault secrets enable -path=secret kv-v2"
+```
+
+### 7. Create a working token
+
+```bash
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=<ROOT_TOKEN> vault token create -ttl=8760h -policy=root"
+```
+
+Use the generated token as `VAULT_TOKEN` in `.env`.
+
+## Environment Variables
+
+Add to your `.env` file:
+
+```bash
+VAULT_ADDR=http://192.168.200.7:8210
+VAULT_TOKEN=hvs.xxxxxxxxxxxxx
+VAULT_ENV=dev                          # optional, defaults to "dev"
+SECRETS_BACKEND=vault                  # set to "vault" to use Vault instead of .env
+```
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `VAULT_ADDR` | Vault server URL (NAS port 8210) | Yes |
+| `VAULT_TOKEN` | Authentication token | Yes |
+| `VAULT_ENV` | Environment name for secret path (`dev`, `prod`, `qa`). Default: `dev` | No |
+| `SECRETS_BACKEND` | Set to `vault` to activate Vault backend in `config_loader.py` | Yes |
+
+## Managing Secrets (`scripts/env_to_vault.py`)
+
+Python script for managing secrets in Vault. Requires `hvac` package. Reads `VAULT_ADDR` and `VAULT_TOKEN` from `.env`.
+
+### Full migration from .env
+
+```bash
+# Dry-run (shows what would be uploaded, no changes)
+python scripts/env_to_vault.py upload --env dev
+
+# Actually write all variables to Vault
+python scripts/env_to_vault.py upload --env dev --write
+
+# Upload from a different .env file to a different environment
+python scripts/env_to_vault.py upload --env prod --env-file .env.prod --write
+```
+
+Bootstrap variables (`VAULT_ADDR`, `VAULT_TOKEN`, `SECRETS_BACKEND`) are automatically excluded from the upload.
+
+### Add or update keys (patch)
+
+```bash
+# Set a single key (other keys are untouched)
+python scripts/env_to_vault.py set --env dev NEW_KEY=new_value
+
+# Set multiple keys at once
+python scripts/env_to_vault.py set --env dev KEY1=value1 KEY2=value2
+```
+
+### Delete keys
+
+```bash
+# Delete a single key
+python scripts/env_to_vault.py delete --env dev OLD_KEY
+
+# Delete multiple keys
+python scripts/env_to_vault.py delete --env dev KEY1 KEY2
+```
+
+### List and read keys
+
+```bash
+# List all keys (values are masked)
+python scripts/env_to_vault.py list --env dev
+
+# Get the actual value of a key
+python scripts/env_to_vault.py get --env dev OPENAI_API_KEY
+```
+
+## Web UI
+
+Vault UI is available at: http://192.168.200.7:8210/ui/vault/auth
+
+Log in with a valid token to browse and manage secrets via the web interface.
+
+## Token Management
+
+Tokens expire. The working token created in step 7 has a TTL of 8760 hours (1 year).
+
+**Check token status:**
+
+```bash
+curl -s -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/auth/token/lookup-self | python -m json.tool
+```
+
+**Create a new token** (requires root token):
+
+```bash
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=<ROOT_TOKEN> vault token create -ttl=8760h -policy=root"
+```
+
+**If root token is lost** and you have the unseal key:
+
+```bash
+# Start root token generation
+docker exec -it vault sh -c "VAULT_ADDR=http://127.0.0.1:8200 vault operator generate-root -init"
+
+# Provide unseal key
+docker exec -it vault sh -c "VAULT_ADDR=http://127.0.0.1:8200 vault operator generate-root"
+
+# Decode the encoded token
+docker exec -it vault sh -c \
+  "VAULT_ADDR=http://127.0.0.1:8200 vault operator generate-root -decode=<ENCODED_TOKEN> -otp=<OTP>"
+```

--- a/docs/CICD/vault.hcl
+++ b/docs/CICD/vault.hcl
@@ -1,0 +1,11 @@
+storage "file" {
+  path = "/vault/file"
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:8200"
+  tls_disable = 1
+}
+
+ui = true
+api_addr = "http://0.0.0.0:8200"

--- a/scripts/env_to_vault.py
+++ b/scripts/env_to_vault.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Manage secrets in HashiCorp Vault KV v2.
+
+Supports full .env migration and individual key operations (set, delete, list, get).
+
+Usage:
+    # Full .env migration
+    python scripts/env_to_vault.py upload --env dev                     # dry-run
+    python scripts/env_to_vault.py upload --env dev --write             # write all
+    python scripts/env_to_vault.py upload --env prod --env-file .env.prod --write
+
+    # Single key operations
+    python scripts/env_to_vault.py set --env dev KEY=value              # set/update one key
+    python scripts/env_to_vault.py set --env dev K1=v1 K2=v2            # set multiple keys
+    python scripts/env_to_vault.py delete --env dev KEY                 # delete one key
+    python scripts/env_to_vault.py delete --env dev K1 K2               # delete multiple keys
+    python scripts/env_to_vault.py list --env dev                       # list all keys
+    python scripts/env_to_vault.py get --env dev KEY                    # get value of one key
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import hvac
+except ImportError:
+    print("ERROR: hvac package required. Install: pip install hvac")
+    sys.exit(1)
+
+# Variables that stay in the real environment -- not uploaded to Vault.
+SKIP_VARS = {
+    "VAULT_ADDR",
+    "VAULT_TOKEN",
+    "SECRETS_BACKEND",
+}
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a .env file into a dict, skipping comments and empty lines."""
+    result = {}
+    with open(path, encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            if not key:
+                continue
+            result[key] = value
+    return result
+
+
+def get_vault_client(env_file: str = ".env") -> tuple:
+    """Read VAULT_ADDR and VAULT_TOKEN from .env, return (client, addr)."""
+    env_path = Path(env_file)
+    if not env_path.exists():
+        print(f"ERROR: {env_path} not found")
+        sys.exit(1)
+
+    all_vars = parse_env_file(env_path)
+    vault_addr = all_vars.get("VAULT_ADDR")
+    vault_token = all_vars.get("VAULT_TOKEN")
+
+    if not vault_addr:
+        print("ERROR: VAULT_ADDR not found in .env")
+        sys.exit(1)
+    if not vault_token:
+        print("ERROR: VAULT_TOKEN not found in .env")
+        sys.exit(1)
+
+    client = hvac.Client(url=vault_addr, token=vault_token)
+    if not client.is_authenticated():
+        print(f"ERROR: Vault authentication failed at {vault_addr}")
+        sys.exit(1)
+
+    return client, vault_addr
+
+
+def read_current_secret(client, secret_path: str) -> dict[str, str]:
+    """Read current secret from Vault. Returns empty dict if not found."""
+    try:
+        response = client.secrets.kv.v2.read_secret_version(
+            path=secret_path,
+            mount_point="secret",
+            raise_on_deleted_version=True,
+        )
+        return dict(response["data"]["data"])
+    except hvac.exceptions.InvalidPath:
+        return {}
+
+
+def mask_value(value: str) -> str:
+    """Mask a secret value for display."""
+    return value[:3] + "***" if len(value) > 3 else "***"
+
+
+# -- Commands ---------------------------------------------------------------
+
+
+def cmd_upload(args):
+    """Upload all variables from .env to Vault."""
+    env_path = Path(args.env_file)
+    if not env_path.exists():
+        print(f"ERROR: {env_path} not found")
+        sys.exit(1)
+
+    all_vars = parse_env_file(env_path)
+    print(f"Parsed {len(all_vars)} variables from {env_path}")
+
+    vault_addr = all_vars.get("VAULT_ADDR")
+    vault_token = all_vars.get("VAULT_TOKEN")
+    if not vault_addr or not vault_token:
+        print("ERROR: VAULT_ADDR and VAULT_TOKEN must be in .env")
+        sys.exit(1)
+
+    upload_vars = {k: v for k, v in all_vars.items() if k not in SKIP_VARS}
+    secret_path = f"lenie/{args.env}"
+
+    print(f"Variables to upload: {len(upload_vars)} (skipping: {', '.join(sorted(SKIP_VARS))})")
+    print(f"Vault target: {vault_addr} -> secret/{secret_path}")
+    print()
+
+    for key in sorted(upload_vars.keys()):
+        print(f"  {key} = {mask_value(upload_vars[key])}")
+    print()
+
+    if not args.write:
+        print("DRY RUN -- no changes made. Use --write to upload to Vault.")
+        return
+
+    client = hvac.Client(url=vault_addr, token=vault_token)
+    if not client.is_authenticated():
+        print(f"ERROR: Vault authentication failed at {vault_addr}")
+        sys.exit(1)
+
+    response = client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret=upload_vars,
+        mount_point="secret",
+    )
+    version = response["data"]["version"]
+    print(f"SUCCESS -- wrote {len(upload_vars)} variables to secret/{secret_path} (version {version})")
+
+
+def cmd_set(args):
+    """Set (add or update) one or more keys using patch."""
+    if not args.pairs:
+        print("ERROR: provide at least one KEY=VALUE pair")
+        sys.exit(1)
+
+    updates = {}
+    for pair in args.pairs:
+        if "=" not in pair:
+            print(f"ERROR: invalid format '{pair}', expected KEY=VALUE")
+            sys.exit(1)
+        key, _, value = pair.partition("=")
+        updates[key.strip()] = value.strip()
+
+    client, vault_addr = get_vault_client(args.env_file)
+    secret_path = f"lenie/{args.env}"
+
+    print(f"Vault: {vault_addr} -> secret/{secret_path}")
+    print(f"Setting {len(updates)} key(s):")
+    for key, value in sorted(updates.items()):
+        print(f"  {key} = {mask_value(value)}")
+
+    response = client.secrets.kv.v2.patch(
+        path=secret_path,
+        secret=updates,
+        mount_point="secret",
+    )
+    version = response["data"]["version"]
+    print(f"SUCCESS -- patched {len(updates)} key(s) (version {version})")
+
+
+def cmd_delete(args):
+    """Delete one or more keys from the secret."""
+    if not args.keys:
+        print("ERROR: provide at least one KEY to delete")
+        sys.exit(1)
+
+    client, vault_addr = get_vault_client(args.env_file)
+    secret_path = f"lenie/{args.env}"
+
+    current = read_current_secret(client, secret_path)
+    if not current:
+        print(f"ERROR: no secret found at secret/{secret_path}")
+        sys.exit(1)
+
+    missing = [k for k in args.keys if k not in current]
+    if missing:
+        print(f"WARNING: keys not found in Vault (skipping): {', '.join(missing)}")
+
+    to_delete = [k for k in args.keys if k in current]
+    if not to_delete:
+        print("Nothing to delete.")
+        return
+
+    for key in to_delete:
+        del current[key]
+
+    print(f"Vault: {vault_addr} -> secret/{secret_path}")
+    print(f"Deleting {len(to_delete)} key(s): {', '.join(to_delete)}")
+
+    response = client.secrets.kv.v2.create_or_update_secret(
+        path=secret_path,
+        secret=current,
+        mount_point="secret",
+    )
+    version = response["data"]["version"]
+    print(f"SUCCESS -- removed {len(to_delete)} key(s), {len(current)} remaining (version {version})")
+
+
+def cmd_list(args):
+    """List all keys in the secret."""
+    client, vault_addr = get_vault_client(args.env_file)
+    secret_path = f"lenie/{args.env}"
+
+    current = read_current_secret(client, secret_path)
+    if not current:
+        print(f"No secret found at secret/{secret_path}")
+        return
+
+    print(f"Vault: {vault_addr} -> secret/{secret_path}")
+    print(f"{len(current)} key(s):")
+    print()
+    for key in sorted(current.keys()):
+        print(f"  {key} = {mask_value(current[key])}")
+
+
+def cmd_get(args):
+    """Get the value of a single key."""
+    if not args.key:
+        print("ERROR: provide a KEY name")
+        sys.exit(1)
+
+    client, vault_addr = get_vault_client(args.env_file)
+    secret_path = f"lenie/{args.env}"
+
+    current = read_current_secret(client, secret_path)
+    if args.key not in current:
+        print(f"ERROR: key '{args.key}' not found at secret/{secret_path}")
+        sys.exit(1)
+
+    print(current[args.key])
+
+
+# -- Main -------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage secrets in Vault KV v2")
+    parser.add_argument(
+        "--env-file",
+        default=".env",
+        help="Path to .env file for Vault connection (default: .env)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # upload
+    p_upload = subparsers.add_parser("upload", help="Upload all .env variables to Vault")
+    p_upload.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+    p_upload.add_argument("--write", action="store_true", help="Actually write (default: dry-run)")
+
+    # set
+    p_set = subparsers.add_parser("set", help="Set (add/update) key(s) via patch")
+    p_set.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+    p_set.add_argument("pairs", nargs="+", help="KEY=VALUE pairs")
+
+    # delete
+    p_delete = subparsers.add_parser("delete", help="Delete key(s) from secret")
+    p_delete.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+    p_delete.add_argument("keys", nargs="+", help="Key names to delete")
+
+    # list
+    p_list = subparsers.add_parser("list", help="List all keys in secret")
+    p_list.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+
+    # get
+    p_get = subparsers.add_parser("get", help="Get value of a single key")
+    p_get.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+    p_get.add_argument("key", help="Key name")
+
+    args = parser.parse_args()
+
+    commands = {
+        "upload": cmd_upload,
+        "set": cmd_set,
+        "delete": cmd_delete,
+        "list": cmd_list,
+        "get": cmd_get,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `VaultBackend` class to `config_loader.py` — reads secrets from HashiCorp Vault KV v2 at `secret/lenie/{ENV_DATA}`
- Token-based auth via `hvac` library, bootstrap env vars (`VAULT_ADDR`, `VAULT_TOKEN`, `ENV_DATA`, `AWS_REGION`, `SECRETS_BACKEND`) preserved and merged with Vault secrets
- Vault secrets override bootstrap vars when keys collide
- 6 new unit tests: missing vars exit, auth failure exit, connection error exit, successful load with correct path, bootstrap var preservation, secret override precedence
- All 25 config_loader tests passing

## Test plan
- [x] Unit tests pass (25/25): `cd backend && PYTHONPATH=. uvx --with python-dotenv --with hvac pytest tests/unit/test_config_loader.py -v`
- [x] Ruff lint passes
- [x] Pre-commit hooks (Gitleaks + TruffleHog) pass
- [ ] Manual integration test with real Vault instance on NAS (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)