### PR TITLE
feat: implement AWS SSM Parameter Store backend (Story 20-3)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -200,8 +200,8 @@ development_status:
   # --- Epic 20: Secrets Management — Migrate .env to Vault & AWS SSM ---
   epic-20: in-progress
   20-1-create-unified-config-loader-module: done  # Config, EnvBackend, factory, singleton, 19 unit tests. Commits: 4870e16, 084ec14.
-  20-2-implement-hashicorp-vault-backend-docker-nas: review  # VaultBackend implemented: hvac KV v2, token auth, path secret/lenie/{ENV_DATA}, bootstrap vars merge, 6 unit tests. Pending: real Vault integration test on NAS.
-  20-3-implement-aws-ssm-secrets-manager-backend: backlog
+  20-2-implement-hashicorp-vault-backend-docker-nas: done  # VaultBackend: hvac KV v2, VAULT_ENV path, bootstrap vars, env_to_vault.py script, 6 unit tests. Tested on NAS Vault.
+  20-3-implement-aws-ssm-secrets-manager-backend: review  # AWSSSMBackend: SSM GetParametersByPath, SecureString, /lenie/{env}/ path. Script extended with ssm+sync commands, 5 unit tests. Tested on AWS us-east-1.
   20-4-integrate-config-loader-into-server-and-lambda-handlers: backlog
   20-5-update-env-example-and-document-config-flow: backlog
   epic-20-retrospective: optional

--- a/backend/library/config_loader.py
+++ b/backend/library/config_loader.py
@@ -2,7 +2,7 @@
 
 Provides a centralized Config object that replaces scattered os.getenv()
 calls.  Backends: ``env`` (dotenv), ``vault`` (HashiCorp Vault KV v2),
-``aws`` (stub for Story 20.3).
+``aws`` (AWS SSM Parameter Store).
 
 Usage::
 
@@ -135,6 +135,58 @@ class VaultBackend(ConfigBackend):
         return result
 
 
+class AWSSSMBackend(ConfigBackend):
+    """Loads configuration from AWS SSM Parameter Store.
+
+    All parameters are stored as SecureString under
+    ``/lenie/{VAULT_ENV}/<key>`` and loaded via ``GetParametersByPath``.
+
+    Bootstrap env vars (``AWS_REGION``, ``VAULT_ENV``) must be set in
+    the real environment.  ``VAULT_ENV`` defaults to ``dev``.
+    Uses default boto3 credential chain (env vars, profile, instance role).
+    """
+
+    def load(self) -> dict[str, str]:
+        vault_env = os.environ.get("VAULT_ENV", "dev")
+        aws_region = os.environ.get("AWS_REGION", "eu-central-1")
+
+        try:
+            import boto3
+        except ImportError:
+            logging.error("boto3 package is required for aws backend: pip install boto3")
+            sys.exit(1)
+
+        prefix = f"/lenie/{vault_env}/"
+        logging.info("AWS SSM: reading parameters under %s (region: %s)", prefix, aws_region)
+
+        try:
+            session = boto3.Session(region_name=aws_region)
+            ssm = session.client("ssm")
+
+            params = {}
+            paginator = ssm.get_paginator("get_parameters_by_path")
+            for page in paginator.paginate(
+                Path=prefix,
+                Recursive=False,
+                WithDecryption=True,
+            ):
+                for param in page["Parameters"]:
+                    key = param["Name"][len(prefix):]
+                    params[key] = param["Value"]
+
+        except Exception as exc:
+            logging.error("Failed to load config from AWS SSM (%s): %s", prefix, exc)
+            sys.exit(1)
+
+        if not params:
+            logging.warning("AWS SSM: no parameters found under %s", prefix)
+
+        # Start with bootstrap env vars, overlay with SSM parameters.
+        result = {k: os.environ[k] for k in _BOOTSTRAP_VARS if k in os.environ}
+        result.update(params)
+        return result
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
@@ -149,9 +201,7 @@ def _create_backend(name: str) -> ConfigBackend:
     if name == "vault":
         return VaultBackend()
     if name == "aws":
-        raise NotImplementedError(
-            "AWS backend is not yet implemented (see Story 20.3)."
-        )
+        return AWSSSMBackend()
     logging.error(
         "Unknown SECRETS_BACKEND value: '%s'. Valid options: %s",
         name,

--- a/backend/tests/unit/test_config_loader.py
+++ b/backend/tests/unit/test_config_loader.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from library.config_loader import (
+    AWSSSMBackend,
     Config,
     EnvBackend,
     VaultBackend,
@@ -70,10 +71,9 @@ class TestCreateBackend(unittest.TestCase):
         backend = _create_backend("vault")
         self.assertIsInstance(backend, VaultBackend)
 
-    def test_aws_not_implemented(self):
-        with self.assertRaises(NotImplementedError) as ctx:
-            _create_backend("aws")
-        self.assertIn("Story 20.3", str(ctx.exception))
+    def test_aws_backend(self):
+        backend = _create_backend("aws")
+        self.assertIsInstance(backend, AWSSSMBackend)
 
     def test_unknown_backend_exits(self):
         with self.assertRaises(SystemExit):
@@ -115,10 +115,13 @@ class TestLoadConfig(unittest.TestCase):
         self.assertEqual(cfg["DB_HOST"], "vault-host")
         mock_vault_load.assert_called_once()
 
-    def test_aws_backend_not_implemented(self):
+    @patch("library.config_loader.AWSSSMBackend.load")
+    def test_aws_backend_loads(self, mock_ssm_load):
+        mock_ssm_load.return_value = {"DB_HOST": "ssm-host", "ENV_DATA": "dev"}
         with patch.dict(os.environ, {"SECRETS_BACKEND": "aws"}, clear=False):
-            with self.assertRaises(NotImplementedError):
-                load_config()
+            cfg = load_config()
+        self.assertEqual(cfg["DB_HOST"], "ssm-host")
+        mock_ssm_load.assert_called_once()
 
     @patch("library.config_loader.load_dotenv")
     def test_singleton_same_instance(self, mock_dotenv):
@@ -248,6 +251,133 @@ class TestVaultBackend(unittest.TestCase):
                 result = backend.load()
 
         # Vault value overrides bootstrap
+        self.assertEqual(result["ENV_DATA"], "prod")
+
+
+class TestAWSSSMBackend(unittest.TestCase):
+    """AWSSSMBackend reads secrets from AWS SSM Parameter Store."""
+
+    @patch("library.config_loader.boto3", create=True)
+    def test_successful_load(self, mock_boto3_module):
+        mock_ssm = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Parameters": [
+                    {"Name": "/lenie/dev/POSTGRESQL_HOST", "Value": "db.ssm.local"},
+                    {"Name": "/lenie/dev/OPENAI_API_KEY", "Value": "sk-ssm-secret"},
+                ]
+            }
+        ]
+        mock_ssm.get_paginator.return_value = mock_paginator
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_ssm
+        mock_boto3_module.Session.return_value = mock_session
+
+        with patch.dict(os.environ, {
+            "VAULT_ENV": "dev",
+            "AWS_REGION": "eu-central-1",
+            "SECRETS_BACKEND": "aws",
+        }, clear=True):
+            with patch.dict("sys.modules", {"boto3": mock_boto3_module}):
+                backend = AWSSSMBackend()
+                result = backend.load()
+
+        self.assertEqual(result["POSTGRESQL_HOST"], "db.ssm.local")
+        self.assertEqual(result["OPENAI_API_KEY"], "sk-ssm-secret")
+        # Bootstrap env vars preserved
+        self.assertEqual(result["VAULT_ENV"], "dev")
+        self.assertEqual(result["AWS_REGION"], "eu-central-1")
+        self.assertEqual(result["SECRETS_BACKEND"], "aws")
+        # Correct path used
+        mock_paginator.paginate.assert_called_once_with(
+            Path="/lenie/dev/",
+            Recursive=False,
+            WithDecryption=True,
+        )
+
+    @patch("library.config_loader.boto3", create=True)
+    def test_default_env_is_dev(self, mock_boto3_module):
+        mock_ssm = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Parameters": [{"Name": "/lenie/dev/KEY", "Value": "val"}]}
+        ]
+        mock_ssm.get_paginator.return_value = mock_paginator
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_ssm
+        mock_boto3_module.Session.return_value = mock_session
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.dict("sys.modules", {"boto3": mock_boto3_module}):
+                backend = AWSSSMBackend()
+                result = backend.load()
+
+        # Default VAULT_ENV=dev, so path is /lenie/dev/
+        mock_paginator.paginate.assert_called_once_with(
+            Path="/lenie/dev/",
+            Recursive=False,
+            WithDecryption=True,
+        )
+        self.assertEqual(result["KEY"], "val")
+
+    @patch("library.config_loader.boto3", create=True)
+    def test_connection_error_exits(self, mock_boto3_module):
+        mock_boto3_module.Session.side_effect = Exception("No credentials")
+
+        with patch.dict(os.environ, {
+            "VAULT_ENV": "dev",
+            "AWS_REGION": "eu-central-1",
+        }, clear=True):
+            with patch.dict("sys.modules", {"boto3": mock_boto3_module}):
+                backend = AWSSSMBackend()
+                with self.assertRaises(SystemExit):
+                    backend.load()
+
+    @patch("library.config_loader.boto3", create=True)
+    def test_empty_result_warns_but_returns(self, mock_boto3_module):
+        mock_ssm = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"Parameters": []}]
+        mock_ssm.get_paginator.return_value = mock_paginator
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_ssm
+        mock_boto3_module.Session.return_value = mock_session
+
+        with patch.dict(os.environ, {
+            "VAULT_ENV": "dev",
+            "AWS_REGION": "eu-central-1",
+        }, clear=True):
+            with patch.dict("sys.modules", {"boto3": mock_boto3_module}):
+                backend = AWSSSMBackend()
+                result = backend.load()
+
+        # Should return bootstrap vars even with no SSM params
+        self.assertEqual(result["VAULT_ENV"], "dev")
+        self.assertNotIn("POSTGRESQL_HOST", result)
+
+    @patch("library.config_loader.boto3", create=True)
+    def test_ssm_overrides_bootstrap(self, mock_boto3_module):
+        """SSM parameters take precedence over bootstrap env vars."""
+        mock_ssm = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {"Parameters": [{"Name": "/lenie/dev/ENV_DATA", "Value": "prod"}]}
+        ]
+        mock_ssm.get_paginator.return_value = mock_paginator
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_ssm
+        mock_boto3_module.Session.return_value = mock_session
+
+        with patch.dict(os.environ, {
+            "VAULT_ENV": "dev",
+            "AWS_REGION": "eu-central-1",
+            "ENV_DATA": "dev",
+        }, clear=True):
+            with patch.dict("sys.modules", {"boto3": mock_boto3_module}):
+                backend = AWSSSMBackend()
+                result = backend.load()
+
         self.assertEqual(result["ENV_DATA"], "prod")
 
 

--- a/docs/CICD/Vault_Setup.md
+++ b/docs/CICD/Vault_Setup.md
@@ -113,51 +113,58 @@ SECRETS_BACKEND=vault                  # set to "vault" to use Vault instead of 
 
 ## Managing Secrets (`scripts/env_to_vault.py`)
 
-Python script for managing secrets in Vault. Requires `hvac` package. Reads `VAULT_ADDR` and `VAULT_TOKEN` from `.env`.
+Unified script for managing secrets in both Vault and AWS SSM Parameter Store. Supports full migration, individual key operations, and synchronization between backends.
 
-### Full migration from .env
+Requirements: `hvac` (for Vault), `boto3` (for SSM).
+
+Bootstrap variables (`VAULT_ADDR`, `VAULT_TOKEN`, `SECRETS_BACKEND`) are automatically excluded from uploads.
+
+### Vault commands
 
 ```bash
-# Dry-run (shows what would be uploaded, no changes)
-python scripts/env_to_vault.py upload --env dev
+# Full migration from .env
+python scripts/env_to_vault.py vault upload --env dev                  # dry-run
+python scripts/env_to_vault.py vault upload --env dev --write          # write all
 
-# Actually write all variables to Vault
-python scripts/env_to_vault.py upload --env dev --write
-
-# Upload from a different .env file to a different environment
-python scripts/env_to_vault.py upload --env prod --env-file .env.prod --write
+# Single key operations
+python scripts/env_to_vault.py vault set --env dev KEY=value           # add/update (patch)
+python scripts/env_to_vault.py vault set --env dev K1=v1 K2=v2        # multiple keys
+python scripts/env_to_vault.py vault delete --env dev KEY              # delete key
+python scripts/env_to_vault.py vault list --env dev                    # list all (masked)
+python scripts/env_to_vault.py vault get --env dev OPENAI_API_KEY      # get actual value
 ```
 
-Bootstrap variables (`VAULT_ADDR`, `VAULT_TOKEN`, `SECRETS_BACKEND`) are automatically excluded from the upload.
+### AWS SSM Parameter Store commands
 
-### Add or update keys (patch)
+All parameters stored as `SecureString` under `/lenie/{env}/`. Uses default boto3 credential chain.
 
 ```bash
-# Set a single key (other keys are untouched)
-python scripts/env_to_vault.py set --env dev NEW_KEY=new_value
+# Full migration from .env
+python scripts/env_to_vault.py ssm upload --env dev                    # dry-run
+python scripts/env_to_vault.py ssm upload --env dev --write            # write all
 
-# Set multiple keys at once
-python scripts/env_to_vault.py set --env dev KEY1=value1 KEY2=value2
+# Single key operations
+python scripts/env_to_vault.py ssm set --env dev KEY=value             # add/update
+python scripts/env_to_vault.py ssm delete --env dev KEY                # delete
+python scripts/env_to_vault.py ssm list --env dev                      # list all (masked)
+python scripts/env_to_vault.py ssm get --env dev OPENAI_API_KEY        # get actual value
+
+# Optional AWS flags (for all ssm commands)
+python scripts/env_to_vault.py ssm list --env dev --region eu-central-1
+python scripts/env_to_vault.py ssm list --env dev --profile lenie-ai-2025-admin
 ```
 
-### Delete keys
+### Sync between backends
+
+Compares source and target, shows diff, writes only new/changed keys. Does **not** delete keys that exist only in the target.
 
 ```bash
-# Delete a single key
-python scripts/env_to_vault.py delete --env dev OLD_KEY
+# Vault -> SSM
+python scripts/env_to_vault.py sync --env dev --from vault --to ssm            # dry-run
+python scripts/env_to_vault.py sync --env dev --from vault --to ssm --write    # actually sync
 
-# Delete multiple keys
-python scripts/env_to_vault.py delete --env dev KEY1 KEY2
-```
-
-### List and read keys
-
-```bash
-# List all keys (values are masked)
-python scripts/env_to_vault.py list --env dev
-
-# Get the actual value of a key
-python scripts/env_to_vault.py get --env dev OPENAI_API_KEY
+# SSM -> Vault
+python scripts/env_to_vault.py sync --env dev --from ssm --to vault --write
 ```
 
 ## Web UI

--- a/scripts/env_to_vault.py
+++ b/scripts/env_to_vault.py
@@ -179,9 +179,10 @@ SSM_TAGS = [
 
 
 def ssm_put_parameter(ssm_client, env: str, key: str, value: str):
-    """Put a single parameter to SSM as SecureString with tags."""
+    """Put a single parameter to SSM as SecureString with tags and description."""
     name = f"{ssm_path_prefix(env)}{key}"
     tags = SSM_TAGS + [{"Key": "environment", "Value": env}]
+    description = f"Lenie {env} | managed by env_to_vault.py"
 
     # SSM doesn't allow Tags on Overwrite, so we try create first.
     try:
@@ -189,6 +190,7 @@ def ssm_put_parameter(ssm_client, env: str, key: str, value: str):
             Name=name,
             Value=value,
             Type="SecureString",
+            Description=description,
             Tags=tags,
         )
     except ssm_client.exceptions.ParameterAlreadyExists:
@@ -197,6 +199,7 @@ def ssm_put_parameter(ssm_client, env: str, key: str, value: str):
             Name=name,
             Value=value,
             Type="SecureString",
+            Description=description,
             Overwrite=True,
         )
 

--- a/scripts/env_to_vault.py
+++ b/scripts/env_to_vault.py
@@ -1,34 +1,36 @@
 #!/usr/bin/env python3
-"""Manage secrets in HashiCorp Vault KV v2.
+"""Manage secrets in HashiCorp Vault KV v2 and AWS SSM Parameter Store.
 
-Supports full .env migration and individual key operations (set, delete, list, get).
+Supports full .env migration, individual key operations, and sync between backends.
 
 Usage:
-    # Full .env migration
-    python scripts/env_to_vault.py upload --env dev                     # dry-run
-    python scripts/env_to_vault.py upload --env dev --write             # write all
-    python scripts/env_to_vault.py upload --env prod --env-file .env.prod --write
+    # --- Vault commands ---
+    python scripts/env_to_vault.py vault upload --env dev                  # dry-run
+    python scripts/env_to_vault.py vault upload --env dev --write          # write all
+    python scripts/env_to_vault.py vault set --env dev KEY=value           # patch one key
+    python scripts/env_to_vault.py vault delete --env dev KEY              # delete key
+    python scripts/env_to_vault.py vault list --env dev                    # list keys
+    python scripts/env_to_vault.py vault get --env dev KEY                 # get value
 
-    # Single key operations
-    python scripts/env_to_vault.py set --env dev KEY=value              # set/update one key
-    python scripts/env_to_vault.py set --env dev K1=v1 K2=v2            # set multiple keys
-    python scripts/env_to_vault.py delete --env dev KEY                 # delete one key
-    python scripts/env_to_vault.py delete --env dev K1 K2               # delete multiple keys
-    python scripts/env_to_vault.py list --env dev                       # list all keys
-    python scripts/env_to_vault.py get --env dev KEY                    # get value of one key
+    # --- SSM Parameter Store commands ---
+    python scripts/env_to_vault.py ssm upload --env dev                    # dry-run
+    python scripts/env_to_vault.py ssm upload --env dev --write            # write all
+    python scripts/env_to_vault.py ssm set --env dev KEY=value             # set one key
+    python scripts/env_to_vault.py ssm delete --env dev KEY                # delete key
+    python scripts/env_to_vault.py ssm list --env dev                      # list keys
+    python scripts/env_to_vault.py ssm get --env dev KEY                   # get value
+
+    # --- Sync between backends ---
+    python scripts/env_to_vault.py sync --env dev --from vault --to ssm    # dry-run
+    python scripts/env_to_vault.py sync --env dev --from vault --to ssm --write
+    python scripts/env_to_vault.py sync --env dev --from ssm --to vault --write
 """
 
 import argparse
 import sys
 from pathlib import Path
 
-try:
-    import hvac
-except ImportError:
-    print("ERROR: hvac package required. Install: pip install hvac")
-    sys.exit(1)
-
-# Variables that stay in the real environment -- not uploaded to Vault.
+# Variables that stay in the real environment -- not uploaded to backends.
 SKIP_VARS = {
     "VAULT_ADDR",
     "VAULT_TOKEN",
@@ -57,8 +59,28 @@ def parse_env_file(path: Path) -> dict[str, str]:
     return result
 
 
-def get_vault_client(env_file: str = ".env") -> tuple:
+def mask_value(value: str) -> str:
+    """Mask a secret value for display."""
+    return value[:3] + "***" if len(value) > 3 else "***"
+
+
+# ===========================================================================
+# Vault helpers
+# ===========================================================================
+
+
+def _require_hvac():
+    try:
+        import hvac
+        return hvac
+    except ImportError:
+        print("ERROR: hvac package required. Install: pip install hvac")
+        sys.exit(1)
+
+
+def get_vault_client(env_file: str = ".env"):
     """Read VAULT_ADDR and VAULT_TOKEN from .env, return (client, addr)."""
+    hvac = _require_hvac()
     env_path = Path(env_file)
     if not env_path.exists():
         print(f"ERROR: {env_path} not found")
@@ -83,8 +105,9 @@ def get_vault_client(env_file: str = ".env") -> tuple:
     return client, vault_addr
 
 
-def read_current_secret(client, secret_path: str) -> dict[str, str]:
-    """Read current secret from Vault. Returns empty dict if not found."""
+def vault_read_all(client, secret_path: str) -> dict[str, str]:
+    """Read all keys from a Vault KV v2 secret."""
+    hvac = _require_hvac()
     try:
         response = client.secrets.kv.v2.read_secret_version(
             path=secret_path,
@@ -96,16 +119,102 @@ def read_current_secret(client, secret_path: str) -> dict[str, str]:
         return {}
 
 
-def mask_value(value: str) -> str:
-    """Mask a secret value for display."""
-    return value[:3] + "***" if len(value) > 3 else "***"
+# ===========================================================================
+# SSM helpers
+# ===========================================================================
 
 
-# -- Commands ---------------------------------------------------------------
+def _require_boto3():
+    try:
+        import boto3
+        return boto3
+    except ImportError:
+        print("ERROR: boto3 package required. Install: pip install boto3")
+        sys.exit(1)
 
 
-def cmd_upload(args):
+def get_ssm_client(env_file: str = ".env", region: str = None, profile: str = None):
+    """Create an SSM client using boto3. Returns (ssm_client, region)."""
+    boto3 = _require_boto3()
+
+    all_vars = parse_env_file(Path(env_file)) if Path(env_file).exists() else {}
+    effective_region = region or all_vars.get("AWS_REGION", "eu-central-1")
+
+    session_kwargs = {}
+    if profile:
+        session_kwargs["profile_name"] = profile
+    session_kwargs["region_name"] = effective_region
+
+    session = boto3.Session(**session_kwargs)
+    ssm = session.client("ssm")
+    return ssm, effective_region
+
+
+def ssm_path_prefix(env: str) -> str:
+    """Return the SSM parameter path prefix for an environment."""
+    return f"/lenie/{env}/"
+
+
+def ssm_read_all(ssm_client, env: str) -> dict[str, str]:
+    """Read all parameters under /lenie/{env}/ from SSM."""
+    prefix = ssm_path_prefix(env)
+    result = {}
+    paginator = ssm_client.get_paginator("get_parameters_by_path")
+    for page in paginator.paginate(
+        Path=prefix,
+        Recursive=False,
+        WithDecryption=True,
+    ):
+        for param in page["Parameters"]:
+            # Strip prefix to get key name: /lenie/dev/MY_KEY -> MY_KEY
+            key = param["Name"][len(prefix):]
+            result[key] = param["Value"]
+    return result
+
+
+SSM_TAGS = [
+    {"Key": "managed-by", "Value": "env-to-vault-script"},
+    {"Key": "project", "Value": "lenie"},
+]
+
+
+def ssm_put_parameter(ssm_client, env: str, key: str, value: str):
+    """Put a single parameter to SSM as SecureString with tags."""
+    name = f"{ssm_path_prefix(env)}{key}"
+    tags = SSM_TAGS + [{"Key": "environment", "Value": env}]
+
+    # SSM doesn't allow Tags on Overwrite, so we try create first.
+    try:
+        ssm_client.put_parameter(
+            Name=name,
+            Value=value,
+            Type="SecureString",
+            Tags=tags,
+        )
+    except ssm_client.exceptions.ParameterAlreadyExists:
+        # Parameter exists -- overwrite (tags are preserved).
+        ssm_client.put_parameter(
+            Name=name,
+            Value=value,
+            Type="SecureString",
+            Overwrite=True,
+        )
+
+
+def ssm_delete_parameter(ssm_client, env: str, key: str):
+    """Delete a single parameter from SSM."""
+    name = f"{ssm_path_prefix(env)}{key}"
+    ssm_client.delete_parameter(Name=name)
+
+
+# ===========================================================================
+# Vault commands
+# ===========================================================================
+
+
+def cmd_vault_upload(args):
     """Upload all variables from .env to Vault."""
+    hvac = _require_hvac()
     env_path = Path(args.env_file)
     if not env_path.exists():
         print(f"ERROR: {env_path} not found")
@@ -149,7 +258,7 @@ def cmd_upload(args):
     print(f"SUCCESS -- wrote {len(upload_vars)} variables to secret/{secret_path} (version {version})")
 
 
-def cmd_set(args):
+def cmd_vault_set(args):
     """Set (add or update) one or more keys using patch."""
     if not args.pairs:
         print("ERROR: provide at least one KEY=VALUE pair")
@@ -180,8 +289,8 @@ def cmd_set(args):
     print(f"SUCCESS -- patched {len(updates)} key(s) (version {version})")
 
 
-def cmd_delete(args):
-    """Delete one or more keys from the secret."""
+def cmd_vault_delete(args):
+    """Delete one or more keys from the Vault secret."""
     if not args.keys:
         print("ERROR: provide at least one KEY to delete")
         sys.exit(1)
@@ -189,7 +298,7 @@ def cmd_delete(args):
     client, vault_addr = get_vault_client(args.env_file)
     secret_path = f"lenie/{args.env}"
 
-    current = read_current_secret(client, secret_path)
+    current = vault_read_all(client, secret_path)
     if not current:
         print(f"ERROR: no secret found at secret/{secret_path}")
         sys.exit(1)
@@ -218,12 +327,12 @@ def cmd_delete(args):
     print(f"SUCCESS -- removed {len(to_delete)} key(s), {len(current)} remaining (version {version})")
 
 
-def cmd_list(args):
-    """List all keys in the secret."""
+def cmd_vault_list(args):
+    """List all keys in the Vault secret."""
     client, vault_addr = get_vault_client(args.env_file)
     secret_path = f"lenie/{args.env}"
 
-    current = read_current_secret(client, secret_path)
+    current = vault_read_all(client, secret_path)
     if not current:
         print(f"No secret found at secret/{secret_path}")
         return
@@ -235,8 +344,8 @@ def cmd_list(args):
         print(f"  {key} = {mask_value(current[key])}")
 
 
-def cmd_get(args):
-    """Get the value of a single key."""
+def cmd_vault_get(args):
+    """Get the value of a single key from Vault."""
     if not args.key:
         print("ERROR: provide a KEY name")
         sys.exit(1)
@@ -244,7 +353,7 @@ def cmd_get(args):
     client, vault_addr = get_vault_client(args.env_file)
     secret_path = f"lenie/{args.env}"
 
-    current = read_current_secret(client, secret_path)
+    current = vault_read_all(client, secret_path)
     if args.key not in current:
         print(f"ERROR: key '{args.key}' not found at secret/{secret_path}")
         sys.exit(1)
@@ -252,52 +361,334 @@ def cmd_get(args):
     print(current[args.key])
 
 
-# -- Main -------------------------------------------------------------------
+# ===========================================================================
+# SSM commands
+# ===========================================================================
+
+
+def cmd_ssm_upload(args):
+    """Upload all variables from .env to SSM Parameter Store."""
+    env_path = Path(args.env_file)
+    if not env_path.exists():
+        print(f"ERROR: {env_path} not found")
+        sys.exit(1)
+
+    all_vars = parse_env_file(env_path)
+    print(f"Parsed {len(all_vars)} variables from {env_path}")
+
+    upload_vars = {k: v for k, v in all_vars.items() if k not in SKIP_VARS}
+    prefix = ssm_path_prefix(args.env)
+
+    print(f"Variables to upload: {len(upload_vars)} (skipping: {', '.join(sorted(SKIP_VARS))})")
+    print(f"SSM target: {prefix}*  (region: {args.region or 'from .env/default'})")
+    print()
+
+    for key in sorted(upload_vars.keys()):
+        print(f"  {prefix}{key} = {mask_value(upload_vars[key])}")
+    print()
+
+    if not args.write:
+        print("DRY RUN -- no changes made. Use --write to upload to SSM.")
+        return
+
+    ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+    print(f"SSM region: {region}")
+
+    for i, (key, value) in enumerate(sorted(upload_vars.items()), 1):
+        ssm_put_parameter(ssm, args.env, key, value)
+        if i % 10 == 0:
+            print(f"  ... {i}/{len(upload_vars)}")
+
+    print(f"SUCCESS -- wrote {len(upload_vars)} parameters to SSM under {prefix}")
+
+
+def cmd_ssm_set(args):
+    """Set (add/update) one or more SSM parameters."""
+    if not args.pairs:
+        print("ERROR: provide at least one KEY=VALUE pair")
+        sys.exit(1)
+
+    updates = {}
+    for pair in args.pairs:
+        if "=" not in pair:
+            print(f"ERROR: invalid format '{pair}', expected KEY=VALUE")
+            sys.exit(1)
+        key, _, value = pair.partition("=")
+        updates[key.strip()] = value.strip()
+
+    ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+    prefix = ssm_path_prefix(args.env)
+
+    print(f"SSM: {prefix}*  (region: {region})")
+    print(f"Setting {len(updates)} key(s):")
+    for key, value in sorted(updates.items()):
+        print(f"  {prefix}{key} = {mask_value(value)}")
+
+    for key, value in updates.items():
+        ssm_put_parameter(ssm, args.env, key, value)
+
+    print(f"SUCCESS -- wrote {len(updates)} parameter(s)")
+
+
+def cmd_ssm_delete(args):
+    """Delete one or more SSM parameters."""
+    if not args.keys:
+        print("ERROR: provide at least one KEY to delete")
+        sys.exit(1)
+
+    ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+    prefix = ssm_path_prefix(args.env)
+
+    print(f"SSM: {prefix}*  (region: {region})")
+    print(f"Deleting {len(args.keys)} key(s):")
+
+    deleted = 0
+    for key in args.keys:
+        try:
+            ssm_delete_parameter(ssm, args.env, key)
+            print(f"  {key} -- deleted")
+            deleted += 1
+        except ssm.exceptions.ParameterNotFound:
+            print(f"  {key} -- not found (skipping)")
+
+    print(f"SUCCESS -- deleted {deleted} parameter(s)")
+
+
+def cmd_ssm_list(args):
+    """List all SSM parameters under /lenie/{env}/."""
+    ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+    prefix = ssm_path_prefix(args.env)
+
+    current = ssm_read_all(ssm, args.env)
+    if not current:
+        print(f"No parameters found under {prefix}")
+        return
+
+    print(f"SSM: {prefix}*  (region: {region})")
+    print(f"{len(current)} parameter(s):")
+    print()
+    for key in sorted(current.keys()):
+        print(f"  {key} = {mask_value(current[key])}")
+
+
+def cmd_ssm_get(args):
+    """Get the value of a single SSM parameter."""
+    if not args.key:
+        print("ERROR: provide a KEY name")
+        sys.exit(1)
+
+    ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+    name = f"{ssm_path_prefix(args.env)}{args.key}"
+
+    try:
+        response = ssm.get_parameter(Name=name, WithDecryption=True)
+        print(response["Parameter"]["Value"])
+    except ssm.exceptions.ParameterNotFound:
+        print(f"ERROR: parameter '{name}' not found")
+        sys.exit(1)
+
+
+# ===========================================================================
+# Sync command
+# ===========================================================================
+
+
+def cmd_sync(args):
+    """Synchronize secrets between Vault and SSM."""
+    source_name = args.source
+    target_name = args.target
+
+    if source_name == target_name:
+        print("ERROR: --from and --to must be different")
+        sys.exit(1)
+
+    # Read source
+    if source_name == "vault":
+        client, vault_addr = get_vault_client(args.env_file)
+        secret_path = f"lenie/{args.env}"
+        source_data = vault_read_all(client, secret_path)
+        print(f"Source: Vault ({vault_addr} -> secret/{secret_path})")
+    else:
+        ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+        source_data = ssm_read_all(ssm, args.env)
+        print(f"Source: SSM ({ssm_path_prefix(args.env)}*, region: {region})")
+
+    if not source_data:
+        print("ERROR: source has no data")
+        sys.exit(1)
+
+    print(f"  {len(source_data)} key(s) in source")
+
+    # Read target for comparison
+    if target_name == "vault":
+        if source_name != "vault":
+            client, vault_addr = get_vault_client(args.env_file)
+        secret_path = f"lenie/{args.env}"
+        target_data = vault_read_all(client, secret_path)
+        print(f"Target: Vault ({vault_addr} -> secret/{secret_path})")
+    else:
+        if source_name != "ssm":
+            ssm, region = get_ssm_client(args.env_file, args.region, args.profile)
+        target_data = ssm_read_all(ssm, args.env)
+        print(f"Target: SSM ({ssm_path_prefix(args.env)}*, region: {region})")
+
+    print(f"  {len(target_data)} key(s) in target")
+    print()
+
+    # Compute diff
+    new_keys = sorted(set(source_data) - set(target_data))
+    changed_keys = sorted(k for k in source_data if k in target_data and source_data[k] != target_data[k])
+    removed_keys = sorted(set(target_data) - set(source_data))
+
+    if not new_keys and not changed_keys:
+        print("Already in sync -- no changes needed.")
+        return
+
+    if new_keys:
+        print(f"New keys ({len(new_keys)}):")
+        for k in new_keys:
+            print(f"  + {k} = {mask_value(source_data[k])}")
+        print()
+
+    if changed_keys:
+        print(f"Changed keys ({len(changed_keys)}):")
+        for k in changed_keys:
+            print(f"  ~ {k} = {mask_value(target_data[k])} -> {mask_value(source_data[k])}")
+        print()
+
+    if removed_keys:
+        print(f"Keys only in target ({len(removed_keys)}) -- will NOT be deleted:")
+        for k in removed_keys:
+            print(f"  ? {k}")
+        print()
+
+    total = len(new_keys) + len(changed_keys)
+    if not args.write:
+        print(f"DRY RUN -- {total} key(s) would be written. Use --write to sync.")
+        return
+
+    # Write to target
+    keys_to_write = new_keys + changed_keys
+    if target_name == "vault":
+        # Merge into existing vault secret
+        merged = dict(target_data)
+        for k in keys_to_write:
+            merged[k] = source_data[k]
+        response = client.secrets.kv.v2.create_or_update_secret(
+            path=secret_path,
+            secret=merged,
+            mount_point="secret",
+        )
+        version = response["data"]["version"]
+        print(f"SUCCESS -- wrote {total} key(s) to Vault (version {version})")
+    else:
+        for i, key in enumerate(keys_to_write, 1):
+            ssm_put_parameter(ssm, args.env, key, source_data[key])
+            if i % 10 == 0:
+                print(f"  ... {i}/{total}")
+        print(f"SUCCESS -- wrote {total} parameter(s) to SSM")
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+
+
+def add_ssm_args(parser):
+    """Add common SSM arguments to a parser."""
+    parser.add_argument("--region", default=None, help="AWS region (default: from .env or eu-central-1)")
+    parser.add_argument("--profile", default=None, help="AWS profile name")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Manage secrets in Vault KV v2")
+    parser = argparse.ArgumentParser(
+        description="Manage secrets in Vault and AWS SSM Parameter Store"
+    )
     parser.add_argument(
         "--env-file",
         default=".env",
-        help="Path to .env file for Vault connection (default: .env)",
+        help="Path to .env file (default: .env)",
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    backend_parsers = parser.add_subparsers(dest="backend", required=True)
 
-    # upload
-    p_upload = subparsers.add_parser("upload", help="Upload all .env variables to Vault")
-    p_upload.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
-    p_upload.add_argument("--write", action="store_true", help="Actually write (default: dry-run)")
+    # ---- vault ----
+    vault_parser = backend_parsers.add_parser("vault", help="HashiCorp Vault KV v2")
+    vault_sub = vault_parser.add_subparsers(dest="command", required=True)
 
-    # set
-    p_set = subparsers.add_parser("set", help="Set (add/update) key(s) via patch")
-    p_set.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
-    p_set.add_argument("pairs", nargs="+", help="KEY=VALUE pairs")
+    p = vault_sub.add_parser("upload", help="Upload all .env variables")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("--write", action="store_true", help="Actually write (default: dry-run)")
 
-    # delete
-    p_delete = subparsers.add_parser("delete", help="Delete key(s) from secret")
-    p_delete.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
-    p_delete.add_argument("keys", nargs="+", help="Key names to delete")
+    p = vault_sub.add_parser("set", help="Set key(s) via patch")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("pairs", nargs="+", help="KEY=VALUE pairs")
 
-    # list
-    p_list = subparsers.add_parser("list", help="List all keys in secret")
-    p_list.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
+    p = vault_sub.add_parser("delete", help="Delete key(s)")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("keys", nargs="+", help="Key names")
 
-    # get
-    p_get = subparsers.add_parser("get", help="Get value of a single key")
-    p_get.add_argument("--env", required=True, help="Environment name (dev, prod, qa)")
-    p_get.add_argument("key", help="Key name")
+    p = vault_sub.add_parser("list", help="List all keys")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+
+    p = vault_sub.add_parser("get", help="Get value of a key")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("key", help="Key name")
+
+    # ---- ssm ----
+    ssm_parser = backend_parsers.add_parser("ssm", help="AWS SSM Parameter Store")
+    ssm_sub = ssm_parser.add_subparsers(dest="command", required=True)
+
+    p = ssm_sub.add_parser("upload", help="Upload all .env variables")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("--write", action="store_true", help="Actually write (default: dry-run)")
+    add_ssm_args(p)
+
+    p = ssm_sub.add_parser("set", help="Set key(s)")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("pairs", nargs="+", help="KEY=VALUE pairs")
+    add_ssm_args(p)
+
+    p = ssm_sub.add_parser("delete", help="Delete key(s)")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("keys", nargs="+", help="Key names")
+    add_ssm_args(p)
+
+    p = ssm_sub.add_parser("list", help="List all keys")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    add_ssm_args(p)
+
+    p = ssm_sub.add_parser("get", help="Get value of a key")
+    p.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    p.add_argument("key", help="Key name")
+    add_ssm_args(p)
+
+    # ---- sync ----
+    sync_parser = backend_parsers.add_parser("sync", help="Sync between Vault and SSM")
+    sync_parser.add_argument("--env", required=True, help="Environment (dev, prod, qa)")
+    sync_parser.add_argument("--from", dest="source", required=True, choices=["vault", "ssm"], help="Source backend")
+    sync_parser.add_argument("--to", dest="target", required=True, choices=["vault", "ssm"], help="Target backend")
+    sync_parser.add_argument("--write", action="store_true", help="Actually sync (default: dry-run)")
+    add_ssm_args(sync_parser)
 
     args = parser.parse_args()
 
     commands = {
-        "upload": cmd_upload,
-        "set": cmd_set,
-        "delete": cmd_delete,
-        "list": cmd_list,
-        "get": cmd_get,
+        ("vault", "upload"): cmd_vault_upload,
+        ("vault", "set"): cmd_vault_set,
+        ("vault", "delete"): cmd_vault_delete,
+        ("vault", "list"): cmd_vault_list,
+        ("vault", "get"): cmd_vault_get,
+        ("ssm", "upload"): cmd_ssm_upload,
+        ("ssm", "set"): cmd_ssm_set,
+        ("ssm", "delete"): cmd_ssm_delete,
+        ("ssm", "list"): cmd_ssm_list,
+        ("ssm", "get"): cmd_ssm_get,
     }
-    commands[args.command](args)
+
+    if args.backend == "sync":
+        cmd_sync(args)
+    else:
+        commands[(args.backend, args.command)](args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `AWSSSMBackend` to `config_loader.py` — reads parameters from SSM via `GetParametersByPath` under `/lenie/{VAULT_ENV}/` with `SecureString` decryption
- Extend `scripts/env_to_vault.py` with `ssm` subcommands (`upload`, `set`, `delete`, `list`, `get`) and `sync` command for Vault<->SSM synchronization
- New SSM parameters are tagged (`managed-by: env-to-vault-script`, `project: lenie`, `environment: dev`) to distinguish from CloudFormation-managed params
- 5 new unit tests for AWSSSMBackend (successful load, default env, connection error, empty result, override bootstrap vars)
- Updated docs/CICD/Vault_Setup.md with SSM and sync command documentation

## Test results
- Unit tests: **30/30 passing**
- Ruff lint: clean
- Real AWS SSM test: 54 params uploaded to `us-east-1`, config_loader read 63 keys successfully
- Sync dry-run: Vault (54 keys) and SSM (59 keys) confirmed in sync
- Tagging: 55 params tagged, 4 CloudFormation params correctly skipped

## Test plan
- [x] Unit tests pass: `cd backend && PYTHONPATH=. uvx --with python-dotenv --with hvac pytest tests/unit/test_config_loader.py -v`
- [x] SSM upload tested on real AWS (`ssm upload --env dev --write`)
- [x] SSM list/get verified
- [x] config_loader with `SECRETS_BACKEND=aws` loads from SSM
- [x] Sync vault->ssm dry-run shows "Already in sync"
- [x] Pre-commit hooks pass (Gitleaks + TruffleHog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)