### PR TITLE
fix: install vault/aws extras in slack bot Docker image

### DIFF
--- a/slack_bot/Dockerfile
+++ b/slack_bot/Dockerfile
@@ -15,8 +15,8 @@ COPY shared_python/unified-config-loader/ /shared_python/unified-config-loader/
 # Copy dependency files
 COPY slack_bot/pyproject.toml slack_bot/uv.lock ./
 
-# Install dependencies
-RUN uv sync --frozen --no-dev --no-install-project
+# Install dependencies (include vault + aws extras for secret backends)
+RUN uv sync --frozen --no-dev --no-install-project --extra vault --extra aws
 
 # Copy source code
 COPY slack_bot/src/ src/


### PR DESCRIPTION
## Summary

- Fix: Slack bot Dockerfile was missing `--extra vault --extra aws` in `uv sync`, causing crash on startup when `SECRETS_BACKEND=vault` or `SECRETS_BACKEND=aws` (missing `hvac`/`boto3`)

## Test plan

- [x] Verify Dockerfile change is syntactically correct
- [ ] `docker compose --profile slack build` with `SECRETS_BACKEND=vault` and verify bot starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)