### PR TITLE
feat: add backend connectivity check to Slack bot startup

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -78,7 +78,7 @@ CORS(app)  # This will enable CORS for all routes
 
 @app.before_request
 def before_request_func():
-    exempt_paths = ['/startup', '/readiness', '/liveness', '/version']
+    exempt_paths = ['/healthz', '/startup', '/readiness', '/liveness', '/version']
     if request.path not in exempt_paths and request.method != 'OPTIONS':
         check_auth_header()
 

--- a/slack_bot/src/api_client.py
+++ b/slack_bot/src/api_client.py
@@ -82,6 +82,10 @@ class LenieApiClient:
                 response_body=resp.text[:MAX_ERROR_BODY_LENGTH],
             ) from exc
 
+    def check_health(self) -> dict:
+        """GET /healthz — returns backend health status (no auth required)."""
+        return self._request("GET", "/healthz")
+
     def get_version(self) -> dict:
         """GET /version — returns backend version info."""
         return self._request("GET", "/version")

--- a/slack_bot/src/commands.py
+++ b/slack_bot/src/commands.py
@@ -13,15 +13,13 @@ from src.api_client import (
     ApiConnectionError,
     ApiError,
     ApiResponseError,
-    create_client,
+    LenieApiClient,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from slack_bolt import App
-    from src.api_client import LenieApiClient
-    from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -153,9 +151,8 @@ def _handle_info(ack: Callable, respond: Callable, client: LenieApiClient, comma
         respond(text="Unexpected response from backend")
 
 
-def register_commands(app: App, cfg: Config) -> None:
+def register_commands(app: App, client: LenieApiClient) -> None:
     """Register all slash commands on the Slack Bolt app."""
-    client = create_client(cfg)
     logger.info("Registering slash commands")
 
     @app.command("/lenie-version")

--- a/slack_bot/src/main.py
+++ b/slack_bot/src/main.py
@@ -14,6 +14,7 @@ from typing import Any
 from pythonjsonlogger import jsonlogger
 
 from src import __version__
+from src.api_client import ApiConnectionError, ApiError, LenieApiClient, create_client
 from src.commands import register_commands
 from src.config import Config, load_config
 
@@ -30,6 +31,29 @@ def setup_logging() -> None:
     root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+
+
+def check_backend_connectivity(client: LenieApiClient) -> None:
+    """Check if the Lenie backend is reachable by calling GET /healthz."""
+    logger = logging.getLogger(__name__)
+    try:
+        client.check_health()
+    except ApiConnectionError as exc:
+        logger.warning("Backend is NOT reachable: %s", exc.message)
+        return
+    except ApiError as exc:
+        logger.warning("Backend health check failed: %s", exc.message)
+        return
+
+    try:
+        data = client.get_version()
+        logger.info(
+            "Backend connection OK — version %s, build %s",
+            data.get("app_version", "unknown"),
+            data.get("app_build_time", "unknown"),
+        )
+    except ApiError:
+        logger.info("Backend is reachable but /version endpoint unavailable")
 
 
 def post_startup_message(app: Any, cfg: Config) -> None:
@@ -70,13 +94,16 @@ def main() -> None:
         logger.error("slack-bolt package is required: pip install slack-bolt")
         sys.exit(1)
 
+    api_client = create_client(cfg)
+
     app = App(token=bot_token)
-    register_commands(app, cfg)
+    register_commands(app, api_client)
 
     handler = SocketModeHandler(app, app_token)
     handler.connect()
     logger.info("Socket Mode connection established")
 
+    check_backend_connectivity(api_client)
     post_startup_message(app, cfg)
 
     logger.info("Bot is running. Press Ctrl+C to stop.")

--- a/slack_bot/tests/unit/test_commands.py
+++ b/slack_bot/tests/unit/test_commands.py
@@ -14,6 +14,7 @@ from src.commands import (
 )
 
 
+
 # --- Helpers ---
 
 
@@ -232,11 +233,9 @@ class TestHandleCount:
 class TestRegisterCommands:
     def test_registers_version_and_count_commands(self):
         app = MagicMock()
-        cfg = MagicMock()
+        client = _make_mock_client()
 
-        with patch("src.commands.create_client") as mock_create:
-            mock_create.return_value = MagicMock()
-            register_commands(app, cfg)
+        register_commands(app, client)
 
         # Verify app.command was called for both slash commands
         command_calls = [c for c in app.command.call_args_list]
@@ -244,14 +243,14 @@ class TestRegisterCommands:
         assert "/lenie-version" in registered
         assert "/lenie-count" in registered
 
-    def test_creates_client_from_config(self):
+    def test_uses_provided_client(self):
         app = MagicMock()
-        cfg = MagicMock()
+        client = _make_mock_client()
 
-        with patch("src.commands.create_client") as mock_create:
-            mock_create.return_value = MagicMock()
-            register_commands(app, cfg)
-            mock_create.assert_called_once_with(cfg)
+        register_commands(app, client)
+
+        # Should register commands without creating a new client
+        assert app.command.call_count == 5
 
 
 # --- Task 5.1-5.3: Test /lenie-add ---
@@ -659,11 +658,9 @@ class TestRegisterCommandsAll:
     def test_registers_all_five_commands(self):
         """5.13: Verify all 5 commands registered (2 from 21-3 + 3 new)."""
         app = MagicMock()
-        cfg = MagicMock()
+        client = _make_mock_client()
 
-        with patch("src.commands.create_client") as mock_create:
-            mock_create.return_value = MagicMock()
-            register_commands(app, cfg)
+        register_commands(app, client)
 
         command_calls = [c for c in app.command.call_args_list]
         registered = {c.args[0] for c in command_calls}

--- a/slack_bot/tests/unit/test_main.py
+++ b/slack_bot/tests/unit/test_main.py
@@ -3,8 +3,9 @@
 import logging
 from unittest.mock import MagicMock
 
+from src.api_client import ApiConnectionError, ApiError
 from src.config import Config
-from src.main import post_startup_message, setup_logging
+from src.main import check_backend_connectivity, post_startup_message, setup_logging
 
 
 class TestSetupLogging:
@@ -24,6 +25,60 @@ class TestSetupLogging:
         setup_logging()
         root = logging.getLogger()
         assert root.level == logging.INFO
+
+
+class TestCheckBackendConnectivity:
+    """Tests for check_backend_connectivity."""
+
+    def test_logs_success_with_version_info(self, caplog):
+        client = MagicMock()
+        client.check_health.return_value = {"status": "OK"}
+        client.get_version.return_value = {
+            "app_version": "0.3.13.0",
+            "app_build_time": "2026.01.23 04:04",
+        }
+        with caplog.at_level(logging.INFO):
+            check_backend_connectivity(client)
+        assert "Backend connection OK" in caplog.text
+        assert "0.3.13.0" in caplog.text
+        assert "2026.01.23 04:04" in caplog.text
+
+    def test_logs_warning_on_connection_error(self, caplog):
+        client = MagicMock()
+        client.check_health.side_effect = ApiConnectionError("Connection refused")
+        with caplog.at_level(logging.WARNING):
+            check_backend_connectivity(client)
+        assert "Backend is NOT reachable" in caplog.text
+        assert "Connection refused" in caplog.text
+
+    def test_logs_warning_on_health_api_error(self, caplog):
+        client = MagicMock()
+        client.check_health.side_effect = ApiError("Internal error")
+        with caplog.at_level(logging.WARNING):
+            check_backend_connectivity(client)
+        assert "Backend health check failed" in caplog.text
+        assert "Internal error" in caplog.text
+
+    def test_does_not_raise_on_connection_error(self):
+        client = MagicMock()
+        client.check_health.side_effect = ApiConnectionError("timeout")
+        # Should not raise
+        check_backend_connectivity(client)
+
+    def test_health_ok_but_version_fails_logs_info(self, caplog):
+        """Backend reachable via /healthz but /version returns error."""
+        client = MagicMock()
+        client.check_health.return_value = {"status": "OK"}
+        client.get_version.side_effect = ApiError("non-JSON response")
+        with caplog.at_level(logging.INFO):
+            check_backend_connectivity(client)
+        assert "Backend is reachable but /version endpoint unavailable" in caplog.text
+
+    def test_does_not_call_version_if_health_fails(self):
+        client = MagicMock()
+        client.check_health.side_effect = ApiConnectionError("timeout")
+        check_backend_connectivity(client)
+        client.get_version.assert_not_called()
 
 
 class TestPostStartupMessage:


### PR DESCRIPTION
## Summary
- Add backend health check at Slack bot startup — calls `/healthz` then `/version` to verify connectivity and log backend version
- Refactor `register_commands()` to accept `LenieApiClient` directly, eliminating duplicate client creation
- Fix missing `/healthz` in `exempt_paths` in `backend/server.py` (was requiring auth for health check endpoint)

## Changes
- `slack_bot/src/main.py` — new `check_backend_connectivity()`, single client creation in `main()`
- `slack_bot/src/api_client.py` — new `check_health()` method
- `slack_bot/src/commands.py` — `register_commands(app, client)` signature change
- `backend/server.py` — `/healthz` added to auth-exempt paths
- 6 new unit tests (106 total, all passing)

## Test plan
- [x] All 106 slack_bot unit tests pass
- [x] Ruff lint clean
- [ ] Deploy and verify health check logs in Docker/NAS environment
- [ ] Verify Slack bot starts correctly when backend is down (graceful warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)