### PR TITLE
feat: Slack Bot, unified config loader, NAS Compose deployment (Epics 20-22)

### DIFF
--- a/_bmad-output/implementation-artifacts/22-1-nas-deployment-end-to-end-verification.md
+++ b/_bmad-output/implementation-artifacts/22-1-nas-deployment-end-to-end-verification.md
@@ -1,0 +1,381 @@
+# Story 22.1: NAS Deployment & End-to-End Verification
+
+Status: in-progress
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer**,
+I want to deploy the Slack Bot to NAS with full Docker Compose infrastructure (registry, MinIO, compose migration),
+So that I have a repeatable deployment pipeline and confidence the MVP works on a real environment.
+
+## Acceptance Criteria
+
+1. **Given** the NAS has Docker and existing containers running individually
+   **When** developer sets up the Docker registry, updates compose.nas.yaml, and runs `nas-deploy.sh`
+   **Then** all services (including Slack Bot and MinIO) run via Docker Compose on `lenie-net` network
+
+2. **Given** the private Docker registry is running on NAS
+   **When** developer runs `./infra/docker/nas-deploy.sh slack-bot`
+   **Then** the image is built locally, pushed to registry, pulled on NAS, and container starts
+
+3. **Given** the bot is running on NAS with real backend
+   **When** user types each of the 5 slash commands in Slack
+   **Then** all commands return correct data from the real backend
+
+4. **Given** MinIO is running on NAS
+   **When** developer accesses `http://192.168.200.7:9001`
+   **Then** MinIO web console is accessible and `website-content` bucket exists
+
+5. **Given** deployment procedure is verified
+   **When** developer documents the process
+   **Then** `docs/CICD/NAS_Deployment.md` reflects the current state
+
+**Covers:** FR21, FR24 | NFR2, NFR5, NFR8
+
+## Tasks / Subtasks
+
+### Part A: Docker Registry Setup
+
+- [x] Task 1: Start private Docker registry on NAS (AC: #2)
+  - [x] 1.1: SSH to NAS, start registry container (registry:2 on port 5005, volume lenie-registry-data)
+  - [x] 1.2: Configure insecure-registries on NAS docker.json
+  - [x] 1.3: Configure insecure-registries on PC (Docker Desktop UI)
+  - [x] 1.4: Verify push/pull to registry — all service images pushed successfully
+
+### Part B: Infrastructure Files Update
+
+- [x] Task 2: Add Slack Bot and MinIO to `compose.nas.yaml` (AC: #1, #4)
+  - [x] 2.1: Add `lenie-ai-slack-bot` service — image from registry, env_file, lenie-net, depends_on server, no ports
+  - [x] 2.2: Add `lenie-minio` service — MinIO single-node, ports 9000:9000 + 9001:9001, volume for data, lenie-net, healthcheck
+  - [x] 2.3: Add `lenie-minio-data` volume (external: true)
+  - [x] 2.4: Ensure Vault container name matches current NAS (`vault` → decide whether to rename to `lenie-vault` or keep as-is)
+  - [x] 2.5: Validate YAML syntax
+
+- [x] Task 3: Add `slack-bot` and `minio` service mappings to `nas-deploy.sh` (AC: #2)
+  - [x] 3.1: Add `slack-bot` to `SVC_IMAGE`, `SVC_REGISTRY_IMAGE`, `SVC_DOCKERFILE`, `SVC_COMPOSE_NAME`
+  - [x] 3.2: Add `minio` to `SVC_IMAGE`, `SVC_REGISTRY_IMAGE`, `SVC_COMPOSE_NAME` — NOTE: MinIO uses official image (no Dockerfile, no build step), so `SVC_DOCKERFILE` entry is not needed. Handle `--skip-build` logic or pull directly
+  - [x] 3.3: Do NOT add `slack-bot` or `minio` to `ALL_SERVICES` — deploy explicitly (opt-in)
+  - [x] 3.4: Verify script works for existing services after changes
+
+- [x] Task 4: Update `nas.env.example` with new variables (AC: #5)
+  - [x] 4.1: Add Slack variables: `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_CHANNEL_STARTUP`
+  - [x] 4.2: Add MinIO variables: `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `S3_ENDPOINT_URL`
+
+### Part C: NAS Configuration
+
+- [x] Task 5: Configure NAS secrets via Vault backend (AC: #1, #3)
+  - [x] 5.1: Migrated NAS from SECRETS_BACKEND=env to SECRETS_BACKEND=vault — minimal .env with bootstrap vars only (SECRETS_BACKEND, SECRETS_ENV, PROJECT_CODE, VAULT_ADDR, VAULT_TOKEN)
+  - [x] 5.2: Added Slack tokens (SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_CHANNEL_STARTUP) to Vault secret/lenie/dev
+  - [x] 5.3: Added MinIO credentials (MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, S3_ENDPOINT_URL) to Vault secret/lenie/dev
+  - [x] 5.4: Created minio.env file at /share/Container/lenie-env/minio.env (MinIO reads env directly, not via Vault)
+  - [x] 5.5: Created MinIO data volume: `docker volume create lenie-minio-data`
+
+### Part D: Deploy to NAS
+
+- [x] Task 6: Sync compose file and deploy (AC: #1, #2)
+  - [x] 6.1: Synced compose.nas.yaml to NAS /share/Container/lenie-compose/
+  - [x] 6.2: Built and pushed all images to registry (server, slack-bot, db, frontend, app2)
+  - [x] 6.3: Stopped old individually-managed containers and migrated to Docker Compose
+  - [x] 6.4: All 7 containers running via `compose up -d`: db(healthy), server(up), frontend(up), app2(up), slack-bot(up), minio(healthy), vault(healthy)
+  - [x] 6.5: Created MinIO bucket `website-content` via `mc mb local/website-content`
+  - [x] 6.6: Full Compose migration completed — all services managed by compose.nas.yaml
+
+### Part E: Slack Bot Verification
+
+- [ ] Task 7: Verify startup and slash commands (AC: #3)
+  - [x] 7.1: Check Slack channel for startup message — confirmed: "Startup message posted to #all-lenie-ai", backend version 0.3.13.0
+  - [ ] 7.2: `/lenie-version` — verify real backend version (manual test needed)
+  - [ ] 7.3: `/lenie-count` — verify real document count (manual test needed)
+  - [ ] 7.4: `/lenie-add https://example.com/test-story-22-1` — verify URL added (manual test needed)
+  - [ ] 7.5: `/lenie-check https://example.com/test-story-22-1` — verify found (manual test needed)
+  - [ ] 7.6: `/lenie-info <id>` — verify document details (manual test needed)
+  - [ ] 7.7: Error cases: `/lenie-info abc`, `/lenie-add` (no URL) (manual test needed)
+
+- [ ] Task 8: Fix integration issues if found (AC: #3)
+  - [ ] 8.1: If API response mismatch (KeyError) — fix in `commands.py` or `api_client.py`
+  - [ ] 8.2: After code fixes — run tests: `cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v`
+  - [ ] 8.3: Rebuild and redeploy: `./infra/docker/nas-deploy.sh slack-bot`
+
+### Part F: MinIO Verification
+
+- [ ] Task 9: Verify MinIO (AC: #4)
+  - [ ] 9.1: Access MinIO console: `http://192.168.200.7:9001` — login with MINIO_ROOT_USER/PASSWORD
+  - [ ] 9.2: Verify `website-content` bucket exists
+  - [ ] 9.3: Test S3 API from backend container:
+    ```bash
+    $DOCKER exec lenie-ai-server python -c "import boto3; s3=boto3.client('s3', endpoint_url='http://lenie-minio:9000', aws_access_key_id='lenie-admin', aws_secret_access_key='<pw>'); print(s3.list_buckets())"
+    ```
+
+### Part G: Documentation
+
+- [x] Task 10: Update documentation (AC: #5)
+  - [x] 10.1: Update `docs/CICD/NAS_Deployment.md` — add Slack Bot and MinIO to Stack Overview, update deployment instructions to use `nas-deploy.sh`
+  - [x] 10.2: Update `infra/docker/nas.env.example` with Slack + MinIO placeholders
+  - [x] 10.3: Document registry setup status and verify instructions
+
+## Dev Notes
+
+### Scope Overview
+
+This story has three infrastructure goals plus verification:
+1. **Docker Registry** — enable `nas-deploy.sh` workflow (build on PC → push → pull on NAS)
+2. **Slack Bot deployment** — add to compose, deploy, verify all 5 commands
+3. **MinIO** — S3-compatible local storage for HTML files (container + bucket only, backend code integration is separate future work)
+4. **Compose migration** — transition from individual containers to Docker Compose management
+
+### NAS Environment — Current State (Verified via SSH 2026-03-02)
+
+**Hardware:** QNAP TS-453Be, Intel Celeron J3455, 16 GB RAM, QTS Linux 5.10, Docker 27.x
+
+**Running containers** (all individually managed, NOT via Docker Compose):
+
+| Container | Status | Port | Network |
+|-----------|--------|------|---------|
+| `lenie-ai-db` | Up 4 days | 5434:5432 | lenie-net |
+| `lenie-ai-server` | Up 4 days | 5055:5000 | lenie-net |
+| `lenie-ai-frontend` | Up 4 days | 3000:80 | default |
+| `lenie-ai-app2` | Up 4 days | 3001:80 | default |
+| `vault` | Up 3 days | 8210:8200 | default |
+
+**Not running:** `lenie-registry` (Docker registry), `lenie-minio` (MinIO)
+**Not deployed:** `compose.nas.yaml` — file does not exist on NAS at `/share/Container/lenie-compose/`
+**Free ports confirmed:** 5005, 9000, 9001
+
+**Docker path on QNAP:**
+```
+DOCKER=/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/.libs/docker
+```
+
+**NAS directories:**
+```
+/share/Container/
+├── lenie-env/          .env file (secrets in plaintext, env backend)
+├── vault/              Vault config + data + logs
+├── lenie-db-build/     DB build context
+└── container-station-data/  Container Station internal
+```
+
+### Target State After Story
+
+```
+NAS (QNAP TS-453Be) — All managed via Docker Compose (compose.nas.yaml)
+
+Services:
+├── lenie-ai-db           PostgreSQL 17 + pgvector        5434:5432    lenie-net
+├── lenie-ai-server       Flask backend                   5055:5000    lenie-net
+├── lenie-ai-slack-bot    Slack Bot (Socket Mode)          no port      lenie-net  ← NEW
+├── lenie-ai-frontend     React SPA (nginx)                3000:80      lenie-net
+├── lenie-ai-app2         Admin Panel (nginx)              3001:80      lenie-net
+├── lenie-vault           HashiCorp Vault                  8210:8200    lenie-net
+└── lenie-minio           MinIO S3-compatible storage      9000+9001    lenie-net  ← NEW
+
+Infrastructure (standalone, not in compose):
+└── lenie-registry        Docker registry                  5005:5000    (host)
+```
+
+### compose.nas.yaml — Services to Add
+
+**Slack Bot:**
+```yaml
+  lenie-ai-slack-bot:
+    image: 192.168.200.7:5005/lenie-ai-slack-bot:latest
+    container_name: lenie-ai-slack-bot
+    restart: unless-stopped
+    env_file:
+      - /share/Container/lenie-env/.env
+    networks:
+      - lenie-net
+    depends_on:
+      - lenie-ai-server
+```
+
+**MinIO:**
+```yaml
+  lenie-minio:
+    image: minio/minio:latest
+    container_name: lenie-minio
+    restart: unless-stopped
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-lenie-admin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-changeme}
+    command: server /data --console-address ":9001"
+    volumes:
+      - lenie-minio-data:/data
+    networks:
+      - lenie-net
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+```
+
+### nas-deploy.sh — Mappings to Add
+
+```bash
+# Slack Bot
+[slack-bot]="lenie-ai-slack-bot:latest"           # SVC_IMAGE
+[slack-bot]="${REGISTRY}/lenie-ai-slack-bot:latest" # SVC_REGISTRY_IMAGE
+[slack-bot]="slack_bot/Dockerfile"                  # SVC_DOCKERFILE
+[slack-bot]="lenie-ai-slack-bot"                    # SVC_COMPOSE_NAME
+
+# MinIO — uses official image, NO Dockerfile
+# Handle in deploy script: skip build, pull official image directly
+```
+
+**MinIO handling:** MinIO uses `minio/minio:latest` from Docker Hub, not from the private registry. The deploy script needs to handle services without a Dockerfile (skip build+push, only pull+deploy). Options:
+- (A) Add `minio` to `SVC_COMPOSE_NAME` only, skip build/push — just `compose pull` + `compose up`
+- (B) Don't add to `nas-deploy.sh` at all — manage MinIO via `docker compose pull/up` directly
+
+### Docker Compose Migration Strategy
+
+Currently all 5 containers run individually. The migration to Compose must:
+
+1. **Sync compose.nas.yaml** to NAS (`--sync-compose`)
+2. **Stop old individual containers** (they'll conflict with compose-managed ones):
+   ```bash
+   $DOCKER stop lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db vault
+   $DOCKER rm lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db vault
+   ```
+3. **Create external volumes** if they don't exist:
+   ```bash
+   $DOCKER volume create lenie-ai-db-data
+   $DOCKER volume create lenie-ai-data
+   $DOCKER volume create lenie-minio-data
+   ```
+4. **Start all via Compose**: `$DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml up -d`
+
+**Risk:** Vault container name changes from `vault` to `lenie-vault` (as in compose.nas.yaml). If backend .env uses `VAULT_ADDR=http://vault:8200`, it must be updated to `http://lenie-vault:8200`. However, the current NAS uses `SECRETS_BACKEND=env` (not Vault), so this is low risk.
+
+**Data safety:** DB data is in Docker volume `lenie-ai-db-data`. If the volume is `external: true` in compose, it won't be destroyed by `compose down`. Verify volume exists before stopping old containers.
+
+### Configuration Variables
+
+| Variable | In NAS .env? | Required? | Notes |
+|----------|-------------|-----------|-------|
+| `SLACK_BOT_TOKEN` | NO — add | Yes | `xoxb-...` from Slack App OAuth |
+| `SLACK_APP_TOKEN` | NO — add | Yes | `xapp-...` from Slack App Basic Info |
+| `STALKER_API_KEY` | YES | Yes | Bot uses for `x-api-key` header |
+| `LENIE_API_URL` | NO (code default) | No | Defaults to `http://lenie-ai-server:5000` |
+| `SLACK_CHANNEL_STARTUP` | NO (code default) | No | Defaults to `#general` |
+| `MINIO_ROOT_USER` | NO — add | Yes | MinIO admin username |
+| `MINIO_ROOT_PASSWORD` | NO — add | Yes | MinIO admin password |
+| `S3_ENDPOINT_URL` | NO — add | For future use | `http://lenie-minio:9000` |
+
+### Known Risk: API Response Field Names
+
+**#1 integration risk for Slack Bot.** Bot developed with mocked responses — real backend may differ:
+
+| Handler | File:Line | Expected Keys |
+|---------|-----------|---------------|
+| `/lenie-version` | `commands.py:34` | `data['app_version']`, `data['app_build_time']` |
+| `/lenie-add` | `commands.py:78` | `data['document_id']` |
+| `/lenie-check` | `commands.py:102-105` | `result['id']`, `result['document_type']`, `result['document_state']`, `result['created_at']` |
+| `/lenie-info` | `commands.py:136-140` | `data['title']`, `data['document_type']`, `data['document_state']`, `data['created_at']` |
+
+If any key missing/renamed → bot logs `KeyError`, shows "Unexpected response from backend" (safe, no crash). Fix by aligning field names.
+
+### Testing Strategy
+
+1. **Slack Bot smoke tests**: Run each slash command in Slack, verify correct output
+2. **MinIO verification**: Access web console, verify bucket, test S3 API from backend container
+3. **Compose verification**: `compose ps` shows all services running
+4. **Regression check after code fixes**:
+   ```bash
+   cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v
+   ```
+   Expected: 100 tests (do NOT use `uvx pytest` — needs venv)
+
+### MinIO — Scope Boundary
+
+This story sets up MinIO **infrastructure only** (container + bucket). Backend code integration (updating boto3 clients to use `S3_ENDPOINT_URL`, migrating `dynamodb_sync.py` to upload to MinIO) is **separate future work** tracked as B-82. The S3_ENDPOINT_URL variable is added to .env for future use.
+
+### Previous Epic Intelligence (Epic 21 Retrospective)
+
+1. **"Deploy before building new features"** — Why this story exists
+2. **Repeated unsafe dict access** — KeyError handlers in place, real responses may trigger them
+3. **Test runner** — `.venv/Scripts/python -m pytest`, NOT `uvx pytest`
+4. **Closure pattern** — `register_commands()` stable, do not change
+
+### Git Intelligence
+
+Recent commits:
+- `64d676d` — backend connectivity check in Slack bot startup
+- `4a5866a` — vault+aws extras in Slack bot Dockerfile
+- `61077f0` — Slack Bot MVP (Epic 21)
+- `7d11b12` — shared unified-config-loader package
+
+### Project Structure Notes
+
+**Files to create/modify:**
+
+| File | Action |
+|------|--------|
+| `infra/docker/compose.nas.yaml` | MODIFY — add slack-bot + minio services, minio volume |
+| `infra/docker/nas-deploy.sh` | MODIFY — add slack-bot + minio service mappings |
+| `infra/docker/nas.env.example` | MODIFY — add Slack + MinIO variable placeholders |
+| `docs/CICD/NAS_Deployment.md` | MODIFY — add Slack Bot + MinIO to stack docs, update deploy instructions |
+
+**Files potentially modified (only if integration bugs):**
+| `slack_bot/src/commands.py` | response field name fixes |
+| `slack_bot/src/api_client.py` | request format fixes |
+
+### References
+
+- [Source: docs/CICD/NAS_Deployment.md] — NAS hardware, Docker paths, registry setup, compose commands
+- [Source: infra/docker/compose.nas.yaml] — Current NAS compose (no slack-bot/minio yet)
+- [Source: infra/docker/nas-deploy.sh] — Build/push/deploy script
+- [Source: infra/docker/nas.env.example] — NAS env template
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 22.1] — Story definition, acceptance criteria
+- [Source: _bmad-output/planning-artifacts/epics/backlog.md#B-82] — MinIO backlog item with full scope
+- [Source: _bmad-output/implementation-artifacts/epic-21-retro-2026-03-02.md] — Deployment-first rationale
+- [Source: _bmad-output/planning-artifacts/prd.md#Technical Context] — Architecture, API communication
+- [Source: slack_bot/src/main.py] — Entry point, Socket Mode, startup message
+- [Source: slack_bot/src/api_client.py] — HTTP client, exception hierarchy
+- [Source: slack_bot/src/commands.py] — 5 slash command handlers
+- [Source: slack_bot/Dockerfile] — Docker build with shared package
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+### Completion Notes List
+
+- **Task 1 (Registry):** Started registry:2 container on NAS port 5005 with persistent volume. Configured insecure-registries on both NAS (docker.json) and PC (Docker Desktop UI). Verified push/pull works.
+- **Task 2 (compose.nas.yaml):** Added `lenie-ai-slack-bot` service (registry image, env_file, lenie-net, depends_on server) and `lenie-minio` service (official minio/minio:latest, ports 9000+9001, healthcheck, external volume). Added `lenie-minio-data` volume. Fixed Vault mount paths from `/share/Container/vault/` to `/share/vault/`. Changed MinIO env from `${MINIO_*}` interpolation to `env_file: minio.env`.
+- **Task 3 (nas-deploy.sh):** Added `slack-bot` to all 4 service arrays. Added `minio` to COMPOSE_NAME only. Modified `deploy_service()` to skip build/push when no SVC_DOCKERFILE. NOT added to ALL_SERVICES (opt-in only).
+- **Task 4 (nas.env.example):** Added Slack + MinIO variable placeholders. Updated VAULT_ADDR to `http://lenie-vault:8200`.
+- **Task 5 (NAS config):** Migrated NAS from SECRETS_BACKEND=env to SECRETS_BACKEND=vault. Minimal .env (5 bootstrap vars). All app secrets in Vault secret/lenie/dev (61 variables). Created separate minio.env for MinIO container (can't use Vault). Created lenie-minio-data volume.
+- **Task 6 (Deploy):** Full Compose migration completed. Stopped old individual containers, started all 7 via `compose up -d`. Fixed stale Docker image issue (old code without unified_config_loader) by rebuilding and pushing server + slack-bot images. Fixed slack-bot Dockerfile missing README.md (hatchling build error).
+- **Task 10 (documentation):** Updated NAS_Deployment.md with Slack Bot + MinIO in Stack Overview, deploy instructions, troubleshooting.
+- **Remaining:** Task 6.5 (MinIO bucket creation), Task 7.2-7.7 (manual Slack command verification), Task 9 (MinIO verification).
+
+### Implementation Notes
+
+- MinIO deploy strategy: Option A chosen — `minio` added to SVC_COMPOSE_NAME, deploy script detects missing SVC_DOCKERFILE and skips build/push automatically. `./nas-deploy.sh minio` triggers compose pull+up only.
+- Vault name decision (subtask 2.4): Kept `lenie-vault` as already defined in compose. Updated nas.env.example VAULT_ADDR accordingly. Low risk since NAS uses `SECRETS_BACKEND=env`.
+- Slack Bot tests: 106 passed (all green). Backend tests: 6 pre-existing failures unrelated to this story.
+
+### File List
+
+- `infra/docker/compose.nas.yaml` — MODIFIED (added slack-bot + minio services, minio volume, fixed vault mount paths, minio env_file)
+- `infra/docker/nas-deploy.sh` — MODIFIED (added slack-bot + minio mappings, skip-build logic for official images)
+- `infra/docker/nas.env.example` — MODIFIED (added Slack + MinIO variables, updated VAULT_ADDR)
+- `slack_bot/Dockerfile` — MODIFIED (added missing README.md COPY for hatchling build)
+- `docs/CICD/NAS_Deployment.md` — MODIFIED (added Slack Bot + MinIO to stack docs, deploy instructions, troubleshooting)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED (22-1 status: ready-for-dev → in-progress, added B-83)
+- `_bmad-output/implementation-artifacts/22-1-nas-deployment-end-to-end-verification.md` — MODIFIED (tasks 1-6,10 marked complete, Dev Agent Record updated)
+
+## Change Log
+
+- 2026-03-02: Implemented infrastructure file changes (Tasks 2, 3, 4, 10) — compose.nas.yaml updated with Slack Bot + MinIO, nas-deploy.sh extended with new service support, nas.env.example updated, NAS_Deployment.md documentation refreshed.
+- 2026-03-02: Completed NAS deployment (Tasks 1, 5, 6). Registry setup, Vault-based secrets migration, full Docker Compose migration. All 7 containers running. Fixed stale images (rebuilt with unified_config_loader). Fixed slack-bot Dockerfile (missing README.md). Backend: 427 documents loaded, connected to DB. Slack Bot: Socket Mode connected, startup message posted. Added B-83 for Vault auto-unseal.

--- a/_bmad-output/implementation-artifacts/epic-21-retro-2026-03-02.md
+++ b/_bmad-output/implementation-artifacts/epic-21-retro-2026-03-02.md
@@ -1,0 +1,171 @@
+# Retrospective — Epic 21: Slack Bot MVP — Slash Commands
+
+> Date: 2026-03-02 | Reviewer: Claude Opus 4.6 | Format: Interactive Team Retrospective
+
+## Epic Summary
+
+- **Epic:** 21 — Slack Bot MVP — Slash Commands
+- **Stories:** 5/5 done (21-1, 21-2, 21-3, 21-4, 21-5)
+- **Sprint:** 7 (Slack Bot MVP & Config Loader Migration)
+- **Production incidents:** 0
+- **Unit tests created:** 100 (30 config/main + 24 API client + 46 commands)
+- **Code reviews:** 5/5 stories (100% — improvement from 4/6 in Epic 20)
+- **Code review findings:** 33 total (7 HIGH, 16 MEDIUM, 10 LOW) — all fixed
+
+## Delivery Metrics
+
+- Completion: 100% (5/5 stories)
+- Slash commands delivered: 5 (`/lenie-version`, `/lenie-count`, `/lenie-add`, `/lenie-check`, `/lenie-info`)
+- Docker deployment: ready (`docker compose --profile slack up -d`)
+- Secrets management: integrated (env/vault/aws backends)
+- Setup documentation: manifest + README (< 15 min setup, verified by Project Lead)
+- Ruff warnings: 0 across all stories
+
+## Team Participants
+
+- Bob (Scrum Master) — facilitation
+- Alice (Product Owner) — business perspective
+- Charlie (Senior Dev) — technical perspective
+- Dana (QA Engineer) — quality and testing
+- Amelia (Developer) — implementation
+- Ziutus (Project Lead) — strategic decisions
+
+## What Went Well
+
+1. **MVP delivered end-to-end** — From zero to working Slack Bot with 5 commands in a single sprint. User can manage the knowledge base from mobile without opening the web UI.
+
+2. **Documentation quality** — Project Lead (Ziutus) was able to configure the entire bot from scratch using only the README and manifest. This validates Story 21-5's goal of "setup in under 15 minutes."
+
+3. **Speed of execution** — 5 stories with well-planned dependency chain (21-1 → 21-2 → 21-3 → 21-4 → 21-5), zero blockers between stories.
+
+4. **Exception hierarchy design** — `ApiError → ApiConnectionError, ApiResponseError` designed in Story 21-2 was used unchanged in ALL subsequent stories. Zero refactoring needed.
+
+5. **100% code review coverage** — Improvement from 4/6 in Epic 20 to 5/5 in Epic 21. Every story had documented findings and fix-commits.
+
+6. **Progressive learning** — Code review findings decreased across stories: 9 (21-2) → 7 (21-3) → 5 (21-4). Each story documented learnings and the next story applied them.
+
+7. **100 unit tests** — Epic record. Solid safety net covering config, API client, and all 5 command handlers.
+
+8. **Closure pattern architecture** — `register_commands()` creates client once, passes via closure to all handlers. Clean, testable, no global state.
+
+## What Could Be Better
+
+1. **Repeated unsafe dict access** — `KeyError` on dict access appeared in 3 stories (21-2 H2, 21-3 H1, 21-4 learned). Systemic pattern: when backend returns JSON, developers naturally write `data['key']` without `except KeyError`. Need a helper function or pattern.
+
+2. **7 HIGH findings in code review** — `JSONDecodeError` (21-2), `KeyError` (21-3), Unicode `isdigit()` (21-4). Normal for greenfield project, but these would have reached production without review.
+
+3. **Inaccurate line counts in File List** — 4 out of 5 stories had wrong line counts. Developer counts lines before review fixes and doesn't update afterward.
+
+4. **Test runner friction** — `uvx pytest` does not work for `slack_bot/` (needs `requests` and `unified_config_loader` from venv). Requires `.venv/Scripts/python -m pytest` instead. Documented but still causes confusion.
+
+5. **Error handling boilerplate** — ~8 lines of duplicated `except ApiConnectionError / ApiResponseError / ApiError / KeyError` across 5 handlers. Candidate for extraction.
+
+6. **No real environment testing** — All 100 tests use mocked HTTP. Zero verification on real Docker environment, real Slack API, real backend responses. This is the primary risk carried into Epic 22.
+
+## Key Learnings
+
+- **Code review catches production bugs** — 7 HIGH findings would have been user-facing bugs. Code review is not overhead, it's essential quality gate.
+- **Progressive learning works** — Documenting findings in story files and applying them in subsequent stories creates a measurable improvement curve (9→7→5 findings).
+- **Good documentation = real value** — Not just a checkbox. When Project Lead can self-serve setup, documentation has proven its worth.
+- **Process improvements over tech debt for MVP** — Investing in story files and code review paid off immediately. Tech debt (B-79, B-65) can wait when it doesn't block the goal.
+- **Deploy before building new features** — 100 unit tests with mocks ≠ production readiness. Real deployment is the true integration test.
+
+## Previous Retro Follow-Through (Epic 20)
+
+| # | Action Item | Status | Evidence |
+|---|-------------|--------|----------|
+| 1 | Formalize story file policy | ✅ Done | 5/5 stories have full Dev Agent Record, code review, file list |
+| 2 | 100% code review for security-sensitive epics | ✅ Done | 5/5 stories reviewed, 33 findings all fixed |
+| 3 | B-79: Migrate standalone scripts to config_loader | ❌ Backlog | Still in backlog — not Epic 21 scope |
+| 4 | B-23: VPC Lambda constraint resolution | ❌ Backlog | Blocked by OpenAI lacking IPv6 |
+| 5 | B-65: Handle empty string in Config.require() | ❌ Backlog | Not addressed |
+| 6 | Docs for standalone scripts migration | ❌ Not done | Depends on B-79 |
+| 7 | Migrate unknown_news_import.py | ⏳ Unclear | B-79 still backlog |
+| 8 | .env for Vault on NAS | ⏳ Unclear | Not verified |
+
+**Score: 2/8 items completed (25%)** — Process items (story files, code review) completed and had direct positive impact on Epic 21 quality. Tech debt items deferred — acceptable since they didn't block MVP.
+
+## Technical Debt
+
+| Item | Description | Priority |
+|------|-------------|----------|
+| Error handling boilerplate | ~8 lines duplicated across 5 handlers (L1 from 21-4) | LOW — extract helper when adding more commands |
+| B-80: Missing .dockerignore | `backend/` and `web_interface_app2/` lack .dockerignore | LOW |
+| B-79: Standalone scripts use load_dotenv() | imports/ and batch scripts not migrated to config_loader (carried from Epic 20) | HIGH — blocks Vault-only deployments |
+| B-65: Empty string in Config.require() | Returns "" without warning for empty values | LOW |
+| Test runner friction | `uvx pytest` doesn't work for slack_bot, requires venv pytest | LOW — documented but still confusing |
+
+## Action Items
+
+### Process Improvements
+
+1. **Extract helper for safe dict access in Slack Bot**
+   - Owner: Amelia (Developer)
+   - Deadline: Before next story
+   - Success criteria: Shared function/pattern eliminates repeated `except KeyError` boilerplate
+
+2. **Document slack_bot test runner in CLAUDE.md**
+   - Owner: Charlie (Senior Dev)
+   - Deadline: Before next story
+   - Success criteria: `slack_bot` test command clearly documented, zero confusion `uvx` vs `.venv`
+
+### Technical Debt
+
+3. **B-80: Add .dockerignore to backend/ and web_interface_app2/**
+   - Owner: Amelia (Developer)
+   - Priority: LOW
+
+4. **B-79: Migrate standalone scripts to config_loader** (carried from Epic 20)
+   - Owner: Charlie (Senior Dev)
+   - Priority: HIGH — blocks Vault-only deployments for batch processing
+
+## Significant Discovery: Epic 22 Scope Change
+
+During the retrospective, the team identified that Epic 22 needs restructuring:
+
+**Original Epic 22 plan:**
+- 1 story: DM Event Subscription & Text Command Parsing (with conversational state)
+
+**Revised Epic 22 plan (deployment-first approach):**
+- **Story 22-1: NAS Deployment** — Docker build, deploy, smoke test all 5 commands end-to-end on real environment
+- **Story 22-2: Backend bugfixes** (if deployment reveals API response issues) — may be empty if deployment is clean
+- **Story 22-3: DM Commands** (simplified, WITHOUT conversational state/bare URL detection)
+
+**Removed from Epic 22:**
+- Bare URL detection with confirmation ("Did you want to add this URL?")
+- Conversational state management
+
+**Rationale:** All 100 unit tests use mocked HTTP. The bot was only tested in development environment, never on real Docker/NAS deployment. Stability of existing MVP on NAS is higher priority than new features. Backend API response issues discovered during deployment would delay DM development anyway.
+
+**Epic Update Required: YES** — Update `epics.md` and `sprint-status.yaml` before starting Epic 22.
+
+## Readiness Assessment
+
+- **Testing & Quality:** 100 unit tests pass. No real environment testing done yet — primary risk.
+- **Deployment:** Docker image and compose.yaml ready but untested on NAS.
+- **Codebase Health:** Solid. No architectural concerns. Risk is in integration, not code quality.
+- **Unresolved Blockers:** None for NAS deployment. B-79 blocks Vault-only batch processing (not bot).
+
+## Combined Team Agreements (Epic 17-21)
+
+1. Every story MUST have a full story file with Dev Agent Record ✅ (enforced in Epic 21)
+2. 100% code review with documented fix-commits ✅ (enforced in Epic 21)
+3. "Verify before assuming" — confirmed across 5 epics
+4. Analysis-first for complex infrastructure changes (3+ AWS resources)
+5. Defense in depth for secret detection — minimum 2 tools in pre-commit
+6. Never commit secrets — even "temporarily"
+7. Standalone scripts must be considered in migration scope
+8. Progressive learning — document findings, apply in next story
+9. **NEW: Deploy and verify on real environment before building new features**
+
+## Next Steps
+
+1. **Update Epic 22 definition in `epics.md`** — restructure with deployment-first approach
+2. **Update `sprint-status.yaml`** — mark epic-21 as done, add Epic 22 stories
+3. **Start Story 22-1: NAS Deployment** — Docker build, deploy, smoke test all 5 commands
+4. **Address bugfixes** if deployment reveals API response issues (Story 22-2)
+5. **Then build DM commands** (Story 22-3) — only after MVP is stable on NAS
+
+---
+
+Bob (Scrum Master): "Great session, Ziutus. 21 epics done, Slack Bot MVP delivered, clear path forward. Deploy first, features second!"

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -217,13 +217,13 @@ development_status:
   # ============================================================
 
   # --- Epic 21: Slack Bot MVP — Slash Commands ---
-  epic-21: in-progress
+  epic-21: done
   21-1-project-scaffolding-slack-connection: done  # Code review fixes: startup message after connect, added main.py tests, Dockerfile CMD, .dockerignore
   21-2-api-client-for-backend-communication: done  # Code review: 9 issues found (3H/4M/2L), all fixed. 24 tests, ruff clean.
   21-3-system-information-slash-commands: done  # Code review: 7 issues found (1H/5M/1L), all fixed. 17 tests, ruff clean.
   21-4-content-management-slash-commands: done  # Code review: 5 issues found (1H/2M/2L), all H+M fixed. 46 command tests, 100 full suite.
   21-5-slack-app-manifest-setup-documentation: done
-  epic-21-retrospective: optional
+  epic-21-retrospective: done  # Retro completed 2026-03-02. Key decisions: Epic 22 restructured (deployment-first), conversational state removed from DM commands.
 
   # --- B-79: Migrate Standalone Scripts to config_loader ---
   B-79-migrate-standalone-scripts-to-config-loader: backlog  # Replace load_dotenv() with load_config() in 6 standalone scripts. HIGH priority — blocks Vault-only deployments for batch processing.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-02-28
+# generated: 2026-03-02
 # project: lenie-server-2025
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-02-28
+generated: 2026-03-02
 project: lenie-server-2025
 project_key: NOKEY
 tracking_system: file-system
@@ -261,11 +261,32 @@ development_status:
   B-41-rss-feed-ingestion-with-llm-filtering: backlog  # RSS feeds (AWS What's New), daily Lambda, LLM relevance scoring, submit to /url_add pipeline.
   # B-42: SUPERSEDED by Epic 21-25 (Slack Bot). Full decomposition in epics.md.
 
-  # --- Future Sprint 8: Slack Bot Enhancements (Epics 22-25) ---
-  # epic-22: Direct Message Interaction (Story 22-1)
-  # epic-23: Channel App Mentions (Story 23-1)
-  # epic-24: Conversational LLM Intelligence (Stories 24-1, 24-2)
-  # epic-25: Proactive Health Monitoring (Story 25-1)
+  # ============================================================
+  # SPRINT 8: Slack Bot Enhancements
+  # ============================================================
+
+  # --- Epic 22: Slack Bot Stabilization & DM Commands ---
+  epic-22: backlog
+  22-1-nas-deployment-end-to-end-verification: backlog
+  22-2-backend-api-response-fixes-conditional: backlog
+  22-3-dm-text-command-parsing-simplified: backlog
+  epic-22-retrospective: optional
+
+  # --- Epic 23: Channel App Mentions ---
+  epic-23: backlog
+  23-1-app-mention-event-handler-thread-responses: backlog
+  epic-23-retrospective: optional
+
+  # --- Epic 24: Conversational LLM Intelligence ---
+  epic-24: backlog
+  24-1-llm-intent-parser: backlog
+  24-2-semantic-search-via-natural-language: backlog
+  epic-24-retrospective: optional
+
+  # --- Epic 25: Proactive Health Monitoring ---
+  epic-25: backlog
+  25-1-scheduled-health-checks-proactive-alerts: backlog
+  epic-25-retrospective: optional
 
   # --- Phase 6: Obsidian Integration ---
   B-60-obsidian-vault-integration: backlog  # Synchronization between Lenie-AI and Obsidian vault — linking, note creation, bidirectional sync.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -239,6 +239,7 @@ development_status:
   B-50-api-type-synchronization-pydantic-openapi-ts: backlog  # Pydantic → OpenAPI → generated TS types. Fixes backend-frontend drift: id type mismatch, missing fields (13 in WebDocument, 5 in ListItem, 7 in SearchResult), untyped enums. Strategy: docs/api-type-sync-strategy.md. 5 phases: Pydantic models, Flask route integration, OpenAPI gen, TS gen, CI check.
 
   # --- Phase 3: Security Hardening & AWS Cleanup ---
+  B-83-vault-auto-unseal-aws-kms: backlog  # Vault on NAS uses Shamir seal (manual unseal). Fix: add seal "awskms" block to vault.hcl, create vault.env with dedicated IAM user credentials, migrate seal (vault operator unseal -migrate), unify mount paths (/share/vault vs /share/Container/vault). Requires: dedicated AWS IAM user for KMS.
   B-13-parameterize-stage-description-for-multi-environment: backlog
   B-19-convert-ec2-to-spot-with-asg-0-1: backlog
   B-22-add-max-retry-limit-to-aws-ec2-route53-script: backlog
@@ -266,8 +267,8 @@ development_status:
   # ============================================================
 
   # --- Epic 22: Slack Bot Stabilization & DM Commands ---
-  epic-22: backlog
-  22-1-nas-deployment-end-to-end-verification: backlog
+  epic-22: in-progress
+  22-1-nas-deployment-end-to-end-verification: in-progress
   22-2-backend-api-response-fixes-conditional: backlog
   22-3-dm-text-command-parsing-simplified: backlog
   epic-22-retrospective: optional

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -122,8 +122,8 @@ User can add links, check duplicates, query system status, and get document info
 **FRs covered:** FR1, FR2, FR3, FR4, FR5, FR6, FR7, FR18, FR19, FR20, FR21, FR22, FR23, FR24, FR25
 **NFRs covered:** NFR1-NFR18 (all — quality foundation from first epic)
 
-### Epic 22: Direct Message Interaction (Sprint 8)
-User can send text commands as direct messages to the bot (without `/` prefix). Bot parses DM text and responds with the same capabilities as slash commands.
+### Epic 22: Slack Bot Stabilization & DM Commands (Sprint 8)
+Deploy Slack Bot MVP to NAS, verify end-to-end on real environment, fix any integration issues, then add simplified DM text commands (without conversational state). Deployment-first approach decided during [Epic 21 retrospective](../implementation-artifacts/epic-21-retro-2026-03-02.md).
 **FRs covered:** FR8, FR9
 **Builds on:** Epic 21
 
@@ -288,11 +288,65 @@ So that I can set up the bot from scratch in under 15 minutes.
 
 ---
 
-## Epic 22: Direct Message Interaction
+## Epic 22: Slack Bot Stabilization & DM Commands
 
-User can send text commands as direct messages to the bot without `/` prefix. Bot parses text and responds identically to slash commands.
+Deploy Slack Bot MVP to NAS, verify end-to-end on real environment, fix any integration issues discovered during deployment, then add simplified DM text commands. Deployment-first approach decided during [Epic 21 retrospective](../implementation-artifacts/epic-21-retro-2026-03-02.md). Conversational state (bare URL detection with confirmation prompt) removed from scope — deferred to future epic if needed.
 
-### Story 22.1: DM Event Subscription & Text Command Parsing
+### Story 22.1: NAS Deployment & End-to-End Verification
+
+As a **developer**,
+I want to deploy the Slack Bot to NAS and verify all 5 slash commands work end-to-end,
+So that I have confidence the MVP works on a real environment before building new features.
+
+**Acceptance Criteria:**
+
+**Given** the NAS has Docker and the Lenie backend running
+**When** developer runs `docker compose --profile slack up -d` on NAS
+**Then** the bot container builds, starts, and connects to Slack via Socket Mode
+
+**Given** the bot is running on NAS
+**When** bot connects to Slack
+**Then** startup confirmation message appears in the designated Slack channel
+
+**Given** the bot is running on NAS with real backend
+**When** user types `/lenie-version` in Slack
+**Then** bot responds with actual backend version and build timestamp
+
+**Given** the bot is running on NAS with real backend
+**When** user types `/lenie-count` in Slack
+**Then** bot responds with real document count and per-type breakdown
+
+**Given** the bot is running on NAS with real backend
+**When** user types `/lenie-add <url>`, `/lenie-check <url>`, `/lenie-info <id>` in Slack
+**Then** all 3 content management commands work correctly with real data
+
+**Given** deployment procedure is verified
+**When** developer documents the process
+**Then** a repeatable deployment procedure exists (git pull, build, up, verify)
+
+**Covers:** FR21, FR24 | NFR2, NFR5, NFR8
+
+### Story 22.2: Backend API Response Fixes (Conditional)
+
+As a **developer**,
+I want to fix any API response format mismatches discovered during NAS deployment,
+So that the Slack Bot receives the exact response format it expects from all backend endpoints.
+
+**Acceptance Criteria:**
+
+**Given** NAS deployment revealed API response mismatches
+**When** developer fixes the backend response format or Slack Bot parser
+**Then** all 5 slash commands work correctly with real backend responses
+
+**Given** NAS deployment revealed no issues
+**When** this story is evaluated
+**Then** story is marked as skipped (no work needed)
+
+**Note:** This story may be empty if Story 22-1 deployment passes cleanly. Reserved as placeholder for integration fixes.
+
+**Covers:** NFR9
+
+### Story 22.3: DM Text Command Parsing (Simplified)
 
 As a **user**,
 I want to send commands as plain messages in a DM with the bot (e.g., "version", "add https://..."),
@@ -320,11 +374,10 @@ So that I can interact without remembering slash command syntax.
 **When** user sends unrecognized text (e.g., "hello" or "asdf")
 **Then** bot responds with a help message listing available commands
 
-**Given** user sends a bare URL without a command keyword
-**When** the message matches URL pattern
-**Then** bot asks: "Did you want to add this URL? Reply 'yes' to confirm."
-
 **Covers:** FR8, FR9 | NFR1, NFR18
+
+**Removed from original scope (Epic 21 retro decision):**
+- ~~Bare URL detection with confirmation prompt ("Did you want to add this URL? Reply 'yes' to confirm.")~~ — requires conversational state management, deferred to future epic
 
 ---
 

--- a/docs/CICD/NAS_Deployment.md
+++ b/docs/CICD/NAS_Deployment.md
@@ -21,8 +21,11 @@ Full Lenie stack running on a local QNAP NAS for personal use and testing.
 | Frontend React | `lenie-ai-frontend` | `192.168.200.7:5005/lenie-ai-frontend` | 3000 | Main web interface |
 | Admin Panel | `lenie-ai-app2` | `192.168.200.7:5005/lenie-ai-app2` | 3001 | Admin panel (app2) |
 | Backend | `lenie-ai-server` | `192.168.200.7:5005/lenie-ai-server` | 5055 | Flask API server |
+| Slack Bot | `lenie-ai-slack-bot` | `192.168.200.7:5005/lenie-ai-slack-bot` | — | Slack Bot (Socket Mode, no exposed port) |
 | PostgreSQL | `lenie-ai-db` | `192.168.200.7:5005/lenie-ai-db` | 5434 | PostgreSQL 17 + pgvector (upgrade to 18 pending — B-69) |
-| Vault | `lenie-vault` | `hashicorp/vault:latest` | 8210 | HashiCorp Vault secrets manager |
+| MinIO | `lenie-minio` | `minio/minio:latest` | 9000, 9001 | S3-compatible storage (API + web console) |
+| Vault | `lenie-vault` | `hashicorp/vault:1.21.3` | 8210 | HashiCorp Vault secrets manager |
+| Registry UI | `lenie-registry-ui` | `joxit/docker-registry-ui:latest` | 8550 | Web UI for Docker registry |
 | **Registry** | `lenie-registry` | `registry:2` | 5005 | Private Docker registry (infra) |
 
 All application services are orchestrated via `docker compose` using `compose.nas.yaml`.
@@ -37,7 +40,9 @@ From any device on the local network:
 - **Frontend:** http://192.168.200.7:3000
 - **Admin Panel:** http://192.168.200.7:3001
 - **Backend API:** http://192.168.200.7:5055
+- **MinIO Console:** http://192.168.200.7:9001
 - **Vault UI:** http://192.168.200.7:8210/ui
+- **Registry UI:** http://192.168.200.7:8550
 - **Registry catalog:** http://192.168.200.7:5005/v2/_catalog
 
 ## Prerequisites
@@ -74,6 +79,7 @@ QNAP uses several ports by default. Known conflicts:
 | 5050 | Python process | — |
 | 5433 | Local PostgreSQL | DB container uses 5434 |
 | 8200 | UPnP Media Server | Vault uses 8210 |
+| 9000, 9001 | — (free) | MinIO S3 API + web console |
 
 ## Private Docker Registry
 
@@ -162,12 +168,18 @@ $DOCKER exec lenie-registry du -sh /var/lib/registry
 The script `infra/docker/nas-deploy.sh` handles building images, pushing to the private registry, and deploying via `docker compose`.
 
 ```bash
-# Deploy all services (build → push → compose up)
+# Deploy all core services (build → push → compose up)
 ./infra/docker/nas-deploy.sh
 
 # Deploy specific service(s)
 ./infra/docker/nas-deploy.sh frontend
 ./infra/docker/nas-deploy.sh backend app2
+
+# Deploy Slack Bot (build → push → compose up)
+./infra/docker/nas-deploy.sh slack-bot
+
+# Deploy MinIO (official image — no build, only compose pull/up)
+./infra/docker/nas-deploy.sh minio
 
 # Push existing image without rebuilding
 ./infra/docker/nas-deploy.sh --skip-build backend
@@ -181,6 +193,8 @@ The script `infra/docker/nas-deploy.sh` handles building images, pushing to the 
 # Sync compose file and deploy specific services
 ./infra/docker/nas-deploy.sh --sync-compose frontend app2
 ```
+
+> **Note:** `slack-bot` and `minio` are not included in the default `all` target — they must be deployed explicitly. MinIO uses the official Docker Hub image, so the build/push step is skipped automatically.
 
 The script performs these steps for each service:
 
@@ -242,11 +256,12 @@ If migrating from the previous tar.gz/scp deployment:
    DOCKER=/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/.libs/docker
    $DOCKER volume create lenie-ai-db-data
    $DOCKER volume create lenie-ai-data
+   $DOCKER volume create lenie-minio-data
    ```
 6. Stop old containers:
    ```bash
-   $DOCKER stop lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db
-   $DOCKER rm lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db
+   $DOCKER stop lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db vault
+   $DOCKER rm lenie-ai-frontend lenie-ai-app2 lenie-ai-server lenie-ai-db vault
    ```
 7. Push all images and deploy: `./nas-deploy.sh`
 
@@ -437,6 +452,8 @@ $DOCKER ps --filter name=lenie
 ```bash
 $DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml logs --tail 50 lenie-ai-server
 $DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml logs --tail 50 lenie-ai-db
+$DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml logs --tail 50 lenie-ai-slack-bot
+$DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml logs --tail 50 lenie-minio
 $DOCKER logs --tail 50 lenie-vault
 $DOCKER logs --tail 50 lenie-registry
 ```

--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -59,6 +59,51 @@ services:
     networks:
       - lenie-net
 
+  lenie-ai-slack-bot:
+    image: 192.168.200.7:5005/lenie-ai-slack-bot:latest
+    container_name: lenie-ai-slack-bot
+    restart: unless-stopped
+    env_file:
+      - /share/Container/lenie-env/.env
+    networks:
+      - lenie-net
+    depends_on:
+      - lenie-ai-server
+
+  lenie-minio:
+    image: minio/minio:latest
+    container_name: lenie-minio
+    restart: unless-stopped
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # Web console
+    env_file:
+      - /share/Container/lenie-env/minio.env
+    command: server /data --console-address ":9001"
+    volumes:
+      - lenie-minio-data:/data
+    networks:
+      - lenie-net
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  lenie-registry-ui:
+    image: joxit/docker-registry-ui:latest
+    container_name: lenie-registry-ui
+    restart: unless-stopped
+    ports:
+      - "8550:80"
+    environment:
+      SINGLE_REGISTRY: "true"
+      REGISTRY_TITLE: "Lenie AI Registry"
+      REGISTRY_URL: "http://192.168.200.7:5005"
+      DELETE_IMAGES: "true"
+    networks:
+      - lenie-net
+
   lenie-vault:
     image: hashicorp/vault:1.21.3
     container_name: lenie-vault
@@ -70,9 +115,9 @@ services:
     env_file:
       - /share/Container/lenie-env/vault.env
     volumes:
-      - /share/Container/vault/config:/vault/config
-      - /share/Container/vault/data:/vault/file
-      - /share/Container/vault/logs:/vault/logs
+      - /share/vault/config:/vault/config
+      - /share/vault/data:/vault/file
+      - /share/vault/logs:/vault/logs
     command: server
     healthcheck:
       test: ["CMD", "vault", "status", "-address=http://127.0.0.1:8200"]
@@ -92,4 +137,6 @@ volumes:
   lenie-ai-db-data:
     external: true
   lenie-ai-data:
+    external: true
+  lenie-minio-data:
     external: true

--- a/infra/docker/nas-deploy.sh
+++ b/infra/docker/nas-deploy.sh
@@ -31,24 +31,29 @@ declare -A SVC_IMAGE=(
     [app2]="lenie-ai-app2:latest"
     [backend]="lenie-ai-server:latest"
     [db]="lenie-ai-db:latest"
+    [slack-bot]="lenie-ai-slack-bot:latest"
 )
 declare -A SVC_REGISTRY_IMAGE=(
     [frontend]="${REGISTRY}/lenie-ai-frontend:latest"
     [app2]="${REGISTRY}/lenie-ai-app2:latest"
     [backend]="${REGISTRY}/lenie-ai-server:latest"
     [db]="${REGISTRY}/lenie-ai-db:latest"
+    [slack-bot]="${REGISTRY}/lenie-ai-slack-bot:latest"
 )
 declare -A SVC_DOCKERFILE=(
     [frontend]="web_interface_react/Dockerfile"
     [app2]="web_interface_app2/Dockerfile"
     [backend]="backend/Dockerfile"
     [db]="infra/docker/Postgresql/Dockerfile"
+    [slack-bot]="slack_bot/Dockerfile"
 )
 declare -A SVC_COMPOSE_NAME=(
     [frontend]="lenie-ai-frontend"
     [app2]="lenie-ai-app2"
     [backend]="lenie-ai-server"
     [db]="lenie-ai-db"
+    [slack-bot]="lenie-ai-slack-bot"
+    [minio]="lenie-minio"
 )
 
 ALL_SERVICES="db backend frontend app2"
@@ -165,6 +170,13 @@ deploy_service() {
     echo -e "${BLUE}  Deploying: ${svc}${NC}"
     echo -e "${BLUE}========================================${NC}"
 
+    # Services without Dockerfile use official images (e.g., minio) — skip build/push
+    if [ -z "${SVC_DOCKERFILE[$svc]:-}" ]; then
+        log "Serwis ${svc} używa oficjalnego obrazu — pomijanie build/push"
+        ok "Deploy ${svc} — obraz z Docker Hub (compose pull)"
+        return
+    fi
+
     if [ "$skip_build" = "false" ]; then
         build_image "$svc"
     else
@@ -185,7 +197,9 @@ show_status() {
 usage() {
     echo "Usage: $0 [OPTIONS] [service ...]"
     echo ""
-    echo "Services: frontend, app2, backend, db, all (default)"
+    echo "Services: frontend, app2, backend, db, slack-bot, minio, all (default: core services)"
+    echo "  Note: 'all' deploys core services only (db, backend, frontend, app2)."
+    echo "  slack-bot and minio must be deployed explicitly."
     echo ""
     echo "Options:"
     echo "  --skip-build      Skip Docker build, push existing local image"
@@ -194,8 +208,10 @@ usage() {
     echo "  --help, -h        Show this help"
     echo ""
     echo "Examples:"
-    echo "  $0                           # Build, push & deploy all"
+    echo "  $0                           # Build, push & deploy core services"
     echo "  $0 frontend                  # Build, push & deploy frontend only"
+    echo "  $0 slack-bot                 # Build, push & deploy Slack Bot"
+    echo "  $0 minio                     # Deploy MinIO (official image, no build)"
     echo "  $0 --skip-build backend      # Push existing image & deploy"
     echo "  $0 --compose-only            # Just compose up on NAS"
     echo "  $0 --sync-compose            # Sync compose file and deploy all"
@@ -216,7 +232,7 @@ while [[ $# -gt 0 ]]; do
         --sync-compose)  SYNC_COMPOSE="true"; shift ;;
         --help|-h)       usage ;;
         all)             SERVICES="$ALL_SERVICES"; shift ;;
-        frontend|app2|backend|db) SERVICES="$SERVICES $1"; shift ;;
+        frontend|app2|backend|db|slack-bot|minio) SERVICES="$SERVICES $1"; shift ;;
         *) error "Nieznany argument: $1. Użyj --help." ;;
     esac
 done
@@ -267,6 +283,7 @@ echo "  Admin Panel: http://${NAS_HOST}:3001"
 echo "  Backend API: http://${NAS_HOST}:5055"
 echo "  PostgreSQL:  ${NAS_HOST}:5434"
 echo "  Vault UI:    http://${NAS_HOST}:8210/ui"
+echo "  MinIO Console: http://${NAS_HOST}:9001"
 echo ""
 echo "  Registry:    http://${REGISTRY}/v2/_catalog"
 echo ""

--- a/infra/docker/nas.env.example
+++ b/infra/docker/nas.env.example
@@ -30,5 +30,15 @@ SECRETS_ENV=dev
 ENV_DATA=2026.02.27
 
 # --- Vault Connection ---
-VAULT_ADDR=http://vault:8200
+VAULT_ADDR=http://lenie-vault:8200
 VAULT_TOKEN=<your-vault-token>
+
+# --- Slack Bot ---
+SLACK_BOT_TOKEN=<xoxb-your-slack-bot-token>
+SLACK_APP_TOKEN=<xapp-your-slack-app-token>
+SLACK_CHANNEL_STARTUP=#general
+
+# --- MinIO (S3-compatible storage) ---
+MINIO_ROOT_USER=lenie-admin
+MINIO_ROOT_PASSWORD=<your-minio-password>
+S3_ENDPOINT_URL=http://lenie-minio:9000

--- a/slack_bot/Dockerfile
+++ b/slack_bot/Dockerfile
@@ -18,7 +18,8 @@ COPY slack_bot/pyproject.toml slack_bot/uv.lock ./
 # Install dependencies (include vault + aws extras for secret backends)
 RUN uv sync --frozen --no-dev --no-install-project --extra vault --extra aws
 
-# Copy source code
+# Copy source code and README (required by hatchling build)
+COPY slack_bot/README.md .
 COPY slack_bot/src/ src/
 
 # Create non-root user


### PR DESCRIPTION
## Summary

- **Epic 20:** Extract shared `unified-config-loader` Python package with env/vault/aws backends, rewrite `config_loader` to use it, add `env_to_vault.py` tooling with vars-classification.yaml
- **Epic 21:** Slack Bot MVP — 5 slash commands (`/lenie-version`, `/lenie-count`, `/lenie-add`, `/lenie-check`, `/lenie-info`), Socket Mode, backend connectivity check, 106 unit tests
- **Epic 22 (Story 22.1):** Full NAS deployment — Docker Compose migration (7 services), private registry setup, Vault-based secrets (SECRETS_BACKEND=vault), MinIO S3 storage, registry web UI (`joxit/docker-registry-ui`)

## Key changes

- `shared_python/unified-config-loader/` — new reusable package (env/vault/aws backends)
- `backend/library/config_loader.py` — rewritten as re-export from unified package
- `slack_bot/` — complete new module (Dockerfile, src/, tests/, manifest)
- `infra/docker/compose.nas.yaml` — added slack-bot, minio, registry-ui, vault path fixes
- `infra/docker/nas-deploy.sh` — extended with slack-bot/minio support, skip-build for official images
- `docs/CICD/NAS_Deployment.md` — comprehensive update with new services and deployment workflow
- `scripts/env_to_vault.py` — tooling for managing secrets across backends

## Test plan

- [x] Backend unit tests pass (6 pre-existing failures unrelated to this PR)
- [x] Slack Bot unit tests pass (106 tests)
- [x] Config loader unit tests pass
- [x] Pre-commit hooks pass (gitleaks + TruffleHog)
- [x] NAS deployment verified — all 7 containers running via Docker Compose
- [x] Slack Bot connected via Socket Mode, startup message posted
- [ ] Manual: verify 5 slash commands in Slack workspace
- [ ] Manual: verify MinIO console at http://192.168.200.7:9001

🤖 Generated with [Claude Code](https://claude.com/claude-code)