### PR TITLE
fix: add CORS headers to Docker registry for UI access

### DIFF
--- a/docs/CICD/NAS_Deployment.md
+++ b/docs/CICD/NAS_Deployment.md
@@ -97,6 +97,11 @@ $DOCKER run -d --name lenie-registry \
   --restart unless-stopped \
   -p 5005:5000 \
   -v lenie-registry-data:/var/lib/registry \
+  -e REGISTRY_HTTP_HEADERS_Access-Control-Allow-Origin='["*"]' \
+  -e REGISTRY_HTTP_HEADERS_Access-Control-Allow-Methods='["HEAD","GET","OPTIONS","DELETE"]' \
+  -e REGISTRY_HTTP_HEADERS_Access-Control-Allow-Headers='["Authorization","Accept","Cache-Control"]' \
+  -e REGISTRY_HTTP_HEADERS_Access-Control-Expose-Headers='["Docker-Content-Digest"]' \
+  -e REGISTRY_STORAGE_DELETE_ENABLED=true \
   registry:2
 ```
 


### PR DESCRIPTION
## Summary

- Add CORS headers (`Access-Control-Allow-Origin`, etc.) to Docker registry startup command in NAS deployment docs
- Without these headers, `joxit/docker-registry-ui` cannot access the registry API (browser blocks cross-origin requests)
- Enable `REGISTRY_STORAGE_DELETE_ENABLED=true` for image deletion from UI

## Test plan

- [x] Registry restarted on NAS with CORS headers — UI shows 6 repositories
- [x] Registry UI accessible at http://192.168.200.7:8550

🤖 Generated with [Claude Code](https://claude.com/claude-code)