### PR TITLE
fix: /lenie-add accepts document type, /lenie-check searches by URL

### DIFF
--- a/_bmad-output/planning-artifacts/epics/backlog.md
+++ b/_bmad-output/planning-artifacts/epics/backlog.md
@@ -725,3 +725,39 @@ so that development uses the same S3 API as production (AWS) and future Kubernet
 
 **Priority:** MEDIUM — enables consistent NAS development, prevents future rewrites
 **Status:** backlog
+
+### B-84: Add CONTENT_NEEDED Document Status for Slack Bot URL Additions
+
+As a **developer**,
+I want a new document processing status `CONTENT_NEEDED` that signals the backend to fetch page content automatically,
+so that URLs added via Slack Bot (which cannot send page HTML/text like the Chrome extension) still get their content downloaded and processed.
+
+**Origin:** Story 22.1 verification — `/lenie-add` works but adding `webpage` type via Slack is incomplete because the Chrome extension sends full HTML/text content with the request, while Slack Bot can only send the URL. Without content, the document sits in the database with no text to process.
+
+**Context — how different sources add documents:**
+- **Chrome extension** (`/url_add`): sends URL + type + full HTML + extracted text + title + language → document is immediately ready for processing
+- **Slack Bot** (`/lenie-add`): can only send URL + type → no content available at submission time
+- **YouTube**: content is fetched automatically via YouTube Transcript API — works fine from Slack
+- **link**: only URL and description matter — works fine from Slack
+- **webpage**: needs HTML/text content that Slack cannot provide → this is the gap
+
+**Proposed solution:**
+1. Add `CONTENT_NEEDED` status to `StalkerDocumentStatus` enum (in `backend/library/models/stalker_document_status.py`)
+2. When `/url_add` receives a `webpage` without `text`/`html` fields, set status to `CONTENT_NEEDED` instead of the default flow
+3. Backend batch processing script (`web_documents_do_the_needful_new.py`) picks up `CONTENT_NEEDED` documents and downloads content using existing tools (BeautifulSoup, Firecrawl, Markdownify)
+4. After content is fetched, status transitions to `DOCUMENT_INTO_DATABASE` and normal processing continues
+
+**Scope:**
+1. Add `CONTENT_NEEDED` to `StalkerDocumentStatus` enum and database `document_types` table
+2. Modify `/url_add` endpoint to detect missing content and set appropriate status
+3. Extend `web_documents_do_the_needful_new.py` to handle `CONTENT_NEEDED` → download content → update status
+4. Update Slack Bot `/lenie-add` response to inform user that content will be fetched automatically
+
+**Acceptance Criteria:**
+- `/lenie-add https://example.com webpage` via Slack → document created with status `CONTENT_NEEDED`
+- Batch processing script picks up `CONTENT_NEEDED` documents and downloads their content
+- After content fetch, document transitions to normal processing pipeline
+- Chrome extension workflow unchanged (still sends content directly)
+
+**Priority:** MEDIUM — improves Slack Bot usefulness for webpage additions
+**Status:** backlog

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -113,7 +113,8 @@ class WebsitesDBPostgreSQL:
 
 
         if search_in_documents:
-            search_clauses = [f"text LIKE '%{search_in_documents}%'",
+            search_clauses = [f"url LIKE '%{search_in_documents}%'",
+                              f"text LIKE '%{search_in_documents}%'",
                               f"title LIKE '%{search_in_documents}%'",
                               f"summary LIKE '%{search_in_documents}%'",
                               f"chapter_list LIKE '%{search_in_documents}%'",

--- a/slack_bot/src/commands.py
+++ b/slack_bot/src/commands.py
@@ -66,16 +66,24 @@ def _handle_count(ack: Callable, respond: Callable, client: LenieApiClient) -> N
         respond(text=f"An error occurred: {exc.message}")
 
 
+_VALID_TYPES = {"link", "webpage", "youtube", "movie", "text_message", "text"}
+
+
 def _handle_add(ack: Callable, respond: Callable, client: LenieApiClient, command: dict) -> None:
     """Handle /lenie-add command — add a URL to the knowledge base."""
     ack()
-    url = command.get("text", "").strip()
-    if not url:
-        respond(text="Usage: `/lenie-add <url>`")
+    parts = command.get("text", "").strip().split()
+    if not parts:
+        respond(text="Usage: `/lenie-add <url> [type]`\nTypes: webpage (default), link, youtube, movie")
+        return
+    url = parts[0]
+    url_type = parts[1] if len(parts) > 1 else "webpage"
+    if url_type not in _VALID_TYPES:
+        respond(text=f"Unknown type `{url_type}`. Valid: {', '.join(sorted(_VALID_TYPES))}")
         return
     try:
-        data = client.add_url(url)
-        respond(text=f"Added to knowledge base (ID: {data['document_id']}). Type: link.")
+        data = client.add_url(url, url_type=url_type)
+        respond(text=f"Added to knowledge base (ID: {data['document_id']}). Type: {url_type}.")
     except ApiConnectionError:
         respond(text="Backend unreachable (connection timeout). Check if lenie-ai-server is running.")
     except ApiResponseError as exc:

--- a/slack_bot/tests/unit/test_commands.py
+++ b/slack_bot/tests/unit/test_commands.py
@@ -257,8 +257,8 @@ class TestRegisterCommands:
 
 
 class TestHandleAdd:
-    def test_success(self):
-        """5.1: Mocked add_url(), verify response format with document_id."""
+    def test_success_default_type(self):
+        """Default type is webpage when no type specified."""
         client = _make_mock_client()
         client.add_url.return_value = {"status": "success", "document_id": 42}
         ack, respond = _make_ack_respond()
@@ -267,11 +267,37 @@ class TestHandleAdd:
         _handle_add(ack, respond, client, command)
 
         ack.assert_called_once()
-        client.add_url.assert_called_once_with("https://example.com/article")
+        client.add_url.assert_called_once_with("https://example.com/article", url_type="webpage")
         text = respond.call_args[1]["text"]
         assert "42" in text
-        assert "link" in text
+        assert "webpage" in text
         assert "Added to knowledge base" in text
+
+    def test_success_explicit_type(self):
+        """Explicit type passed as second argument."""
+        client = _make_mock_client()
+        client.add_url.return_value = {"status": "success", "document_id": 99}
+        ack, respond = _make_ack_respond()
+        command = {"text": "https://youtube.com/watch?v=abc youtube"}
+
+        _handle_add(ack, respond, client, command)
+
+        client.add_url.assert_called_once_with("https://youtube.com/watch?v=abc", url_type="youtube")
+        text = respond.call_args[1]["text"]
+        assert "99" in text
+        assert "youtube" in text
+
+    def test_invalid_type(self):
+        """Invalid type returns error message."""
+        client = _make_mock_client()
+        ack, respond = _make_ack_respond()
+        command = {"text": "https://example.com badtype"}
+
+        _handle_add(ack, respond, client, command)
+
+        client.add_url.assert_not_called()
+        text = respond.call_args[1]["text"]
+        assert "Unknown type" in text
 
     def test_empty_url(self):
         """5.2: Empty URL — verify usage hint response."""


### PR DESCRIPTION
## Summary

- `/lenie-add` now accepts optional type: `/lenie-add <url> [type]` — default changed from `link` to `webpage`
  - Valid types: webpage, link, youtube, movie, text_message, text
- Backend `search_in_documents` now includes the `url` column — `/lenie-check` can find documents by URL
  - Previously only searched text, title, summary, chapter_list, and English translations

## Test plan

- [x] Slack bot unit tests: 48 passed (3 new tests for type handling)
- [x] Pre-commit hooks pass (gitleaks + TruffleHog)
- [ ] Manual: `/lenie-add https://example.com` → should add as webpage
- [ ] Manual: `/lenie-add https://youtube.com/... youtube` → should add as youtube
- [ ] Manual: `/lenie-check <url>` → should find previously added URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)