### PR TITLE
fix: Backend API response fixes for Slack Bot (Story 22.2)

### DIFF
--- a/_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md
+++ b/_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md
@@ -1,0 +1,184 @@
+# Story 22.2: Backend API Response Fixes (Conditional)
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **developer**,
+I want to fix API response format mismatches and backend bugs discovered during NAS deployment (Story 22.1),
+So that the Slack Bot receives correct responses from all backend endpoints and the fixes are merged to main.
+
+## Acceptance Criteria
+
+1. **Given** NAS deployment revealed `/lenie-check` could not find documents by URL
+   **When** user types `/lenie-check <url>` against the real backend
+   **Then** the backend `GET /website_list?search_in_document=<url>` includes `url` column in its search and returns matching documents
+
+2. **Given** NAS deployment revealed `/lenie-add` had no document type parameter
+   **When** user types `/lenie-add <url> [type]` in Slack
+   **Then** bot sends the optional `type` parameter (default: `webpage`) and backend creates the document with the correct type
+
+3. **Given** the `get_list()` method used string formatting for SQL parameters
+   **When** any API call uses `search_in_document`, `type`, `state`, or other filters
+   **Then** all WHERE clause parameters use `%s` parameterized queries (no SQL injection)
+
+4. **Given** the `project` filter in `get_list()` uses the wrong column name (`document_state` instead of `project`)
+   **When** any code calls `GET /website_list?project=<value>`
+   **Then** the query correctly filters by the `project` column
+
+5. **Given** all fixes are applied and tested
+   **When** developer runs the full test suite (backend + slack_bot)
+   **Then** all existing tests pass with no regressions and new tests cover the fixed behavior
+
+6. **Given** all fixes are verified
+   **When** developer creates a PR from `fix/slack-bot-add-type-and-check-url` to `main`
+   **Then** the PR is created with a clear summary of all changes
+
+## Tasks / Subtasks
+
+### Part A: Verify Existing Fixes (already on branch)
+
+- [x] Task 1: Verify `/lenie-check` URL search fix (AC: #1)
+  - [x] 1.1: Confirm `url` column added to search clauses in `stalker_web_documents_db_postgresql.py:get_list()`
+  - [x] 1.2: Confirm parameterized `%s` placeholder used (not f-string)
+  - [x] 1.3: Run existing backend tests to verify no regressions
+
+- [x] Task 2: Verify `/lenie-add` type parameter fix (AC: #2)
+  - [x] 2.1: Confirm `commands.py` passes optional `url_type` to `api_client.add_url()`
+  - [x] 2.2: Confirm `api_client.add_url()` default type is `"webpage"` (not `"link"`)
+  - [x] 2.3: Confirm `_VALID_TYPES = frozenset(DOCUMENT_TYPES)` (no duplicate constant)
+  - [x] 2.4: Run slack_bot unit tests to verify
+
+- [x] Task 3: Verify SQL injection fix (AC: #3)
+  - [x] 3.1: Confirm ALL WHERE clause parameters in `get_list()` use `%s` parameterized queries
+  - [x] 3.2: Confirm `params` list passed to `cur.execute(query, params)`
+  - [x] 3.3: Verify `print()` statements replaced with `logger.debug()`
+
+### Part B: Fix Remaining Bug
+
+- [x] Task 4: Fix `project` filter column bug in `get_list()` (AC: #4)
+  - [x] 4.1: In `stalker_web_documents_db_postgresql.py`, find the `project` filter clause
+  - [x] 4.2: Change `document_state = %s` to `project = %s` in the project filter
+  - [x] 4.3: Add unit test for `get_list(project=...)` to prevent regression
+
+### Part C: Testing & PR
+
+- [x] Task 5: Run full test suites (AC: #5)
+  - [x] 5.1: Run backend tests: `cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v`
+  - [x] 5.2: Run slack_bot tests: `cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v`
+  - [x] 5.3: Run ruff linter: `uvx ruff check backend/ slack_bot/`
+  - [x] 5.4: Verify all tests pass, fix any failures
+
+- [x] Task 6: Create PR to main (AC: #6)
+  - [x] 6.1: Commit the `project` filter fix (Task 4)
+  - [x] 6.2: Create PR from `fix/slack-bot-add-type-and-check-url` to `main`
+  - [x] 6.3: PR summary should list all fixes: URL search, type parameter, SQL injection, project filter, logging
+
+## Dev Notes
+
+### Scope Assessment
+
+This is a **conditional story** that was reserved as a placeholder for integration fixes. NAS deployment in Story 22-1 **did** reveal issues, and most fixes were already applied on branch `fix/slack-bot-add-type-and-check-url` (commits `265c58e`, `69c207b`). One remaining bug (`project` filter) was discovered during code analysis.
+
+**Already fixed (verify only):**
+- `/lenie-check` URL search — `url` added to search clauses in `get_list()`
+- `/lenie-add` type parameter — optional second argument, default `"webpage"`
+- SQL injection — all WHERE parameters use `%s` placeholders
+- Default type alignment — `api_client.add_url()` default changed to `"webpage"`
+- Duplicate constant — `_VALID_TYPES = frozenset(DOCUMENT_TYPES)`
+- Debug logging — `print()` → `logger.debug()`
+
+**Still needs fix:**
+- `project` filter bug in `get_list()` — uses `document_state` column instead of `project`
+
+**Out of scope (separate backlog items):**
+- B-85: `/website_get` returns HTTP 500 for non-existent ID (should be 404) — separate bug fix
+- B-84: CONTENT_NEEDED status for URL-only additions — separate feature
+
+### Key Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/library/stalker_web_documents_db_postgresql.py` | VERIFY + FIX | Verify URL search, SQL params, logging. Fix `project` filter bug |
+| `slack_bot/src/commands.py` | VERIFY | Verify type parameter, `_VALID_TYPES`, usage messages |
+| `slack_bot/src/api_client.py` | VERIFY | Verify default type `"webpage"` |
+| `slack_bot/tests/unit/test_commands.py` | VERIFY | Verify tests for type parameter |
+
+### `project` Filter Bug Details
+
+In `backend/library/stalker_web_documents_db_postgresql.py`, the `get_list()` method has a `project` parameter filter. The WHERE clause incorrectly uses `document_state = %s` instead of `project = %s`. This is a copy-paste bug that existed before the SQL injection fix and was preserved during parameterization.
+
+**Location:** Look for the `if project:` block in `get_list()` — the generated SQL clause should be `project = %s`, not `document_state = %s`.
+
+### Testing Strategy
+
+1. **Backend unit tests:** `cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v`
+2. **Slack bot unit tests:** `cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v` (NOT `uvx pytest` — needs venv dependencies)
+3. **Ruff linting:** `uvx ruff check backend/ slack_bot/` (line-length=120)
+4. Expected: 108+ slack_bot tests, all passing
+
+### Previous Story Intelligence (Story 22-1)
+
+- **Deployment-first approach** decided in Epic 21 retrospective — verify on real environment before adding features
+- **All 5 slash commands verified** against live NAS backend — field names aligned
+- **Test runner:** `.venv/Scripts/python -m pytest` for slack_bot (NOT `uvx pytest`)
+- **`register_commands()` closure pattern** is stable — do not modify
+- **B-85 filed:** `GET /website_get?id=<nonexistent>` returns HTTP 500 instead of 404
+- **B-84 documented:** URLs added via Slack have no content (CONTENT_NEEDED status proposal)
+
+### Git Intelligence
+
+Current branch: `fix/slack-bot-add-type-and-check-url`
+
+Recent commits on this branch:
+- `69c207b` — code review fixes: SQL injection, type defaults, cleanup
+- `b1bb8c6` — B-84 CONTENT_NEEDED status documentation
+- `265c58e` — /lenie-add accepts document type, /lenie-check searches by URL
+
+### Project Structure Notes
+
+- Backend follows raw `psycopg2` pattern (no ORM) — maintain parameterized queries
+- Slack bot module separation: `commands.py` (handlers) / `api_client.py` (HTTP) / `config.py` (config)
+- All routes except health checks require `x-api-key` header
+- Ruff linting with `line-length=120`, consistent across backend and slack_bot
+
+### References
+
+- [Source: backend/library/stalker_web_documents_db_postgresql.py] — `get_list()` method with search, filters, SQL
+- [Source: slack_bot/src/commands.py] — 5 slash command handlers
+- [Source: slack_bot/src/api_client.py] — HTTP client, exception hierarchy
+- [Source: _bmad-output/implementation-artifacts/22-1-nas-deployment-end-to-end-verification.md] — Previous story details
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 22.2] — Story definition
+- [Source: _bmad-output/implementation-artifacts/epic-21-retro-2026-03-02.md] — Deployment-first rationale
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+- Backend unit tests: 24 passed, 6 pre-existing failures (markdown/transcript), 5 skipped, 8 new tests passed
+- Slack bot unit tests: 108 passed, 0 failures
+- Ruff: new file clean, pre-existing issues in other files (out of scope)
+
+### Completion Notes List
+
+- **Task 1-3 (Verification):** All previously applied fixes on branch confirmed correct: URL search in `get_list()`, `/lenie-add` type parameter with default `"webpage"`, `_VALID_TYPES = frozenset(DOCUMENT_TYPES)`, all SQL parameters use `%s` placeholders, `logger.debug()` replaces `print()`.
+- **Task 4 (Bug Fix):** Fixed `project` filter copy-paste bug in `get_list()` — changed `document_state = %s` to `project = %s` in the project filter WHERE clause. Added 8 unit tests for query construction covering project filter, parameterization, search fields, and combined filters.
+- **Task 5 (Testing):** Full test suites run: backend 32/35 pass (6 pre-existing failures unrelated to this story), slack_bot 108/108 pass, ruff clean on modified files.
+- **Task 6 (PR):** Committed fix and new tests, PR created from `fix/slack-bot-add-type-and-check-url` to `main`.
+
+### Change Log
+
+- 2026-03-03: Fixed `project` filter column bug in `get_list()` (AC #4). Added 8 unit tests for `get_list()` query construction. Verified all prior fixes (AC #1-3). Created PR.
+
+### File List
+
+- `backend/library/stalker_web_documents_db_postgresql.py` — MODIFIED: Fixed `project` filter WHERE clause (line 107: `document_state = %s` → `project = %s`)
+- `backend/tests/unit/test_get_list_query.py` — NEW: 8 unit tests for `get_list()` query construction (project filter, parameterization, search fields)
+- `_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md` — MODIFIED: Updated tasks, status, dev agent record
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED: Story status `ready-for-dev` → `in-progress` → `review`

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -272,7 +272,7 @@ development_status:
   # --- Epic 22: Slack Bot Stabilization & DM Commands ---
   epic-22: in-progress
   22-1-nas-deployment-end-to-end-verification: done
-  22-2-backend-api-response-fixes-conditional: backlog
+  22-2-backend-api-response-fixes-conditional: review
   22-3-dm-text-command-parsing-simplified: backlog
   epic-22-retrospective: optional
 

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -104,7 +104,7 @@ class WebsitesDBPostgreSQL:
             params.append(document_state)
 
         if project:
-            where_clauses.append("document_state = %s")
+            where_clauses.append("project = %s")
             params.append(project)
 
         if ai_correction_needed:

--- a/backend/tests/unit/test_get_list_query.py
+++ b/backend/tests/unit/test_get_list_query.py
@@ -1,0 +1,146 @@
+"""Unit tests for WebsitesDBPostgreSQL.get_list() query construction.
+
+Tests verify that SQL WHERE clauses use correct column names and parameterized queries.
+Uses sys.modules mocking to avoid psycopg2 dependency.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock psycopg2 before importing the module under test
+_mock_psycopg2 = MagicMock()
+sys.modules["psycopg2"] = _mock_psycopg2
+
+
+@pytest.fixture(autouse=True)
+def _reset_psycopg2_mock():
+    """Reset mock state before each test."""
+    _mock_psycopg2.reset_mock()
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    _mock_psycopg2.connect.return_value = mock_conn
+    yield mock_conn, mock_cursor
+
+
+@pytest.fixture
+def db_instance(_reset_psycopg2_mock):
+    """Create a WebsitesDBPostgreSQL instance with mocked connection."""
+    mock_conn, mock_cursor = _reset_psycopg2_mock
+
+    from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
+
+    instance = WebsitesDBPostgreSQL()
+    instance._mock_cursor = mock_cursor
+    return instance
+
+
+class TestGetListProjectFilter:
+    """Tests for the project filter in get_list()."""
+
+    def test_project_filter_uses_project_column(self, db_instance):
+        """Verify that project filter generates 'project = %s', not 'document_state = %s'."""
+        db_instance.get_list(project="my-project")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+
+        assert "project = %s" in query, f"Expected 'project = %s' in query, got: {query}"
+        assert "my-project" in params, f"Expected 'my-project' in params, got: {params}"
+
+    def test_project_filter_does_not_use_document_state_for_project(self, db_instance):
+        """Ensure project filter doesn't accidentally filter by document_state."""
+        db_instance.get_list(project="test-project", document_state="ALL")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+
+        # When document_state is ALL, there should be no "document_state = %s" in query
+        assert query.count("document_state = %s") == 0, (
+            f"project filter should not generate 'document_state = %s' clause, got: {query}"
+        )
+        assert "project = %s" in query
+
+
+class TestGetListParameterization:
+    """Tests verifying all filters use parameterized queries."""
+
+    def test_document_type_parameterized(self, db_instance):
+        """Verify document_type filter uses %s placeholder."""
+        db_instance.get_list(document_type="webpage")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+
+        assert "document_type = %s" in query
+        assert "webpage" in params
+
+    def test_document_state_parameterized(self, db_instance):
+        """Verify document_state filter uses %s placeholder."""
+        db_instance.get_list(document_state="URL_ADDED")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+
+        assert "document_state = %s" in query
+        assert "URL_ADDED" in params
+
+    def test_search_in_documents_parameterized(self, db_instance):
+        """Verify search_in_documents uses LIKE %s (not f-string)."""
+        db_instance.get_list(search_in_documents="https://example.com")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+
+        assert "LIKE %s" in query
+        assert "%https://example.com%" in params
+
+    def test_search_includes_url_field(self, db_instance):
+        """Verify search_in_documents searches in url column."""
+        db_instance.get_list(search_in_documents="test")
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+
+        assert "url LIKE %s" in query
+
+    def test_combined_filters_all_parameterized(self, db_instance):
+        """Verify combining multiple filters all use parameterized queries."""
+        db_instance.get_list(
+            document_type="webpage",
+            document_state="URL_ADDED",
+            project="my-project",
+            search_in_documents="test",
+        )
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query, params = call_args[0][0], call_args[0][1]
+
+        assert "document_type = %s" in query
+        assert "document_state = %s" in query
+        assert "project = %s" in query
+        assert "LIKE %s" in query
+        # No string interpolation of values in the query itself
+        assert "webpage" not in query
+        assert "URL_ADDED" not in query
+        assert "my-project" not in query
+        assert len(params) > 0
+
+    def test_no_filters_no_where_clause(self, db_instance):
+        """Verify no WHERE clause when all filters are default."""
+        db_instance.get_list()
+
+        call_args = db_instance._mock_cursor.execute.call_args
+        query = call_args[0][0]
+
+        assert "WHERE" not in query

--- a/slack_bot/src/main.py
+++ b/slack_bot/src/main.py
@@ -91,7 +91,7 @@ def main() -> None:
         from slack_bolt import App
         from slack_bolt.adapter.socket_mode import SocketModeHandler
     except ImportError:
-        logger.error("slack-bolt package is required: pip install slack-bolt")
+        logger.error("slack-bolt package is required. Install: uv sync (or pip install slack-bolt)")
         sys.exit(1)
 
     api_client = create_client(cfg)


### PR DESCRIPTION
## Summary

- **Fix `/lenie-check` URL search**: Added `url` column to search fields in `get_list()` so `/lenie-check <url>` finds documents by URL
- **Fix `/lenie-add` type parameter**: Added optional document type argument (default: `webpage`) to `/lenie-add` command
- **Fix SQL injection**: Converted all WHERE clause parameters in `get_list()` from f-string formatting to `%s` parameterized queries
- **Fix `project` filter bug**: Corrected copy-paste bug where project filter used `document_state` column instead of `project` column
- **Logging cleanup**: Replaced `print()` with `logger.debug()` in query methods
- **New unit tests**: Added 8 tests for `get_list()` query construction (project filter, parameterization, search fields)

## Changes by file

| File | Change |
|------|--------|
| `backend/library/stalker_web_documents_db_postgresql.py` | URL search, SQL parameterization, project filter fix, logging |
| `backend/tests/unit/test_get_list_query.py` | NEW: 8 unit tests for query construction |
| `slack_bot/src/commands.py` | Type parameter support, `_VALID_TYPES`, usage messages |
| `slack_bot/src/api_client.py` | Default type `"webpage"` |
| `slack_bot/tests/unit/test_commands.py` | Tests for type parameter |

## Test plan

- [x] Backend unit tests: 32 passed (6 pre-existing failures unrelated to this PR)
- [x] Slack bot unit tests: 108 passed
- [x] Ruff linting: clean on modified files
- [x] Pre-commit hooks: gitleaks + TruffleHog passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)