### PR TITLE
fix: code review fixes for Story 22.2

### DIFF
--- a/_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md
+++ b/_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md
@@ -1,6 +1,6 @@
 # Story 22.2: Backend API Response Fixes (Conditional)
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -175,10 +175,13 @@ Claude Opus 4.6
 ### Change Log
 
 - 2026-03-03: Fixed `project` filter column bug in `get_list()` (AC #4). Added 8 unit tests for `get_list()` query construction. Verified all prior fixes (AC #1-3). Created PR.
+- 2026-03-03: **Code Review (AI):** 7 issues found (0H/3M/4L). Fixed M2 (`print()` → `logging.debug()` in `server.py`), M3 (boolean params `is not None` check in `get_list()`), L1 (invalid type hint). M1 (SQL injection in sibling methods) deferred to backlog. All issues were pre-existing, not introduced by this story. PR #56 merged. Story → done.
 
 ### File List
 
 - `backend/library/stalker_web_documents_db_postgresql.py` — MODIFIED: Fixed `project` filter WHERE clause (line 107: `document_state = %s` → `project = %s`)
 - `backend/tests/unit/test_get_list_query.py` — NEW: 8 unit tests for `get_list()` query construction (project filter, parameterization, search fields)
 - `_bmad-output/implementation-artifacts/22-2-backend-api-response-fixes-conditional.md` — MODIFIED: Updated tasks, status, dev agent record
-- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED: Story status `ready-for-dev` → `in-progress` → `review`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED: Story status `ready-for-dev` → `in-progress` → `review` → `done`
+- `backend/server.py` — MODIFIED: `print()` → `logging.debug()` in `/website_list` endpoint (review fix M2)
+- `backend/library/stalker_web_documents_db_postgresql.py` — MODIFIED: Boolean params `is not None` check, fixed return type hint (review fixes M3, L1)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -272,7 +272,7 @@ development_status:
   # --- Epic 22: Slack Bot Stabilization & DM Commands ---
   epic-22: in-progress
   22-1-nas-deployment-end-to-end-verification: done
-  22-2-backend-api-response-fixes-conditional: review
+  22-2-backend-api-response-fixes-conditional: done
   22-3-dm-text-command-parsing-simplified: backlog
   epic-22-retrospective: optional
 

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -77,8 +77,7 @@ class WebsitesDBPostgreSQL:
     def get_list(self, limit: int = 100, offset: int = 0, document_type: str = "ALL", document_state: str = "ALL",
                  search_in_documents = None, count = False, project = None, ai_summary_needed: bool = None,# noqa
                  ai_correction_needed: bool = None, start_id = None) -> \
-            list[
-                dict[str, str, str, str, str, str, str, str, str]]:
+            list[dict[str, Any]]:
         offset = offset * limit
 
         logger.debug("count: %s", count)
@@ -90,7 +89,6 @@ class WebsitesDBPostgreSQL:
 
 
         order_by = "ORDER BY created_at DESC"
-        limit_offset = f"LIMIT {int(limit)} OFFSET {int(offset)}"
 
         where_clauses = []
         params = []
@@ -107,11 +105,11 @@ class WebsitesDBPostgreSQL:
             where_clauses.append("project = %s")
             params.append(project)
 
-        if ai_correction_needed:
+        if ai_correction_needed is not None:
             where_clauses.append("ai_correction_needed = %s")
             params.append(ai_correction_needed)
 
-        if ai_summary_needed:
+        if ai_summary_needed is not None:
             where_clauses.append("ai_summary_needed = %s")
             params.append(ai_summary_needed)
 
@@ -124,7 +122,8 @@ class WebsitesDBPostgreSQL:
         if search_in_documents:
             search_fields = ["url", "text", "title", "summary", "chapter_list", "summary_english", "text_english"]
             search_clauses = [f"{field} LIKE %s" for field in search_fields]
-            search_pattern = f"%{search_in_documents}%"
+            escaped = search_in_documents.replace("%", "\\%").replace("_", "\\_")
+            search_pattern = f"%{escaped}%"
             params.extend([search_pattern] * len(search_fields))
             where_clauses.append(f"({' OR '.join(search_clauses)})")
 
@@ -138,7 +137,8 @@ class WebsitesDBPostgreSQL:
         if count:
             query = f"{base_query}{where_query}"
         else:
-            query = f"{base_query}{where_query} {order_by} {limit_offset}"
+            query = f"{base_query}{where_query} {order_by} LIMIT %s OFFSET %s"
+            params.extend([int(limit), int(offset)])
 
         logger.debug("query: %s", query)
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -301,7 +301,7 @@ def website_list():
     websites_list = websites.get_list(document_type=document_type, document_state=document_state, search_in_documents=search_in_documents)
     websites_list_count = websites.get_list(document_type=document_type, document_state=document_state, search_in_documents=search_in_documents, count=True)
     # pprint_debug(websites_list)
-    print(f"website count: {websites_list_count}")
+    logging.debug("website count: %s", websites_list_count)
 
     response = {
         "status": "success",

--- a/backend/tests/unit/test_config_loader.py
+++ b/backend/tests/unit/test_config_loader.py
@@ -2,6 +2,10 @@ import os
 import unittest
 from unittest.mock import patch, MagicMock
 
+import pytest
+
+pytest.importorskip("unified_config_loader", reason="unified_config_loader not installed (path dependency)")
+
 from library.config_loader import (
     AWSSSMBackend,
     Config,


### PR DESCRIPTION
## Summary
- Parameterize `LIMIT`/`OFFSET` in `get_list()` — consistent with WHERE clause style
- Escape LIKE wildcards (`%`, `_`) in `search_in_documents` to prevent unintended matching
- Fix boolean params (`ai_correction_needed`, `ai_summary_needed`) to use `is not None` instead of truthy check
- Fix invalid return type hint on `get_list()` — `dict[str, str, ...]` → `dict[str, Any]`
- Replace `print()` with `logging.debug()` in `/website_list` endpoint
- Add `pytest.importorskip` for `test_config_loader.py` (graceful skip when `unified_config_loader` not installed)
- Story 22-2 status → done, sprint-status synced

## Test plan
- [x] Backend unit tests: 24 passed, 6 pre-existing failures, 6 skipped (config_loader now skips gracefully)
- [x] `test_get_list_query.py`: 8/8 passed
- [x] Ruff lint: all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)