### PR TITLE
feat: migrate standalone scripts to config_loader (B-79)

### DIFF
--- a/backend/library/lenie_markdown.py
+++ b/backend/library/lenie_markdown.py
@@ -29,7 +29,7 @@ def get_images_with_links_md(markdown_text):
         # logger.debug(f"Tekst szukany występuje {liczba_wystapien} razy.")
 
         if liczba_wystapien > 1:
-            markdown_text = re.sub(alt_text_original, alt_text_original.replace("\n", " "), markdown_text, 1, re.DOTALL)
+            markdown_text = re.sub(alt_text_original, alt_text_original.replace("\n", " "), markdown_text, count=1, flags=re.DOTALL)
             markdown_text = remove_new_line_only_in_string(markdown_text, alt_text_original)
 
 
@@ -47,7 +47,7 @@ def get_images_with_links_md(markdown_text):
 
             tmp_to_replace = rf'\!\[{re.escape(image["alt_text"])}\]\({re.escape(image["url"])}\)\s*{re.escape(image["owner"])}\s*{re.escape(image["alt_text"])}'
             tmp_replace = f'picture[{i}]:"{image["alt_text"]}"'
-            markdown_text = re.sub(tmp_to_replace, tmp_replace, markdown_text, 1, re.DOTALL)
+            markdown_text = re.sub(tmp_to_replace, tmp_replace, markdown_text, count=1, flags=re.DOTALL)
         # else:
             # logger.debug("Not found reach")
         image["url"] = image["url"].replace("\n", "")

--- a/backend/library/lenie_markdown.py
+++ b/backend/library/lenie_markdown.py
@@ -13,7 +13,6 @@ def get_images_with_links_md(markdown_text):
     matches = re.findall(regex, markdown_text, re.DOTALL)
 
     extracted_images = []
-    updated_text = markdown_text
     for i, match in enumerate(matches):
         alt_text_original = match[0]
         image = {
@@ -47,7 +46,7 @@ def get_images_with_links_md(markdown_text):
 
 
             tmp_to_replace = rf'\!\[{re.escape(image["alt_text"])}\]\({re.escape(image["url"])}\)\s*{re.escape(image["owner"])}\s*{re.escape(image["alt_text"])}'
-            tmp_replace = f'picture({i}):"{image["alt_text"]}"'
+            tmp_replace = f'picture[{i}]:"{image["alt_text"]}"'
             markdown_text = re.sub(tmp_to_replace, tmp_replace, markdown_text, 1, re.DOTALL)
         # else:
             # logger.debug("Not found reach")
@@ -154,7 +153,8 @@ def md_square_brackets_in_one_line(text):
                 is_in_brackets = False
             continue
         elif char == "\n" and is_in_brackets and level > 0:
-            text_new += " "
+            if text_new and text_new[-1] not in (" ", "["):
+                text_new += " "
             continue
         else:
             text_new += char

--- a/backend/library/text_transcript.py
+++ b/backend/library/text_transcript.py
@@ -11,9 +11,9 @@ def time_to_seconds(time_str: str) -> int:
         return minutes * 60 + seconds
 
 
-def split_text_and_time(input_string: str | None) -> dict[str, str] | None:
+def split_text_and_time(input_string: str | None) -> dict[str, str]:
     if input_string is None:
-        return None
+        return {}
 
     match = re.match(r'(.*)\s(\d{1,2}:\d{2})$', input_string)
     if match:
@@ -28,7 +28,7 @@ def split_text_and_time(input_string: str | None) -> dict[str, str] | None:
         time, text = match3.groups()
         return {'text': text, 'czas': time}
     else:
-        return None
+        return {}
 
 
 def chapters_text_to_list(chapters_string):

--- a/backend/test_code/embeddings_search.py
+++ b/backend/test_code/embeddings_search.py
@@ -1,16 +1,16 @@
 import os
 from pprint import pprint
-from dotenv import load_dotenv
 import argparse
 import logging
 
 import library.embedding as embedding
 from library.ai import ai_ask, ai_model_need_translation_to_english
+from library.config_loader import load_config
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.text_detect_language import text_language_detect
 from library.stalker_cache import cache_get, cache_write
 
-load_dotenv()
+cfg = load_config()
 logging.basicConfig(level=logging.INFO)
 
 

--- a/backend/test_code/gcloud_firestore_example.py
+++ b/backend/test_code/gcloud_firestore_example.py
@@ -1,14 +1,13 @@
 from google.cloud import firestore
 from pprint import pprint
 import dateparser
-from dotenv import load_dotenv
-import os
-load_dotenv()
 
+from library.config_loader import load_config
 
+cfg = load_config()
 
-project_id = os.environ.get("GCP_FIRESTORE_PROJECT_ID")
-database = os.environ.get("GCP_FIRESTORE_DATABASE")
+project_id = cfg.get("GCP_FIRESTORE_PROJECT_ID")
+database = cfg.get("GCP_FIRESTORE_DATABASE")
 
 db = firestore.Client(project=project_id, database=database)
 
@@ -44,7 +43,7 @@ Kolejne cztery zostaną zbudowane w Luizjanie, a wszystkie sześć statków zost
 
 Zamówienia dla USA są częścią starań o dorównanie rosyjskiej liczbie lodołamaczy. Obecnie Rosja posiada ich około 40, w tym osiem o napędzie jądrowym. Dla porównania, w USA obecnie eksploatowane są tylko trzy. Tymczasem Chiny eksploatują około pięciu jednostek zdolnych do żeglugi polarnej.
 
-Źródło: BBC        
+Źródło: BBC
     """
 
 }

--- a/backend/test_code/vault_tests.py
+++ b/backend/test_code/vault_tests.py
@@ -1,10 +1,8 @@
 import hvac
-from dotenv import load_dotenv
-import os
 from pprint import pprint
 import requests
-import os
-from urllib.parse import urlparse
+
+from library.config_loader import load_config
 
 
 def sprawdz_dostepnosc_vault(url, timeout=2):
@@ -32,7 +30,7 @@ def sprawdz_dostepnosc_vault(url, timeout=2):
         print(f"Błąd podczas sprawdzania dostępności serwera: {e}")
         return False, None
 
-load_dotenv()
+cfg = load_config()
 
 def get_vault_client(vault_url, token=None, role_id=None, secret_id=None):
     """
@@ -77,7 +75,7 @@ def list_secrets(client, path, mount_point="kv"):
         print(f"Błąd podczas listowania sekretów: {e}")
         return []
 
-vault_client = get_vault_client(os.getenv("VAULT_URL"), token=os.getenv("VAULT_TOKEN"))
+vault_client = get_vault_client(cfg.get("VAULT_URL"), token=cfg.get("VAULT_TOKEN"))
 CLOUDFERRO_SHERLOCK_KEY=get_secret(vault_client, "lenie-ai/dev/cloudferro", "SHERLOCK_KEY")
 print(CLOUDFERRO_SHERLOCK_KEY)
 
@@ -96,7 +94,7 @@ print(health_status)
 status = vault_client.sys.read_health_status(method='GET')
 print('Vault initialization status is: %s' % status['initialized'])
 
-vault_url = os.getenv("VAULT_URL", "http://127.0.0.1:8200")
+vault_url = cfg.get("VAULT_URL") or "http://127.0.0.1:8200"
 
 dostepny, kod = sprawdz_dostepnosc_vault(vault_url)
 if dostepny:

--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -5,7 +5,7 @@ import uuid
 
 from markitdown import MarkItDown
 import boto3
-from dotenv import load_dotenv
+from library.config_loader import load_config
 
 # Importacja własnych modułów
 from library.website.website_download_context import download_raw_html, webpage_raw_parse, webpage_text_clean
@@ -16,12 +16,12 @@ from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.embedding import embedding_need_translation
 from library.youtube_processing import process_youtube_url
 
-# Ładowanie zmiennych środowiskowych
-load_dotenv()
+# Ładowanie konfiguracji (obsługuje .env, Vault, AWS SSM)
+cfg = load_config()
 
 logging.basicConfig(level=logging.INFO)  # Change level as per your need
 
-aws_xray_enabled = os.getenv("AWS_XRAY_ENABLED")
+aws_xray_enabled = cfg.get("AWS_XRAY_ENABLED")
 print(f"aws_xray_enabled: {aws_xray_enabled}")
 
 
@@ -35,13 +35,13 @@ The maximum file size for a local file uploaded to the API via the /v2/upload en
 
 if __name__ == '__main__':
 
-    # model = os.getenv("EMBEDDING_MODEL")
-    embedding_model = os.getenv("EMBEDDING_MODEL")
-    cache_dir = os.getenv("CACHE_DIR")
-    s3_bucket = os.getenv("AWS_S3_WEBSITE_CONTENT")
-    s3_bucket_transcript = os.getenv("AWS_S3_TRANSCRIPT")
-    transcript_provider = os.getenv("TRANSCRIPT_PROVIDER")
-    llm_model = os.getenv("AI_MODEL_SUMMARY")
+    # model = cfg.get("EMBEDDING_MODEL")
+    embedding_model = cfg.get("EMBEDDING_MODEL")
+    cache_dir = cfg.get("CACHE_DIR")
+    s3_bucket = cfg.get("AWS_S3_WEBSITE_CONTENT")
+    s3_bucket_transcript = cfg.get("AWS_S3_TRANSCRIPT")
+    transcript_provider = cfg.get("TRANSCRIPT_PROVIDER")
+    llm_model = cfg.get("AI_MODEL_SUMMARY")
     interactive: bool = False
 
     print(f"Using >{embedding_model}< for embedding")
@@ -57,14 +57,14 @@ if __name__ == '__main__':
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
 
-    print("AWS REGION: ", os.getenv("AWS_REGION"))
-    queue_url = os.getenv("AWS_QUEUE_URL_ADD")
+    print("AWS REGION: ", cfg.get("AWS_REGION"))
+    queue_url = cfg.get("AWS_QUEUE_URL_ADD")
 
     print("Step 1: Taking pages to put into RDS database")
     boto_session = boto3.session.Session(
-        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-        region_name=os.getenv("AWS_REGION")
+        aws_access_key_id=cfg.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=cfg.get("AWS_SECRET_ACCESS_KEY"),
+        region_name=cfg.get("AWS_REGION")
     )
 
     sqs = boto_session.client('sqs')

--- a/backend/webdocument_md_decode.py
+++ b/backend/webdocument_md_decode.py
@@ -2,7 +2,6 @@ import os.path
 import re
 import json
 import logging
-from dotenv import load_dotenv
 from pprint import pprint
 
 from markitdown import MarkItDown
@@ -16,14 +15,15 @@ from library.stalker_web_document import StalkerDocumentStatusError, StalkerDocu
 from library.stalker_web_document_db import StalkerWebDocumentDB
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.api.aws.s3_aws import s3_file_exist, s3_take_file
+from library.config_loader import load_config
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-load_dotenv()
+cfg = load_config()
 
-S3_BUCKET_NAME = os.getenv("AWS_S3_WEBSITE_CONTENT")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL")
+S3_BUCKET_NAME = cfg.get("AWS_S3_WEBSITE_CONTENT")
+EMBEDDING_MODEL = cfg.get("EMBEDDING_MODEL")
 
 
 def calculate_reduction(html_size, markdown_size):

--- a/backend/webdocument_prepare_regexp_by_ai.py
+++ b/backend/webdocument_prepare_regexp_by_ai.py
@@ -2,34 +2,29 @@ import os.path
 import re
 import json
 import logging
-from dotenv import load_dotenv
 from pprint import pprint
 
 from markitdown import MarkItDown
 from html2markdown import convert
 import html2text
 
-from library.api.cloudferro.sherlock.sherlock_embedding import sherlock_create_embeddings
-from library.lenie_markdown import get_images_with_links_md, links_correct, process_markdown_and_extract_links, \
-    md_square_brackets_in_one_line, md_split_for_emb, md_get_images_as_links, md_remove_markdown
-from library.stalker_web_document import StalkerDocumentStatusError, StalkerDocumentStatus
 from library.stalker_web_document_db import StalkerWebDocumentDB
-from library.stalker_web_document import StalkerWebDocument
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.api.aws.s3_aws import s3_file_exist, s3_take_file
+from library.config_loader import load_config
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-load_dotenv()
+cfg = load_config()
 
-S3_BUCKET_NAME = os.getenv("AWS_S3_WEBSITE_CONTENT")
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL")
+S3_BUCKET_NAME = cfg.get("AWS_S3_WEBSITE_CONTENT")
+EMBEDDING_MODEL = cfg.get("EMBEDDING_MODEL")
 
 wb_db = WebsitesDBPostgreSQL()
 
 # cache dir for S3 downloads and markdown output
-cache_dir_base = os.getenv("CACHE_DIR", "tmp/markdown")
+cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
 
 def calculate_reduction(html_size, markdown_size):
     return ((html_size - markdown_size) / html_size) * 100

--- a/backend/youtube_add.py
+++ b/backend/youtube_add.py
@@ -10,11 +10,11 @@ import logging
 import sys
 import time
 
-from dotenv import load_dotenv
+from library.config_loader import load_config
 
-load_dotenv()
+load_config()
 
-from library.youtube_processing import process_youtube_url
+from library.youtube_processing import process_youtube_url  # noqa: E402
 
 
 def main():


### PR DESCRIPTION
## Summary
- Migrate 7 standalone scripts from `load_dotenv()` to `load_config()` so they work with Vault/AWS SSM backends, not just `.env` files
- Fix 6 pre-existing unit test failures in `text_transcript`, `lenie_markdown`
- Fix 2 `DeprecationWarning` for `re.sub` positional args (Python 3.13)
- Remove 12 unused imports and 1 unused variable (ruff cleanup)

## Migrated files
- `backend/web_documents_do_the_needful_new.py` — batch processing pipeline
- `backend/webdocument_md_decode.py` — markdown decoding
- `backend/webdocument_prepare_regexp_by_ai.py` — AI regex generation
- `backend/youtube_add.py` — CLI YouTube processing
- `backend/test_code/vault_tests.py` — Vault integration tests
- `backend/test_code/embeddings_search.py` — RAG pipeline CLI
- `backend/test_code/gcloud_firestore_example.py` — Firestore CRUD example

## Bug fixes
- `text_transcript.split_text_and_time()`: return `{}` instead of `None` for edge cases
- `lenie_markdown.md_square_brackets_in_one_line()`: avoid double spaces when `\n` follows a space
- `lenie_markdown.get_images_with_links_md()`: use `picture[i]` instead of `picture(i)`
- `lenie_markdown.py`: use `count=` and `flags=` keyword args in `re.sub` (Python 3.13 compat)

## Test plan
- [x] `uvx ruff check` — 0 errors on all changed files
- [x] `uvx pytest tests/unit/` — 30 passed, 0 failed, 0 warnings
- [x] `grep -r "load_dotenv" backend/` — no occurrences in migrated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)