### PR TITLE
feat: B-79 config_loader migration + B-88 Notion changelog PoC

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -228,6 +228,9 @@ development_status:
   # --- B-79: Migrate Standalone Scripts to config_loader ---
   B-79-migrate-standalone-scripts-to-config-loader: done  # DONE 2026-03-04. Migrated 10 scripts from load_dotenv() to load_config(). Additional fixes: re.sub kwargs, text_transcript safer return. Remaining load_dotenv() in test_code/ and sherlock tracked in B-85.
 
+  # --- B-88: Notion Changelog Script (PoC) ---
+  B-88-notion-changelog-script: done  # DONE 2026-03-04. PoC script backend/scripts/notion_changelog.py — fetches N recent documents from PostgreSQL, publishes as table on Notion page. Uses config_loader for NOTION_API_TOKEN + NOTION_PAGE_ID. Added notion-client optional dep to pyproject.toml, vars to vars-classification.yaml. Code review: 4 fixes (pagination, rate limit 429, DB info leak, PRD date_added→created_at).
+
   # ============================================================
   # BACKLOG (only items TO DO)
   # ============================================================

--- a/_bmad-output/planning-artifacts/archive/prd-sprint5-slack-bot-2026-03-04.md
+++ b/_bmad-output/planning-artifacts/archive/prd-sprint5-slack-bot-2026-03-04.md
@@ -1,0 +1,386 @@
+---
+stepsCompleted:
+  - step-01-init
+  - step-02-discovery
+  - step-02b-vision
+  - step-02c-executive-summary
+  - step-03-success
+  - step-04-journeys
+  - step-05-domain
+  - step-06-innovation
+  - step-07-project-type
+  - step-08-scoping
+  - step-09-functional
+  - step-10-nonfunctional
+  - step-11-polish
+  - step-12-complete
+classification:
+  projectType: chatbot_integration
+  domain: personal_ai_knowledge_management
+  complexity: low
+  projectContext: brownfield
+  deploymentScope: docker_nas_only
+  modularity: docker_compose_profiles
+inputDocuments:
+  - docs/index.md
+  - docs/api-contracts-backend.md
+  - docs/architecture-backend.md
+  - docs/architecture-infra.md
+  - _bmad-output/planning-artifacts/archive/prd-sprint4-infra-consolidation-2026-02-27.md
+workflowType: 'prd'
+lastEdited: '2026-02-27'
+---
+
+# Product Requirements Document - lenie-server-2025
+
+**Author:** Ziutus
+**Date:** 2026-02-27
+
+## Executive Summary
+
+Lenie Slack Bot is an optional chatbot module for the Lenie-AI personal knowledge management system, providing a natural language interface to the existing REST API via Slack. It replaces the click-heavy Chrome Extension workflow with conversational interaction — users type messages instead of filling forms. Deployed exclusively on Docker/NAS (Socket Mode), it avoids AWS costs associated with persistent processes.
+
+The project serves a dual purpose: (1) a practical interface upgrade enabling mobile-friendly, natural language interaction with the knowledge base, and (2) a structured learning project for Slack bot development, bot command design, and external API integration — skills directly transferable to professional work.
+
+Built in five phases: slash commands (foundation), DM command-based (event subscriptions), app mentions (channel interactions), conversational LLM-powered DM (intent parsing via OpenAI), and proactive monitoring (health checks, alerting). Each phase delivers immediate value while teaching a distinct Slack API capability.
+
+**Target vision:** A Slack bot that answers questions about the knowledge base ("how many articles about Kubernetes?"), adds links via simple message paste, reports system version and health, and proactively alerts when infrastructure problems occur — all from a Slack conversation, including mobile.
+
+### What Makes This Special
+
+Three values converge in one project: (1) **UX paradigm shift** — from form-based Chrome Extension to natural language chat, making the system accessible from any device with Slack; (2) **professional skill building** — practical, portfolio-ready experience with Slack Bolt SDK, bot architecture, command design, and API integration patterns; (3) **proactive system awareness** — the bot monitors infrastructure health and initiates contact when problems arise, transforming Slack from a query tool into an operations assistant.
+
+The core insight: Slack is not "another UI" — it is the interface where the user already lives. Meeting the knowledge base where the user is (mobile, desktop, anywhere) removes the friction that makes Chrome Extension usage feel heavy.
+
+## Project Classification
+
+| Dimension | Value |
+|-----------|-------|
+| **Project Type** | Chatbot integration (Slack Bot as optional module) |
+| **Domain** | Personal AI knowledge management |
+| **Complexity** | Low (single user, no regulatory requirements, educational project) |
+| **Project Context** | Brownfield — new component added to running system (19 REST endpoints, PostgreSQL + pgvector, Docker Compose) |
+| **Deployment Scope** | Docker/NAS only (AWS excluded — Socket Mode requires persistent process) |
+| **Modularity** | Docker Compose profiles (`--profile slack`); formal plugin architecture deferred to backlog |
+
+## Success Criteria
+
+### User Success
+
+- User pastes a link in Slack and the bot confirms it was added to the knowledge base within 3 seconds
+- User asks the bot a question (version, count, check link, document info) and gets an accurate response in a single message
+- User can interact with the bot via all three Slack methods: slash commands, direct messages, and app mentions
+- User can operate the bot from mobile (Slack mobile app) with zero functionality loss compared to desktop
+
+### Business Success
+
+- **Portfolio quality**: Code is clean, well-structured, documented, and presentable as a professional portfolio piece — this applies to the entire Lenie project, not just the Slack bot
+- **Transferable skills**: Developer can replicate Slack bot integration patterns in a professional context without referring to tutorials
+- **Learning milestones completed**: Each of the 5 phases teaches a distinct, demonstrable Slack API capability (slash commands, event subscriptions, app mentions, LLM integration, proactive messaging)
+
+### Technical Success
+
+- Bot connects to existing Lenie REST API endpoints (`/version`, `/website_list`, `/url_add`, `/website_get`, `/website_similar`) and returns correct data
+- Bot runs as a separate Docker container using Docker Compose profiles (`--profile slack`)
+- Slack Bolt SDK (Python) handles all three interaction modes (slash commands, DM events, app mention events) in a single codebase
+- Socket Mode connection remains stable during normal NAS operation (auto-reconnect on transient network issues handled by Bolt SDK)
+- Code follows Python best practices: type hints, clear module structure, separation of Slack handling from API client logic, ruff-clean
+
+### Measurable Outcomes
+
+- 5 slash commands operational: `/lenie-version`, `/lenie-count`, `/lenie-check`, `/lenie-add`, `/lenie-info`
+- Same 5 commands available via DM and app mentions
+- Zero hardcoded URLs or credentials in bot code (all via environment variables or secret manager)
+- Code passes `ruff check` with zero warnings (line-length=120, consistent with backend)
+- Bot responds to commands in under 3 seconds (network latency to backend API excluded)
+
+## Product Scope
+
+### MVP — Phase 1 (Slash Commands)
+
+1. Create Slack workspace (free plan) and Slack App with Bot user
+2. Implement Slack Bolt SDK (Python) with Socket Mode
+3. Implement 5 slash commands calling existing REST API:
+   - `/lenie-version` → `GET /version`
+   - `/lenie-count` → `GET /website_list` (count only)
+   - `/lenie-check <url>` → `GET /website_list` (search by URL)
+   - `/lenie-add <url>` → `POST /url_add`
+   - `/lenie-info <id>` → `GET /website_get`
+4. Docker container with `Dockerfile`, added to `compose.yaml` under `slack` profile
+5. Documentation: setup guide, environment variables, Slack App configuration steps
+
+### Growth Features (Post-MVP)
+
+- **Phase 2: DM command-based** — Event subscriptions for direct messages, same 5 commands via text parsing
+- **Phase 3: App mentions** — `@Lenie version` on channels, same command set
+- **Phase 4: Conversational LLM** — Natural language intent parsing via OpenAI ("how many articles about Kubernetes?"), semantic search via `/website_similar`
+
+### Vision (Future)
+
+- **Phase 5: Proactive monitoring** — Scheduled health checks (database, backend, SQS queue), bot initiates DM on failures (nice-to-have)
+- **Formal plugin architecture** — Modular system where Slack, RSS, MCP server are optional plugins with shared configuration
+- **HTTP Mode + Lambda** — Alternative deployment for AWS (if cost-justified in the future)
+
+## User Journeys
+
+### Journey 1: "Found an interesting link" — Adding Content via Slack
+
+**Persona:** Ziutus — sole developer and user, browsing news on mobile during commute.
+
+**Opening Scene:** Ziutus is on a tram, scrolling Twitter on his phone. He spots an article about new pgvector features in PostgreSQL 18. With Chrome Extension, he'd need to: open the link in browser, click extension icon, fill the form, submit. Too much friction on mobile.
+
+**Rising Action:** Ziutus opens Slack on his phone, pastes the URL into a DM with @Lenie, and types `/lenie-add https://example.com/pgvector-18-features`. The bot receives the command, calls `POST /url_add` on the backend, and waits for confirmation.
+
+**Climax:** Within 2 seconds, the bot responds: "Added to knowledge base (ID: 1847). Type: link. Title auto-detected: 'What's New in pgvector 0.8.0'." Ziutus smiles — done. One message, no forms, no popups.
+
+**Resolution:** The link is in the processing pipeline. Later, when Ziutus is at his desk, he can open the React UI to review, edit metadata, or trigger embedding generation. The Slack bot handled the capture — the heavy lifting happens elsewhere.
+
+### Journey 2: "Do I already have this?" — Checking for Duplicates
+
+**Persona:** Ziutus — reviewing shared links from a colleague.
+
+**Opening Scene:** A friend sends Ziutus a link to an AWS re:Invent talk. Ziutus thinks "I might have added this last month" but doesn't want to open the React UI just to check.
+
+**Rising Action:** Ziutus types `/lenie-check https://youtube.com/watch?v=abc123` in Slack.
+
+**Climax:** Bot responds: "Found in database (ID: 1203). Type: youtube. Status: EMBEDDING_EXIST. Added: 2026-01-15." — Ziutus already has it, fully processed with embeddings.
+
+**Resolution:** No duplicate added, no wasted processing. If the bot had responded "Not found in database," Ziutus would immediately follow up with `/lenie-add` to capture it.
+
+### Journey 3: "System Status Check" — Quick Health Query
+
+**Persona:** Ziutus — starting his work session, wants to know the system state.
+
+**Opening Scene:** Ziutus opens his laptop in the morning. Before diving into development, he wants a quick pulse check on Lenie.
+
+**Rising Action:** In Slack, he types `/lenie-version` and `/lenie-count`.
+
+**Climax:** Bot responds: "Version: 0.3.13.0, Build: 2026-02-25T14:30:00Z" and "Database contains 1,847 documents (423 webpages, 312 youtube, 891 links, 221 other)."
+
+**Resolution:** Ziutus knows the system is running the expected version and has a quick mental model of his knowledge base size. If the version were wrong or count unexpectedly low, he'd investigate immediately.
+
+### Journey 4: "Something Went Wrong" — Error Handling
+
+**Persona:** Ziutus — adding a link when backend is unreachable.
+
+**Opening Scene:** Ziutus tries `/lenie-add https://example.com/article` from his phone. The NAS backend is down for maintenance — but Ziutus doesn't know that.
+
+**Rising Action:** The bot attempts to call `POST /url_add` on the backend. The HTTP request times out after 5 seconds.
+
+**Climax:** Bot responds: "Failed to add link. Backend unreachable (connection timeout). Check if lenie-ai-server container is running." — Clear error message, no cryptic stack trace, actionable suggestion.
+
+**Resolution:** Ziutus knows exactly what happened and what to check. He saves the link in Slack (it's in the message history) and retries later. No data lost, no confusion.
+
+### Journey 5: "First Time Setup" — Developer Onboarding
+
+**Persona:** Ziutus — setting up the Slack bot for the first time.
+
+**Opening Scene:** Ziutus has the Lenie Docker stack running on NAS. He wants to add the Slack bot module. He's never created a Slack App before.
+
+**Rising Action:** Following the setup guide in the bot's README, Ziutus: (1) creates a free Slack workspace at slack.com, (2) creates a new Slack App at api.slack.com with the manifest from the repo, (3) copies the Bot Token and App-Level Token into the `.env` file, (4) runs `docker compose --profile slack up -d`.
+
+**Climax:** The bot container starts, connects via Socket Mode, and posts in `#general`: "Lenie Bot connected. Version 0.3.13.0. Type `/lenie-version` to verify." Ziutus types the command and gets a response. It works.
+
+**Resolution:** Setup took 15 minutes. The README covered every step. Ziutus has a working Slack bot connected to his knowledge base. The learning journey begins.
+
+### Journey Requirements Summary
+
+| Journey | Capabilities Required |
+|---------|----------------------|
+| Adding Content | `/lenie-add` slash command, `POST /url_add` API call, success/error response formatting |
+| Checking Duplicates | `/lenie-check` slash command, `GET /website_list` with URL filter, result formatting |
+| System Status | `/lenie-version` and `/lenie-count` slash commands, `GET /version` and `GET /website_list` API calls |
+| Error Handling | HTTP timeout handling, user-friendly error messages, actionable suggestions, no data loss |
+| First Time Setup | Slack App manifest in repo, Docker Compose profile, setup documentation, startup confirmation message |
+
+The user journeys above define *what* the bot does. The following section defines *how* it integrates into the existing system.
+
+## Technical Context
+
+### Architectural Position
+
+Slack Bot is an independent service communicating with the backend exclusively via HTTP REST API — zero code-level dependencies on `backend/`. Architecturally equivalent to Chrome Extension and React UI: a standalone API consumer.
+
+### Repository Structure
+
+New top-level directory `slack_bot/` — consistent with existing layout (`backend/`, `web_interface_react/`, `web_chrome_extension/`). Optional module, not embedded in the backend.
+
+```
+slack_bot/
+├── Dockerfile
+├── README.md
+├── pyproject.toml
+├── src/
+│   ├── __init__.py
+│   ├── main.py          # Entry point, Socket Mode connection
+│   ├── commands.py       # Slash command handlers
+│   ├── api_client.py     # HTTP client for Lenie REST API
+│   └── config.py         # Configuration loading (Vault/SSM/env)
+└── tests/
+    └── unit/
+```
+
+### API Communication
+
+Bot calls existing backend REST API endpoints over HTTP:
+
+| Bot Command | Backend Endpoint | Method | Auth |
+|-------------|-----------------|--------|------|
+| `/lenie-version` | `/version` | GET | None |
+| `/lenie-count` | `/website_list` | GET | `x-api-key` |
+| `/lenie-check <url>` | `/website_list` | GET | `x-api-key` |
+| `/lenie-add <url>` | `/url_add` | POST | `x-api-key` |
+| `/lenie-info <id>` | `/website_get` | GET | `x-api-key` |
+
+Backend base URL configurable via environment variable (e.g., `LENIE_API_URL=http://lenie-ai-server:5000`).
+
+### Secrets Management
+
+Slack tokens (Bot Token `xoxb-...`, App-Level Token `xapp-...`) stored in:
+- **Docker/NAS:** HashiCorp Vault (consistent with B-63 migration)
+- **AWS (future):** SSM Secrets Manager
+
+Backend API key (`STALKER_API_KEY`) retrieved from the same secret backend.
+
+### Logging
+
+- **Format:** JSON structured logging from day one (e.g., `python-json-logger`)
+- **Output:** stdout (Docker logs collects automatically)
+- **Backend migration to JSON logging:** Deferred to backlog (separate cross-project change)
+
+### Docker Deployment
+
+```yaml
+# In infra/docker/compose.yaml
+services:
+  lenie-ai-slack-bot:
+    build: ../../slack_bot
+    profiles: ["slack"]
+    environment:
+      - LENIE_API_URL=http://lenie-ai-server:5000
+      - SECRETS_BACKEND=vault
+    depends_on:
+      - lenie-ai-server
+```
+
+Started with: `docker compose --profile slack up -d`
+
+### Implementation Considerations
+
+- **Slack Bolt SDK** (`slack-bolt`) handles Socket Mode, slash commands, events, and app mentions in a unified framework
+- **Separation of concerns:** `commands.py` (Slack interaction) decoupled from `api_client.py` (HTTP calls) — testable independently, patterns reusable in professional context
+- **Error handling:** All API calls wrapped with timeout (5s) and user-friendly error messages (no stack traces in Slack responses)
+- **Portfolio quality:** Type hints, docstrings on public functions, ruff-clean code, comprehensive unit tests for `api_client.py` and command handlers
+
+## Project Scoping & Risk Mitigation
+
+### MVP Strategy
+
+**Approach:** Problem-solving MVP — deliver the smallest useful bot that proves Slack integration works end-to-end. One slash command working reliably is more valuable than five commands half-working.
+
+**Resources:** Solo developer (Ziutus), Python + Slack Bolt SDK knowledge, existing NAS with Docker stack running.
+
+**MVP covers all 5 User Journeys** via Phase 1 capabilities defined in Product Scope. Post-MVP phases (2-5) are also defined in Product Scope — each phase is a separate backlog epic with its own acceptance criteria.
+
+### Risk Mitigation Strategy
+
+**Technical Risk — Slack App Configuration:**
+First-time Slack App setup (permissions, OAuth scopes, Socket Mode toggle) can be confusing. **Mitigation:** Include a Slack App manifest YAML in the repo (`slack_bot/slack-app-manifest.yaml`) — this automates 90% of the configuration. Document the remaining manual steps with screenshots in README.
+
+**Dependency Risk — Backend Must Be Running:**
+Bot is useless when `lenie-ai-server` is down. On NAS, Docker containers may restart after power events. **Mitigation:** Bot handles backend unavailability gracefully — clear error message ("Backend unreachable"), no crash, auto-retry on next command. The bot itself stays connected to Slack regardless of backend state. `depends_on` in Docker Compose ensures correct startup order.
+
+**Process Risk — Scope Creep Across Phases:**
+5 phases is ambitious. Risk of starting Phase 2 before Phase 1 is solid. **Mitigation:** Each phase is a separate backlog epic. Phase 1 must pass all acceptance criteria (5 commands working, tests passing, documentation complete) before Phase 2 starts. No mixing phases.
+
+## Functional Requirements
+
+### Content Management
+
+- FR1: User can add a URL to the knowledge base by providing the link via Slack
+- FR2: User can check whether a specific URL already exists in the knowledge base
+- FR3: User can retrieve detailed information about a document by its ID (type, status, title, date added)
+
+### System Information
+
+- FR4: User can query the current backend version and build timestamp
+- FR5: User can query the total document count in the knowledge base, broken down by document type
+
+### Slack Interaction — Slash Commands (Phase 1)
+
+- FR6: User can invoke bot capabilities via slash commands (`/lenie-version`, `/lenie-count`, `/lenie-check`, `/lenie-add`, `/lenie-info`)
+- FR7: Bot responds to slash commands with formatted text messages in the same Slack channel
+
+### Slack Interaction — Direct Messages (Phase 2)
+
+- FR8: User can invoke the same capabilities by sending text commands in a direct message to the bot
+- FR9: Bot parses DM text to identify the intended command and parameters
+
+### Slack Interaction — App Mentions (Phase 3)
+
+- FR10: User can invoke bot capabilities by mentioning the bot on any channel (`@Lenie version`)
+- FR11: Bot responds to app mentions in the same channel thread
+
+### Conversational Intelligence (Phase 4)
+
+- FR12: User can interact with the bot using natural language instead of structured commands
+- FR13: Bot interprets user intent via LLM and maps it to the appropriate backend API call
+- FR14: User can perform semantic search across the knowledge base via natural language query
+
+### Proactive Monitoring (Phase 5 — Nice-to-Have)
+
+- FR15: Bot can periodically check backend health (API reachability, database connectivity)
+- FR16: Bot can send unprompted messages to the user when a health check fails
+- FR17: Bot does not send repeated alerts for the same ongoing failure (alert deduplication)
+
+### Error Communication
+
+- FR18: Bot displays user-friendly error messages when backend is unreachable (no stack traces, actionable suggestions)
+- FR19: Bot remains connected to Slack and responsive even when backend is down
+- FR20: Bot communicates specific failure reasons (timeout, HTTP error, invalid response) in plain language
+
+### Configuration & Deployment
+
+- FR21: Developer can deploy the bot as an optional Docker container using Compose profiles (`--profile slack`)
+- FR22: Developer can configure Slack tokens and backend URL via secret manager (Vault for Docker/NAS, SSM for AWS)
+- FR23: Developer can set up the Slack App using a manifest file included in the repository
+- FR24: Bot posts a startup confirmation message to a designated Slack channel upon successful connection
+
+### Documentation
+
+- FR25: Developer can follow a step-by-step README to set up the bot from scratch (Slack workspace creation, App setup, token configuration, Docker launch)
+
+## Non-Functional Requirements
+
+### Performance
+
+- NFR1: Bot responds to slash commands within 3 seconds (excluding backend API latency)
+- NFR2: Bot establishes Socket Mode connection within 10 seconds of container startup
+- NFR3: API client uses 5-second timeout for all backend HTTP calls — no hanging requests
+
+### Security
+
+- NFR4: Zero secrets (Slack tokens, API keys) hardcoded in source code or Docker images
+- NFR5: All secrets retrieved from secret manager at runtime (Vault for Docker/NAS, SSM for AWS)
+- NFR6: Bot logs never contain secret values, tokens, or API keys (even at DEBUG level)
+- NFR7: Backend API key transmitted via `x-api-key` header, never as URL parameter
+
+### Integration
+
+- NFR8: Bot communicates with backend exclusively via HTTP REST API — zero code-level dependencies on `backend/`
+- NFR9: Bot tolerates backend API response format changes gracefully (logs warning, returns user-friendly error instead of crashing)
+- NFR10: Slack Bolt SDK version pinned in `pyproject.toml` to prevent breaking changes from automatic updates
+
+### Code Quality
+
+- NFR11: Code passes `ruff check` with zero warnings (line-length=120, consistent with backend)
+- NFR12: All public functions have type hints
+- NFR13: `api_client.py` and command handlers have unit tests with >80% coverage
+- NFR14: Clear module separation: Slack interaction logic (`commands.py`) decoupled from HTTP client (`api_client.py`)
+- NFR15: JSON structured logging from day one (`python-json-logger`)
+
+### Reliability
+
+- NFR16: Bot process remains running and connected to Slack when backend is unreachable
+- NFR17: Slack Bolt SDK auto-reconnect handles transient Socket Mode disconnections without manual intervention
+- NFR18: Bot does not crash on malformed user input (invalid URL, missing ID, empty command arguments)

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -14,373 +14,256 @@ stepsCompleted:
   - step-10-nonfunctional
   - step-11-polish
   - step-12-complete
-classification:
-  projectType: chatbot_integration
-  domain: personal_ai_knowledge_management
-  complexity: low
-  projectContext: brownfield
-  deploymentScope: docker_nas_only
-  modularity: docker_compose_profiles
 inputDocuments:
   - docs/index.md
   - docs/api-contracts-backend.md
   - docs/architecture-backend.md
-  - docs/architecture-infra.md
-  - _bmad-output/planning-artifacts/archive/prd-sprint4-infra-consolidation-2026-02-27.md
+  - docs/secrets-management.md
+  - _bmad-output/planning-artifacts/archive/prd-sprint5-slack-bot-2026-03-04.md
+documentCounts:
+  briefs: 0
+  research: 0
+  brainstorming: 0
+  projectDocs: 4
+classification:
+  projectType: api_backend
+  domain: personal_ai_knowledge_management
+  complexity: low
+  projectContext: brownfield
+  deploymentScope: script
 workflowType: 'prd'
-lastEdited: '2026-02-27'
+lastEdited: '2026-03-04'
 ---
 
 # Product Requirements Document - lenie-server-2025
 
 **Author:** Ziutus
-**Date:** 2026-02-27
+**Date:** 2026-03-04
 
 ## Executive Summary
 
-Lenie Slack Bot is an optional chatbot module for the Lenie-AI personal knowledge management system, providing a natural language interface to the existing REST API via Slack. It replaces the click-heavy Chrome Extension workflow with conversational interaction — users type messages instead of filling forms. Deployed exclusively on Docker/NAS (Socket Mode), it avoids AWS costs associated with persistent processes.
+Notion Changelog is a lightweight proof-of-concept script that pushes the 10 most recently added documents from the Lenie knowledge base to a Notion workspace page. The goal is to evaluate whether Notion is a viable communication channel for keeping the team informed about new content — without requiring them to access the Lenie React UI.
 
-The project serves a dual purpose: (1) a practical interface upgrade enabling mobile-friendly, natural language interaction with the knowledge base, and (2) a structured learning project for Slack bot development, bot command design, and external API integration — skills directly transferable to professional work.
+This is a technical experiment, not a product feature. The script runs manually from the command line, reads directly from the PostgreSQL database, and writes to a Notion page via the Notion API. Success is measured by integration simplicity and maintainability — if the API connection is clean, reliable, and easy to keep running, Notion passes the test as a future communication channel.
 
-Built in five phases: slash commands (foundation), DM command-based (event subscriptions), app mentions (channel interactions), conversational LLM-powered DM (intent parsing via OpenAI), and proactive monitoring (health checks, alerting). Each phase delivers immediate value while teaching a distinct Slack API capability.
-
-**Target vision:** A Slack bot that answers questions about the knowledge base ("how many articles about Kubernetes?"), adds links via simple message paste, reports system version and health, and proactively alerts when infrastructure problems occur — all from a Slack conversation, including mobile.
+Built as a standalone Python script in `backend/scripts/`, it reuses existing database access patterns and the unified config loader for secrets management (Notion API token stored in Vault/SSM/env, consistent with all other Lenie credentials).
 
 ### What Makes This Special
 
-Three values converge in one project: (1) **UX paradigm shift** — from form-based Chrome Extension to natural language chat, making the system accessible from any device with Slack; (2) **professional skill building** — practical, portfolio-ready experience with Slack Bolt SDK, bot architecture, command design, and API integration patterns; (3) **proactive system awareness** — the bot monitors infrastructure health and initiates contact when problems arise, transforming Slack from a query tool into an operations assistant.
-
-The core insight: Slack is not "another UI" — it is the interface where the user already lives. Meeting the knowledge base where the user is (mobile, desktop, anywhere) removes the friction that makes Chrome Extension usage feel heavy.
+This is not about building a feature — it is about answering a question: "Is Notion a good fit for team communication in this project?" The smallest possible integration (one script, one API call, 10 items) gives the answer with minimal investment. If Notion works, it opens the door to richer integrations (automatic updates, bidirectional sync). If it doesn't, nothing was wasted.
 
 ## Project Classification
 
 | Dimension | Value |
 |-----------|-------|
-| **Project Type** | Chatbot integration (Slack Bot as optional module) |
+| **Project Type** | API backend integration (Notion API consumer) |
 | **Domain** | Personal AI knowledge management |
-| **Complexity** | Low (single user, no regulatory requirements, educational project) |
-| **Project Context** | Brownfield — new component added to running system (19 REST endpoints, PostgreSQL + pgvector, Docker Compose) |
-| **Deployment Scope** | Docker/NAS only (AWS excluded — Socket Mode requires persistent process) |
-| **Modularity** | Docker Compose profiles (`--profile slack`); formal plugin architecture deferred to backlog |
+| **Complexity** | Low (single user, no regulatory requirements, PoC) |
+| **Project Context** | Brownfield — new script added to existing backend |
+| **Deployment Scope** | CLI script (manually triggered) |
 
 ## Success Criteria
 
 ### User Success
 
-- User pastes a link in Slack and the bot confirms it was added to the knowledge base within 3 seconds
-- User asks the bot a question (version, count, check link, document info) and gets an accurate response in a single message
-- User can interact with the bot via all three Slack methods: slash commands, direct messages, and app mentions
-- User can operate the bot from mobile (Slack mobile app) with zero functionality loss compared to desktop
+- Script executes with a single command (`python backend/scripts/notion_changelog.py`) and completes without errors
+- Notion page displays the 10 most recently added documents with correct data: title, URL, document type, and date added
+- Data in Notion is readable and useful — a team member glancing at the page understands what was recently added
 
 ### Business Success
 
-- **Portfolio quality**: Code is clean, well-structured, documented, and presentable as a professional portfolio piece — this applies to the entire Lenie project, not just the Slack bot
-- **Transferable skills**: Developer can replicate Slack bot integration patterns in a professional context without referring to tutorials
-- **Learning milestones completed**: Each of the 5 phases teaches a distinct, demonstrable Slack API capability (slash commands, event subscriptions, app mentions, LLM integration, proactive messaging)
+- The experiment answers the question: "Is Notion a viable team communication channel for Lenie?"
+- Decision made (yes/no) based on hands-on experience with the API, not speculation
+- Minimal time investment — PoC built and evaluated within a single work session
 
 ### Technical Success
 
-- Bot connects to existing Lenie REST API endpoints (`/version`, `/website_list`, `/url_add`, `/website_get`, `/website_similar`) and returns correct data
-- Bot runs as a separate Docker container using Docker Compose profiles (`--profile slack`)
-- Slack Bolt SDK (Python) handles all three interaction modes (slash commands, DM events, app mention events) in a single codebase
-- Socket Mode connection remains stable during normal NAS operation (auto-reconnect on transient network issues handled by Bolt SDK)
-- Code follows Python best practices: type hints, clear module structure, separation of Slack handling from API client logic, ruff-clean
+- Small script — compact codebase, easy to read and modify
+- Configuration limited to 2 variables in Vault: `NOTION_API_TOKEN` and `NOTION_PAGE_ID`
+- No new heavyweight dependencies — only `notion-client` (official Notion SDK)
+- Reuses existing patterns: `config_loader` for secrets, direct PostgreSQL access for data
 
 ### Measurable Outcomes
 
-- 5 slash commands operational: `/lenie-version`, `/lenie-count`, `/lenie-check`, `/lenie-add`, `/lenie-info`
-- Same 5 commands available via DM and app mentions
-- Zero hardcoded URLs or credentials in bot code (all via environment variables or secret manager)
-- Code passes `ruff check` with zero warnings (line-length=120, consistent with backend)
-- Bot responds to commands in under 3 seconds (network latency to backend API excluded)
+- Script runs end-to-end with exit code 0
+- Notion page contains exactly 10 items with correct titles and URLs (verified manually)
+- Total new dependencies: 1 (`notion-client`)
+- Total new config variables: 2 (`NOTION_API_TOKEN`, `NOTION_PAGE_ID`)
 
 ## Product Scope
 
-### MVP — Phase 1 (Slash Commands)
+### MVP
 
-1. Create Slack workspace (free plan) and Slack App with Bot user
-2. Implement Slack Bolt SDK (Python) with Socket Mode
-3. Implement 5 slash commands calling existing REST API:
-   - `/lenie-version` → `GET /version`
-   - `/lenie-count` → `GET /website_list` (count only)
-   - `/lenie-check <url>` → `GET /website_list` (search by URL)
-   - `/lenie-add <url>` → `POST /url_add`
-   - `/lenie-info <id>` → `GET /website_get`
-4. Docker container with `Dockerfile`, added to `compose.yaml` under `slack` profile
-5. Documentation: setup guide, environment variables, Slack App configuration steps
+1. Python script at `backend/scripts/notion_changelog.py`
+2. Reads 10 most recently added documents from PostgreSQL (ordered by `created_at DESC`)
+3. Writes/updates a Notion page with a formatted list: title, URL, type, date added
+4. Uses `config_loader` for `NOTION_API_TOKEN` and `NOTION_PAGE_ID`
+5. Single command execution, clear stdout output (success/failure)
 
 ### Growth Features (Post-MVP)
 
-- **Phase 2: DM command-based** — Event subscriptions for direct messages, same 5 commands via text parsing
-- **Phase 3: App mentions** — `@Lenie version` on channels, same command set
-- **Phase 4: Conversational LLM** — Natural language intent parsing via OpenAI ("how many articles about Kubernetes?"), semantic search via `/website_similar`
+- To be decided after PoC evaluation — no commitments at this stage
 
 ### Vision (Future)
 
-- **Phase 5: Proactive monitoring** — Scheduled health checks (database, backend, SQS queue), bot initiates DM on failures (nice-to-have)
-- **Formal plugin architecture** — Modular system where Slack, RSS, MCP server are optional plugins with shared configuration
-- **HTTP Mode + Lambda** — Alternative deployment for AWS (if cost-justified in the future)
+- To be decided based on PoC results — potential directions include automatic scheduling, richer content, bidirectional sync, or abandoning Notion entirely
 
 ## User Journeys
 
-### Journey 1: "Found an interesting link" — Adding Content via Slack
+### Journey 1: "Team Update" — Pushing Changelog to Notion
 
-**Persona:** Ziutus — sole developer and user, browsing news on mobile during commute.
+**Persona:** Ziutus — sole developer and operator of the Lenie knowledge base.
 
-**Opening Scene:** Ziutus is on a tram, scrolling Twitter on his phone. He spots an article about new pgvector features in PostgreSQL 18. With Chrome Extension, he'd need to: open the link in browser, click extension icon, fill the form, submit. Too much friction on mobile.
+**Opening Scene:** Ziutus has just finished an import session — 15 new links and articles added to the knowledge base over the past few days. His team has no idea these resources exist because they don't use the React UI.
 
-**Rising Action:** Ziutus opens Slack on his phone, pastes the URL into a DM with @Lenie, and types `/lenie-add https://example.com/pgvector-18-features`. The bot receives the command, calls `POST /url_add` on the backend, and waits for confirmation.
+**Rising Action:** Ziutus opens a terminal and runs `python backend/scripts/notion_changelog.py`. The script connects to PostgreSQL, fetches the 10 most recently added documents, and calls the Notion API to update the designated page.
 
-**Climax:** Within 2 seconds, the bot responds: "Added to knowledge base (ID: 1847). Type: link. Title auto-detected: 'What's New in pgvector 0.8.0'." Ziutus smiles — done. One message, no forms, no popups.
+**Climax:** Within seconds, stdout confirms: "Updated Notion page with 10 items. Page URL: https://notion.so/..." Ziutus clicks the link — the Notion page shows a clean bulleted list: title, URL, type, and date for each item. His colleagues can see it immediately.
 
-**Resolution:** The link is in the processing pipeline. Later, when Ziutus is at his desk, he can open the React UI to review, edit metadata, or trigger embedding generation. The Slack bot handled the capture — the heavy lifting happens elsewhere.
+**Resolution:** The team now has a living page showing what's new in the knowledge base. Ziutus decides whether to mention it in Slack or just let people discover it. The whole operation took 5 seconds and one command.
 
-### Journey 2: "Do I already have this?" — Checking for Duplicates
+### Journey 2: "Something Went Wrong" — Error Handling
 
-**Persona:** Ziutus — reviewing shared links from a colleague.
+**Persona:** Ziutus — running the script after a configuration change.
 
-**Opening Scene:** A friend sends Ziutus a link to an AWS re:Invent talk. Ziutus thinks "I might have added this last month" but doesn't want to open the React UI just to check.
+**Opening Scene:** Ziutus rotated the Notion API token in Vault but forgot to update one environment. He runs the script.
 
-**Rising Action:** Ziutus types `/lenie-check https://youtube.com/watch?v=abc123` in Slack.
+**Rising Action:** The script loads config via `config_loader`, gets the token, and attempts to connect to Notion API. The API returns 401 Unauthorized.
 
-**Climax:** Bot responds: "Found in database (ID: 1203). Type: youtube. Status: EMBEDDING_EXIST. Added: 2026-01-15." — Ziutus already has it, fully processed with embeddings.
+**Climax:** The script prints a clear error: "ERROR: Notion API authentication failed (401). Check NOTION_API_TOKEN in your secret backend." No stack trace, no crash — just an actionable message. Exit code 1.
 
-**Resolution:** No duplicate added, no wasted processing. If the bot had responded "Not found in database," Ziutus would immediately follow up with `/lenie-add` to capture it.
-
-### Journey 3: "System Status Check" — Quick Health Query
-
-**Persona:** Ziutus — starting his work session, wants to know the system state.
-
-**Opening Scene:** Ziutus opens his laptop in the morning. Before diving into development, he wants a quick pulse check on Lenie.
-
-**Rising Action:** In Slack, he types `/lenie-version` and `/lenie-count`.
-
-**Climax:** Bot responds: "Version: 0.3.13.0, Build: 2026-02-25T14:30:00Z" and "Database contains 1,847 documents (423 webpages, 312 youtube, 891 links, 221 other)."
-
-**Resolution:** Ziutus knows the system is running the expected version and has a quick mental model of his knowledge base size. If the version were wrong or count unexpectedly low, he'd investigate immediately.
-
-### Journey 4: "Something Went Wrong" — Error Handling
-
-**Persona:** Ziutus — adding a link when backend is unreachable.
-
-**Opening Scene:** Ziutus tries `/lenie-add https://example.com/article` from his phone. The NAS backend is down for maintenance — but Ziutus doesn't know that.
-
-**Rising Action:** The bot attempts to call `POST /url_add` on the backend. The HTTP request times out after 5 seconds.
-
-**Climax:** Bot responds: "Failed to add link. Backend unreachable (connection timeout). Check if lenie-ai-server container is running." — Clear error message, no cryptic stack trace, actionable suggestion.
-
-**Resolution:** Ziutus knows exactly what happened and what to check. He saves the link in Slack (it's in the message history) and retries later. No data lost, no confusion.
-
-### Journey 5: "First Time Setup" — Developer Onboarding
-
-**Persona:** Ziutus — setting up the Slack bot for the first time.
-
-**Opening Scene:** Ziutus has the Lenie Docker stack running on NAS. He wants to add the Slack bot module. He's never created a Slack App before.
-
-**Rising Action:** Following the setup guide in the bot's README, Ziutus: (1) creates a free Slack workspace at slack.com, (2) creates a new Slack App at api.slack.com with the manifest from the repo, (3) copies the Bot Token and App-Level Token into the `.env` file, (4) runs `docker compose --profile slack up -d`.
-
-**Climax:** The bot container starts, connects via Socket Mode, and posts in `#general`: "Lenie Bot connected. Version 0.3.13.0. Type `/lenie-version` to verify." Ziutus types the command and gets a response. It works.
-
-**Resolution:** Setup took 15 minutes. The README covered every step. Ziutus has a working Slack bot connected to his knowledge base. The learning journey begins.
+**Resolution:** Ziutus checks Vault, spots the stale token, updates it, reruns the script. It works. Total debugging time: 30 seconds thanks to a clear error message.
 
 ### Journey Requirements Summary
 
 | Journey | Capabilities Required |
 |---------|----------------------|
-| Adding Content | `/lenie-add` slash command, `POST /url_add` API call, success/error response formatting |
-| Checking Duplicates | `/lenie-check` slash command, `GET /website_list` with URL filter, result formatting |
-| System Status | `/lenie-version` and `/lenie-count` slash commands, `GET /version` and `GET /website_list` API calls |
-| Error Handling | HTTP timeout handling, user-friendly error messages, actionable suggestions, no data loss |
-| First Time Setup | Slack App manifest in repo, Docker Compose profile, setup documentation, startup confirmation message |
-
-The user journeys above define *what* the bot does. The following section defines *how* it integrates into the existing system.
+| Team Update | PostgreSQL query (10 latest docs), Notion API page update, bulleted list formatting, stdout success confirmation |
+| Error Handling | Config loader integration, Notion API error detection, user-friendly error messages, non-zero exit code on failure |
 
 ## Technical Context
 
 ### Architectural Position
 
-Slack Bot is an independent service communicating with the backend exclusively via HTTP REST API — zero code-level dependencies on `backend/`. Architecturally equivalent to Chrome Extension and React UI: a standalone API consumer.
+Standalone Python script in `backend/scripts/` — not part of the Flask API. Reads directly from PostgreSQL, writes to Notion API. Zero coupling with Flask server; can run independently when database is accessible.
 
-### Repository Structure
-
-New top-level directory `slack_bot/` — consistent with existing layout (`backend/`, `web_interface_react/`, `web_chrome_extension/`). Optional module, not embedded in the backend.
+### Data Flow
 
 ```
-slack_bot/
-├── Dockerfile
-├── README.md
-├── pyproject.toml
-├── src/
-│   ├── __init__.py
-│   ├── main.py          # Entry point, Socket Mode connection
-│   ├── commands.py       # Slash command handlers
-│   ├── api_client.py     # HTTP client for Lenie REST API
-│   └── config.py         # Configuration loading (Vault/SSM/env)
-└── tests/
-    └── unit/
+PostgreSQL (web_documents table)
+  ↓ SELECT id, url, title, document_type, created_at
+  ↓ ORDER BY created_at DESC LIMIT 10
+  ↓
+notion_changelog.py
+  ↓ notion-client SDK
+  ↓
+Notion Page (bulleted list)
 ```
 
-### API Communication
+### Database Query
 
-Bot calls existing backend REST API endpoints over HTTP:
+Single SQL query against `web_documents` table — no ORM, no abstraction layer. Direct `psycopg2` connection using credentials from `config_loader`.
 
-| Bot Command | Backend Endpoint | Method | Auth |
-|-------------|-----------------|--------|------|
-| `/lenie-version` | `/version` | GET | None |
-| `/lenie-count` | `/website_list` | GET | `x-api-key` |
-| `/lenie-check <url>` | `/website_list` | GET | `x-api-key` |
-| `/lenie-add <url>` | `/url_add` | POST | `x-api-key` |
-| `/lenie-info <id>` | `/website_get` | GET | `x-api-key` |
+### Notion API Integration
 
-Backend base URL configurable via environment variable (e.g., `LENIE_API_URL=http://lenie-ai-server:5000`).
+- **SDK**: `notion-client` (official Python SDK by Notion)
+- **Auth**: Internal Integration token (Bearer), stored as `NOTION_API_TOKEN`
+- **Operation**: Replace page content with bulleted list (Notion Block API)
+- **Target**: Single page identified by `NOTION_PAGE_ID`
 
 ### Secrets Management
 
-Slack tokens (Bot Token `xoxb-...`, App-Level Token `xapp-...`) stored in:
-- **Docker/NAS:** HashiCorp Vault (consistent with B-63 migration)
-- **AWS (future):** SSM Secrets Manager
+Two new variables added to existing secret backends:
 
-Backend API key (`STALKER_API_KEY`) retrieved from the same secret backend.
+| Variable | Type | Description |
+|----------|------|-------------|
+| `NOTION_API_TOKEN` | secret | Notion Internal Integration token |
+| `NOTION_PAGE_ID` | config | Target Notion page ID |
 
-### Logging
-
-- **Format:** JSON structured logging from day one (e.g., `python-json-logger`)
-- **Output:** stdout (Docker logs collects automatically)
-- **Backend migration to JSON logging:** Deferred to backlog (separate cross-project change)
-
-### Docker Deployment
-
-```yaml
-# In infra/docker/compose.yaml
-services:
-  lenie-ai-slack-bot:
-    build: ../../slack_bot
-    profiles: ["slack"]
-    environment:
-      - LENIE_API_URL=http://lenie-ai-server:5000
-      - SECRETS_BACKEND=vault
-    depends_on:
-      - lenie-ai-server
-```
-
-Started with: `docker compose --profile slack up -d`
+Managed via `config_loader` — works with env, Vault, and AWS SSM backends without code changes.
 
 ### Implementation Considerations
 
-- **Slack Bolt SDK** (`slack-bolt`) handles Socket Mode, slash commands, events, and app mentions in a unified framework
-- **Separation of concerns:** `commands.py` (Slack interaction) decoupled from `api_client.py` (HTTP calls) — testable independently, patterns reusable in professional context
-- **Error handling:** All API calls wrapped with timeout (5s) and user-friendly error messages (no stack traces in Slack responses)
-- **Portfolio quality:** Type hints, docstrings on public functions, ruff-clean code, comprehensive unit tests for `api_client.py` and command handlers
+- Script reuses `config_loader` from `unified-config-loader` package — same pattern as `backend/server.py` and `slack_bot/`
+- No Flask dependency — runs standalone with `python backend/scripts/notion_changelog.py`
+- Error handling: catch Notion API errors (401, 404, rate limit), print actionable message, exit with code 1
+- Logging: simple print statements to stdout (PoC scope — no structured logging needed)
 
 ## Project Scoping & Risk Mitigation
 
 ### MVP Strategy
 
-**Approach:** Problem-solving MVP — deliver the smallest useful bot that proves Slack integration works end-to-end. One slash command working reliably is more valuable than five commands half-working.
+**Approach:** Problem-solving MVP — the smallest script that answers the question "does Notion work for us?"
 
-**Resources:** Solo developer (Ziutus), Python + Slack Bolt SDK knowledge, existing NAS with Docker stack running.
+**Resources:** Solo developer (Ziutus), one work session, zero infrastructure changes.
 
-**MVP covers all 5 User Journeys** via Phase 1 capabilities defined in Product Scope. Post-MVP phases (2-5) are also defined in Product Scope — each phase is a separate backlog epic with its own acceptance criteria.
+**MVP covers both User Journeys** (Team Update + Error Handling) via the 5-point scope defined in Product Scope section.
 
 ### Risk Mitigation Strategy
 
-**Technical Risk — Slack App Configuration:**
-First-time Slack App setup (permissions, OAuth scopes, Socket Mode toggle) can be confusing. **Mitigation:** Include a Slack App manifest YAML in the repo (`slack_bot/slack-app-manifest.yaml`) — this automates 90% of the configuration. Document the remaining manual steps with screenshots in README.
+**Technical Risk — Notion API Changes:**
+Notion API is versioned. The `notion-client` SDK pins to a specific API version. **Mitigation:** Pin SDK version in `pyproject.toml`. For a PoC, this is sufficient.
 
-**Dependency Risk — Backend Must Be Running:**
-Bot is useless when `lenie-ai-server` is down. On NAS, Docker containers may restart after power events. **Mitigation:** Bot handles backend unavailability gracefully — clear error message ("Backend unreachable"), no crash, auto-retry on next command. The bot itself stays connected to Slack regardless of backend state. `depends_on` in Docker Compose ensures correct startup order.
+**Dependency Risk — Database Must Be Accessible:**
+Script requires direct PostgreSQL access. If DB is down, script fails. **Mitigation:** Clear error message on connection failure. No retry logic needed for manual execution.
 
-**Process Risk — Scope Creep Across Phases:**
-5 phases is ambitious. Risk of starting Phase 2 before Phase 1 is solid. **Mitigation:** Each phase is a separate backlog epic. Phase 1 must pass all acceptance criteria (5 commands working, tests passing, documentation complete) before Phase 2 starts. No mixing phases.
+**Integration Risk — Notion Page Permissions:**
+The Internal Integration must be explicitly connected to the target page. Forgetting this step causes 404 errors. **Mitigation:** Document the "Connect to integration" step in script's docstring/README comment.
 
 ## Functional Requirements
 
-### Content Management
+### Data Retrieval
 
-- FR1: User can add a URL to the knowledge base by providing the link via Slack
-- FR2: User can check whether a specific URL already exists in the knowledge base
-- FR3: User can retrieve detailed information about a document by its ID (type, status, title, date added)
+- FR1: Script can retrieve the 10 most recently added documents from the PostgreSQL database
+- FR2: Script can extract title, URL, document type, and date added for each retrieved document
 
-### System Information
+### Notion Integration
 
-- FR4: User can query the current backend version and build timestamp
-- FR5: User can query the total document count in the knowledge base, broken down by document type
+- FR3: Script can authenticate with the Notion API using an Internal Integration token
+- FR4: Script can update a designated Notion page with a bulleted list of retrieved documents
+- FR5: Script can format each list item to display title, URL, type, and date added
 
-### Slack Interaction — Slash Commands (Phase 1)
+### Configuration
 
-- FR6: User can invoke bot capabilities via slash commands (`/lenie-version`, `/lenie-count`, `/lenie-check`, `/lenie-add`, `/lenie-info`)
-- FR7: Bot responds to slash commands with formatted text messages in the same Slack channel
-
-### Slack Interaction — Direct Messages (Phase 2)
-
-- FR8: User can invoke the same capabilities by sending text commands in a direct message to the bot
-- FR9: Bot parses DM text to identify the intended command and parameters
-
-### Slack Interaction — App Mentions (Phase 3)
-
-- FR10: User can invoke bot capabilities by mentioning the bot on any channel (`@Lenie version`)
-- FR11: Bot responds to app mentions in the same channel thread
-
-### Conversational Intelligence (Phase 4)
-
-- FR12: User can interact with the bot using natural language instead of structured commands
-- FR13: Bot interprets user intent via LLM and maps it to the appropriate backend API call
-- FR14: User can perform semantic search across the knowledge base via natural language query
-
-### Proactive Monitoring (Phase 5 — Nice-to-Have)
-
-- FR15: Bot can periodically check backend health (API reachability, database connectivity)
-- FR16: Bot can send unprompted messages to the user when a health check fails
-- FR17: Bot does not send repeated alerts for the same ongoing failure (alert deduplication)
+- FR6: Script can load Notion credentials (`NOTION_API_TOKEN`, `NOTION_PAGE_ID`) via the unified config loader
+- FR7: Script can load database credentials via the unified config loader
 
 ### Error Communication
 
-- FR18: Bot displays user-friendly error messages when backend is unreachable (no stack traces, actionable suggestions)
-- FR19: Bot remains connected to Slack and responsive even when backend is down
-- FR20: Bot communicates specific failure reasons (timeout, HTTP error, invalid response) in plain language
+- FR8: Script can display a clear, actionable error message when Notion API authentication fails
+- FR9: Script can display a clear, actionable error message when database connection fails
+- FR10: Script can display a clear, actionable error message when the target Notion page is not found or not shared with the integration
+- FR11: Script can exit with code 0 on success and code 1 on any failure
 
-### Configuration & Deployment
+### Execution
 
-- FR21: Developer can deploy the bot as an optional Docker container using Compose profiles (`--profile slack`)
-- FR22: Developer can configure Slack tokens and backend URL via secret manager (Vault for Docker/NAS, SSM for AWS)
-- FR23: Developer can set up the Slack App using a manifest file included in the repository
-- FR24: Bot posts a startup confirmation message to a designated Slack channel upon successful connection
-
-### Documentation
-
-- FR25: Developer can follow a step-by-step README to set up the bot from scratch (Slack workspace creation, App setup, token configuration, Docker launch)
+- FR12: User can run the script with a single command from the terminal
 
 ## Non-Functional Requirements
 
-### Performance
-
-- NFR1: Bot responds to slash commands within 3 seconds (excluding backend API latency)
-- NFR2: Bot establishes Socket Mode connection within 10 seconds of container startup
-- NFR3: API client uses 5-second timeout for all backend HTTP calls — no hanging requests
-
 ### Security
 
-- NFR4: Zero secrets (Slack tokens, API keys) hardcoded in source code or Docker images
-- NFR5: All secrets retrieved from secret manager at runtime (Vault for Docker/NAS, SSM for AWS)
-- NFR6: Bot logs never contain secret values, tokens, or API keys (even at DEBUG level)
-- NFR7: Backend API key transmitted via `x-api-key` header, never as URL parameter
+- NFR1: Zero secrets (Notion token, DB credentials) hardcoded in source code
+- NFR2: All secrets retrieved from config loader at runtime (env, Vault, or SSM)
+- NFR3: Script never prints secret values to stdout, even in error messages
 
 ### Integration
 
-- NFR8: Bot communicates with backend exclusively via HTTP REST API — zero code-level dependencies on `backend/`
-- NFR9: Bot tolerates backend API response format changes gracefully (logs warning, returns user-friendly error instead of crashing)
-- NFR10: Slack Bolt SDK version pinned in `pyproject.toml` to prevent breaking changes from automatic updates
+- NFR4: Script uses the official `notion-client` SDK with pinned version in `pyproject.toml`
+- NFR5: Script tolerates Notion API rate limiting gracefully (clear error message, no crash)
+- NFR6: Script handles database connection timeout with actionable error message
 
 ### Code Quality
 
-- NFR11: Code passes `ruff check` with zero warnings (line-length=120, consistent with backend)
-- NFR12: All public functions have type hints
-- NFR13: `api_client.py` and command handlers have unit tests with >80% coverage
-- NFR14: Clear module separation: Slack interaction logic (`commands.py`) decoupled from HTTP client (`api_client.py`)
-- NFR15: JSON structured logging from day one (`python-json-logger`)
+- NFR7: Code passes `ruff check` with zero warnings (line-length=120, consistent with backend)
+- NFR8: Script is self-contained — single file, no additional module creation needed
 
-### Reliability
+## Appendix: Notion Setup Checklist
 
-- NFR16: Bot process remains running and connected to Slack when backend is unreachable
-- NFR17: Slack Bolt SDK auto-reconnect handles transient Socket Mode disconnections without manual intervention
-- NFR18: Bot does not crash on malformed user input (invalid URL, missing ID, empty command arguments)
+1. Create Internal Integration at https://www.notion.so/my-integrations (name: `Lenie Changelog Bot`, capability: Read & Insert content)
+2. Copy the Integration Token (`ntn_...`) → store as `NOTION_API_TOKEN` in secret backend
+3. Create a new page in the target workspace (e.g., "Lenie — Co nowego")
+4. On that page: click `...` → "Connect to" → select `Lenie Changelog Bot`
+5. Copy Page ID from the URL → store as `NOTION_PAGE_ID` in secret backend
+6. Add `notion-client` to `pyproject.toml` dependencies
+7. Add `NOTION_API_TOKEN` and `NOTION_PAGE_ID` to `scripts/vars-classification.yaml`

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,6 +49,10 @@ markdown = [
     "html2text",
 ]
 
+notion = [
+    "notion-client>=2.2.0,<3",
+]
+
 docker = [
     "requests",
     "beautifulsoup4",
@@ -100,6 +104,7 @@ all = [
     "google-api-python-client",
     "google-auth-httplib2",
     "google-auth-oauthlib",
+    "notion-client>=2.2.0,<3",
 ]
 
 [build-system]

--- a/backend/scripts/notion_changelog.py
+++ b/backend/scripts/notion_changelog.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Push recent documents to a Notion page as a changelog.
+
+Fetches the N most recently added documents from PostgreSQL and publishes
+them as a formatted list on a Notion page.
+
+Usage:
+    cd backend
+    PYTHONPATH=. python scripts/notion_changelog.py --dry-run
+    PYTHONPATH=. python scripts/notion_changelog.py --limit 10
+"""
+
+import argparse
+import io
+import sys
+from datetime import datetime
+
+# Ensure stdout handles Unicode on Windows (cp1250 cannot encode some chars)
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+
+import psycopg2
+from notion_client import Client as NotionClient
+from notion_client.errors import APIResponseError
+
+from library.config_loader import load_config
+
+
+def get_recent_documents(conn, limit: int) -> list[dict]:
+    """Fetch the most recently added documents from the database."""
+    sql = """
+        SELECT id, url, title, document_type, created_at
+        FROM public.web_documents
+        ORDER BY created_at DESC
+        LIMIT %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (limit,))
+        columns = [desc[0] for desc in cur.description]
+        return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+
+def _rich_text(content: str) -> list[dict]:
+    return [{"type": "text", "text": {"content": content}}]
+
+
+def _rich_text_link(content: str, url: str) -> list[dict]:
+    return [{"type": "text", "text": {"content": content, "link": {"url": url}}}]
+
+
+def _table_row(cells: list[list[dict]]) -> dict:
+    return {"object": "block", "type": "table_row", "table_row": {"cells": cells}}
+
+
+def build_notion_blocks(documents: list[dict]) -> list[dict]:
+    """Build Notion block children from a list of documents."""
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    header_row = _table_row([
+        _rich_text("Type"),
+        _rich_text("Title"),
+        _rich_text("URL"),
+        _rich_text("Date"),
+    ])
+
+    data_rows = []
+    for doc in documents:
+        doc_type = doc.get("document_type", "?")
+        title = doc.get("title") or "(no title)"
+        url = doc.get("url") or ""
+        created = ""
+        if doc.get("created_at"):
+            created = doc["created_at"].strftime("%Y-%m-%d") if isinstance(doc["created_at"], datetime) else str(doc["created_at"])
+
+        url_cell = _rich_text_link(url, url) if url else _rich_text("")
+
+        data_rows.append(_table_row([
+            _rich_text(doc_type),
+            _rich_text(title),
+            url_cell,
+            _rich_text(created),
+        ]))
+
+    table_block = {
+        "object": "block",
+        "type": "table",
+        "table": {
+            "table_width": 4,
+            "has_column_header": True,
+            "has_row_header": False,
+            "children": [header_row] + data_rows,
+        },
+    }
+
+    return [
+        {
+            "object": "block",
+            "type": "heading_2",
+            "heading_2": {"rich_text": _rich_text(f"Changelog — {now}")},
+        },
+        table_block,
+    ]
+
+
+def clear_page_children(notion: NotionClient, page_id: str) -> int:
+    """Delete all existing children blocks from a Notion page (handles pagination)."""
+    deleted = 0
+    start_cursor = None
+    while True:
+        kwargs = {"block_id": page_id}
+        if start_cursor:
+            kwargs["start_cursor"] = start_cursor
+        children = notion.blocks.children.list(**kwargs)
+        for block in children.get("results", []):
+            notion.blocks.delete(block_id=block["id"])
+            deleted += 1
+        if not children.get("has_more"):
+            break
+        start_cursor = children.get("next_cursor")
+    return deleted
+
+
+def update_notion_page(token: str, page_id: str, blocks: list[dict]) -> None:
+    """Clear a Notion page and append new blocks."""
+    notion = NotionClient(auth=token)
+
+    deleted = clear_page_children(notion, page_id)
+    print(f"Cleared {deleted} existing block(s) from page.")
+
+    notion.blocks.children.append(block_id=page_id, children=blocks)
+    print(f"Appended {len(blocks)} block(s) to page.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Push recent documents changelog to Notion")
+    parser.add_argument("--limit", type=int, default=10, help="Number of recent documents to include (default: 10)")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and display documents without pushing to Notion")
+    args = parser.parse_args()
+
+    config = load_config()
+    print(f"Config backend: {config.get('SECRETS_BACKEND', 'env')}")
+
+    db_host = config.get("POSTGRESQL_HOST", "localhost")
+    db_port = config.get("POSTGRESQL_PORT", "5432")
+    db_name = config.get("POSTGRESQL_DATABASE", "lenie")
+    db_user = config.get("POSTGRESQL_USER", "lenie")
+    db_pass = config.get("POSTGRESQL_PASSWORD", "")
+    print(f"Database: {db_host}:{db_port}/{db_name}")
+
+    try:
+        conn = psycopg2.connect(host=db_host, port=db_port, dbname=db_name, user=db_user, password=db_pass)
+    except psycopg2.OperationalError as exc:
+        print(f"ERROR: Cannot connect to database: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        documents = get_recent_documents(conn, args.limit)
+    finally:
+        conn.close()
+
+    print(f"\nFetched {len(documents)} document(s):\n")
+    for doc in documents:
+        created = doc.get("created_at", "")
+        print(f"  [{doc.get('document_type', '?')}] {doc.get('title', '(no title)')} -- {doc.get('url', '')} ({created})")
+
+    if args.dry_run:
+        print("\n--dry-run: skipping Notion update.")
+        return
+
+    notion_token = config.get("NOTION_API_TOKEN")
+    notion_page_id = config.get("NOTION_PAGE_ID")
+
+    if not notion_token:
+        print("ERROR: NOTION_API_TOKEN is not set.", file=sys.stderr)
+        sys.exit(1)
+    if not notion_page_id:
+        print("ERROR: NOTION_PAGE_ID is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    blocks = build_notion_blocks(documents)
+
+    try:
+        update_notion_page(notion_token, notion_page_id, blocks)
+    except APIResponseError as exc:
+        if exc.status == 401:
+            print("ERROR: Notion API token is invalid or expired.", file=sys.stderr)
+        elif exc.status == 404:
+            print(f"ERROR: Notion page not found (id: {notion_page_id}). Check NOTION_PAGE_ID.", file=sys.stderr)
+        elif exc.status == 429:
+            print("ERROR: Notion API rate limit exceeded. Try again later.", file=sys.stderr)
+        else:
+            print(f"ERROR: Notion API error ({exc.status}): {exc.message}", file=sys.stderr)
+        sys.exit(1)
+
+    print("\nDone — changelog published to Notion.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1162,6 +1162,7 @@ all = [
     { name = "markdownify" },
     { name = "markitdown" },
     { name = "neo4j" },
+    { name = "notion-client" },
     { name = "openai" },
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
@@ -1199,6 +1200,9 @@ markdown = [
     { name = "markitdown" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
+]
+notion = [
+    { name = "notion-client" },
 ]
 vault = [
     { name = "hvac" },
@@ -1258,6 +1262,8 @@ requires-dist = [
     { name = "markitdown", marker = "extra == 'markdown'" },
     { name = "neo4j" },
     { name = "neo4j", marker = "extra == 'all'" },
+    { name = "notion-client", marker = "extra == 'all'", specifier = ">=2.2.0,<3" },
+    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.2.0,<3" },
     { name = "openai" },
     { name = "openai", marker = "extra == 'all'" },
     { name = "openai", marker = "extra == 'docker'" },
@@ -1292,7 +1298,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'all'" },
     { name = "youtube-transcript-api", marker = "extra == 'docker'" },
 ]
-provides-extras = ["vault", "markdown", "docker", "all"]
+provides-extras = ["vault", "markdown", "notion", "docker", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1619,6 +1625,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/99/da515f7bc3bce35cfa6005f0e0c4e3c4042a466782b143112eb393b663be/nodejs_wheel_binaries-24.13.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0e581ae219a39073dcadd398a2eb648f0707b0f5d68c565586139f919c91cbe9", size = 61870142, upload-time = "2026-02-12T17:30:54.563Z" },
     { url = "https://files.pythonhosted.org/packages/cc/c0/22001d2c96d8200834af7d1de5e72daa3266c7270330275104c3d9ddd143/nodejs_wheel_binaries-24.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:d4c969ea0bcb8c8b20bc6a7b4ad2796146d820278f17d4dc20229b088c833e22", size = 41185473, upload-time = "2026-02-12T17:30:57.524Z" },
     { url = "https://files.pythonhosted.org/packages/ab/c4/7532325f968ecfc078e8a028e69a52e4c3f95fb800906bf6931ac1e89e2b/nodejs_wheel_binaries-24.13.1-py2.py3-none-win_arm64.whl", hash = "sha256:caec398cb9e94c560bacdcba56b3828df22a355749eb291f47431af88cbf26dc", size = 38881194, upload-time = "2026-02-12T17:31:00.214Z" },
+]
+
+[[package]]
+name = "notion-client"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ff/06695dca5d0691346fbd89ba300a2ceeeaf0b0632fe8235b588e83e505a3/notion_client-2.7.0.tar.gz", hash = "sha256:31bde3ae03ede77650cadce136152916efdd86579ff65f49fc6705fbe462e2fb", size = 26384, upload-time = "2025-10-31T12:10:15.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/6a/9716315432f5aba4c82979f9677aeb101018f0e790835721dc4e01deb933/notion_client-2.7.0-py2.py3-none-any.whl", hash = "sha256:9057a8ac2103ff245556c2a5102bde1d2ccdd3505f66bcc130fc31857731d91e", size = 16999, upload-time = "2025-10-31T12:10:13.835Z" },
 ]
 
 [[package]]

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -355,6 +355,16 @@ groups:
         type: secret
         required: false
         used_by: [local]
+      NOTION_API_TOKEN:
+        description: "Notion integration token for API access"
+        type: secret
+        required: false
+        used_by: [local]
+      NOTION_PAGE_ID:
+        description: "Notion page ID where changelog is published"
+        type: config
+        required: false
+        used_by: [local]
 
   media:
     description: "Media processing settings"


### PR DESCRIPTION
## Summary

- **B-79**: Migrated 10 standalone scripts from `load_dotenv()` to `load_config()` (unified config loader). Additional fixes: `re.sub` keyword args, safer `text_transcript` return.
- **B-88**: New PoC script `backend/scripts/notion_changelog.py` — fetches recent documents from PostgreSQL and publishes as a formatted table on a Notion page. Uses `config_loader` for secrets, `notion-client` SDK as optional dependency.
- Adversarial code review performed on B-88 with 4 fixes applied (pagination, rate limit 429, info leak, PRD sync).
- Sprint-status and PRD updated accordingly.

## Changes

- `backend/scripts/notion_changelog.py` — new Notion changelog script
- `backend/pyproject.toml` — added `notion` optional dependency group
- `backend/uv.lock` — lock file updated
- `scripts/vars-classification.yaml` — added `NOTION_API_TOKEN`, `NOTION_PAGE_ID`
- `_bmad-output/planning-artifacts/prd.md` — updated for Notion PoC sprint
- `_bmad-output/implementation-artifacts/sprint-status.yaml` — B-79 done, B-88 done

## Test plan

- [ ] Verify `uvx ruff check backend/` passes
- [ ] Verify `cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v` passes
- [ ] Manual: `cd backend && PYTHONPATH=. python scripts/notion_changelog.py --dry-run` (requires DB access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)