### PR TITLE
feat: add channel @mention support (Epic 23)

### DIFF
--- a/slack_bot/CHANGELOG.md
+++ b/slack_bot/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to the Lenie Slack Bot will be documented in this file.
+
+## [0.2.0] - 2026-03-04
+
+### Added
+- Channel `@Lenie` mention support (Epic 23) — same command set as DMs, responses posted as thread replies
+- `mention_handler.py` — handles `app_mention` events, strips bot mention prefix, routes to shared handlers
+- Slack manifest: `app_mentions:read` OAuth scope and `app_mention` bot event subscription
+
+### Changed
+- Handler functions in `dm_handler.py` renamed from private (`_handle_*`) to public (`handle_*`) for reuse by mention handler
+
+## [0.1.0] - 2026-02-15
+
+### Added
+- Initial release with Socket Mode connection
+- Slash commands: `/lenie-version`, `/lenie-count`, `/lenie-add`, `/lenie-check`, `/lenie-info`
+- DM text command handler (Epic 22) — same commands via direct messages
+- Backend API client with health checks and error handling
+- JSON structured logging
+- Startup message posted to configured channel

--- a/slack_bot/slack-app-manifest.yaml
+++ b/slack_bot/slack-app-manifest.yaml
@@ -44,6 +44,7 @@ oauth_config:
       - commands
       - chat:write
       - chat:write.public
+      - app_mentions:read  # Required to receive @mentions in channels
       - im:history  # Required to receive DM messages
 
 settings:
@@ -52,6 +53,7 @@ settings:
   # for new scopes and event subscriptions to take effect.
   event_subscriptions:
     bot_events:
+      - app_mention  # Receive @mentions in channels for command parsing
       - message.im  # Receive DM text messages for command parsing
   socket_mode_enabled: true
   org_deploy_enabled: false

--- a/slack_bot/src/__init__.py
+++ b/slack_bot/src/__init__.py
@@ -1,3 +1,3 @@
 """Lenie Slack Bot — optional chatbot module for Lenie-AI."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/slack_bot/src/dm_handler.py
+++ b/slack_bot/src/dm_handler.py
@@ -38,8 +38,8 @@ HELP_TEXT = (
 )
 
 
-def _handle_version(say: Callable, client: LenieApiClient) -> None:
-    """Handle 'version' DM command."""
+def handle_version(say: Callable, client: LenieApiClient) -> None:
+    """Handle 'version' command."""
     try:
         data = client.get_version()
         say(text=f"Version: {data['app_version']}\nBuild: {data['app_build_time']}")
@@ -55,8 +55,8 @@ def _handle_version(say: Callable, client: LenieApiClient) -> None:
         say(text="Unexpected response from backend")
 
 
-def _handle_count(say: Callable, client: LenieApiClient) -> None:
-    """Handle 'count' DM command."""
+def handle_count(say: Callable, client: LenieApiClient) -> None:
+    """Handle 'count' command."""
     try:
         counts = client.get_all_counts()
         total = counts.get("ALL", 0)
@@ -80,8 +80,8 @@ def _handle_count(say: Callable, client: LenieApiClient) -> None:
         say(text="Unexpected response from backend")
 
 
-def _handle_add(say: Callable, client: LenieApiClient, args_str: str) -> None:
-    """Handle 'add <url> [type]' DM command."""
+def handle_add(say: Callable, client: LenieApiClient, args_str: str) -> None:
+    """Handle 'add <url> [type]' command."""
     parts = args_str.strip().split()
     if not parts:
         say(text=f"Usage: `add <url> [type]`\nTypes: {', '.join(DOCUMENT_TYPES)} (default: webpage)")
@@ -112,8 +112,8 @@ def _handle_add(say: Callable, client: LenieApiClient, args_str: str) -> None:
         say(text="Unexpected response from backend")
 
 
-def _handle_check(say: Callable, client: LenieApiClient, args_str: str) -> None:
-    """Handle 'check <url>' DM command."""
+def handle_check(say: Callable, client: LenieApiClient, args_str: str) -> None:
+    """Handle 'check <url>' command."""
     url = args_str.strip()
     if not url:
         say(text="Usage: `check <url>`")
@@ -144,8 +144,8 @@ def _handle_check(say: Callable, client: LenieApiClient, args_str: str) -> None:
         say(text="Unexpected response from backend")
 
 
-def _handle_info(say: Callable, client: LenieApiClient, args_str: str) -> None:
-    """Handle 'info <id>' DM command."""
+def handle_info(say: Callable, client: LenieApiClient, args_str: str) -> None:
+    """Handle 'info <id>' command."""
     text_input = args_str.strip()
     if not text_input:
         say(text="Usage: `info <document_id>` (numeric ID required)")
@@ -181,11 +181,11 @@ def register_dm_handler(app: App, client: LenieApiClient) -> None:
     logger.info("Registering DM message handler")
 
     commands = {
-        "version": lambda say, args: _handle_version(say, client),
-        "count": lambda say, args: _handle_count(say, client),
-        "add": lambda say, args: _handle_add(say, client, args),
-        "check": lambda say, args: _handle_check(say, client, args),
-        "info": lambda say, args: _handle_info(say, client, args),
+        "version": lambda say, args: handle_version(say, client),
+        "count": lambda say, args: handle_count(say, client),
+        "add": lambda say, args: handle_add(say, client, args),
+        "check": lambda say, args: handle_check(say, client, args),
+        "info": lambda say, args: handle_info(say, client, args),
         "help": lambda say, args: say(text=HELP_TEXT),
     }
 

--- a/slack_bot/src/main.py
+++ b/slack_bot/src/main.py
@@ -17,6 +17,7 @@ from src import __version__
 from src.api_client import ApiConnectionError, ApiError, LenieApiClient, create_client
 from src.commands import register_commands
 from src.dm_handler import register_dm_handler
+from src.mention_handler import register_mention_handler
 from src.config import Config, load_config
 
 
@@ -100,6 +101,7 @@ def main() -> None:
     app = App(token=bot_token)
     register_commands(app, api_client)
     register_dm_handler(app, api_client)
+    register_mention_handler(app, api_client)
 
     handler = SocketModeHandler(app, app_token)
     handler.connect()

--- a/slack_bot/src/mention_handler.py
+++ b/slack_bot/src/mention_handler.py
@@ -1,0 +1,74 @@
+"""Channel @mention handler for Lenie Slack Bot.
+
+Routes @Lenie mentions in channels to the same command handlers used
+by DM messages. All responses are posted as thread replies to keep
+channels clean.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from src.dm_handler import (
+    HELP_TEXT,
+    handle_add,
+    handle_check,
+    handle_count,
+    handle_info,
+    handle_version,
+)
+
+if TYPE_CHECKING:
+    from slack_bolt import App
+
+    from src.api_client import LenieApiClient
+
+logger = logging.getLogger(__name__)
+
+_BOT_MENTION_RE = re.compile(r"<@[A-Z0-9]+>\s*")
+
+
+def _strip_mention(text: str) -> str:
+    """Remove the leading bot mention (e.g. ``<@U123ABC>``) from event text."""
+    return _BOT_MENTION_RE.sub("", text, count=1).strip()
+
+
+def register_mention_handler(app: App, client: LenieApiClient) -> None:
+    """Register app_mention event handler on the Slack Bolt app."""
+    logger.info("Registering app_mention handler")
+
+    commands = {
+        "version": lambda say, args: handle_version(say, client),
+        "count": lambda say, args: handle_count(say, client),
+        "add": lambda say, args: handle_add(say, client, args),
+        "check": lambda say, args: handle_check(say, client, args),
+        "info": lambda say, args: handle_info(say, client, args),
+        "help": lambda say, args: say(text=HELP_TEXT),
+    }
+
+    @app.event("app_mention")
+    def handle_app_mention(event, say):
+        if event.get("bot_id"):
+            return
+
+        thread_ts = event.get("ts")
+        threaded_say = lambda **kw: say(thread_ts=thread_ts, **kw)  # noqa: E731
+
+        raw_text = event.get("text") or ""
+        text = _strip_mention(raw_text)
+
+        if not text:
+            threaded_say(text=HELP_TEXT)
+            return
+
+        parts = text.split(maxsplit=1)
+        command = parts[0].lower()
+        args_str = parts[1] if len(parts) > 1 else ""
+
+        handler = commands.get(command)
+        if handler:
+            handler(threaded_say, args_str)
+        else:
+            threaded_say(text=f"I didn't understand that. {HELP_TEXT}")

--- a/slack_bot/tests/unit/test_dm_handler.py
+++ b/slack_bot/tests/unit/test_dm_handler.py
@@ -5,11 +5,11 @@ from unittest.mock import MagicMock, patch
 from src.api_client import ApiConnectionError, ApiError, ApiResponseError
 from src.dm_handler import (
     HELP_TEXT,
-    _handle_add,
-    _handle_check,
-    _handle_count,
-    _handle_info,
-    _handle_version,
+    handle_add,
+    handle_check,
+    handle_count,
+    handle_info,
+    handle_version,
     register_dm_handler,
 )
 
@@ -51,7 +51,7 @@ class TestDmHandleVersion:
         }
         say = _make_say()
 
-        _handle_version(say, client)
+        handle_version(say, client)
 
         say.assert_called_once()
         text = say.call_args[1]["text"]
@@ -63,7 +63,7 @@ class TestDmHandleVersion:
         client.get_version.side_effect = ApiConnectionError("timeout")
         say = _make_say()
 
-        _handle_version(say, client)
+        handle_version(say, client)
 
         text = say.call_args[1]["text"]
         assert "Backend unreachable" in text
@@ -74,7 +74,7 @@ class TestDmHandleVersion:
         client.get_version.side_effect = ApiResponseError("bad", status_code=502, response_body="error")
         say = _make_say()
 
-        _handle_version(say, client)
+        handle_version(say, client)
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -85,7 +85,7 @@ class TestDmHandleVersion:
         client.get_version.side_effect = ApiError("something broke")
         say = _make_say()
 
-        _handle_version(say, client)
+        handle_version(say, client)
 
         text = say.call_args[1]["text"]
         assert "An error occurred" in text
@@ -96,7 +96,7 @@ class TestDmHandleVersion:
         client.get_version.return_value = {"status": "success"}
         say = _make_say()
 
-        _handle_version(say, client)
+        handle_version(say, client)
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -107,7 +107,7 @@ class TestDmHandleVersion:
         say = _make_say()
 
         with patch("src.dm_handler.logger") as mock_logger:
-            _handle_version(say, client)
+            handle_version(say, client)
             mock_logger.warning.assert_called_once()
 
 
@@ -122,7 +122,7 @@ class TestDmHandleCount:
         }
         say = _make_say()
 
-        _handle_count(say, client)
+        handle_count(say, client)
 
         client.get_all_counts.assert_called_once()
         text = say.call_args[1]["text"]
@@ -138,7 +138,7 @@ class TestDmHandleCount:
         client.get_all_counts.return_value = {"ALL": 10, "webpage": 10}
         say = _make_say()
 
-        _handle_count(say, client)
+        handle_count(say, client)
 
         text = say.call_args[1]["text"]
         assert "webpage: 10" in text
@@ -155,7 +155,7 @@ class TestDmHandleCount:
         client.get_all_counts.side_effect = ApiConnectionError("timeout")
         say = _make_say()
 
-        _handle_count(say, client)
+        handle_count(say, client)
 
         text = say.call_args[1]["text"]
         assert "Backend unreachable" in text
@@ -165,7 +165,7 @@ class TestDmHandleCount:
         client.get_all_counts.side_effect = ApiResponseError("bad", status_code=500, response_body="error")
         say = _make_say()
 
-        _handle_count(say, client)
+        handle_count(say, client)
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -176,7 +176,7 @@ class TestDmHandleCount:
         client.get_all_counts.side_effect = ApiError("count failed")
         say = _make_say()
 
-        _handle_count(say, client)
+        handle_count(say, client)
 
         text = say.call_args[1]["text"]
         assert "An error occurred" in text
@@ -192,7 +192,7 @@ class TestDmHandleAdd:
         client.add_url.return_value = {"status": "success", "document_id": 42}
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com/article")
+        handle_add(say, client, "https://example.com/article")
 
         client.add_url.assert_called_once_with("https://example.com/article", url_type="webpage")
         text = say.call_args[1]["text"]
@@ -205,7 +205,7 @@ class TestDmHandleAdd:
         client.add_url.return_value = {"status": "success", "document_id": 99}
         say = _make_say()
 
-        _handle_add(say, client, "https://youtube.com/watch?v=abc youtube")
+        handle_add(say, client, "https://youtube.com/watch?v=abc youtube")
 
         client.add_url.assert_called_once_with("https://youtube.com/watch?v=abc", url_type="youtube")
         text = say.call_args[1]["text"]
@@ -216,7 +216,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "example.com")
+        handle_add(say, client, "example.com")
 
         client.add_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -226,7 +226,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "hello")
+        handle_add(say, client, "hello")
 
         client.add_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -236,7 +236,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com webpage extra stuff")
+        handle_add(say, client, "https://example.com webpage extra stuff")
 
         client.add_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -246,7 +246,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com badtype")
+        handle_add(say, client, "https://example.com badtype")
 
         client.add_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -256,7 +256,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "")
+        handle_add(say, client, "")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -266,7 +266,7 @@ class TestDmHandleAdd:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_add(say, client, "   ")
+        handle_add(say, client, "   ")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -277,7 +277,7 @@ class TestDmHandleAdd:
         client.add_url.side_effect = ApiConnectionError("timeout")
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com/article")
+        handle_add(say, client, "https://example.com/article")
 
         text = say.call_args[1]["text"]
         assert "Backend unreachable" in text
@@ -287,7 +287,7 @@ class TestDmHandleAdd:
         client.add_url.side_effect = ApiResponseError("bad", status_code=500, response_body="error")
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com/article")
+        handle_add(say, client, "https://example.com/article")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -298,7 +298,7 @@ class TestDmHandleAdd:
         client.add_url.side_effect = ApiError("add failed")
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com/article")
+        handle_add(say, client, "https://example.com/article")
 
         text = say.call_args[1]["text"]
         assert "An error occurred" in text
@@ -309,7 +309,7 @@ class TestDmHandleAdd:
         client.add_url.return_value = {"status": "success"}
         say = _make_say()
 
-        _handle_add(say, client, "https://example.com")
+        handle_add(say, client, "https://example.com")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -330,7 +330,7 @@ class TestDmHandleCheck:
         }
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com/article")
+        handle_check(say, client, "https://example.com/article")
 
         client.check_url.assert_called_once_with("https://example.com/article")
         text = say.call_args[1]["text"]
@@ -344,7 +344,7 @@ class TestDmHandleCheck:
         client.check_url.return_value = None
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com/new")
+        handle_check(say, client, "https://example.com/new")
 
         text = say.call_args[1]["text"]
         assert "Not found in database." in text
@@ -353,7 +353,7 @@ class TestDmHandleCheck:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_check(say, client, "example.com")
+        handle_check(say, client, "example.com")
 
         client.check_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -363,7 +363,7 @@ class TestDmHandleCheck:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_check(say, client, "random-text")
+        handle_check(say, client, "random-text")
 
         client.check_url.assert_not_called()
         text = say.call_args[1]["text"]
@@ -373,7 +373,7 @@ class TestDmHandleCheck:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_check(say, client, "")
+        handle_check(say, client, "")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -383,7 +383,7 @@ class TestDmHandleCheck:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_check(say, client, "   ")
+        handle_check(say, client, "   ")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -394,7 +394,7 @@ class TestDmHandleCheck:
         client.check_url.side_effect = ApiConnectionError("timeout")
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com")
+        handle_check(say, client, "https://example.com")
 
         text = say.call_args[1]["text"]
         assert "Backend unreachable" in text
@@ -404,7 +404,7 @@ class TestDmHandleCheck:
         client.check_url.side_effect = ApiResponseError("bad", status_code=502, response_body="error")
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com")
+        handle_check(say, client, "https://example.com")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -415,7 +415,7 @@ class TestDmHandleCheck:
         client.check_url.side_effect = ApiError("check failed")
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com")
+        handle_check(say, client, "https://example.com")
 
         text = say.call_args[1]["text"]
         assert "An error occurred" in text
@@ -426,7 +426,7 @@ class TestDmHandleCheck:
         client.check_url.return_value = {"id": 123}
         say = _make_say()
 
-        _handle_check(say, client, "https://example.com")
+        handle_check(say, client, "https://example.com")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -447,7 +447,7 @@ class TestDmHandleInfo:
         }
         say = _make_say()
 
-        _handle_info(say, client, "123")
+        handle_info(say, client, "123")
 
         client.get_document.assert_called_once_with(123)
         text = say.call_args[1]["text"]
@@ -461,7 +461,7 @@ class TestDmHandleInfo:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_info(say, client, "abc")
+        handle_info(say, client, "abc")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -472,7 +472,7 @@ class TestDmHandleInfo:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_info(say, client, "")
+        handle_info(say, client, "")
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -481,7 +481,7 @@ class TestDmHandleInfo:
         client = _make_mock_client()
         say = _make_say()
 
-        _handle_info(say, client, "\u00b2")  # superscript 2
+        handle_info(say, client, "\u00b2")  # superscript 2
 
         text = say.call_args[1]["text"]
         assert "Usage:" in text
@@ -493,7 +493,7 @@ class TestDmHandleInfo:
         client.get_document.side_effect = ApiConnectionError("timeout")
         say = _make_say()
 
-        _handle_info(say, client, "123")
+        handle_info(say, client, "123")
 
         text = say.call_args[1]["text"]
         assert "Backend unreachable" in text
@@ -503,7 +503,7 @@ class TestDmHandleInfo:
         client.get_document.side_effect = ApiResponseError("bad", status_code=404, response_body="not found")
         say = _make_say()
 
-        _handle_info(say, client, "999")
+        handle_info(say, client, "999")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text
@@ -514,7 +514,7 @@ class TestDmHandleInfo:
         client.get_document.side_effect = ApiError("info failed")
         say = _make_say()
 
-        _handle_info(say, client, "123")
+        handle_info(say, client, "123")
 
         text = say.call_args[1]["text"]
         assert "An error occurred" in text
@@ -525,7 +525,7 @@ class TestDmHandleInfo:
         client.get_document.return_value = {"id": 123}
         say = _make_say()
 
-        _handle_info(say, client, "123")
+        handle_info(say, client, "123")
 
         text = say.call_args[1]["text"]
         assert "Unexpected response from backend" in text

--- a/slack_bot/tests/unit/test_mention_handler.py
+++ b/slack_bot/tests/unit/test_mention_handler.py
@@ -1,0 +1,217 @@
+"""Unit tests for src.mention_handler module."""
+
+from unittest.mock import MagicMock
+
+from src.mention_handler import _strip_mention, register_mention_handler
+
+
+# --- Helpers ---
+
+
+def _make_mock_client() -> MagicMock:
+    return MagicMock()
+
+
+def _make_say() -> MagicMock:
+    return MagicMock()
+
+
+def _make_mention_event(text: str = "", **overrides) -> dict:
+    """Create a fake app_mention event dict."""
+    event = {
+        "type": "app_mention",
+        "channel": "C123ABC",
+        "user": "U456DEF",
+        "text": text,
+        "ts": "1234567890.123456",
+    }
+    event.update(overrides)
+    return event
+
+
+def _get_handler(client=None):
+    """Register mention handler and return the event handler function."""
+    app = MagicMock()
+    if client is None:
+        client = _make_mock_client()
+        client.get_version.return_value = {"app_version": "1.0", "app_build_time": "2026-01-01"}
+    register_mention_handler(app, client)
+    app.event.assert_called_once_with("app_mention")
+    handler_fn = app.event.return_value.call_args[0][0]
+    return handler_fn, client
+
+
+# --- Test mention text stripping ---
+
+
+class TestStripMention:
+    def test_strips_bot_mention(self):
+        assert _strip_mention("<@U123ABC> version") == "version"
+
+    def test_strips_with_extra_spaces(self):
+        assert _strip_mention("<@U123ABC>   count") == "count"
+
+    def test_strips_no_space_after_mention(self):
+        assert _strip_mention("<@U123ABC>version") == "version"
+
+    def test_no_mention_returns_text(self):
+        assert _strip_mention("version") == "version"
+
+    def test_empty_after_mention(self):
+        assert _strip_mention("<@U123ABC>") == ""
+
+    def test_empty_string(self):
+        assert _strip_mention("") == ""
+
+    def test_mention_with_args(self):
+        assert _strip_mention("<@U123ABC> add https://example.com youtube") == "add https://example.com youtube"
+
+
+# --- Test thread_ts is passed ---
+
+
+class TestThreadResponse:
+    def test_thread_ts_passed_on_command(self):
+        handler_fn, client = _get_handler()
+        event = _make_mention_event("<@U123ABC> version", ts="9999.1234")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        say.assert_called_once()
+        assert say.call_args[1]["thread_ts"] == "9999.1234"
+
+    def test_thread_ts_passed_on_help(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC>", ts="9999.1234")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        assert say.call_args[1]["thread_ts"] == "9999.1234"
+
+    def test_thread_ts_passed_on_unknown_command(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC> foobar", ts="9999.1234")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        assert say.call_args[1]["thread_ts"] == "9999.1234"
+
+
+# --- Test command routing ---
+
+
+class TestMentionCommandRouting:
+    def test_version_command(self):
+        handler_fn, client = _get_handler()
+        event = _make_mention_event("<@U123ABC> version")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_version.assert_called_once()
+        text = say.call_args[1]["text"]
+        assert "1.0" in text
+
+    def test_count_command(self):
+        client = _make_mock_client()
+        client.get_all_counts.return_value = {"ALL": 5, "webpage": 5}
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> count")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_all_counts.assert_called_once()
+
+    def test_add_command(self):
+        client = _make_mock_client()
+        client.add_url.return_value = {"status": "success", "document_id": 42}
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> add https://example.com")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.add_url.assert_called_once_with("https://example.com", url_type="webpage")
+
+    def test_check_command(self):
+        client = _make_mock_client()
+        client.check_url.return_value = None
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> check https://example.com")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.check_url.assert_called_once_with("https://example.com")
+
+    def test_info_command(self):
+        client = _make_mock_client()
+        client.get_document.return_value = {
+            "id": 123, "title": "T", "document_type": "link",
+            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+        }
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> info 123")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_document.assert_called_once_with(123)
+
+    def test_help_command(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC> help")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "Available commands:" in text
+
+    def test_case_insensitive(self):
+        handler_fn, client = _get_handler()
+        event = _make_mention_event("<@U123ABC> VERSION")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_version.assert_called_once()
+
+
+# --- Test filtering ---
+
+
+class TestMentionFiltering:
+    def test_bot_message_ignored(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC> version", bot_id="B123")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        say.assert_not_called()
+
+    def test_empty_mention_shows_help(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC>")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "Available commands:" in text
+
+    def test_unknown_command_shows_help(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC> foobar")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "I didn't understand that" in text
+        assert "Available commands:" in text


### PR DESCRIPTION
## Summary
- Add `app_mention` event handler so `@Lenie` mentions in channels route to the same commands as DMs
- All responses posted as thread replies to keep channels clean
- Reuse existing handler functions (renamed from `_handle_*` to `handle_*`)
- Bump Slack bot version to 0.2.0
- Add CHANGELOG.md

## Changes
- **New:** `slack_bot/src/mention_handler.py` — parses mentions, strips bot ID, routes commands
- **New:** `slack_bot/tests/unit/test_mention_handler.py` — 14 unit tests
- **New:** `slack_bot/CHANGELOG.md`
- **Modified:** `slack_bot/src/dm_handler.py` — public handler functions
- **Modified:** `slack_bot/src/main.py` — register mention handler
- **Modified:** `slack_bot/slack-app-manifest.yaml` — `app_mentions:read` scope + `app_mention` event

## Test plan
- [x] `uvx ruff check slack_bot/` — passed
- [x] 192 unit tests passed
- [x] Deployed to NAS and verified `@Lenie version` responds in thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)