### PR TITLE
feat: LLM intent parser + Bielik v3.0 + security-check command

### DIFF
--- a/_bmad-output/implementation-artifacts/24-1-llm-intent-parser.md
+++ b/_bmad-output/implementation-artifacts/24-1-llm-intent-parser.md
@@ -1,0 +1,242 @@
+# Story 24.1: LLM Intent Parser
+
+Status: done
+
+## Story
+
+As a **user**,
+I want to ask the bot questions in natural language ("how many articles do I have?"),
+so that I don't need to remember specific command syntax.
+
+## Acceptance Criteria
+
+1. **Given** the bot is in a DM and LLM is configured, **When** user sends "how many articles do I have?", **Then** LLM interprets intent as `count` command, bot responds with document count.
+
+2. **Given** the bot is in a DM, **When** user sends "do I already have this link? https://example.com", **Then** LLM interprets intent as `check` command with URL, bot responds with found/not-found.
+
+3. **Given** the LLM service is unreachable, **When** user sends a natural language message, **Then** bot falls back to direct text parsing (Epic 22 logic) and responds or shows help.
+
+4. **Given** the LLM cannot determine intent, **When** user sends ambiguous message, **Then** bot responds: "I'm not sure what you mean. Available commands: version, count, check, add, info".
+
+**Covers:** FR12, FR13 | NFR3, NFR9
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `/ai_parse_intent` backend endpoint (AC: #1, #2, #3, #4)
+  - [x] 1.1 Create `backend/library/ai_intent_parser.py` — system prompt + LLM call via existing `ai.py` → returns structured JSON `{command, args, confidence}`
+  - [x] 1.2 Add `POST /ai_parse_intent` route in `server.py` — accepts `{text: str}`, returns `{command, args, confidence}` or `{command: "unknown"}`
+  - [x] 1.3 Add unit tests for intent parser (prompt construction, response parsing, edge cases)
+  - [x] 1.4 Add `INTENT_PARSER_MODEL` and `INTENT_PARSER_ENABLED` to `vars-classification.yaml`
+
+- [x] Task 2: Add `intent_parser.py` to slack_bot (AC: #1, #2, #3, #4)
+  - [x] 2.1 Create `slack_bot/src/intent_parser.py` — calls backend `/ai_parse_intent`, returns `ParsedIntent` dataclass
+  - [x] 2.2 Add `parse_intent()` and `search_similar()` methods to `LenieApiClient` in `api_client.py`
+  - [x] 2.3 Unit tests for intent_parser module (success, fallback, timeout)
+
+- [x] Task 3: Integrate intent parsing into DM handler (AC: #1, #2, #3)
+  - [x] 3.1 Modify `dm_handler.py`: if keyword match fails AND intent parsing enabled → call intent parser → route to command handler
+  - [x] 3.2 Preserve existing keyword matching as primary path (zero latency for explicit commands)
+  - [x] 3.3 Unit tests for DM handler with intent parsing (keyword match, LLM fallback, LLM failure fallback)
+
+- [x] Task 4: Integrate intent parsing into mention handler (AC: #1, #2, #3)
+  - [x] 4.1 Modify `mention_handler.py`: same fallback-to-LLM pattern as DM handler
+  - [x] 4.2 Thread responses preserved for LLM-parsed commands
+  - [x] 4.3 Unit tests for mention handler with intent parsing
+
+- [x] Task 5: Configuration and documentation (AC: #3)
+  - [x] 5.1 Add config vars to `vars-classification.yaml`
+  - [x] 5.2 Update `slack_bot/README.md` with LLM intent parsing section
+  - [x] 5.3 Bump version to 0.3.0 in `slack_bot/src/__init__.py`, update CHANGELOG.md
+
+## Dev Notes
+
+### Architecture Decision: Backend Endpoint vs Direct LLM Call
+
+**Recommended: New backend endpoint `/ai_parse_intent`** (Option A).
+
+Rationale:
+- Reuses existing `backend/library/ai.py` multi-provider LLM routing (OpenAI, Bedrock, Vertex AI, Bielik)
+- No LLM config duplication in slack_bot — backend already has `OPENAI_API_KEY`, `LLM_PROVIDER`, model vars
+- Slack bot stays a thin REST client (established pattern from Epics 21-23)
+- Single place to tune prompts, change models, add caching
+- Follows NFR8: "Bot communicates exclusively via HTTP REST API"
+
+**Do NOT:**
+- Add `openai` dependency to slack_bot
+- Duplicate LLM provider routing logic
+- Store LLM API keys in slack_bot config
+
+### Intent Parser Design
+
+**System prompt approach** — send a system prompt defining available commands and expected JSON output, then user's natural language text as the user message.
+
+Available commands to map to:
+| Command | Args | Example natural language |
+|---------|------|------------------------|
+| `version` | none | "what version is running?" |
+| `count` | none | "how many articles do I have?" |
+| `check` | `{url: str}` | "do I already have this link? https://..." |
+| `add` | `{url: str, type?: str}` | "save this article https://..." |
+| `info` | `{id: int}` | "show me document 42" |
+| `search` | `{query: str}` | "find articles about Kubernetes" (Story 24.2) |
+| `unknown` | none | ambiguous or unrelated text |
+
+**Response format** (JSON):
+```json
+{
+  "command": "check",
+  "args": {"url": "https://example.com"},
+  "confidence": 0.95
+}
+```
+
+**Confidence threshold:** If confidence < 0.5, treat as `unknown` and show help text.
+
+**Model recommendation:** Default to `Bielik-11B-v2.3-Instruct` (CloudFerro — prepaid package already purchased, supports Polish natively). If Bielik proves insufficient for intent classification accuracy during testing, fall back to `gpt-4o-mini` or `amazon.nova-micro`. Intent parsing is a simple classification task; start with the model that's already paid for.
+
+### Fallback Chain (Critical)
+
+```
+User message
+  → 1. Keyword match (existing dm_handler/mention_handler logic) — instant, no LLM cost
+  → 2. If no keyword match AND INTENT_PARSER_ENABLED=true:
+       → Call POST /ai_parse_intent {text: message}
+       → If success + confidence >= 0.5: route to command handler
+       → If success + confidence < 0.5: show "I'm not sure..." + help
+  → 3. If LLM unreachable (timeout, error): show help text (Epic 22 fallback)
+```
+
+**CRITICAL:** Existing keyword commands MUST work identically with or without LLM. LLM is an additive fallback, not a replacement.
+
+### Existing Code to Reuse (Do NOT Reinvent)
+
+| What | Where | How to use |
+|------|-------|-----------|
+| LLM multi-provider router | `backend/library/ai.py` → `ai_ask()` | Call from new intent parser module |
+| OpenAI client | `backend/library/api/openai/openai_my.py` → `OpenAIClient` | Used internally by `ai_ask()` |
+| Bedrock client | `backend/library/api/aws/bedrock_ask.py` | Used internally by `ai_ask()` |
+| API client pattern | `slack_bot/src/api_client.py` → `LenieApiClient` | Add `parse_intent()` method |
+| DM command handlers | `slack_bot/src/dm_handler.py` → `handle_*()` functions | Reuse after intent parsing |
+| Error hierarchy | `slack_bot/src/api_client.py` → `ApiError`, `ApiConnectionError` | Handle LLM endpoint errors |
+| Config loading | `backend/library/config_loader.py` → `get_config()` | Load `INTENT_PARSER_MODEL`, `INTENT_PARSER_ENABLED` |
+
+### Config Variables to Add
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `INTENT_PARSER_ENABLED` | config | `false` | Enable/disable LLM intent parsing |
+| `INTENT_PARSER_MODEL` | config | `Bielik-11B-v2.3-Instruct` | LLM model for intent classification (Bielik default, fallback: gpt-4o-mini) |
+
+Add to `scripts/vars-classification.yaml` under the `llm` group.
+
+### Project Structure Notes
+
+**New files:**
+- `backend/library/ai_intent_parser.py` — intent parsing logic (system prompt, response parsing)
+- `backend/tests/unit/test_ai_intent_parser.py` — unit tests
+- `slack_bot/src/intent_parser.py` — thin wrapper calling backend endpoint
+
+**Modified files:**
+- `backend/server.py` — add `POST /ai_parse_intent` route
+- `slack_bot/src/api_client.py` — add `parse_intent()` method
+- `slack_bot/src/dm_handler.py` — add LLM fallback after keyword mismatch
+- `slack_bot/src/mention_handler.py` — add LLM fallback after keyword mismatch
+- `slack_bot/src/__init__.py` — version bump to 0.3.0
+- `slack_bot/CHANGELOG.md` — add v0.3.0 entry
+- `scripts/vars-classification.yaml` — add INTENT_PARSER_ENABLED, INTENT_PARSER_MODEL
+
+### Testing Requirements
+
+**Backend tests** (`backend/tests/unit/test_ai_intent_parser.py`):
+- System prompt construction
+- JSON response parsing (valid, malformed, empty)
+- Confidence threshold logic
+- Unknown command handling
+- Model selection from config
+
+**Slack bot tests** (`slack_bot/tests/unit/test_intent_parser.py`):
+- Successful intent parsing via API client
+- API timeout fallback (returns None → keyword help text shown)
+- API error fallback (ApiConnectionError → keyword help text shown)
+
+**Slack bot handler tests** (update existing):
+- `test_dm_handler.py`: keyword match still works, LLM fallback when no keyword match, LLM disabled path
+- `test_mention_handler.py`: same patterns as DM handler tests
+
+**Run tests:**
+```bash
+# Backend
+cd backend && PYTHONPATH=. uvx pytest tests/unit/test_ai_intent_parser.py -v
+
+# Slack bot
+cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v
+```
+
+### Security Notes
+
+- `/ai_parse_intent` endpoint MUST require `x-api-key` header (same as all other endpoints)
+- Never log raw user text at INFO level (could contain sensitive URLs/data) — use DEBUG
+- LLM system prompt must not leak internal architecture details in responses
+- Sanitize LLM JSON response before processing (prevent injection via crafted LLM output)
+
+### Performance Notes
+
+- Keyword matching is instant (< 1ms) — always try first
+- LLM call adds 0.5-2s latency — only used when keyword match fails
+- Use cheapest viable model (`gpt-4o-mini`: ~$0.15/1M input tokens)
+- Consider adding response caching in backend for repeated queries (future optimization, NOT in scope)
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 24]
+- [Source: _bmad-output/planning-artifacts/prd.md — FR12, FR13, NFR3, NFR9]
+- [Source: backend/library/ai.py — LLM router pattern]
+- [Source: slack_bot/src/dm_handler.py — current command parsing]
+- [Source: slack_bot/src/api_client.py — API client pattern]
+- [Source: scripts/vars-classification.yaml — config variable SSOT]
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Opus 4.6
+
+### Debug Log References
+- boto3 import cascade: `ai_intent_parser.py` initially had top-level `from library.ai import ai_ask` which triggered boto3 import in test env. Fixed with lazy imports inside `parse_intent()`.
+- `@patch` decorator failure: `library/` has no `__init__.py`, so `@patch("library.ai.ai_ask")` failed. Fixed using `patch.dict(sys.modules, {...})`.
+
+### Completion Notes List
+- All 5 tasks completed successfully
+- 27 backend unit tests (test_ai_intent_parser.py) — all passing
+- 214 slack_bot unit tests — all passing (8 intent_parser, 9 dm_handler intent, 5 mention_handler intent, rest existing)
+- Ruff linting clean for both backend and slack_bot
+- Lazy imports used in `ai_intent_parser.py` to avoid cascading heavy dependencies (boto3, openai) in test environment
+- `_route_intent()` helper maps ParsedIntent args to existing handler function signatures
+
+### Code Review Fixes (2026-03-05)
+- **H1**: Removed unused `CONFIDENCE_THRESHOLD` import from `server.py` (ruff F401)
+- **H2**: Removed unused `client` parameter from `_route_intent()`, added type hints
+- **M1**: Added "not yet available" message for LLM-parsed commands without handlers (e.g. `search`)
+- **M3**: Added input length limit (2000 chars) and documented prompt injection limitation in `ai_intent_parser.py`
+- **M4**: Added test for unimplemented command scenario (`test_llm_unimplemented_command_shows_not_available`)
+
+### File List
+
+**New files:**
+- `backend/library/ai_intent_parser.py` — intent parsing logic with system prompt, JSON response validation, confidence threshold
+- `backend/tests/unit/test_ai_intent_parser.py` — 27 unit tests (19 response parsing + 8 integration with mocked LLM)
+- `slack_bot/src/intent_parser.py` — thin client calling backend `/ai_parse_intent`, returns `ParsedIntent` dataclass
+- `slack_bot/tests/unit/test_intent_parser.py` — 8 unit tests
+
+**Modified files:**
+- `backend/server.py` — added `POST /ai_parse_intent` endpoint, gated by `INTENT_PARSER_ENABLED`
+- `scripts/vars-classification.yaml` — added `INTENT_PARSER_ENABLED` and `INTENT_PARSER_MODEL` under `llm` group
+- `slack_bot/src/api_client.py` — added `parse_intent()` and `search_similar()` methods to `LenieApiClient`
+- `slack_bot/src/dm_handler.py` — added `intent_enabled` parameter, `_route_intent()` helper, LLM fallback chain
+- `slack_bot/src/mention_handler.py` — added `intent_enabled` parameter, LLM fallback chain with thread_ts preservation
+- `slack_bot/src/main.py` — reads `INTENT_PARSER_ENABLED` config, passes `intent_enabled` to handlers
+- `slack_bot/src/__init__.py` — version bumped from `0.2.0` to `0.3.0`
+- `slack_bot/CHANGELOG.md` — added v0.3.0 entry
+- `slack_bot/README.md` — added LLM Intent Parsing section, updated config reference and project structure
+- `slack_bot/tests/unit/test_dm_handler.py` — added `TestDmIntentParsing` class (8 tests)
+- `slack_bot/tests/unit/test_mention_handler.py` — added `TestMentionIntentParsing` class (5 tests)
+

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -283,13 +283,13 @@ development_status:
   epic-22-retrospective: optional
 
   # --- Epic 23: Channel App Mentions ---
-  epic-23: backlog
-  23-1-app-mention-event-handler-thread-responses: backlog
+  epic-23: done
+  23-1-app-mention-event-handler-thread-responses: done  # DONE 2026-03-04. Implemented in PR #64 (commit c9d01c5). mention_handler.py with thread responses, shared command handlers from dm_handler.py, 21 unit tests, manifest updated (app_mentions:read scope + app_mention event). Version bumped to 0.2.0.
   epic-23-retrospective: optional
 
   # --- Epic 24: Conversational LLM Intelligence ---
-  epic-24: backlog
-  24-1-llm-intent-parser: backlog
+  epic-24: in-progress
+  24-1-llm-intent-parser: done  # DONE 2026-03-05. Backend /ai_parse_intent endpoint + slack_bot intent_parser.py + DM/mention handler LLM fallback chain. 27 backend tests, 214 slack_bot tests (22 new). Version 0.3.0. Code review: 6 issues fixed (H1 unused import, H2 dead param, M1 unimplemented cmd UX, M3 input sanitization, M4 missing test).
   24-2-semantic-search-via-natural-language: backlog
   epic-24-retrospective: optional
 
@@ -314,6 +314,9 @@ development_status:
   B-30-define-analysis-json-schema-and-db-storage: backlog  # Schemat JSON, kolumna JSONB lub dedykowana tabela, indeksy GIN.
   B-31-frontend-ui-for-analysis-results: backlog  # Wyświetlanie wyników analizy, ręczna korekta, filtrowanie po metadanych.
   B-32-batch-analysis-for-existing-documents: backlog  # Batch processing istniejących dokumentów, nowy status ANALYSIS_NEEDED → ANALYSIS_DONE.
+
+  # --- Observability & Cost Management ---
+  B-89-api-usage-cost-and-limits-dashboard: backlog  # Admin panel (app2) showing external API usage, costs, and remaining limits/quotas. Covers: OpenAI, AWS Bedrock, CloudFerro Bielik, AssemblyAI, Firecrawl, Google Vertex AI, AWS Textract. Display per-provider: calls made, tokens/units consumed, estimated cost, free-tier/package limits remaining. Backend endpoint to aggregate usage data. Future: alerts when approaching limits.
 
   # --- Phase 9: Multiuser ---
   B-33-implement-user-authentication-with-aws-cognito: backlog  # Cognito User Pool, integracja z API Gateway (Cognito Authorizer).

--- a/_bmad-output/planning-artifacts/epics/backlog.md
+++ b/_bmad-output/planning-artifacts/epics/backlog.md
@@ -814,3 +814,222 @@ so that the acceptance criterion from [B-79](#b-79-migrate-standalone-scripts-to
 **Priority:** LOW — `test_code/` scripts are experimental; sherlock library files are medium priority
 **Status:** backlog
 **Related:** [B-79](#b-79-migrate-standalone-scripts-to-config_loader)
+
+---
+
+## Backlog: Security — CodeQL & SAST Findings
+
+### B-86: Triage CodeQL Clear-Text Logging Alerts (12 HIGH)
+
+As a **developer**,
+I want to review and resolve CodeQL "clear-text logging of sensitive data" alerts,
+so that actual credential leaks are fixed and false positives are properly suppressed.
+
+**Origin:** First CodeQL scan (2026-03-05) — 12 HIGH alerts of rule `py/clear-text-logging-sensitive-data`.
+
+**Alerts to review (12):**
+
+| # | File | Line | Assessment |
+|---|------|------|------------|
+| 3,4,5 | `shared_python/unified-config-loader/.../aws.py` | 30, 48, 52 | Logs SSM parameter **names** (paths like `/lenie/dev/db_host`), not values. **Likely false positive** — but verify each `logging.info()` call. |
+| 6,7 | `shared_python/unified-config-loader/.../config.py` | 62, 101 | Logs config key names being loaded. **Likely false positive.** |
+| 10 | `shared_python/unified-config-loader/.../vault.py` | 44 | Logs Vault path. **Verify** — could log secret value if variable naming is ambiguous. |
+| 8 | `scripts/gitguardian_manage_incidents.py` | 203 | **Verify** — script handles incident data, may log token/secret info. |
+| 9 | `backend/scripts/notion_changelog.py` | 141 | **Verify** — may log Notion API token. |
+| 11,12,13 | `backend/imports/unknown_news_import.py` | 77, 90, 95 | **Verify** — import script, check what is logged. |
+| 14 | `backend/test_code/vault_tests.py` | 80 | Logs Vault secret values for debugging. **True positive** in test code — low risk but should be suppressed or removed. |
+
+**How to suppress false positives in CodeQL:**
+
+1. **Per-alert dismissal** (recommended for individual false positives):
+   ```bash
+   gh api repos/{owner}/{repo}/code-scanning/alerts/{alert_number} \
+     -X PATCH -f state=dismissed -f dismissed_reason="false_positive" \
+     -f dismissed_comment="Logs parameter name/path, not secret value"
+   ```
+
+2. **CodeQL config file** (recommended for excluding paths like `test_code/`):
+   Create `.github/codeql/codeql-config.yml`:
+   ```yaml
+   paths-ignore:
+     - backend/test_code
+   ```
+   Then reference it in `.github/workflows/codeql.yml`:
+   ```yaml
+   - name: Initialize CodeQL
+     uses: github/codeql-action/init@v3
+     with:
+       languages: ${{ matrix.language }}
+       config-file: .github/codeql/codeql-config.yml
+   ```
+
+3. **Disable specific rule globally** (NOT recommended — rule catches real issues):
+   ```yaml
+   # in codeql-config.yml
+   query-filters:
+     - exclude:
+         id: py/clear-text-logging-sensitive-data
+   ```
+
+**Acceptance Criteria:**
+- Each of the 12 alerts is reviewed and categorized as true positive or false positive
+- True positives are fixed (remove secret logging or mask values)
+- False positives are dismissed via GitHub API with explanation
+- `test_code/` path excluded from CodeQL scanning via config file
+
+**Priority:** MEDIUM — no actual secrets are being leaked (initial assessment), but alerts should be triaged
+**Status:** backlog
+
+---
+
+### B-87: Fix Stack Trace Exposure in server.py Error Handlers (7 MEDIUM)
+
+As a **developer**,
+I want error handlers in `server.py` to return generic error messages instead of raw exception details,
+so that stack traces and internal implementation details are not exposed to API consumers.
+
+**Origin:** CodeQL scan (2026-03-05) — 7 MEDIUM alerts of rule `py/stack-trace-exposure`.
+
+**Affected lines in `backend/server.py`:** 189, 204, 222, 237, 277, 285, 682
+
+**Current pattern:**
+```python
+except Exception as e:
+    return jsonify({"error": str(e)}), 500
+```
+
+**Proposed fix:**
+```python
+except Exception as e:
+    logging.exception("Error in endpoint_name")
+    return jsonify({"error": "Internal server error"}), 500
+```
+
+For development, keep detailed errors behind a `DEBUG` flag:
+```python
+except Exception as e:
+    logging.exception("Error in endpoint_name")
+    if cfg.require("DEBUG", "false").lower() == "true":
+        return jsonify({"error": str(e)}), 500
+    return jsonify({"error": "Internal server error"}), 500
+```
+
+**Acceptance Criteria:**
+- All `except` blocks in `server.py` return generic error messages in production
+- Full exception details are logged server-side via `logging.exception()`
+- DEBUG mode still returns detailed errors for development
+- CodeQL alerts resolve after fix
+
+**Priority:** MEDIUM — API is behind `x-api-key` auth, but good practice
+**Status:** backlog
+
+---
+
+### B-88: Review Reflected XSS Alerts in server.py (8 MEDIUM)
+
+As a **developer**,
+I want to verify that Flask endpoints in `server.py` are not vulnerable to reflected XSS,
+so that CodeQL alerts are resolved — either by fixing real issues or dismissing false positives.
+
+**Origin:** CodeQL scan (2026-03-05) — 8 MEDIUM alerts of rule `py/reflective-xss`.
+
+**Affected lines in `backend/server.py`:** 364, 428, 462, 467, 519, 569, 603, 674
+
+**Assessment needed:**
+- All endpoints return `jsonify()` responses (Content-Type: `application/json`)
+- JSON responses are generally not vulnerable to reflected XSS because browsers don't render them as HTML
+- If all responses use `jsonify()`, these are **likely false positives**
+- However, verify that no endpoint returns raw `str` or `make_response()` with HTML content-type
+
+**How to suppress if confirmed false positive:**
+```bash
+# Per-alert dismissal
+gh api repos/{owner}/{repo}/code-scanning/alerts/{alert_number} \
+  -X PATCH -f state=dismissed -f dismissed_reason="false_positive" \
+  -f dismissed_comment="Endpoint returns application/json via jsonify(), not rendered as HTML"
+```
+
+**Acceptance Criteria:**
+- Each of the 8 alerts is reviewed — verify response Content-Type
+- True positives fixed (add escaping or ensure JSON response)
+- False positives dismissed with explanation
+
+**Priority:** MEDIUM — API returns JSON, likely false positives, but should be verified
+**Status:** backlog
+
+---
+
+### B-89: Fix ReDoS Vulnerability in webdocument_prepare_regexp_by_ai.py
+
+As a **developer**,
+I want to fix the regular expression with exponential backtracking risk,
+so that the application is not vulnerable to ReDoS (Regular Expression Denial of Service).
+
+**Origin:** CodeQL scan (2026-03-05) — 1 HIGH alert of rule `py/redos` at line 36.
+
+**Details:** The regex pattern may cause exponential backtracking on strings starting with `\n` and containing many repetitions of `\n`.
+
+**Acceptance Criteria:**
+- Regex is rewritten to avoid catastrophic backtracking
+- Unit test added to verify regex works on edge cases (long strings with many newlines)
+- CodeQL alert resolves after fix
+
+**Priority:** HIGH — ReDoS can cause application hangs with crafted input
+**Status:** backlog
+
+---
+
+### B-90: Add Timeout to All requests Calls (6 locations)
+
+As a **developer**,
+I want all `requests.get()` and `requests.post()` calls to include a `timeout` parameter,
+so that the application does not hang indefinitely on unresponsive external services.
+
+**Origin:** Bandit scan (2026-03-05) — 6 MEDIUM alerts of rule B113.
+
+**Affected files:**
+1. `backend/library/api/cloudferro/sherlock/sherlock_embedding.py:40` — `requests.post()` (production)
+2. `backend/library/website/website_download_context.py:18` — `requests.get()` (production)
+3. `backend/library/youtube_processing.py:272` — `requests.get()` (production)
+4. `backend/imports/unknown_news_import.py:44` — `requests.get()` (import script)
+5. `backend/test_code/cloudferro_ark_labs_models.py:30,52` — `requests.get()` (test code)
+6. `backend/test_code/cloudferro_embeddings.py:38` — `requests.post()` (test code)
+
+**Fix:** Add `timeout=30` (or appropriate value) to each call.
+
+**Acceptance Criteria:**
+- All `requests` calls in `backend/` have explicit `timeout=` parameter
+- No new Bandit B113 alerts
+
+**Priority:** MEDIUM — production code (items 1-3) should be fixed soon; test code is lower priority
+**Status:** backlog
+
+---
+
+### B-91: Migrate SQL F-Strings to Parameterized Queries
+
+As a **developer**,
+I want SQL queries in `stalker_web_documents_db_postgresql.py` to use parameterized queries instead of f-strings,
+so that the code follows security best practices and SAST tools stop flagging SQL injection risks.
+
+**Origin:** Semgrep (22 findings) + Bandit (11 findings) + CodeQL scan (2026-03-05). All three tools flag the same pattern.
+
+**Risk assessment:**
+- Most f-strings interpolate Python enum `.name` attributes (e.g., `StalkerDocumentStatus.URL_ADDED.name`) — these are **not user-controlled** and are safe
+- However, some queries interpolate function parameters: `embedding`, `model`, `url`, `min` — these could be risky if upstream validation is missing
+- **Highest risk locations:** lines 358-363 (`min` param), 387-392 (`url` param)
+
+**Scope:**
+1. `backend/library/stalker_web_documents_db_postgresql.py` — ~15 queries
+2. `backend/library/stalker_web_document_db.py` — 1 query
+3. `backend/imports/dynamodb_sync.py` — 1 query
+
+**Acceptance Criteria:**
+- All SQL queries use `%s` placeholders with parameter tuples
+- Semgrep/Bandit/CodeQL scans show 0 SQL injection alerts
+- All existing unit tests pass
+- Integration tests pass against test database
+
+**Priority:** LOW — enum `.name` interpolation is safe in practice; parameterized queries are better practice but not urgent
+**Status:** backlog
+**Related:** [B-85](#b-85-migrate-remaining-test_code-and-library-scripts-to-config_loader)

--- a/backend/library/ai.py
+++ b/backend/library/ai.py
@@ -1,8 +1,5 @@
-import library.api.aws.bedrock_ask
-import library.api.openai.openai_my
 from library.models.ai_response import AiResponse
-from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
-import library.api.google.google_vertexai as google_vertexai
+
 
 def get_all_models_info():
     return {
@@ -10,6 +7,7 @@ def get_all_models_info():
         "gpt-4": {"need_translation": True},
         "gpt-3.5-turbo": {"need_translation": True},
         "Bielik-11B-v2.3-Instruct": {"need_translation": False},
+        "Bielik-11B-v3.0-Instruct": {"need_translation": False},
         "gemini-2.0-flash-lite-001": {"need_translation": False},
     }
 
@@ -26,6 +24,7 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         -> AiResponse:
 
     if model in ["gpt-3.5-turbo", "gpt-3.5-turbo-16k"]:
+        import library.api.openai.openai_my
         if len(query) < 8000:
             model = "gpt-3.5-turbo"
         elif len(query) < 16000:
@@ -43,6 +42,7 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         ai_response.response_text = response
         return ai_response
     if model in ["gpt-4", "gpt-4o", "gpt-4o-2024-05-13"]:
+        import library.api.openai.openai_my
         response = library.api.openai.openai_my.OpenAIClient.get_completion(query, model)
         ai_response = AiResponse(query=query, model=model)
 
@@ -53,6 +53,7 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         return ai_response
 
     elif model in ["gpt-4o-mini"]:
+        import library.api.openai.openai_my
         response = library.api.openai.openai_my.OpenAIClient.get_completion(query, model)
         ai_response = AiResponse(query=query, model=model)
 
@@ -63,17 +64,16 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         return ai_response
 
     elif model in ('amazon.titan-tg1-large', 'amazon.nova-micro', 'amazon.nova-pro', 'aws'):
+        import library.api.aws.bedrock_ask
         ai_response = library.api.aws.bedrock_ask.query_aws_bedrock(query, model, temperature=temperature,
                                                                     max_token_count=max_token_count, top_p=top_p)
 
-        # if isinstance(response, bytes):
-        #     response = response.decode('utf-8')
-
-        # ai_response.response_text = response
         return ai_response
-    elif model in ["Bielik-11B-v2.3-Instruct"]:
+    elif model in ["Bielik-11B-v2.3-Instruct", "Bielik-11B-v3.0-Instruct"]:
+        from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
         return sherlock_get_completion(query, model=model)
     elif model in ['gemini-2.0-flash-lite-001']:
+        import library.api.google.google_vertexai as google_vertexai
         return google_vertexai.connect_to_google_llm_with_role(query, model)
 
     else:

--- a/backend/library/ai_intent_parser.py
+++ b/backend/library/ai_intent_parser.py
@@ -1,0 +1,121 @@
+"""LLM-based intent parser for natural language command recognition.
+
+Sends a system prompt defining available commands and expected JSON output,
+then the user's natural language text. Returns a structured ParsedIntent
+with command, args, and confidence score.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+CONFIDENCE_THRESHOLD = 0.5
+
+SYSTEM_PROMPT = """You are a command classifier for a knowledge base assistant.
+Given a user message, determine which command the user wants to execute.
+
+Available commands:
+- version: Show system version (no args). Examples: "what version?", "which version is running?"
+- count: Show document count (no args). Examples: "how many articles?", "ile mam dokumentów?"
+- check: Check if URL exists in database (args: {url: str}). Examples: "do I have this? https://...", "czy mam ten link?"
+- add: Save a URL to knowledge base (args: {url: str, type?: str}). Examples: "save https://...", "dodaj ten artykuł"
+- info: Get document details by numeric ID (args: {id: int}). Examples: "show document 42", "pokaż dokument 15"
+- search: Search for documents by query (args: {query: str}). Examples: "find articles about Kubernetes", "szukaj artykułów o AI"
+- unknown: Cannot determine intent or message is unrelated.
+
+Valid document types for 'add': webpage, link, youtube, movie, text_message, text.
+
+Respond ONLY with valid JSON (no markdown, no explanation):
+{"command": "<command_name>", "args": {<args if any>}, "confidence": <0.0-1.0>}
+
+Rules:
+- Extract URLs from the message when relevant (for check/add commands)
+- Extract numeric IDs for info command
+- Set confidence to 0.0-1.0 based on how certain you are
+- If the message is ambiguous or unrelated, use command "unknown" with confidence 0.0
+- Always respond with valid JSON, nothing else"""
+
+
+def parse_intent(text: str, model: str | None = None) -> dict:
+    """Parse user text into a structured command intent using LLM.
+
+    Args:
+        text: Natural language user message.
+        model: LLM model to use. If None, reads from config INTENT_PARSER_MODEL.
+
+    Returns:
+        Dict with keys: command (str), args (dict), confidence (float).
+        On failure returns {"command": "unknown", "args": {}, "confidence": 0.0}.
+    """
+    if not text or not text.strip():
+        return {"command": "unknown", "args": {}, "confidence": 0.0}
+
+    if model is None:
+        from library.config_loader import load_config
+        cfg = load_config()
+        model = cfg.get("INTENT_PARSER_MODEL", "Bielik-11B-v3.0-Instruct")
+
+    # NOTE: ai_ask() accepts a single string, so system prompt and user text
+    # are concatenated. Ideally these should be separate system/user messages
+    # for stronger prompt injection defense. Response validation below mitigates this.
+    sanitized_text = text.strip()[:2000]  # Limit input length to prevent abuse
+    prompt = f"{SYSTEM_PROMPT}\n\nUser message: {sanitized_text}"
+
+    try:
+        from library.ai import ai_ask
+        ai_response = ai_ask(prompt, model=model, temperature=0.1, max_token_count=256)
+        raw_response = ai_response.response_text
+        if not raw_response:
+            logger.warning("Empty LLM response for intent parsing")
+            return {"command": "unknown", "args": {}, "confidence": 0.0}
+
+        result = _parse_llm_response(raw_response)
+        logger.debug("Intent parsed: command=%s, confidence=%.2f", result["command"], result["confidence"])
+        return result
+
+    except Exception:
+        logger.exception("LLM intent parsing failed")
+        return {"command": "unknown", "args": {}, "confidence": 0.0}
+
+
+def _parse_llm_response(raw: str) -> dict:
+    """Parse and validate LLM JSON response.
+
+    Handles markdown code blocks, extra whitespace, and malformed JSON.
+    Validates command is in the allowed set and confidence is a valid float.
+    """
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        cleaned = "\n".join(lines).strip()
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        logger.warning("Malformed LLM JSON response: %s", cleaned[:200])
+        return {"command": "unknown", "args": {}, "confidence": 0.0}
+
+    if not isinstance(data, dict):
+        return {"command": "unknown", "args": {}, "confidence": 0.0}
+
+    allowed_commands = {"version", "count", "check", "add", "info", "search", "unknown"}
+    command = data.get("command", "unknown")
+    if command not in allowed_commands:
+        command = "unknown"
+
+    args = data.get("args", {})
+    if not isinstance(args, dict):
+        args = {}
+
+    try:
+        confidence = float(data.get("confidence", 0.0))
+        confidence = max(0.0, min(1.0, confidence))
+    except (ValueError, TypeError):
+        confidence = 0.0
+
+    if confidence < CONFIDENCE_THRESHOLD:
+        command = "unknown"
+
+    return {"command": command, "args": args, "confidence": confidence}

--- a/backend/server.py
+++ b/backend/server.py
@@ -14,6 +14,7 @@ from library.website.website_download_context import download_raw_html, webpage_
 from library.models.webpage_parse_result import WebPageParseResult
 from library.website.website_paid import website_is_paid
 from library.text_functions import split_text_for_embedding
+from library.ai_intent_parser import parse_intent
 
 logging.basicConfig(level=logging.INFO)
 
@@ -680,6 +681,32 @@ def website_save():
         logging.error(e)
         logging.debug(f"Error while saving new webpage: {e}")
         return {"status": "error", "message": str(e)}, 500
+
+
+@app.route('/ai_parse_intent', methods=['POST'])
+def ai_parse_intent():
+    """Parse natural language text into a structured command intent using LLM."""
+    intent_enabled = cfg.get("INTENT_PARSER_ENABLED", "false").lower() == "true"
+    if not intent_enabled:
+        return {"status": "error", "message": "Intent parser is disabled"}, 400
+
+    if request.json:
+        text = request.json.get("text", "")
+    else:
+        return {"status": "error", "message": "JSON body with 'text' field required"}, 400
+
+    if not text or not text.strip():
+        return {"status": "error", "message": "Empty text provided"}, 400
+
+    logging.debug("Intent parse request received")
+
+    result = parse_intent(text)
+    return {
+        "status": "success",
+        "command": result["command"],
+        "args": result["args"],
+        "confidence": result["confidence"],
+    }, 200
 
 
 @app.route('/healthz', methods=['GET'])

--- a/backend/test_code/cloudferro_ark_labs_models.py
+++ b/backend/test_code/cloudferro_ark_labs_models.py
@@ -1,21 +1,21 @@
 import os
+import sys
 import requests
-from dotenv import load_dotenv
 from pprint import pprint
 from datetime import datetime
 
-load_dotenv()
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from library.config_loader import load_config
+
+load_config()
 
 to_check = "cloudferro"
-# Ustawienie klucza API i niestandardowego URL dla OpenAI API
 
 if to_check == "cloudferro":
     api_key = os.environ["CLOUDFERRO_SHERLOCK_KEY"]
     api_base = "https://api-sherlock.cloudferro.com/openai/v1/"
 elif to_check == "ARK_LABS":
-    # Ark LABS nie obsługuje tego endpointu jeszcze
     api_key = os.environ["ARK_LABS_KEY"]
-    # api_base = "https://api-sherlock.cloudferro.com/openai/v1/"
     api_base = "https://api.ark-labs.cloud/api/v1"
 else:
     print("ERROR: Unknown provider, exiting.")

--- a/backend/tests/unit/test_ai_intent_parser.py
+++ b/backend/tests/unit/test_ai_intent_parser.py
@@ -1,0 +1,235 @@
+"""Unit tests for ai_intent_parser module."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+from library.ai_intent_parser import CONFIDENCE_THRESHOLD, _parse_llm_response, parse_intent
+
+
+class TestParseLlmResponse:
+    """Tests for _parse_llm_response (JSON parsing and validation)."""
+
+    def test_valid_response(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": 0.95})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "count"
+        assert result["args"] == {}
+        assert result["confidence"] == 0.95
+
+    def test_check_command_with_url_arg(self):
+        raw = json.dumps({"command": "check", "args": {"url": "https://example.com"}, "confidence": 0.9})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "check"
+        assert result["args"]["url"] == "https://example.com"
+
+    def test_add_command_with_type(self):
+        raw = json.dumps({"command": "add", "args": {"url": "https://x.com", "type": "youtube"}, "confidence": 0.85})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "add"
+        assert result["args"]["type"] == "youtube"
+
+    def test_info_command_with_id(self):
+        raw = json.dumps({"command": "info", "args": {"id": 42}, "confidence": 0.92})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "info"
+        assert result["args"]["id"] == 42
+
+    def test_search_command(self):
+        raw = json.dumps({"command": "search", "args": {"query": "kubernetes"}, "confidence": 0.88})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "search"
+        assert result["args"]["query"] == "kubernetes"
+
+    def test_unknown_command_returned_as_is(self):
+        raw = json.dumps({"command": "unknown", "args": {}, "confidence": 0.0})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "unknown"
+
+    def test_low_confidence_becomes_unknown(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": 0.3})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "unknown"
+        assert result["confidence"] == 0.3
+
+    def test_confidence_at_threshold(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": CONFIDENCE_THRESHOLD})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "count"
+
+    def test_confidence_just_below_threshold(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": CONFIDENCE_THRESHOLD - 0.01})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "unknown"
+
+    def test_malformed_json(self):
+        result = _parse_llm_response("this is not json at all")
+        assert result["command"] == "unknown"
+        assert result["confidence"] == 0.0
+
+    def test_empty_string(self):
+        result = _parse_llm_response("")
+        assert result["command"] == "unknown"
+
+    def test_markdown_code_block(self):
+        raw = '```json\n{"command": "version", "args": {}, "confidence": 0.9}\n```'
+        result = _parse_llm_response(raw)
+        assert result["command"] == "version"
+
+    def test_invalid_command_name(self):
+        raw = json.dumps({"command": "delete_everything", "args": {}, "confidence": 0.99})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "unknown"
+
+    def test_missing_command_key(self):
+        raw = json.dumps({"args": {}, "confidence": 0.9})
+        result = _parse_llm_response(raw)
+        assert result["command"] == "unknown"
+
+    def test_non_dict_args(self):
+        raw = json.dumps({"command": "count", "args": "invalid", "confidence": 0.9})
+        result = _parse_llm_response(raw)
+        assert result["args"] == {}
+
+    def test_confidence_clamped_above_1(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": 1.5})
+        result = _parse_llm_response(raw)
+        assert result["confidence"] == 1.0
+
+    def test_confidence_clamped_below_0(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": -0.5})
+        result = _parse_llm_response(raw)
+        assert result["confidence"] == 0.0
+
+    def test_non_numeric_confidence(self):
+        raw = json.dumps({"command": "count", "args": {}, "confidence": "high"})
+        result = _parse_llm_response(raw)
+        assert result["confidence"] == 0.0
+
+    def test_response_is_json_array(self):
+        result = _parse_llm_response('[{"command": "count"}]')
+        assert result["command"] == "unknown"
+
+
+class TestParseIntent:
+    """Tests for parse_intent (full flow with LLM mock)."""
+
+    @staticmethod
+    def _make_ai_response(response_text):
+        mock = MagicMock()
+        mock.response_text = response_text
+        return mock
+
+    def test_empty_text_input(self):
+        result = parse_intent("")
+        assert result["command"] == "unknown"
+
+    def test_whitespace_only_input(self):
+        result = parse_intent("   ")
+        assert result["command"] == "unknown"
+
+    def test_successful_parse(self):
+        mock_ai = MagicMock()
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask = mock_ai
+        mock_ai.return_value = self._make_ai_response(
+            json.dumps({"command": "count", "args": {}, "confidence": 0.95})
+        )
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.return_value = "gpt-4o-mini"
+        mock_config_module = MagicMock()
+        mock_config_module.load_config.return_value = mock_cfg
+
+        with patch.dict(sys.modules, {
+            "library.ai": mock_ai_module,
+            "library.config_loader": mock_config_module,
+        }):
+            result = parse_intent("how many articles do I have?")
+            assert result["command"] == "count"
+            assert result["confidence"] == 0.95
+            mock_ai.assert_called_once()
+
+    def test_llm_exception_returns_unknown(self):
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask.side_effect = Exception("LLM service unavailable")
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.return_value = "gpt-4o-mini"
+        mock_config_module = MagicMock()
+        mock_config_module.load_config.return_value = mock_cfg
+
+        with patch.dict(sys.modules, {
+            "library.ai": mock_ai_module,
+            "library.config_loader": mock_config_module,
+        }):
+            result = parse_intent("how many articles?")
+            assert result["command"] == "unknown"
+            assert result["confidence"] == 0.0
+
+    def test_empty_llm_response(self):
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask.return_value = self._make_ai_response("")
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.return_value = "gpt-4o-mini"
+        mock_config_module = MagicMock()
+        mock_config_module.load_config.return_value = mock_cfg
+
+        with patch.dict(sys.modules, {
+            "library.ai": mock_ai_module,
+            "library.config_loader": mock_config_module,
+        }):
+            result = parse_intent("count articles")
+            assert result["command"] == "unknown"
+
+    def test_explicit_model_parameter(self):
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask.return_value = self._make_ai_response(
+            json.dumps({"command": "version", "args": {}, "confidence": 0.9})
+        )
+
+        with patch.dict(sys.modules, {"library.ai": mock_ai_module}):
+            result = parse_intent("what version?", model="gpt-4o-mini")
+            assert result["command"] == "version"
+            mock_ai_module.ai_ask.assert_called_once()
+            call_args = mock_ai_module.ai_ask.call_args
+            assert call_args[1]["model"] == "gpt-4o-mini"
+
+    def test_prompt_contains_user_text(self):
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask.return_value = self._make_ai_response(
+            json.dumps({"command": "check", "args": {"url": "https://x.com"}, "confidence": 0.9})
+        )
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.return_value = "gpt-4o-mini"
+        mock_config_module = MagicMock()
+        mock_config_module.load_config.return_value = mock_cfg
+
+        with patch.dict(sys.modules, {
+            "library.ai": mock_ai_module,
+            "library.config_loader": mock_config_module,
+        }):
+            parse_intent("do I have https://x.com?")
+            call_args = mock_ai_module.ai_ask.call_args
+            assert "do I have https://x.com?" in call_args[0][0]
+
+    def test_temperature_is_low(self):
+        mock_ai_module = MagicMock()
+        mock_ai_module.ai_ask.return_value = self._make_ai_response(
+            json.dumps({"command": "count", "args": {}, "confidence": 0.9})
+        )
+
+        mock_cfg = MagicMock()
+        mock_cfg.get.return_value = "gpt-4o-mini"
+        mock_config_module = MagicMock()
+        mock_config_module.load_config.return_value = mock_cfg
+
+        with patch.dict(sys.modules, {
+            "library.ai": mock_ai_module,
+            "library.config_loader": mock_config_module,
+        }):
+            parse_intent("count")
+            call_args = mock_ai_module.ai_ask.call_args
+            assert call_args[1]["temperature"] == 0.1

--- a/docs/backlog-reference.md
+++ b/docs/backlog-reference.md
@@ -54,3 +54,14 @@ Quick reference of all backlog items. For full specifications (acceptance criter
 | B-73 | CI/CD — GitLab CI Pipeline | backlog | B-70 |
 | B-74 | CI/CD — Jenkins Pipeline | backlog | B-70 |
 | B-76 | Restore pytest-html for CI/CD Test Reports | backlog | B-70 |
+
+## Security — CodeQL & SAST Findings
+
+| ID | Title | Status | Depends on |
+|----|-------|--------|------------|
+| B-86 | Triage CodeQL Clear-Text Logging Alerts (12 HIGH) | backlog | — |
+| B-87 | Fix Stack Trace Exposure in server.py Error Handlers (7 MEDIUM) | backlog | — |
+| B-88 | Review Reflected XSS Alerts in server.py (8 MEDIUM) | backlog | — |
+| B-89 | Fix ReDoS Vulnerability in webdocument_prepare_regexp_by_ai.py | backlog | — |
+| B-90 | Add Timeout to All requests Calls (6 locations) | backlog | — |
+| B-91 | Migrate SQL F-Strings to Parameterized Queries | backlog | — |

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -182,6 +182,20 @@ groups:
         required: true
         example: "gpt-4o-2024-05-13"
         used_by: [docker, lambda, local]
+      INTENT_PARSER_ENABLED:
+        description: "Enable/disable LLM intent parsing for natural language commands"
+        type: config
+        required: false
+        default: "false"
+        example: "false"
+        used_by: [docker, local]
+      INTENT_PARSER_MODEL:
+        description: "LLM model for intent classification (Bielik default, fallback: gpt-4o-mini)"
+        type: config
+        required: false
+        default: "Bielik-11B-v2.3-Instruct"
+        example: "Bielik-11B-v2.3-Instruct"
+        used_by: [docker, local]
 
   aws:
     description: "AWS credentials and resource identifiers"

--- a/slack_bot/CHANGELOG.md
+++ b/slack_bot/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Lenie Slack Bot will be documented in this file.
 
+## [0.3.0] - 2026-03-05
+
+### Added
+- LLM intent parsing for natural language commands (Epic 24, Story 24.1)
+- Backend endpoint `POST /ai_parse_intent` — classifies natural language into structured commands via LLM
+- `backend/library/ai_intent_parser.py` — intent parsing logic with system prompt, JSON response validation, confidence threshold
+- `slack_bot/src/intent_parser.py` — thin client calling backend endpoint, returns `ParsedIntent` dataclass
+- `LenieApiClient.parse_intent()` and `search_similar()` methods
+- LLM fallback chain: keyword match (instant) → LLM intent parsing → help text
+- Config variables: `INTENT_PARSER_ENABLED`, `INTENT_PARSER_MODEL`
+- 27 backend unit tests, 8 slack_bot intent parser tests, 8+5 handler integration tests
+
+### Changed
+- `dm_handler.register_dm_handler()` accepts `intent_enabled` parameter
+- `mention_handler.register_mention_handler()` accepts `intent_enabled` parameter
+- `main.py` reads `INTENT_PARSER_ENABLED` config and passes to handlers
+
 ## [0.2.0] - 2026-03-04
 
 ### Added

--- a/slack_bot/README.md
+++ b/slack_bot/README.md
@@ -95,6 +95,23 @@ You should see a message like: `Lenie Bot started successfully` and a startup me
 | `/lenie-check` | Check if a URL exists in the database | `/lenie-check https://example.com` |
 | `/lenie-info` | Get document details by ID | `/lenie-info 42` |
 
+## LLM Intent Parsing
+
+The bot supports natural language command recognition via LLM. When enabled, if a message doesn't match any keyword command, the bot calls the backend `/ai_parse_intent` endpoint to classify the user's intent.
+
+**Fallback chain:**
+1. Keyword match (instant, no LLM cost) — always tried first
+2. LLM intent parsing (0.5-2s latency) — only when keyword fails and `INTENT_PARSER_ENABLED=true`
+3. Help text — shown when LLM returns "unknown" or is unreachable
+
+**Examples of natural language that works with intent parsing:**
+- "how many articles do I have?" → `count` command
+- "do I already have this link? https://example.com" → `check` command
+- "save this article https://example.com" → `add` command
+- "show me document 42" → `info` command
+
+To enable, set `INTENT_PARSER_ENABLED=true` in your configuration. The default model is `Bielik-11B-v2.3-Instruct` (CloudFerro); override with `INTENT_PARSER_MODEL`.
+
 ## Configuration Reference
 
 | Variable | Type | Required | Default | Description |
@@ -104,6 +121,8 @@ You should see a message like: `Lenie Bot started successfully` and a startup me
 | `LENIE_API_URL` | config | No | `http://lenie-ai-server:5000` | Backend API base URL |
 | `SLACK_CHANNEL_STARTUP` | config | No | `#general` | Channel for bot startup messages |
 | `STALKER_API_KEY` | secret | Yes | — | API key for backend authentication |
+| `INTENT_PARSER_ENABLED` | config | No | `false` | Enable LLM intent parsing for natural language commands |
+| `INTENT_PARSER_MODEL` | config | No | `Bielik-11B-v2.3-Instruct` | LLM model for intent classification |
 
 ## Troubleshooting
 
@@ -162,11 +181,17 @@ slack_bot/
 │   ├── config.py            # Configuration loader wrapper
 │   ├── main.py              # App entry point (Socket Mode)
 │   ├── api_client.py        # Backend API client
-│   └── commands.py          # Slash command handlers
+│   ├── commands.py          # Slash command handlers
+│   ├── dm_handler.py        # DM text command handler
+│   ├── mention_handler.py   # Channel @mention handler
+│   └── intent_parser.py     # LLM intent parser client
 └── tests/
     └── unit/
         ├── test_config.py
         ├── test_main.py
         ├── test_api_client.py
-        └── test_commands.py
+        ├── test_commands.py
+        ├── test_dm_handler.py
+        ├── test_mention_handler.py
+        └── test_intent_parser.py
 ```

--- a/slack_bot/src/__init__.py
+++ b/slack_bot/src/__init__.py
@@ -1,3 +1,3 @@
 """Lenie Slack Bot — optional chatbot module for Lenie-AI."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/slack_bot/src/api_client.py
+++ b/slack_bot/src/api_client.py
@@ -127,6 +127,15 @@ class LenieApiClient:
         websites = data.get("websites", [])
         return websites[0] if websites else None
 
+    def parse_intent(self, text: str) -> dict:
+        """POST /ai_parse_intent — parse natural language into command intent."""
+        return self._request("POST", "/ai_parse_intent", json={"text": text})
+
+    def search_similar(self, query: str, limit: int = 5) -> list[dict]:
+        """POST /website_similar — vector similarity search."""
+        data = self._request("POST", "/website_similar", json={"search": query, "limit": limit})
+        return data.get("websites", [])
+
 
 # --- Factory ---
 

--- a/slack_bot/src/dm_handler.py
+++ b/slack_bot/src/dm_handler.py
@@ -16,6 +16,7 @@ from src.api_client import (
     ApiResponseError,
 )
 from src.commands import DOCUMENT_TYPES, _VALID_TYPES
+from src.intent_parser import ParsedIntent, parse_intent
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -176,9 +177,40 @@ def handle_info(say: Callable, client: LenieApiClient, args_str: str) -> None:
         say(text="Unexpected response from backend")
 
 
-def register_dm_handler(app: App, client: LenieApiClient) -> None:
+def _route_intent(intent: "ParsedIntent", say: "Callable", commands: dict) -> bool:
+    """Route a parsed intent to the appropriate command handler.
+
+    Returns True if a command was successfully routed, False otherwise.
+    """
+    cmd = intent.command
+    if cmd == "unknown":
+        return False
+
+    handler = commands.get(cmd)
+    if not handler:
+        logger.debug("No handler for LLM-parsed command: %s", cmd)
+        return False
+
+    args = intent.args
+    if cmd == "check":
+        handler(say, args.get("url", ""))
+    elif cmd == "add":
+        parts = [args.get("url", "")]
+        if args.get("type"):
+            parts.append(args["type"])
+        handler(say, " ".join(parts))
+    elif cmd == "info":
+        handler(say, str(args.get("id", "")))
+    elif cmd == "search":
+        handler(say, args.get("query", ""))
+    else:
+        handler(say, "")
+    return True
+
+
+def register_dm_handler(app: App, client: LenieApiClient, intent_enabled: bool = False) -> None:
     """Register DM message event handler on the Slack Bolt app."""
-    logger.info("Registering DM message handler")
+    logger.info("Registering DM message handler (intent_parsing=%s)", intent_enabled)
 
     commands = {
         "version": lambda say, args: handle_version(say, client),
@@ -208,6 +240,7 @@ def register_dm_handler(app: App, client: LenieApiClient) -> None:
             say(text=HELP_TEXT)
             return
 
+        # 1. Try keyword matching first (instant, no LLM cost)
         parts = text.split(maxsplit=1)
         command = parts[0].lower()
         args_str = parts[1] if len(parts) > 1 else ""
@@ -215,5 +248,20 @@ def register_dm_handler(app: App, client: LenieApiClient) -> None:
         handler = commands.get(command)
         if handler:
             handler(say, args_str)
-        else:
-            say(text=f"I didn't understand that. {HELP_TEXT}")
+            return
+
+        # 2. If no keyword match and intent parsing enabled, try LLM
+        if intent_enabled:
+            intent = parse_intent(client, text)
+            if intent and intent.command != "unknown":
+                if _route_intent(intent, say, commands):
+                    return
+                # If routing failed (e.g. unimplemented command like "search"), inform user
+                say(text=f"I understood your request ({intent.command}), but this command is not yet available. {HELP_TEXT}")
+                return
+            if intent and intent.command == "unknown":
+                say(text=f"I'm not sure what you mean. {HELP_TEXT}")
+                return
+            # intent is None (LLM unreachable) — fall through to help
+
+        say(text=f"I didn't understand that. {HELP_TEXT}")

--- a/slack_bot/src/intent_parser.py
+++ b/slack_bot/src/intent_parser.py
@@ -1,0 +1,56 @@
+"""Intent parser client for Lenie Slack Bot.
+
+Calls the backend /ai_parse_intent endpoint to classify natural language
+messages into structured commands. Returns ParsedIntent dataclass or None
+on failure (enabling graceful fallback to keyword matching).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from src.api_client import ApiConnectionError, ApiError
+
+if TYPE_CHECKING:
+    from src.api_client import LenieApiClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParsedIntent:
+    """Structured result from LLM intent parsing."""
+    command: str
+    args: dict
+    confidence: float
+
+
+def parse_intent(client: LenieApiClient, text: str) -> ParsedIntent | None:
+    """Parse natural language text into a command intent via backend LLM.
+
+    Args:
+        client: Configured LenieApiClient instance.
+        text: Raw user message text.
+
+    Returns:
+        ParsedIntent if backend successfully parsed the intent,
+        None if backend is unreachable or returns an error (fallback signal).
+    """
+    try:
+        data = client.parse_intent(text)
+        return ParsedIntent(
+            command=data.get("command", "unknown"),
+            args=data.get("args", {}),
+            confidence=data.get("confidence", 0.0),
+        )
+    except ApiConnectionError:
+        logger.warning("Intent parser backend unreachable — falling back to keyword matching")
+        return None
+    except ApiError as exc:
+        logger.warning("Intent parser error: %s — falling back to keyword matching", exc.message)
+        return None
+    except Exception:
+        logger.exception("Unexpected error in intent parser")
+        return None

--- a/slack_bot/src/main.py
+++ b/slack_bot/src/main.py
@@ -97,11 +97,14 @@ def main() -> None:
         sys.exit(1)
 
     api_client = create_client(cfg)
+    intent_enabled = cfg.get("INTENT_PARSER_ENABLED", "false").lower() == "true"
+    if intent_enabled:
+        logger.info("LLM intent parsing is ENABLED")
 
     app = App(token=bot_token)
     register_commands(app, api_client)
-    register_dm_handler(app, api_client)
-    register_mention_handler(app, api_client)
+    register_dm_handler(app, api_client, intent_enabled=intent_enabled)
+    register_mention_handler(app, api_client, intent_enabled=intent_enabled)
 
     handler = SocketModeHandler(app, app_token)
     handler.connect()

--- a/slack_bot/src/mention_handler.py
+++ b/slack_bot/src/mention_handler.py
@@ -13,12 +13,14 @@ from typing import TYPE_CHECKING
 
 from src.dm_handler import (
     HELP_TEXT,
+    _route_intent,
     handle_add,
     handle_check,
     handle_count,
     handle_info,
     handle_version,
 )
+from src.intent_parser import parse_intent
 
 if TYPE_CHECKING:
     from slack_bolt import App
@@ -35,9 +37,9 @@ def _strip_mention(text: str) -> str:
     return _BOT_MENTION_RE.sub("", text, count=1).strip()
 
 
-def register_mention_handler(app: App, client: LenieApiClient) -> None:
+def register_mention_handler(app: App, client: LenieApiClient, intent_enabled: bool = False) -> None:
     """Register app_mention event handler on the Slack Bolt app."""
-    logger.info("Registering app_mention handler")
+    logger.info("Registering app_mention handler (intent_parsing=%s)", intent_enabled)
 
     commands = {
         "version": lambda say, args: handle_version(say, client),
@@ -63,6 +65,7 @@ def register_mention_handler(app: App, client: LenieApiClient) -> None:
             threaded_say(text=HELP_TEXT)
             return
 
+        # 1. Try keyword matching first (instant, no LLM cost)
         parts = text.split(maxsplit=1)
         command = parts[0].lower()
         args_str = parts[1] if len(parts) > 1 else ""
@@ -70,5 +73,19 @@ def register_mention_handler(app: App, client: LenieApiClient) -> None:
         handler = commands.get(command)
         if handler:
             handler(threaded_say, args_str)
-        else:
-            threaded_say(text=f"I didn't understand that. {HELP_TEXT}")
+            return
+
+        # 2. If no keyword match and intent parsing enabled, try LLM
+        if intent_enabled:
+            intent = parse_intent(client, text)
+            if intent and intent.command != "unknown":
+                if _route_intent(intent, threaded_say, commands):
+                    return
+                threaded_say(text=f"I understood your request ({intent.command}), but this command is not yet available. {HELP_TEXT}")
+                return
+            if intent and intent.command == "unknown":
+                threaded_say(text=f"I'm not sure what you mean. {HELP_TEXT}")
+                return
+            # intent is None (LLM unreachable) — fall through to help
+
+        threaded_say(text=f"I didn't understand that. {HELP_TEXT}")

--- a/slack_bot/tests/unit/test_dm_handler.py
+++ b/slack_bot/tests/unit/test_dm_handler.py
@@ -12,6 +12,7 @@ from src.dm_handler import (
     handle_version,
     register_dm_handler,
 )
+from src.intent_parser import ParsedIntent
 
 
 # --- Helpers ---
@@ -829,3 +830,156 @@ class TestHelpText:
         assert "link" in HELP_TEXT
         assert "movie" in HELP_TEXT
         assert "text_message" in HELP_TEXT
+
+
+# --- Test DM handler with intent parsing ---
+
+
+class TestDmIntentParsing:
+    """Test LLM intent fallback in the DM event handler."""
+
+    def _get_handler_with_intent(self, client=None):
+        """Register DM handler with intent_enabled=True and return handler."""
+        app = MagicMock()
+        if client is None:
+            client = _make_mock_client()
+        register_dm_handler(app, client, intent_enabled=True)
+        return app.event.return_value.call_args[0][0], client
+
+    def _get_handler_without_intent(self, client=None):
+        """Register DM handler with intent_enabled=False and return handler."""
+        app = MagicMock()
+        if client is None:
+            client = _make_mock_client()
+        register_dm_handler(app, client, intent_enabled=False)
+        return app.event.return_value.call_args[0][0], client
+
+    def test_keyword_match_takes_priority_over_llm(self):
+        """Keyword match should work even when intent parsing is enabled."""
+        client = _make_mock_client()
+        client.get_all_counts.return_value = {"ALL": 5, "webpage": 5}
+        handler_fn, _ = self._get_handler_with_intent(client)
+        event = _make_dm_event("count")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_all_counts.assert_called_once()
+        client.parse_intent.assert_not_called()
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_fallback_count_command(self, mock_parse):
+        """When keyword fails, LLM should parse intent."""
+        client = _make_mock_client()
+        client.get_all_counts.return_value = {"ALL": 42, "webpage": 42}
+        mock_parse.return_value = ParsedIntent(command="count", args={}, confidence=0.95)
+        handler_fn, _ = self._get_handler_with_intent(client)
+        event = _make_dm_event("how many articles do I have?")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        mock_parse.assert_called_once_with(client, "how many articles do I have?")
+        client.get_all_counts.assert_called_once()
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_fallback_check_command(self, mock_parse):
+        client = _make_mock_client()
+        client.check_url.return_value = None
+        mock_parse.return_value = ParsedIntent(
+            command="check", args={"url": "https://example.com"}, confidence=0.9
+        )
+        handler_fn, _ = self._get_handler_with_intent(client)
+        event = _make_dm_event("do I have https://example.com?")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.check_url.assert_called_once()
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_unknown_shows_help(self, mock_parse):
+        """When LLM returns unknown, show help text."""
+        mock_parse.return_value = ParsedIntent(command="unknown", args={}, confidence=0.0)
+        handler_fn, client = self._get_handler_with_intent()
+        event = _make_dm_event("random gibberish that makes no sense")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "I'm not sure what you mean" in text
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_unreachable_shows_fallback(self, mock_parse):
+        """When LLM is unreachable (returns None), show default help."""
+        mock_parse.return_value = None
+        handler_fn, client = self._get_handler_with_intent()
+        event = _make_dm_event("tell me something")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "I didn't understand that" in text
+
+    def test_intent_disabled_no_llm_call(self):
+        """When intent parsing is disabled, no LLM call should be made."""
+        handler_fn, client = self._get_handler_without_intent()
+        event = _make_dm_event("how many articles?")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.parse_intent.assert_not_called()
+        text = say.call_args[1]["text"]
+        assert "I didn't understand that" in text
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_fallback_add_command(self, mock_parse):
+        client = _make_mock_client()
+        client.add_url.return_value = {"document_id": 77}
+        mock_parse.return_value = ParsedIntent(
+            command="add", args={"url": "https://test.com", "type": "youtube"}, confidence=0.85
+        )
+        handler_fn, _ = self._get_handler_with_intent(client)
+        event = _make_dm_event("save this youtube video https://test.com")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.add_url.assert_called_once()
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_fallback_info_command(self, mock_parse):
+        client = _make_mock_client()
+        client.get_document.return_value = {
+            "id": 42, "title": "T", "document_type": "link",
+            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+        }
+        mock_parse.return_value = ParsedIntent(
+            command="info", args={"id": 42}, confidence=0.92
+        )
+        handler_fn, _ = self._get_handler_with_intent(client)
+        event = _make_dm_event("show me document 42")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_document.assert_called_once_with(42)
+
+    @patch("src.dm_handler.parse_intent")
+    def test_llm_unimplemented_command_shows_not_available(self, mock_parse):
+        """When LLM returns a valid command with no handler (e.g. search), show not-available message."""
+        mock_parse.return_value = ParsedIntent(
+            command="search", args={"query": "kubernetes"}, confidence=0.9
+        )
+        handler_fn, client = self._get_handler_with_intent()
+        event = _make_dm_event("find articles about kubernetes")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "not yet available" in text
+        assert "search" in text

--- a/slack_bot/tests/unit/test_intent_parser.py
+++ b/slack_bot/tests/unit/test_intent_parser.py
@@ -1,0 +1,94 @@
+"""Unit tests for src.intent_parser module."""
+
+from unittest.mock import MagicMock
+
+from src.api_client import ApiConnectionError, ApiError, ApiResponseError
+from src.intent_parser import ParsedIntent, parse_intent
+
+
+def _make_mock_client():
+    return MagicMock()
+
+
+class TestParseIntent:
+    """Tests for parse_intent function."""
+
+    def test_successful_parse(self):
+        client = _make_mock_client()
+        client.parse_intent.return_value = {
+            "status": "success",
+            "command": "count",
+            "args": {},
+            "confidence": 0.95,
+        }
+
+        result = parse_intent(client, "how many articles?")
+        assert result is not None
+        assert isinstance(result, ParsedIntent)
+        assert result.command == "count"
+        assert result.args == {}
+        assert result.confidence == 0.95
+        client.parse_intent.assert_called_once_with("how many articles?")
+
+    def test_check_command_with_url(self):
+        client = _make_mock_client()
+        client.parse_intent.return_value = {
+            "command": "check",
+            "args": {"url": "https://example.com"},
+            "confidence": 0.9,
+        }
+
+        result = parse_intent(client, "do I have https://example.com?")
+        assert result.command == "check"
+        assert result.args["url"] == "https://example.com"
+
+    def test_unknown_command(self):
+        client = _make_mock_client()
+        client.parse_intent.return_value = {
+            "command": "unknown",
+            "args": {},
+            "confidence": 0.0,
+        }
+
+        result = parse_intent(client, "random gibberish")
+        assert result.command == "unknown"
+        assert result.confidence == 0.0
+
+    def test_connection_error_returns_none(self):
+        client = _make_mock_client()
+        client.parse_intent.side_effect = ApiConnectionError("Backend unreachable")
+
+        result = parse_intent(client, "how many articles?")
+        assert result is None
+
+    def test_api_response_error_returns_none(self):
+        client = _make_mock_client()
+        client.parse_intent.side_effect = ApiResponseError(
+            "Backend returned HTTP 400", status_code=400, response_body="Intent parser disabled"
+        )
+
+        result = parse_intent(client, "how many articles?")
+        assert result is None
+
+    def test_api_error_returns_none(self):
+        client = _make_mock_client()
+        client.parse_intent.side_effect = ApiError("Unknown error")
+
+        result = parse_intent(client, "how many articles?")
+        assert result is None
+
+    def test_unexpected_exception_returns_none(self):
+        client = _make_mock_client()
+        client.parse_intent.side_effect = RuntimeError("something broke")
+
+        result = parse_intent(client, "count")
+        assert result is None
+
+    def test_missing_fields_in_response(self):
+        client = _make_mock_client()
+        client.parse_intent.return_value = {"status": "success"}
+
+        result = parse_intent(client, "test")
+        assert result.command == "unknown"
+        assert result.args == {}
+        assert result.confidence == 0.0

--- a/slack_bot/tests/unit/test_mention_handler.py
+++ b/slack_bot/tests/unit/test_mention_handler.py
@@ -1,7 +1,8 @@
 """Unit tests for src.mention_handler module."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from src.intent_parser import ParsedIntent
 from src.mention_handler import _strip_mention, register_mention_handler
 
 
@@ -215,3 +216,85 @@ class TestMentionFiltering:
         text = say.call_args[1]["text"]
         assert "I didn't understand that" in text
         assert "Available commands:" in text
+
+
+# --- Test mention handler with intent parsing ---
+
+
+def _get_handler_with_intent(client=None):
+    """Register mention handler with intent_enabled=True."""
+    app = MagicMock()
+    if client is None:
+        client = _make_mock_client()
+    register_mention_handler(app, client, intent_enabled=True)
+    handler_fn = app.event.return_value.call_args[0][0]
+    return handler_fn, client
+
+
+class TestMentionIntentParsing:
+    """Test LLM intent fallback in the mention event handler."""
+
+    def test_keyword_match_takes_priority(self):
+        client = _make_mock_client()
+        client.get_all_counts.return_value = {"ALL": 5, "webpage": 5}
+        handler_fn, _ = _get_handler_with_intent(client)
+        event = _make_mention_event("<@U123ABC> count")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.get_all_counts.assert_called_once()
+        client.parse_intent.assert_not_called()
+
+    @patch("src.mention_handler.parse_intent")
+    def test_llm_fallback_count(self, mock_parse):
+        client = _make_mock_client()
+        client.get_all_counts.return_value = {"ALL": 42, "webpage": 42}
+        mock_parse.return_value = ParsedIntent(command="count", args={}, confidence=0.95)
+        handler_fn, _ = _get_handler_with_intent(client)
+        event = _make_mention_event("<@U123ABC> how many articles?")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        mock_parse.assert_called_once()
+        client.get_all_counts.assert_called_once()
+        assert say.call_args[1]["thread_ts"] == "1234567890.123456"
+
+    @patch("src.mention_handler.parse_intent")
+    def test_llm_unknown_shows_help_in_thread(self, mock_parse):
+        mock_parse.return_value = ParsedIntent(command="unknown", args={}, confidence=0.0)
+        handler_fn, _ = _get_handler_with_intent()
+        event = _make_mention_event("<@U123ABC> random gibberish", ts="9999.1234")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "I'm not sure what you mean" in text
+        assert say.call_args[1]["thread_ts"] == "9999.1234"
+
+    @patch("src.mention_handler.parse_intent")
+    def test_llm_unreachable_shows_fallback(self, mock_parse):
+        mock_parse.return_value = None
+        handler_fn, _ = _get_handler_with_intent()
+        event = _make_mention_event("<@U123ABC> tell me something")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "I didn't understand that" in text
+
+    @patch("src.mention_handler.parse_intent")
+    def test_thread_response_preserved_for_llm(self, mock_parse):
+        client = _make_mock_client()
+        client.get_version.return_value = {"app_version": "1.0", "app_build_time": "2026-01-01"}
+        mock_parse.return_value = ParsedIntent(command="version", args={}, confidence=0.9)
+        handler_fn, _ = _get_handler_with_intent(client)
+        event = _make_mention_event("<@U123ABC> what version is running?", ts="5555.6666")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        assert say.call_args[1]["thread_ts"] == "5555.6666"


### PR DESCRIPTION
## Summary
- **Story 24-1**: LLM-based intent parser for natural language commands in Slack bot (DM + @mentions)
- **Bielik v3.0**: Updated from v2.3 to v3.0-Instruct as default intent parsing model, added lazy imports in `ai.py` to prevent cascading dependency failures in Docker
- **Security-check**: Added `/security-check` slash command and CodeQL workflow
- **Backend**: New `POST /ai_parse_intent` endpoint, gated by `INTENT_PARSER_ENABLED`
- **Slack bot**: Fallback chain — keyword match first, LLM intent parsing second, help text on failure
- **Tests**: 27 backend + 214 slack_bot unit tests passing
- **Deployed & verified** on NAS with live Slack testing using Bielik v3.0 via CloudFerro Sherlock

## Test plan
- [x] Backend unit tests (27/27 passing)
- [x] Slack bot unit tests (214/214 passing)
- [x] Pre-commit hooks (gitleaks + TruffleHog) passing
- [x] Live testing on NAS — intent parsing works with Polish natural language queries
- [x] Fallback chain verified: keyword match > LLM > help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)