### PR TITLE
feat: semantic search via natural language (Story 24-2)

### DIFF
--- a/_bmad-output/implementation-artifacts/24-2-semantic-search-via-natural-language.md
+++ b/_bmad-output/implementation-artifacts/24-2-semantic-search-via-natural-language.md
@@ -1,0 +1,238 @@
+# Story 24.2: Semantic Search via Natural Language
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **user**,
+I want to search my knowledge base with natural language ("articles about Kubernetes security"),
+so that I can find relevant documents without knowing exact titles or IDs.
+
+## Acceptance Criteria
+
+1. **Given** the bot is connected and embeddings exist in the database
+   **When** user types `/lenie-search Kubernetes security`
+   **Then** bot calls `/website_similar` and responds with top results (title, type, similarity score)
+
+2. **Given** the bot is in a DM with LLM enabled
+   **When** user sends "find articles about pgvector performance"
+   **Then** LLM maps to `search` intent, bot calls `/website_similar` and returns similar documents
+
+3. **Given** the bot is mentioned on a channel
+   **When** user posts `@Lenie search Kubernetes security`
+   **Then** bot responds in a thread with search results
+
+4. **Given** no similar documents are found (cosine similarity below threshold)
+   **When** user searches for an obscure topic
+   **Then** bot responds: "No similar documents found for '<query>'."
+
+5. **Given** the query is empty
+   **When** user types `/lenie-search` without arguments
+   **Then** bot responds with usage hint: "Usage: `/lenie-search <query>`"
+
+6. **Given** the backend is unreachable
+   **When** user types `/lenie-search <query>`
+   **Then** bot responds with user-friendly error message (same pattern as other commands)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `/lenie-search` slash command handler (AC: #1, #4, #5, #6)
+  - [x] 1.1 Add `handle_search(ack, command, client_instance)` to `slack_bot/src/commands.py`
+  - [x] 1.2 Register `/lenie-search` slash command in `commands.py` via `register_commands()`
+  - [x] 1.3 Format results as Slack message (title, URL, type, similarity %)
+  - [x] 1.4 Handle empty query with usage hint
+  - [x] 1.5 Handle empty results with "No similar documents found" message
+  - [x] 1.6 Handle backend errors with user-friendly message
+  - [x] 1.7 Unit tests for search command handler (10 tests)
+
+- [x] Task 2: Add `search` command to DM handler (AC: #2, #4, #5, #6)
+  - [x] 2.1 Add `handle_search(say, client, args_str)` function to `dm_handler.py`
+  - [x] 2.2 Register "search" in DM commands dict in `register_dm_handler()`
+  - [x] 2.3 `_route_intent()` already wired for search (from Story 24-1); now routes to real handler
+  - [x] 2.4 Unit tests for DM search command (9 tests: 7 handler + 2 routing)
+
+- [x] Task 3: Add `search` command to mention handler (AC: #3, #4, #5, #6)
+  - [x] 3.1 Register "search" in mention commands dict in `register_mention_handler()`
+  - [x] 3.2 Thread response works for search results (verified by tests)
+  - [x] 3.3 Unit tests for mention search command (4 tests: 3 routing + 1 intent)
+
+- [x] Task 4: Create shared search result formatter (AC: #1, #4)
+  - [x] 4.1 Created `slack_bot/src/search_formatter.py` with `format_search_results()` function
+  - [x] 4.2 Include: result number, title (or URL if no title), document type, similarity percentage
+  - [x] 4.3 Limit display to top 5 results (configurable via `SEARCH_RESULTS_LIMIT` env var, default 5)
+  - [x] 4.4 Unit tests for formatter (13 tests)
+
+- [x] Task 5: Update Slack App manifest and documentation (AC: all)
+  - [x] 5.1 Add `/lenie-search` to `slack_bot/slack-app-manifest.yaml`
+  - [x] 5.2 Update help text in `dm_handler.py` (shared via HELP_TEXT, used by mention_handler too)
+  - [x] 5.3 Update `slack_bot/README.md` with search command documentation
+  - [x] 5.4 Bump slack_bot version to 0.4.0
+
+## Dev Notes
+
+### Architecture & Implementation Patterns
+
+- **Backend endpoint is FULLY IMPLEMENTED**: `POST /website_similar` accepts `{"search": "<query>", "limit": N}` and returns `{"status": "success", "websites": [...]}` with pgvector cosine similarity search
+- **API client method EXISTS**: `slack_bot/src/api_client.py:134` — `search_similar(query, limit=5)` already calls `/website_similar`
+- **Intent parser already recognizes "search"**: `backend/library/ai_intent_parser.py` has `search` in `allowed_commands` with extraction of `{query: str}` arg
+- **No new backend code needed** — this story is purely Slack bot integration work
+
+### Key Code Patterns to Follow
+
+Follow the EXACT patterns established in Story 24-1 and Epic 21-23:
+
+1. **Slash command handler pattern** — see `commands.py` existing handlers (e.g., `handle_info`):
+   ```python
+   def handle_search(ack, command, client_instance):
+       ack()
+       query = command.get("text", "").strip()
+       if not query:
+           command["respond"](text="Usage: `/lenie-search <query>`")
+           return
+       # ... call client_instance.search_similar(query) ...
+   ```
+
+2. **DM command handler pattern** — see `dm_handler.py` existing handlers:
+   - Commands dict maps string → handler function: `{"search": handle_search, ...}`
+   - Handler signature: `def handle_search(say, args_str)`
+
+3. **Mention handler pattern** — see `mention_handler.py`:
+   - Same commands dict pattern as DM handler
+   - Responses go to thread (already handled by mention handler framework)
+
+4. **Error handling pattern** — all commands use try/except around API calls with user-friendly messages:
+   ```python
+   except LenieApiError as e:
+       say(text=f"Error searching: {e.user_message}")
+   ```
+
+5. **Intent routing** — `_route_intent()` in `dm_handler.py` (line 180+) must be updated to handle `search` command with `intent.args.get("query", "")` as parameter
+
+### Result Formatting
+
+The `/website_similar` response contains objects with these fields (from `stalker_web_documents_db_postgresql.py:get_similar()`):
+- `website_id` — document ID
+- `title` — document title (may be None)
+- `url` — document URL
+- `document_type` — type (webpage, youtube, link, movie)
+- `similarity` — cosine similarity score (0.0–1.0)
+- `language` — document language
+- `text` — embedded text chunk (don't display — too long)
+
+**Recommended Slack format:**
+```
+Found 3 results for "Kubernetes security":
+
+1. *Kubernetes Security Best Practices* (webpage, 87%)
+   https://example.com/k8s-security
+
+2. *CKS Exam Prep Guide* (link, 72%)
+   https://example.com/cks-guide
+
+3. *K8s Network Policies* (youtube, 65%)
+   https://youtube.com/watch?v=abc123
+```
+
+### Critical Implementation Details
+
+- **`api_client.search_similar()` returns `list[dict]`** — already implemented, returns `data.get("websites", [])` (line 137)
+- **Similarity is a float 0.0–1.0** — multiply by 100 and format as percentage for display
+- **Default limit is 5** in `api_client.search_similar()` — keep this as default, make configurable
+- **Minimum similarity threshold is 0.30** (30%) — set in backend `get_similar()`, no need to override
+- **SQL injection warning**: `get_similar()` in `stalker_web_documents_db_postgresql.py` uses f-string interpolation (tracked in B-86) — this is a known issue, do NOT fix in this story
+- **The `text` field in results can be very large** — do NOT include it in Slack messages
+
+### Testing Standards
+
+- Follow existing test patterns in `slack_bot/tests/unit/`
+- Mock `api_client.search_similar()` in all tests — no real backend
+- Test cases: valid query, empty query, no results, backend error, large result set
+- Use `pytest` with `PYTHONPATH=.` from `slack_bot/` directory
+- All tests must pass `ruff check` (line-length=120)
+
+### Project Structure Notes
+
+- All changes in `slack_bot/` directory — no backend changes needed
+- New files: none expected (add to existing modules)
+- Modified files:
+  - `slack_bot/src/commands.py` — add search slash command handler
+  - `slack_bot/src/dm_handler.py` — add search to DM commands, update `_route_intent()`, update help text
+  - `slack_bot/src/mention_handler.py` — add search to mention commands, update help text
+  - `slack_bot/src/main.py` — register `/lenie-search` slash command
+  - `slack_bot/slack-app-manifest.yaml` — add `/lenie-search` command definition
+  - `slack_bot/README.md` — document search command
+  - `slack_bot/pyproject.toml` — version bump to 0.4.0
+  - `slack_bot/tests/unit/test_commands.py` — search command tests
+  - `slack_bot/tests/unit/test_dm_handler.py` — DM search tests
+  - `slack_bot/tests/unit/test_mention_handler.py` — mention search tests
+
+### Previous Story Intelligence (24-1)
+
+From Story 24-1 (LLM Intent Parser) implementation:
+- Intent parser system prompt already includes `search` command with `{query: str}` arg
+- Fallback chain: keyword match → LLM parse → help text — search must be added to keyword matching
+- `_route_intent()` currently handles: `check` (with URL arg), `add` (with URL arg), `info` (with ID arg) — add `search` (with query arg)
+- DM handler line ~204: unrecognized intents fall through to `handler(say, "")` — search must be explicitly routed
+- Code review found issues with unused imports and dead params — be thorough with cleanup
+- 214 total slack_bot tests after 24-1 — maintain test count growth pattern
+
+### Git Intelligence
+
+Recent commits show:
+- `027dac3` — feat: add LLM intent parser with Bielik v3.0 support (Epic 24, Story 24-1)
+- `c9d01c5` — feat: add channel @mention support for Slack bot (Epic 23)
+- Pattern: feature commits use `feat: <description> (Epic N, Story N-M)` format
+
+### References
+
+- [Source: `slack_bot/src/api_client.py`#search_similar — lines 134-137]
+- [Source: `slack_bot/src/commands.py` — existing slash command patterns]
+- [Source: `slack_bot/src/dm_handler.py`#_route_intent — lines 180-208]
+- [Source: `slack_bot/src/mention_handler.py` — mention command registration]
+- [Source: `backend/server.py`#search_similar — `/website_similar` endpoint, lines 433-469]
+- [Source: `backend/library/stalker_web_documents_db_postgresql.py`#get_similar — pgvector query, lines 194-248]
+- [Source: `backend/library/ai_intent_parser.py` — search in allowed_commands]
+- [Source: `_bmad-output/planning-artifacts/epics.md`#Story 24.2 — requirements]
+- [Source: `_bmad-output/implementation-artifacts/24-1-llm-intent-parser.md` — previous story learnings]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+None — clean implementation with no debug issues.
+
+### Completion Notes List
+
+- Created shared `search_formatter.py` module with `format_search_results()` and configurable `SEARCH_RESULTS_LIMIT`
+- Added `_handle_search()` slash command handler in `commands.py` following existing patterns (ack, respond, error handling)
+- Added `handle_search()` DM handler in `dm_handler.py` with same error handling pattern
+- Registered "search" in both DM and mention handler command dicts
+- `_route_intent()` already had search routing from Story 24-1 — now routes to real handler instead of "not yet available"
+- Updated HELP_TEXT to include `search <query>` command
+- Added `/lenie-search` to Slack app manifest
+- Updated README with search command, LLM example, config reference, project structure
+- Bumped version to 0.4.0
+- 250 total tests (36 new: 10 commands, 9 DM, 4 mention, 13 formatter), all passing
+- Ruff linting clean
+
+### File List
+
+- `slack_bot/src/search_formatter.py` — NEW: shared search result formatter
+- `slack_bot/src/commands.py` — MODIFIED: added `_handle_search()`, registered `/lenie-search`
+- `slack_bot/src/dm_handler.py` — MODIFIED: added `handle_search()`, registered in commands dict, updated HELP_TEXT
+- `slack_bot/src/mention_handler.py` — MODIFIED: imported `handle_search`, registered in commands dict
+- `slack_bot/src/__init__.py` — MODIFIED: version bump 0.3.0 → 0.4.0
+- `slack_bot/slack-app-manifest.yaml` — MODIFIED: added `/lenie-search` command definition
+- `slack_bot/README.md` — MODIFIED: added search command docs, config reference, project structure
+- `slack_bot/tests/unit/test_search_formatter.py` — NEW: 13 unit tests for formatter
+- `slack_bot/tests/unit/test_commands.py` — MODIFIED: 10 search tests, updated registration tests
+- `slack_bot/tests/unit/test_dm_handler.py` — MODIFIED: 9 search tests, updated help/intent tests
+- `slack_bot/tests/unit/test_mention_handler.py` — MODIFIED: 4 search tests
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED: status update
+- `_bmad-output/implementation-artifacts/24-2-semantic-search-via-natural-language.md` — MODIFIED: task completion

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -290,7 +290,7 @@ development_status:
   # --- Epic 24: Conversational LLM Intelligence ---
   epic-24: in-progress
   24-1-llm-intent-parser: done  # DONE 2026-03-05. Backend /ai_parse_intent endpoint + slack_bot intent_parser.py + DM/mention handler LLM fallback chain. 27 backend tests, 214 slack_bot tests (22 new). Version 0.3.0. Code review: 6 issues fixed (H1 unused import, H2 dead param, M1 unimplemented cmd UX, M3 input sanitization, M4 missing test).
-  24-2-semantic-search-via-natural-language: backlog
+  24-2-semantic-search-via-natural-language: review
   epic-24-retrospective: optional
 
   # --- Epic 25: Proactive Health Monitoring ---

--- a/backend/library/api/openai/openai_embedding.py
+++ b/backend/library/api/openai/openai_embedding.py
@@ -1,6 +1,6 @@
 from openai import OpenAI
 
-from library.embedding_results import EmbeddingResult
+from library.models.embedding_result import EmbeddingResult
 
 
 def get_embedding(text: str) -> EmbeddingResult:

--- a/backend/test_code/cloudferro_embeddings.py
+++ b/backend/test_code/cloudferro_embeddings.py
@@ -2,7 +2,7 @@ import os
 import requests
 from dotenv import load_dotenv
 from pprint import pprint
-from library.embedding_results import EmbeddingResults
+from library.models.embedding_results import EmbeddingResults
 
 load_dotenv()
 

--- a/slack_bot/README.md
+++ b/slack_bot/README.md
@@ -94,6 +94,7 @@ You should see a message like: `Lenie Bot started successfully` and a startup me
 | `/lenie-add` | Add a URL to the knowledge base | `/lenie-add https://example.com` |
 | `/lenie-check` | Check if a URL exists in the database | `/lenie-check https://example.com` |
 | `/lenie-info` | Get document details by ID | `/lenie-info 42` |
+| `/lenie-search` | Semantic search in knowledge base | `/lenie-search Kubernetes security` |
 
 ## LLM Intent Parsing
 
@@ -109,6 +110,7 @@ The bot supports natural language command recognition via LLM. When enabled, if 
 - "do I already have this link? https://example.com" → `check` command
 - "save this article https://example.com" → `add` command
 - "show me document 42" → `info` command
+- "find articles about pgvector performance" → `search` command
 
 To enable, set `INTENT_PARSER_ENABLED=true` in your configuration. The default model is `Bielik-11B-v2.3-Instruct` (CloudFerro); override with `INTENT_PARSER_MODEL`.
 
@@ -123,6 +125,7 @@ To enable, set `INTENT_PARSER_ENABLED=true` in your configuration. The default m
 | `STALKER_API_KEY` | secret | Yes | — | API key for backend authentication |
 | `INTENT_PARSER_ENABLED` | config | No | `false` | Enable LLM intent parsing for natural language commands |
 | `INTENT_PARSER_MODEL` | config | No | `Bielik-11B-v2.3-Instruct` | LLM model for intent classification |
+| `SEARCH_RESULTS_LIMIT` | config | No | `5` | Max number of search results to display |
 
 ## Troubleshooting
 
@@ -184,7 +187,8 @@ slack_bot/
 │   ├── commands.py          # Slash command handlers
 │   ├── dm_handler.py        # DM text command handler
 │   ├── mention_handler.py   # Channel @mention handler
-│   └── intent_parser.py     # LLM intent parser client
+│   ├── intent_parser.py     # LLM intent parser client
+│   └── search_formatter.py  # Shared search result formatter
 └── tests/
     └── unit/
         ├── test_config.py

--- a/slack_bot/slack-app-manifest.yaml
+++ b/slack_bot/slack-app-manifest.yaml
@@ -37,6 +37,10 @@ features:
       description: "Get document details by ID"
       usage_hint: "<document_id>"
       should_escape: false
+    - command: /lenie-search
+      description: "Semantic search in the knowledge base"
+      usage_hint: "<query>"
+      should_escape: false
 
 oauth_config:
   scopes:

--- a/slack_bot/src/__init__.py
+++ b/slack_bot/src/__init__.py
@@ -1,3 +1,3 @@
 """Lenie Slack Bot — optional chatbot module for Lenie-AI."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/slack_bot/src/commands.py
+++ b/slack_bot/src/commands.py
@@ -1,6 +1,6 @@
 """Slack slash command handlers.
 
-Implements /lenie-version, /lenie-count, /lenie-check, /lenie-add, /lenie-info.
+Implements /lenie-version, /lenie-count, /lenie-check, /lenie-add, /lenie-info, /lenie-search.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ from src.api_client import (
     ApiResponseError,
     LenieApiClient,
 )
+from src.search_formatter import format_search_results
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -165,6 +166,25 @@ def _handle_info(ack: Callable, respond: Callable, client: LenieApiClient, comma
         respond(text="Unexpected response from backend")
 
 
+def _handle_search(ack: Callable, respond: Callable, client: LenieApiClient, command: dict) -> None:
+    """Handle /lenie-search command — semantic search via vector similarity."""
+    ack()
+    query = command.get("text", "").strip()
+    if not query:
+        respond(text="Usage: `/lenie-search <query>`")
+        return
+    try:
+        results = client.search_similar(query)
+        respond(text=format_search_results(query, results))
+    except ApiConnectionError:
+        respond(text="Backend unreachable (connection timeout). Check if lenie-ai-server is running.")
+    except ApiResponseError as exc:
+        logger.warning("Unexpected response from backend: %s", exc.message)
+        respond(text=f"Unexpected response from backend (HTTP {exc.status_code})")
+    except ApiError as exc:
+        respond(text=f"An error occurred: {exc.message}")
+
+
 def register_commands(app: App, client: LenieApiClient) -> None:
     """Register all slash commands on the Slack Bolt app."""
     logger.info("Registering slash commands")
@@ -188,3 +208,7 @@ def register_commands(app: App, client: LenieApiClient) -> None:
     @app.command("/lenie-info")
     def handle_info(ack, respond, command):
         _handle_info(ack, respond, client, command)
+
+    @app.command("/lenie-search")
+    def handle_search(ack, respond, command):
+        _handle_search(ack, respond, client, command)

--- a/slack_bot/src/dm_handler.py
+++ b/slack_bot/src/dm_handler.py
@@ -17,6 +17,7 @@ from src.api_client import (
 )
 from src.commands import DOCUMENT_TYPES, _VALID_TYPES
 from src.intent_parser import ParsedIntent, parse_intent
+from src.search_formatter import format_search_results
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -31,6 +32,7 @@ HELP_TEXT = (
     "Available commands:\n"
     "  version  — Show backend version and build info\n"
     "  count    — Show document count by type\n"
+    "  search <query>  — Semantic search in knowledge base\n"
     "  add <url> [type]  — Add a URL to the knowledge base\n"
     "  check <url>  — Check if a URL exists in the database\n"
     "  info <id>  — Get document details by ID\n"
@@ -177,6 +179,24 @@ def handle_info(say: Callable, client: LenieApiClient, args_str: str) -> None:
         say(text="Unexpected response from backend")
 
 
+def handle_search(say: Callable, client: "LenieApiClient", args_str: str) -> None:
+    """Handle 'search <query>' command."""
+    query = args_str.strip()
+    if not query:
+        say(text="Usage: `search <query>`")
+        return
+    try:
+        results = client.search_similar(query)
+        say(text=format_search_results(query, results))
+    except ApiConnectionError:
+        say(text="Backend unreachable (connection timeout). Check if lenie-ai-server is running.")
+    except ApiResponseError as exc:
+        logger.warning("Unexpected response from backend: %s", exc.message)
+        say(text=f"Unexpected response from backend (HTTP {exc.status_code})")
+    except ApiError as exc:
+        say(text=f"An error occurred: {exc.message}")
+
+
 def _route_intent(intent: "ParsedIntent", say: "Callable", commands: dict) -> bool:
     """Route a parsed intent to the appropriate command handler.
 
@@ -215,6 +235,7 @@ def register_dm_handler(app: App, client: LenieApiClient, intent_enabled: bool =
     commands = {
         "version": lambda say, args: handle_version(say, client),
         "count": lambda say, args: handle_count(say, client),
+        "search": lambda say, args: handle_search(say, client, args),
         "add": lambda say, args: handle_add(say, client, args),
         "check": lambda say, args: handle_check(say, client, args),
         "info": lambda say, args: handle_info(say, client, args),
@@ -256,7 +277,7 @@ def register_dm_handler(app: App, client: LenieApiClient, intent_enabled: bool =
             if intent and intent.command != "unknown":
                 if _route_intent(intent, say, commands):
                     return
-                # If routing failed (e.g. unimplemented command like "search"), inform user
+                # If routing failed (unimplemented command), inform user
                 say(text=f"I understood your request ({intent.command}), but this command is not yet available. {HELP_TEXT}")
                 return
             if intent and intent.command == "unknown":

--- a/slack_bot/src/mention_handler.py
+++ b/slack_bot/src/mention_handler.py
@@ -18,6 +18,7 @@ from src.dm_handler import (
     handle_check,
     handle_count,
     handle_info,
+    handle_search,
     handle_version,
 )
 from src.intent_parser import parse_intent
@@ -44,6 +45,7 @@ def register_mention_handler(app: App, client: LenieApiClient, intent_enabled: b
     commands = {
         "version": lambda say, args: handle_version(say, client),
         "count": lambda say, args: handle_count(say, client),
+        "search": lambda say, args: handle_search(say, client, args),
         "add": lambda say, args: handle_add(say, client, args),
         "check": lambda say, args: handle_check(say, client, args),
         "info": lambda say, args: handle_info(say, client, args),

--- a/slack_bot/src/search_formatter.py
+++ b/slack_bot/src/search_formatter.py
@@ -1,0 +1,48 @@
+"""Shared formatter for search results from /website_similar endpoint.
+
+Converts API response to Slack-friendly text format.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def get_search_results_limit() -> int:
+    """Return the max number of search results to display."""
+    try:
+        return int(os.environ.get("SEARCH_RESULTS_LIMIT", "5"))
+    except (ValueError, TypeError):
+        return 5
+
+
+def format_search_results(query: str, results: list[dict]) -> str:
+    """Format search results as Slack message text.
+
+    Args:
+        query: The original search query.
+        results: List of dicts from api_client.search_similar().
+
+    Returns:
+        Formatted Slack message string.
+    """
+    if not results:
+        return f"No similar documents found for '{query}'."
+
+    limit = get_search_results_limit()
+    limited = results[:limit]
+
+    lines = [f"Found {len(limited)} result{'s' if len(limited) != 1 else ''} for \"{query}\":\n"]
+
+    for i, doc in enumerate(limited, 1):
+        title = doc.get("title") or doc.get("url", "Untitled")
+        doc_type = doc.get("document_type", "unknown")
+        similarity = doc.get("similarity", 0.0)
+        url = doc.get("url", "")
+
+        pct = int(similarity * 100)
+        lines.append(f"{i}. *{title}* ({doc_type}, {pct}%)")
+        if url:
+            lines.append(f"   {url}")
+
+    return "\n".join(lines)

--- a/slack_bot/tests/unit/test_commands.py
+++ b/slack_bot/tests/unit/test_commands.py
@@ -9,6 +9,7 @@ from src.commands import (
     _handle_check,
     _handle_count,
     _handle_info,
+    _handle_search,
     _handle_version,
     register_commands,
 )
@@ -249,7 +250,7 @@ class TestRegisterCommands:
         register_commands(app, client)
 
         # Should register commands without creating a new client
-        assert app.command.call_count == 5
+        assert app.command.call_count == 6
 
 
 # --- Task 5.1-5.3: Test /lenie-add ---
@@ -692,8 +693,8 @@ class TestHandleInfo:
 
 
 class TestRegisterCommandsAll:
-    def test_registers_all_five_commands(self):
-        """5.13: Verify all 5 commands registered (2 from 21-3 + 3 new)."""
+    def test_registers_all_six_commands(self):
+        """Verify all 6 commands registered."""
         app = MagicMock()
         client = _make_mock_client()
 
@@ -707,7 +708,142 @@ class TestRegisterCommandsAll:
             "/lenie-add",
             "/lenie-check",
             "/lenie-info",
+            "/lenie-search",
         }
+
+
+# --- Test /lenie-search ---
+
+
+class TestHandleSearch:
+    def test_success(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "K8s Security Guide", "url": "https://example.com/k8s", "document_type": "webpage", "similarity": 0.87},
+            {"title": "CKS Prep", "url": "https://example.com/cks", "document_type": "link", "similarity": 0.72},
+        ]
+        ack, respond = _make_ack_respond()
+        command = {"text": "Kubernetes security"}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        client.search_similar.assert_called_once_with("Kubernetes security")
+        text = respond.call_args[1]["text"]
+        assert "K8s Security Guide" in text
+        assert "87%" in text
+        assert "CKS Prep" in text
+        assert "72%" in text
+
+    def test_empty_query(self):
+        client = _make_mock_client()
+        ack, respond = _make_ack_respond()
+        command = {"text": ""}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "Usage:" in text
+        assert "/lenie-search" in text
+        client.search_similar.assert_not_called()
+
+    def test_whitespace_only_query(self):
+        client = _make_mock_client()
+        ack, respond = _make_ack_respond()
+        command = {"text": "   "}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "Usage:" in text
+        client.search_similar.assert_not_called()
+
+    def test_no_results(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = []
+        ack, respond = _make_ack_respond()
+        command = {"text": "obscure topic xyz"}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "No similar documents found" in text
+
+    def test_connection_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiConnectionError("timeout")
+        ack, respond = _make_ack_respond()
+        command = {"text": "test query"}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "Backend unreachable" in text
+
+    def test_response_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiResponseError("bad", status_code=500, response_body="error")
+        ack, respond = _make_ack_respond()
+        command = {"text": "test query"}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "Unexpected response from backend" in text
+        assert "500" in text
+
+    def test_generic_api_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiError("search failed")
+        ack, respond = _make_ack_respond()
+        command = {"text": "test query"}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "An error occurred" in text
+        assert "search failed" in text
+
+    def test_ack_called_before_respond(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "Doc", "url": "https://ex.com", "document_type": "webpage", "similarity": 0.5}
+        ]
+        call_order = []
+        ack = MagicMock(side_effect=lambda: call_order.append("ack"))
+        respond = MagicMock(side_effect=lambda **kw: call_order.append("respond"))
+        command = {"text": "test"}
+
+        _handle_search(ack, respond, client, command)
+
+        assert call_order == ["ack", "respond"]
+
+    def test_response_error_logs_warning(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiResponseError("bad", status_code=500, response_body="error")
+        ack, respond = _make_ack_respond()
+        command = {"text": "test"}
+
+        with patch("src.commands.logger") as mock_logger:
+            _handle_search(ack, respond, client, command)
+            mock_logger.warning.assert_called_once()
+
+    def test_no_text_key(self):
+        client = _make_mock_client()
+        ack, respond = _make_ack_respond()
+        command = {}
+
+        _handle_search(ack, respond, client, command)
+
+        ack.assert_called_once()
+        text = respond.call_args[1]["text"]
+        assert "Usage:" in text
 
 
 class TestDocumentTypes:

--- a/slack_bot/tests/unit/test_dm_handler.py
+++ b/slack_bot/tests/unit/test_dm_handler.py
@@ -9,6 +9,7 @@ from src.dm_handler import (
     handle_check,
     handle_count,
     handle_info,
+    handle_search,
     handle_version,
     register_dm_handler,
 )
@@ -532,6 +533,87 @@ class TestDmHandleInfo:
         assert "Unexpected response from backend" in text
 
 
+# --- Test DM search handler ---
+
+
+class TestDmHandleSearch:
+    def test_success(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "K8s Guide", "url": "https://example.com/k8s", "document_type": "webpage", "similarity": 0.87},
+        ]
+        say = _make_say()
+
+        handle_search(say, client, "Kubernetes security")
+
+        client.search_similar.assert_called_once_with("Kubernetes security")
+        text = say.call_args[1]["text"]
+        assert "K8s Guide" in text
+        assert "87%" in text
+
+    def test_empty_query(self):
+        client = _make_mock_client()
+        say = _make_say()
+
+        handle_search(say, client, "")
+
+        text = say.call_args[1]["text"]
+        assert "Usage:" in text
+        client.search_similar.assert_not_called()
+
+    def test_whitespace_only(self):
+        client = _make_mock_client()
+        say = _make_say()
+
+        handle_search(say, client, "   ")
+
+        text = say.call_args[1]["text"]
+        assert "Usage:" in text
+        client.search_similar.assert_not_called()
+
+    def test_no_results(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = []
+        say = _make_say()
+
+        handle_search(say, client, "obscure xyz")
+
+        text = say.call_args[1]["text"]
+        assert "No similar documents found" in text
+
+    def test_connection_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiConnectionError("timeout")
+        say = _make_say()
+
+        handle_search(say, client, "test query")
+
+        text = say.call_args[1]["text"]
+        assert "Backend unreachable" in text
+
+    def test_response_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiResponseError("bad", status_code=500, response_body="error")
+        say = _make_say()
+
+        handle_search(say, client, "test query")
+
+        text = say.call_args[1]["text"]
+        assert "Unexpected response from backend" in text
+        assert "500" in text
+
+    def test_generic_api_error(self):
+        client = _make_mock_client()
+        client.search_similar.side_effect = ApiError("search failed")
+        say = _make_say()
+
+        handle_search(say, client, "test query")
+
+        text = say.call_args[1]["text"]
+        assert "An error occurred" in text
+        assert "search failed" in text
+
+
 # --- Test DM event filtering and parsing ---
 
 
@@ -775,6 +857,29 @@ class TestDmCommandParsing:
         text = say.call_args[1]["text"]
         assert "numeric ID required" in text
 
+    def test_search_command(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "Doc A", "url": "https://a.com", "document_type": "webpage", "similarity": 0.8}
+        ]
+        handler_fn, _ = self._get_handler(client)
+        event = _make_dm_event("search kubernetes security")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.search_similar.assert_called_once_with("kubernetes security")
+
+    def test_search_no_args(self):
+        handler_fn, _ = self._get_handler()
+        event = _make_dm_event("search")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "Usage:" in text
+
     def test_help_command(self):
         handler_fn, _ = self._get_handler()
         event = _make_dm_event("help")
@@ -786,6 +891,7 @@ class TestDmCommandParsing:
         assert "Available commands:" in text
         assert "version" in text
         assert "count" in text
+        assert "search" in text
         assert "add" in text
         assert "check" in text
         assert "info" in text
@@ -819,6 +925,7 @@ class TestHelpText:
     def test_contains_all_commands(self):
         assert "version" in HELP_TEXT
         assert "count" in HELP_TEXT
+        assert "search" in HELP_TEXT
         assert "add" in HELP_TEXT
         assert "check" in HELP_TEXT
         assert "info" in HELP_TEXT
@@ -969,17 +1076,21 @@ class TestDmIntentParsing:
         client.get_document.assert_called_once_with(42)
 
     @patch("src.dm_handler.parse_intent")
-    def test_llm_unimplemented_command_shows_not_available(self, mock_parse):
-        """When LLM returns a valid command with no handler (e.g. search), show not-available message."""
+    def test_llm_fallback_search_command(self, mock_parse):
+        """When LLM returns search command, route to search handler."""
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "K8s Article", "url": "https://example.com/k8s", "document_type": "webpage", "similarity": 0.85}
+        ]
         mock_parse.return_value = ParsedIntent(
             command="search", args={"query": "kubernetes"}, confidence=0.9
         )
-        handler_fn, client = self._get_handler_with_intent()
+        handler_fn, _ = self._get_handler_with_intent(client)
         event = _make_dm_event("find articles about kubernetes")
         say = _make_say()
 
         handler_fn(event=event, say=say)
 
+        client.search_similar.assert_called_once_with("kubernetes")
         text = say.call_args[1]["text"]
-        assert "not yet available" in text
-        assert "search" in text
+        assert "K8s Article" in text

--- a/slack_bot/tests/unit/test_mention_handler.py
+++ b/slack_bot/tests/unit/test_mention_handler.py
@@ -173,6 +173,41 @@ class TestMentionCommandRouting:
         text = say.call_args[1]["text"]
         assert "Available commands:" in text
 
+    def test_search_command(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "Result", "url": "https://ex.com", "document_type": "webpage", "similarity": 0.8}
+        ]
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> search kubernetes")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.search_similar.assert_called_once_with("kubernetes")
+        assert say.call_args[1]["thread_ts"] == "1234567890.123456"
+
+    def test_search_with_multi_word_query(self):
+        client = _make_mock_client()
+        client.search_similar.return_value = []
+        handler_fn, _ = _get_handler(client)
+        event = _make_mention_event("<@U123ABC> search kubernetes security best practices")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.search_similar.assert_called_once_with("kubernetes security best practices")
+
+    def test_search_no_args(self):
+        handler_fn, _ = _get_handler()
+        event = _make_mention_event("<@U123ABC> search")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        text = say.call_args[1]["text"]
+        assert "Usage:" in text
+
     def test_case_insensitive(self):
         handler_fn, client = _get_handler()
         event = _make_mention_event("<@U123ABC> VERSION")
@@ -285,6 +320,22 @@ class TestMentionIntentParsing:
 
         text = say.call_args[1]["text"]
         assert "I didn't understand that" in text
+
+    @patch("src.mention_handler.parse_intent")
+    def test_llm_fallback_search(self, mock_parse):
+        client = _make_mock_client()
+        client.search_similar.return_value = [
+            {"title": "Result", "url": "https://ex.com", "document_type": "webpage", "similarity": 0.8}
+        ]
+        mock_parse.return_value = ParsedIntent(command="search", args={"query": "k8s"}, confidence=0.9)
+        handler_fn, _ = _get_handler_with_intent(client)
+        event = _make_mention_event("<@U123ABC> find articles about k8s", ts="5555.6666")
+        say = _make_say()
+
+        handler_fn(event=event, say=say)
+
+        client.search_similar.assert_called_once_with("k8s")
+        assert say.call_args[1]["thread_ts"] == "5555.6666"
 
     @patch("src.mention_handler.parse_intent")
     def test_thread_response_preserved_for_llm(self, mock_parse):

--- a/slack_bot/tests/unit/test_search_formatter.py
+++ b/slack_bot/tests/unit/test_search_formatter.py
@@ -1,0 +1,145 @@
+"""Unit tests for src.search_formatter module."""
+
+from unittest.mock import patch
+
+from src.search_formatter import format_search_results, get_search_results_limit
+
+
+# --- Test get_search_results_limit ---
+
+
+class TestGetSearchResultsLimit:
+    def test_default_value(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert get_search_results_limit() == 5
+
+    def test_custom_value(self):
+        with patch.dict("os.environ", {"SEARCH_RESULTS_LIMIT": "3"}):
+            assert get_search_results_limit() == 3
+
+    def test_invalid_value_returns_default(self):
+        with patch.dict("os.environ", {"SEARCH_RESULTS_LIMIT": "abc"}):
+            assert get_search_results_limit() == 5
+
+    def test_empty_value_returns_default(self):
+        with patch.dict("os.environ", {"SEARCH_RESULTS_LIMIT": ""}):
+            assert get_search_results_limit() == 5
+
+
+# --- Test format_search_results ---
+
+
+class TestFormatSearchResults:
+    def test_no_results(self):
+        result = format_search_results("kubernetes", [])
+        assert "No similar documents found for 'kubernetes'." == result
+
+    def test_single_result(self):
+        results = [
+            {
+                "website_id": 1,
+                "title": "K8s Security Guide",
+                "url": "https://example.com/k8s",
+                "document_type": "webpage",
+                "similarity": 0.87,
+                "language": "en",
+            }
+        ]
+        text = format_search_results("kubernetes security", results)
+        assert 'Found 1 result for "kubernetes security"' in text
+        assert "*K8s Security Guide*" in text
+        assert "webpage" in text
+        assert "87%" in text
+        assert "https://example.com/k8s" in text
+
+    def test_multiple_results(self):
+        results = [
+            {
+                "title": "Article A",
+                "url": "https://a.com",
+                "document_type": "webpage",
+                "similarity": 0.90,
+            },
+            {
+                "title": "Article B",
+                "url": "https://b.com",
+                "document_type": "youtube",
+                "similarity": 0.75,
+            },
+            {
+                "title": "Article C",
+                "url": "https://c.com",
+                "document_type": "link",
+                "similarity": 0.60,
+            },
+        ]
+        text = format_search_results("test query", results)
+        assert 'Found 3 results for "test query"' in text
+        assert "1. *Article A*" in text
+        assert "2. *Article B*" in text
+        assert "3. *Article C*" in text
+        assert "90%" in text
+        assert "75%" in text
+        assert "60%" in text
+
+    def test_no_title_uses_url(self):
+        results = [
+            {
+                "title": None,
+                "url": "https://example.com/no-title",
+                "document_type": "link",
+                "similarity": 0.50,
+            }
+        ]
+        text = format_search_results("query", results)
+        assert "*https://example.com/no-title*" in text
+
+    def test_empty_title_uses_url(self):
+        results = [
+            {
+                "title": "",
+                "url": "https://example.com/empty",
+                "document_type": "webpage",
+                "similarity": 0.40,
+            }
+        ]
+        text = format_search_results("query", results)
+        assert "*https://example.com/empty*" in text
+
+    def test_respects_limit(self):
+        results = [
+            {"title": f"Doc {i}", "url": f"https://ex.com/{i}", "document_type": "webpage", "similarity": 0.9 - i * 0.1}
+            for i in range(10)
+        ]
+        with patch.dict("os.environ", {"SEARCH_RESULTS_LIMIT": "3"}):
+            text = format_search_results("query", results)
+        assert "Found 3 results" in text
+        assert "1. *Doc 0*" in text
+        assert "3. *Doc 2*" in text
+        assert "Doc 3" not in text
+
+    def test_default_limit_five(self):
+        results = [
+            {"title": f"Doc {i}", "url": f"https://ex.com/{i}", "document_type": "webpage", "similarity": 0.9 - i * 0.05}
+            for i in range(8)
+        ]
+        with patch.dict("os.environ", {}, clear=True):
+            text = format_search_results("query", results)
+        assert "Found 5 results" in text
+        assert "5. *Doc 4*" in text
+        assert "Doc 5" not in text
+
+    def test_similarity_as_percentage(self):
+        results = [
+            {"title": "Doc", "url": "https://ex.com", "document_type": "webpage", "similarity": 0.123}
+        ]
+        text = format_search_results("query", results)
+        assert "12%" in text
+
+    def test_no_url_field(self):
+        results = [
+            {"title": "Doc", "document_type": "webpage", "similarity": 0.5}
+        ]
+        text = format_search_results("query", results)
+        assert "*Doc*" in text
+        # Should not crash without url


### PR DESCRIPTION
## Summary
- Add `/lenie-search` slash command, DM `search <query>`, and @mention search routing to Slack bot
- Create shared `search_formatter.py` for consistent result formatting (title, type, similarity %, URL)
- Fix pre-existing `ModuleNotFoundError` in backend embedding imports (`openai_embedding.py`, `cloudferro_embeddings.py`)
- Bump slack_bot version to 0.4.0

## Test plan
- [x] 250 unit tests pass (36 new), ruff clean
- [x] Deployed to NAS and verified `/lenie-search` returns results from backend
- [ ] Test with queries matching existing documents in DB
- [ ] Verify @mention and DM search paths work on Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)