### PR TITLE
feat: PostgreSQL search extensions and lookup tables architecture

### DIFF
--- a/_bmad-output/planning-artifacts/epics/backlog.md
+++ b/_bmad-output/planning-artifacts/epics/backlog.md
@@ -1091,6 +1091,110 @@ Consumers (no API changes needed — wrappers preserve signatures):
 **Status:** backlog
 **Plan:** [`.claude/exports/plan-sqlalchemy-migration.md`](../../.claude/exports/plan-sqlalchemy-migration.md)
 
+---
+
+## Epic 30: Database Lookup Tables & Search Extensions
+
+Introduce database-level enum enforcement via lookup tables with FK constraints (matching AWS production schema), and add PostgreSQL search extensions (`unaccent`, `pg_trgm`) for Polish name/city search. Prepares the database for personal CRM capabilities.
+
+**Related ADRs:** [ADR-009](../../docs/architecture-decisions.md#adr-009-postgresql-search-strategy--unaccent--pg_trgm-for-structured-fields-embeddings-for-content), [ADR-010](../../docs/architecture-decisions.md#adr-010-database-lookup-tables-with-foreign-keys-for-enum-like-fields)
+
+### B-94: Create Lookup Tables and Seed Data
+
+As a **developer**,
+I want lookup tables (`document_status_types`, `document_status_error_types`, `document_types`, `embedding_models`) created in the database with seed data from Python enums,
+so that valid values are defined at the database level, not just in application code.
+
+**Origin:** AWS production database already has these tables (visible in dump from 2026-01-23). Docker init scripts do not create them, causing schema divergence. See [ADR-010](../../docs/architecture-decisions.md#adr-010-database-lookup-tables-with-foreign-keys-for-enum-like-fields).
+
+**Scope:**
+- Add new init script (e.g., `backend/database/init/09-create-lookup-tables.sql`) creating 4 lookup tables
+- Seed with values from `StalkerDocumentStatus` (16), `StalkerDocumentStatusError` (17), `StalkerDocumentType` (6)
+- Seed `embedding_models` with currently used models (ada-002, titan-v1, titan-v2, stella, bge-m3, bge-gemma2, e5-mistral)
+- Create Alembic migration for existing databases
+
+**Acceptance Criteria:**
+- All 4 lookup tables exist after `docker compose up` (fresh volume)
+- `SELECT count(*) FROM document_status_types` returns 16
+- `SELECT count(*) FROM document_types` returns 6
+- Alembic migration applies cleanly to existing Docker database
+- Alembic migration applies cleanly to AWS RDS (via VPN)
+
+**Priority:** MEDIUM
+**Status:** backlog
+
+### B-95: Add Foreign Key Constraints to web_documents and websites_embeddings
+
+As a **developer**,
+I want FK constraints on `document_state`, `document_state_error`, `document_type`, and `embedding model` columns,
+so that the database rejects invalid values and matches the AWS production schema.
+
+**Origin:** [ADR-010](../../docs/architecture-decisions.md#adr-010-database-lookup-tables-with-foreign-keys-for-enum-like-fields). Depends on [B-94](#b-94-create-lookup-tables-and-seed-data).
+
+**Scope:**
+- Add FK constraints in init script (e.g., `backend/database/init/10-add-foreign-keys.sql`)
+- Create Alembic migration for existing databases
+- Verify no orphaned values exist before adding constraints (clean up if needed)
+
+**Acceptance Criteria:**
+- `INSERT INTO web_documents (..., document_state, ...) VALUES (..., 'INVALID_STATE', ...)` fails with FK violation
+- `INSERT INTO web_documents (..., document_type, ...) VALUES (..., 'podcast', ...)` fails with FK violation
+- All existing data passes FK validation (no orphaned values)
+- All unit and integration tests pass
+
+**Depends on:** [B-94](#b-94-create-lookup-tables-and-seed-data)
+**Priority:** MEDIUM
+**Status:** backlog
+
+### B-96: Update SQLAlchemy ORM Models for Lookup Table Relationships
+
+As a **developer**,
+I want the SQLAlchemy ORM models to use `ForeignKey` + `relationship()` for enum-like fields instead of `SAEnum(..., native_enum=False)`,
+so that the ORM reflects the actual database schema and enables JOIN queries on lookup tables.
+
+**Origin:** [ADR-010](../../docs/architecture-decisions.md#adr-010-database-lookup-tables-with-foreign-keys-for-enum-like-fields). Depends on [B-95](#b-95-add-foreign-key-constraints-to-web_documents-and-websites_embeddings).
+
+**Scope:**
+- Create SQLAlchemy ORM models for 4 lookup tables (`DocumentStatusType`, `DocumentStatusErrorType`, `DocumentType`, `EmbeddingModel`)
+- Update `WebDocument` model: replace `SAEnum` columns with `String` + `ForeignKey('document_types.name')`
+- Update `WebsiteEmbedding` model: add `ForeignKey('embedding_models.name')` to `model` column
+- Add startup sync: on app start, verify Python enum values match lookup table rows (log warnings for mismatches)
+
+**Acceptance Criteria:**
+- `WebDocument.document_type` has FK relationship to `DocumentType` model
+- `session.query(DocumentStatusType).all()` returns all 16 states
+- All existing unit and integration tests pass
+- Adding a new enum value + Alembic migration seeds it into lookup table
+
+**Depends on:** [B-95](#b-95-add-foreign-key-constraints-to-web_documents-and-websites_embeddings)
+**Priority:** MEDIUM
+**Status:** backlog
+
+### B-97: Install unaccent and pg_trgm Extensions on Existing Databases
+
+As a **developer**,
+I want `unaccent` and `pg_trgm` PostgreSQL extensions installed on all database environments (Docker, NAS, AWS RDS),
+so that diacritic-insensitive and fuzzy search is available for future CRM features.
+
+**Origin:** [ADR-009](../../docs/architecture-decisions.md#adr-009-postgresql-search-strategy--unaccent--pg_trgm-for-structured-fields-embeddings-for-content). Init scripts already updated (`02-create-extension.sql`), but existing databases need manual migration.
+
+**Scope:**
+- Run `CREATE EXTENSION IF NOT EXISTS unaccent; CREATE EXTENSION IF NOT EXISTS pg_trgm;` on:
+  - Docker local database (port 5433)
+  - NAS Docker database
+  - AWS RDS (via VPN)
+- Verify extensions are installed: `SELECT extname FROM pg_extension;`
+
+**Acceptance Criteria:**
+- `SELECT unaccent('Łódź')` returns `Lodz` on all three environments
+- `SELECT similarity('Warszawa', 'Warszawie')` returns a value > 0.3 on all three environments
+- No errors in application logs after extension installation
+
+**Priority:** MEDIUM
+**Status:** backlog
+
+---
+
 ### B-93: Synchronize Document States from Backend to Frontend
 
 As a **developer**,

--- a/_bmad-output/planning-artifacts/epics/backlog.md
+++ b/_bmad-output/planning-artifacts/epics/backlog.md
@@ -1180,18 +1180,18 @@ so that diacritic-insensitive and fuzzy search is available for future CRM featu
 
 **Scope:**
 - Run `CREATE EXTENSION IF NOT EXISTS unaccent; CREATE EXTENSION IF NOT EXISTS pg_trgm;` on:
-  - Docker local database (port 5433)
-  - NAS Docker database
-  - AWS RDS (via VPN)
+  - ~~Docker local database (port 5433)~~ — not actively used
+  - NAS Docker database — **DONE** (2026-03-10)
+  - AWS RDS (via VPN) — deferred, AWS not a priority until NAS MVP is complete
 - Verify extensions are installed: `SELECT extname FROM pg_extension;`
 
 **Acceptance Criteria:**
-- `SELECT unaccent('Łódź')` returns `Lodz` on all three environments
-- `SELECT similarity('Warszawa', 'Warszawie')` returns a value > 0.3 on all three environments
+- `SELECT unaccent('Łódź')` returns `Lodz` — **verified on NAS** (`unaccent('Łódź')` → `Lodz`)
+- `SELECT similarity('Warszawa', 'Warszawie')` returns a value > 0.3 — **verified on NAS** (→ `0.58`)
 - No errors in application logs after extension installation
 
 **Priority:** MEDIUM
-**Status:** backlog
+**Status:** done (NAS), deferred (AWS RDS)
 
 ---
 

--- a/backend/database/init/02-create-extension.sql
+++ b/backend/database/init/02-create-extension.sql
@@ -1,8 +1,14 @@
--- Przełączenie na bazę danych lenie-ai i instalacja rozszerzenia pgvector
+-- Przełączenie na bazę danych lenie-ai i instalacja rozszerzeń
 \c "lenie-ai";
 
--- Instalacja rozszerzenia pgvector
+-- Instalacja rozszerzenia pgvector (vector similarity search)
 CREATE EXTENSION IF NOT EXISTS vector;
 
+-- Instalacja rozszerzenia unaccent (diacritic-insensitive search: Łódź → lodz, Michał → michal)
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Instalacja rozszerzenia pg_trgm (fuzzy matching via trigram similarity)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
 -- Sprawdzenie instalacji
-SELECT 'Extension pgvector installed successfully in lenie-ai database' as status;
+SELECT 'Extensions pgvector, unaccent, pg_trgm installed successfully in lenie-ai database' as status;

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -443,3 +443,135 @@ WHERE embedding <=> query_embedding < 0.3;
 - `backend/database/init/04-create-table.sql` — `websites_embeddings` table (pgvector)
 - `backend/tmp/sql_data/lenie_aws-2026_01_23_05_00_40-dump.sql` — AWS dump showing `unaccent` and `polish` text search config already present
 - `docs/architecture-decisions.md` — ADR-001 (native-language embeddings decision)
+
+---
+
+## ADR-010: Database Lookup Tables with Foreign Keys for Enum-Like Fields
+
+**Date:** 2026-03-10
+**Status:** Accepted
+**Decision Makers:** Ziutus
+
+### Context
+
+The project uses three Python enums to define constrained value sets for `web_documents` columns:
+
+| Python Enum | Column | Values |
+|-------------|--------|--------|
+| `StalkerDocumentStatus` | `document_state` | 16 states (ERROR → TEMPORARY_ERROR) |
+| `StalkerDocumentStatusError` | `document_state_error` | 17 error types |
+| `StalkerDocumentType` | `document_type` | 6 types (movie, youtube, link, webpage, text_message, text) |
+
+Additionally, `websites_embeddings.model` stores embedding model names as free-text `varchar`.
+
+The AWS production database (dump from 2026-01-23) already has four lookup tables with FK constraints enforcing these values at the database level:
+
+- `document_status_types` (FK on `web_documents.document_state`)
+- `document_status_error_types` (FK on `web_documents.document_state_error`)
+- `document_types` (FK on `web_documents.document_type`)
+- `embedding_models` (FK on `websites_embeddings.model` and `embeddings_cache.model`)
+
+The Docker init scripts (`03-create-table.sql`, `04-create-table.sql`) do **not** create these lookup tables — they store enum values as plain `varchar` strings with no FK constraints. The Python code comments confirm this gap: `# Those errors status are also defined in Postgresql table: document_status_types`.
+
+The current SQLAlchemy ORM models (`db/models.py`) use `SAEnum(..., native_enum=False)` which stores values as VARCHAR with application-level validation only — the database does not enforce valid values.
+
+### Decision
+
+Create database lookup tables with FK constraints to enforce data integrity at the database level, matching the existing AWS production schema:
+
+1. **`document_status_types`** — lookup for `web_documents.document_state`
+2. **`document_status_error_types`** — lookup for `web_documents.document_state_error`
+3. **`document_types`** — lookup for `web_documents.document_type`
+4. **`embedding_models`** — lookup for `websites_embeddings.model` (and future `embeddings_cache.model`)
+
+Each lookup table has `id SERIAL PRIMARY KEY` and `name VARCHAR UNIQUE NOT NULL`. FK constraints reference the `name` column (not `id`) for readability of raw queries and data exports.
+
+Python enums (`StalkerDocumentStatus`, `StalkerDocumentStatusError`, `StalkerDocumentType`) remain the **source of truth** for values — an Alembic migration or init script seeds the lookup tables from the enum definitions.
+
+### Rationale
+
+1. **Data integrity.** Without FK constraints, a bug or manual SQL could insert `document_state = 'EMBEDING_EXIST'` (typo) and the database would accept it silently. FK constraints catch this immediately.
+
+2. **Consistency with production.** The AWS database already has these tables and constraints. The Docker development environment should match production schema to avoid "works locally, breaks in prod" issues.
+
+3. **ORM alignment.** SQLAlchemy supports FK-backed enums naturally. The ORM can be updated to define proper `relationship()` mappings to lookup tables, enabling JOIN queries (e.g., statistics per document type).
+
+4. **Extensibility.** Adding a new document type or status becomes: (a) add to Python enum, (b) INSERT into lookup table (via Alembic migration). The FK constraint ensures both stay in sync.
+
+5. **Query clarity.** `SELECT DISTINCT document_state FROM web_documents` is fragile (shows only used values). `SELECT name FROM document_status_types` shows all valid values regardless of usage.
+
+### Implementation
+
+**Phase 1 — Lookup tables & seed data (init scripts + Alembic migration):**
+
+```sql
+CREATE TABLE IF NOT EXISTS document_status_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_status_error_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS document_types (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS embedding_models (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) UNIQUE NOT NULL
+);
+```
+
+Seed with values from Python enums. Add FK constraints:
+
+```sql
+ALTER TABLE web_documents
+    ADD CONSTRAINT fk_document_type
+    FOREIGN KEY (document_type) REFERENCES document_types(name);
+
+ALTER TABLE web_documents
+    ADD CONSTRAINT fk_document_state
+    FOREIGN KEY (document_state) REFERENCES document_status_types(name);
+
+ALTER TABLE web_documents
+    ADD CONSTRAINT fk_document_state_error
+    FOREIGN KEY (document_state_error) REFERENCES document_status_error_types(name);
+
+ALTER TABLE websites_embeddings
+    ADD CONSTRAINT model_fk
+    FOREIGN KEY (model) REFERENCES embedding_models(name) ON UPDATE CASCADE ON DELETE CASCADE;
+```
+
+**Phase 2 — ORM model updates:**
+
+Update SQLAlchemy models to reflect FK relationships. Replace `SAEnum(..., native_enum=False)` with `String` + `ForeignKey` + `relationship()`.
+
+**Phase 3 — Sync mechanism:**
+
+Add a startup check or Alembic migration that inserts missing enum values into lookup tables, ensuring Python enums and database stay in sync.
+
+### Consequences
+
+- **Positive:** Database enforces valid values — impossible to insert invalid states, types, or models.
+- **Positive:** Docker and AWS schemas converge — reduces environment-specific bugs.
+- **Positive:** Lookup tables serve as queryable documentation of valid values.
+- **Positive:** Enables future features like status/type metadata (descriptions, display order, active/deprecated flags).
+- **Negative:** Adding a new enum value now requires both a code change and a database migration (INSERT into lookup table).
+- **Negative:** FK constraints may complicate bulk data imports if values are inserted before lookup tables are populated.
+- **Trade-off:** FK references `name` (not `id`) — more readable in raw SQL but slightly less efficient for joins. Acceptable for the table sizes involved (< 20 rows each).
+
+### Related Artifacts
+
+- `backend/library/models/stalker_document_status.py` — 16 document states
+- `backend/library/models/stalker_document_status_error.py` — 17 error types
+- `backend/library/models/stalker_document_type.py` — 6 document types
+- `backend/library/db/models.py` — SQLAlchemy ORM models (lines 59-92, `SAEnum` definitions)
+- `backend/database/init/03-create-table.sql` — `web_documents` table (no FK constraints)
+- `backend/database/init/04-create-table.sql` — `websites_embeddings` table (no FK constraints)
+- `backend/tmp/sql_data/lenie_aws-2026_01_23_05_00_40-dump.sql` — AWS dump with lookup tables and FK constraints
+- [ADR-004a](../../docs/architecture-decisions.md#adr-004a-migrate-to-sqlalchemy-orm--pydantic-schemas) — SQLAlchemy ORM migration
+- [B-92](#b-92-migrate-database-layer-to-sqlalchemy-orm--pydantic-schemas) — ORM migration backlog item

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -362,3 +362,84 @@ Use **`ruamel.yaml>=0.18`** instead of `pyyaml` for all YAML operations in `env_
 - `scripts/env_to_vault.py` — consumer (YAML loader infrastructure, Task 3)
 - `scripts/vars-classification.yaml` — the SSOT file that benefits from round-trip preservation
 - `backend/pyproject.toml` — dependency declaration (Task 1)
+
+---
+
+## ADR-009: PostgreSQL Search Strategy — `unaccent` + `pg_trgm` for Structured Fields, Embeddings for Content
+
+**Date:** 2026-03-10
+**Status:** Accepted
+**Decision Makers:** Ziutus
+
+### Context
+
+Project Lenie is evolving toward a personal CRM capability — linking contacts from Google Contacts with notes and documents in the database and Obsidian. The key use case: *"I met person X, we talked about Y — I want to find this quickly before the next meeting."*
+
+This requires effective search across two dimensions:
+
+1. **Structured fields** — names (`Michał Śliwiński` vs `Michal Sliwinski`), cities (`Łódź` vs `Lodz`, `w Warszawie` vs `Warszawa`), and other metadata with Polish diacritics and variant spellings.
+2. **Content/notes** — free-text notes and document content where semantic understanding matters (e.g., finding notes about "Warsaw" when the text says "warszawski meetup").
+
+Four PostgreSQL search mechanisms were evaluated:
+
+| Mechanism | Strengths | Weaknesses for this use case |
+|-----------|-----------|------------------------------|
+| `simple` dictionary | Trivial setup, lowercase normalization | No diacritic handling, no fuzzy matching |
+| `unaccent` extension | Normalizes diacritics (`ł→l`, `ą→a`, `ź→z`) | Exact match only, no fuzzy/typo tolerance |
+| `pg_trgm` extension | Fuzzy matching via trigram similarity, handles typos and partial matches | Doesn't understand semantics |
+| Hunspell `pl_PL` | Polish stemming for common words | Poor with proper nouns (names, small towns not in dictionary), complex setup, high maintenance |
+| pgvector embeddings | Semantic understanding, handles inflection naturally | Already implemented; overkill for exact name lookups |
+
+### Decision
+
+Adopt a **three-layer search strategy**:
+
+1. **`unaccent` extension** — for diacritic-insensitive matching on structured fields (names, cities, authors). Solves the primary problem of `Michał` vs `Michal`, `Łódź` vs `Lodz`.
+
+2. **`pg_trgm` extension** — for fuzzy/approximate matching on structured fields. Handles typos (`karboviak` → `Karbowiak`), partial matches, and Polish case inflection at the trigram level (`Warszawa` ↔ `Warszawie` share 5/7 trigrams, similarity ~0.6).
+
+3. **pgvector embeddings** (existing) — for semantic content search in notes and documents. Already handles Polish inflection, synonyms, and meaning-based retrieval naturally.
+
+**Rejected alternative:** Hunspell/Ispell Polish stemmer. While it handles inflection for common Polish words well, it fails for proper nouns — names like `Karbowiaka` (genitive) and small towns like `Pcim Dolny` or `Huta Dłutowska` are not in the dictionary. The setup and maintenance cost (dictionary files, custom text search configuration) is not justified given that embeddings already solve the content search problem and `pg_trgm` provides sufficient fuzzy matching for names.
+
+### Implementation
+
+Add to database init scripts:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+Example usage patterns:
+
+```sql
+-- Diacritic-insensitive name search
+SELECT * FROM contacts
+WHERE unaccent(lower(name)) LIKE '%' || unaccent(lower('Michal')) || '%';
+
+-- Fuzzy city matching (handles typos and partial inflection)
+SELECT * FROM contacts
+WHERE similarity(unaccent(lower(address_1_city)), unaccent(lower('Łódź'))) > 0.3;
+
+-- Semantic content search (existing pgvector mechanism)
+SELECT * FROM websites_embeddings
+WHERE embedding <=> query_embedding < 0.3;
+```
+
+### Consequences
+
+- **Positive:** Covers all search scenarios — exact names, fuzzy names, diacritics, semantic content — with minimal new infrastructure.
+- **Positive:** `unaccent` and `pg_trgm` are built-in PostgreSQL extensions — no external dependencies or dictionary files to manage.
+- **Positive:** Both extensions are lightweight and have negligible impact on database performance.
+- **Positive:** Works with existing PostgreSQL 16/18 deployments (both Docker and AWS RDS support these extensions).
+- **Negative:** `pg_trgm` similarity threshold (0.3) may need tuning per use case — too low gives false positives, too high misses valid matches.
+- **Negative:** Neither `unaccent` nor `pg_trgm` solves full Polish inflection (e.g., `Pcim Dolny` → `w Pcimiu Dolnym`) — but embeddings handle this for content search.
+
+### Related Artifacts
+
+- `backend/database/init/02-create-extension.sql` — extension installation (to be updated)
+- `backend/database/init/03-create-table.sql` — `web_documents` table
+- `backend/database/init/04-create-table.sql` — `websites_embeddings` table (pgvector)
+- `backend/tmp/sql_data/lenie_aws-2026_01_23_05_00_40-dump.sql` — AWS dump showing `unaccent` and `polish` text search config already present
+- `docs/architecture-decisions.md` — ADR-001 (native-language embeddings decision)

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -14,6 +14,44 @@
 | PostgreSQL | 18 | Database (via Docker or standalone) |
 | Git | latest | Version control |
 
+## Recommended Local Tools
+
+Development tools installed on the developer's Windows machine:
+
+| Tool | Version | Install | Purpose |
+|------|---------|---------|---------|
+| `psql` | 18.3 | [PostgreSQL 18 installer](https://www.postgresql.org/download/windows/) | Direct database access (NAS, AWS RDS) |
+| `uv` | latest | `pip install uv` or [installer](https://docs.astral.sh/uv/) | Python package & project manager |
+| `uvx` | (part of uv) | — | Run Python tools without installing (pytest, ruff) |
+| `ruff` | latest | `uvx ruff` | Python linter & formatter |
+| `pre-commit` | latest | `uv tool install pre-commit` | Git pre-commit hooks (secret detection) |
+| `docker` | latest | [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Container builds, local stack |
+| `gh` | latest | `winget install GitHub.cli` | GitHub CLI (PRs, issues) |
+
+### PostgreSQL client tools (`psql`)
+
+Installed at `C:\Program Files\PostgreSQL\18\bin\`. Not in PATH by default in Git Bash.
+
+```bash
+# Connect to NAS database
+PGPASSWORD=postgres "/c/Program Files/PostgreSQL/18/bin/psql.exe" -h 192.168.200.7 -p 5434 -U postgres -d lenie-ai
+
+# Or add to PATH (add to ~/.bashrc):
+export PATH="/c/Program Files/PostgreSQL/18/bin:$PATH"
+```
+
+Other useful tools from the PostgreSQL package:
+- `pg_dump` — database export/backup
+- `pg_restore` — database import/restore
+- `createdb` / `dropdb` — database management
+
+### WSL tools
+
+For scripts requiring Linux (deploy, imports):
+- `ssh` — NAS access (`admin@192.168.200.7`)
+- `scp` — file transfer to/from NAS
+- `uv` — Python package manager (`~/.local/bin/uv`)
+
 ## Quick Start (Docker)
 
 ```bash
@@ -301,7 +339,7 @@ For batch processing scripts that access AWS RDS:
 - **Pre-commit**: TruffleHog for secret detection
 - **Makefile targets**: `aws-*` (AWS), `gcloud-*` (GCloud), no prefix (local)
 - **API auth**: All routes except health checks require `x-api-key` header
-- **Database**: Raw psycopg2 (no ORM)
+- **Database**: SQLAlchemy ORM (see [ADR-004a](architecture-decisions.md#adr-004a-migrate-to-sqlalchemy-orm--pydantic-schemas))
 - **Commits**: CI/CD varies by tool (CircleCI, GitLab CI, Jenkins)
 
 ## Line Endings (.gitattributes)


### PR DESCRIPTION
## Summary
- **ADR-009**: Three-layer search strategy — `unaccent` (diacritics), `pg_trgm` (fuzzy matching), pgvector embeddings (semantic). Hunspell rejected for proper nouns.
- **ADR-010**: Database lookup tables with FK constraints for `document_state`, `document_type`, `document_state_error`, `embedding model` — matching existing AWS production schema.
- **Epic 30** (B-94 to B-97): Backlog items for lookup tables, FK constraints, ORM updates, and extension installation.
- Extensions `unaccent` + `pg_trgm` installed and verified on NAS PostgreSQL.
- Added recommended local tools section to development guide (`psql`, `uv`, `ruff`, `docker`, `gh`).

## Test plan
- [x] `unaccent('Łódź')` returns `Lodz` on NAS
- [x] `similarity('Warszawa', 'Warszawie')` returns 0.58 on NAS
- [x] `psql 18.3` connects from Windows to NAS database
- [ ] Docker init scripts create extensions on fresh volume (manual verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)