### PR TITLE
fix: B-93 code review — frontend cleanup + docs endpoint count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ See [`docs/development-guide.md`](docs/development-guide.md) for full WSL setup 
 ## Architecture
 
 ### Backend (`backend/`)
-Flask application (`server.py`) exposing REST API with 19 endpoints (see `docs/infrastructure-metrics.md` for full inventory). Python 3.11, dependencies managed via uv, Docker build with `python:3.11-slim`. All routes (except health checks) require `x-api-key` header.
+Flask application (`server.py`) exposing REST API with 20 endpoints (see `docs/infrastructure-metrics.md` for full inventory). Python 3.11, dependencies managed via uv, Docker build with `python:3.11-slim`. All routes (except health checks) require `x-api-key` header.
 
 Key subdirectories: `library/` (core logic & integrations), `database/` (PostgreSQL schema), `imports/` (bulk import scripts), `data/` (site cleanup rules), `tests/` (unit + integration), `test_code/` (experimental scripts). Each has its own `CLAUDE.md`.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [Current Architecture](#current-architecture) for a detailed breakdown of wh
 
 ## Current Architecture
 
-- **Backend** — Flask REST API (Python 3.11) serving 19 endpoints with `x-api-key` auth. Handles document CRUD, text processing, AI embeddings, and vector similarity search
+- **Backend** — Flask REST API (Python 3.11) serving 20 endpoints with `x-api-key` auth. Handles document CRUD, text processing, AI embeddings, and vector similarity search
 - **Web Interface** — React 18 SPA for browsing, editing, and AI-processing documents. Supports two backend modes: AWS Serverless (Lambda) and Docker (Flask)
 - **Browser Extension** — Chrome/Kiwi Manifest v3 extension for capturing webpages and sending them to the backend
 - **Database** — PostgreSQL 18 with pgvector for vector similarity search (multi-model, variable-dimension embeddings)

--- a/_bmad-output/implementation-artifacts/B-93-synchronize-document-states-from-backend-to-frontend.md
+++ b/_bmad-output/implementation-artifacts/B-93-synchronize-document-states-from-backend-to-frontend.md
@@ -1,6 +1,6 @@
 # Story B-93: Synchronize Document States from Backend to Frontend
 
-Status: review
+Status: done
 
 ## Story
 
@@ -166,13 +166,35 @@ No issues encountered during implementation.
 - **Task 3 (Fallback):** Hook catches fetch errors and falls back to `localStorage` cached values. If no cache exists, empty arrays used (dropdowns render only "ALL").
 - **Task 4 (Verification):** Confirmed 16 states (was 13 hardcoded), 6 types (was 4 hardcoded), 17 errors returned. Frontend builds with zero TypeScript errors. No regressions in backend test suite (392 pass, 26 pre-existing failures in unrelated test files).
 
+### Senior Developer Review (AI)
+
+**Reviewer:** Claude Opus 4.6 | **Date:** 2026-03-10
+
+**Issues Found:** 1 High, 3 Medium, 2 Low | **All H+M Fixed**
+
+- **[H1] FIXED** — Endpoint count "19" not updated to "20" in 8+ documentation files (infrastructure-metrics.md SSOT, CLAUDE.md, backend/CLAUDE.md, README.md, project-overview.md, api-contracts-backend.md, source-tree-analysis.md, index.md). Updated all files and added `/document_states` to SSOT table.
+- **[M1] FIXED** — `err: any` TypeScript anti-pattern in useDocumentStates.ts catch block → changed to `err: unknown` with proper type narrowing and `axios.isCancel()` check.
+- **[M2] FIXED** — No AbortController cleanup in useEffect → added AbortController with cleanup return, prevents state updates on unmounted component.
+- **[M3] FIXED** — `loading` initialized as `false` even without cache → changed to `useState(!cached)` so loading=true when no cached data exists.
+- **[L1] NOT FIXED** — `errors` field fetched but unused in frontend. Acceptable — available for future error filter dropdown.
+- **[L2] NOT FIXED** — Redundant localStorage re-read in catch block. Refactored to reuse `loadCached()` helper instead.
+
 ### Change Log
 
 - 2026-03-10: Implemented B-93 — backend endpoint + frontend dynamic dropdowns + localStorage caching + error fallback
+- 2026-03-10: Code review — 4 fixes (H1 docs endpoint count, M1 err:any→unknown, M2 AbortController cleanup, M3 loading init)
 
 ### File List
 
 - `backend/server.py` (modified — added imports + `/document_states` route)
 - `backend/tests/unit/test_flask_endpoints_document_states.py` (new — 7 unit tests)
-- `web_interface_react/src/modules/shared/hooks/useDocumentStates.ts` (new — hook)
+- `web_interface_react/src/modules/shared/hooks/useDocumentStates.ts` (new — hook; review: AbortController, err:unknown, loading init)
 - `web_interface_react/src/modules/shared/pages/list.tsx` (modified — dynamic dropdowns)
+- `docs/infrastructure-metrics.md` (review fix — added `/document_states`, count 19→20)
+- `docs/api-contracts-backend.md` (review fix — count 19→20)
+- `docs/project-overview.md` (review fix — count 19→20)
+- `docs/source-tree-analysis.md` (review fix — count 19→20)
+- `docs/index.md` (review fix — count 19→20)
+- `CLAUDE.md` (review fix — count 19→20)
+- `backend/CLAUDE.md` (review fix — count 19→20, added `/document_states` to Metadata)
+- `README.md` (review fix — count 19→20)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -363,7 +363,7 @@ development_status:
 
   # --- Epic 30: Database Lookup Tables & Search Extensions ---
   epic-30: in-progress  # B-97 done (NAS), remaining stories in backlog
-  B-93-synchronize-document-states-from-backend-to-frontend: review  # Backend GET /document_states endpoint + frontend dynamic dropdowns. Eliminates hardcoded enum subsets in list.tsx.
+  B-93-synchronize-document-states-from-backend-to-frontend: done  # Backend GET /document_states endpoint + frontend dynamic dropdowns. Eliminates hardcoded enum subsets in list.tsx. Code review: 4 fixes (H1 docs count 19→20, M1 err:unknown, M2 AbortController, M3 loading init).
   B-94-create-lookup-tables-and-seed-data: backlog  # 4 lookup tables (document_status_types, document_status_error_types, document_types, embedding_models) + Alembic migration. ADR-010.
   B-95-add-foreign-key-constraints-to-web-documents-and-websites-embeddings: backlog  # FK constraints on document_state, document_state_error, document_type, embedding model. Depends on B-94.
   B-96-update-sqlalchemy-orm-models-for-lookup-table-relationships: backlog  # ORM models for lookup tables, ForeignKey + relationship() instead of SAEnum. Depends on B-95.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -6,7 +6,7 @@ Flask REST API backend for Project Lenie. Provides document management, AI/LLM o
 
 ```
 backend/
-├── server.py                              # Main Flask application (19 endpoints)
+├── server.py                              # Main Flask application (20 endpoints)
 ├── pyproject.toml                         # Dependencies, build config, tool settings
 ├── uv.lock                                # Frozen dependency lock file
 ├── Dockerfile                             # Multi-stage Docker build (Python 3.11-slim + uv)
@@ -36,7 +36,7 @@ backend/
 
 ## Main Application (`server.py`)
 
-Flask + Flask-CORS application exposing 19 REST API endpoints. **Version**: 0.3.13.0.
+Flask + Flask-CORS application exposing 20 REST API endpoints. **Version**: 0.3.13.0.
 
 ### API Endpoints
 
@@ -45,7 +45,7 @@ Flask + Flask-CORS application exposing 19 REST API endpoints. **Version**: 0.3.
 | **Document CRUD** | `/url_add`, `/website_list`, `/website_get`, `/website_save`, `/website_delete` |
 | **AI Operations** | `/ai_get_embedding`, `/website_similar` |
 | **Content Processing** | `/website_download_text_content`, `/website_text_remove_not_needed`, `/website_split_for_embedding` |
-| **Metadata** | `/website_is_paid`, `/website_get_next_to_correct` |
+| **Metadata** | `/website_is_paid`, `/website_get_next_to_correct`, `/document_states` |
 | **Health & Info** | `/` (root), `/healthz`, `/startup`, `/readiness`, `/liveness`, `/version`, `/metrics` |
 
 All routes (except health checks) require `x-api-key` header validated against `STALKER_API_KEY` env var.

--- a/docs/api-contracts-backend.md
+++ b/docs/api-contracts-backend.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Flask REST API with **19 endpoints** (including root `/` informational endpoint). Version 0.3.13.0. All routes except health checks require `x-api-key` header validated against `STALKER_API_KEY` environment variable.
+Flask REST API with **20 endpoints** (including root `/` informational endpoint). Version 0.3.13.0. All routes except health checks require `x-api-key` header validated against `STALKER_API_KEY` environment variable.
 
 **Base URL**: `http://localhost:5000` (Docker) or AWS API Gateway endpoint (serverless)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@
 ### Backend API (`backend/`)
 - **Type:** REST API (Flask)
 - **Tech Stack:** Python 3.11, Flask, psycopg2, uv
-- **Entry Point:** `server.py` (19 endpoints)
+- **Entry Point:** `server.py` (20 endpoints)
 - **Architecture:** Layered API with service pattern
 
 ### Main Frontend (`web_interface_react/`)

--- a/docs/infrastructure-metrics.md
+++ b/docs/infrastructure-metrics.md
@@ -1,12 +1,12 @@
 # Infrastructure Metrics — Single Source of Truth
 
-> Last verified: 2026-02-23 | Post-Sprint 5 (Epic 18: Lambda consolidation ec2-manager + rds-manager)
+> Last verified: 2026-03-10 | Post-Sprint 10 (B-93: /document_states endpoint)
 
 This file is the authoritative source for infrastructure counts. All other documentation files should reference or be consistent with values here.
 
 ## Flask Server (Docker / Kubernetes)
 
-**Entry point:** `backend/server.py` | **Total endpoints: 19**
+**Entry point:** `backend/server.py` | **Total endpoints: 20**
 
 | # | Path | Method | Category |
 |---|------|--------|----------|
@@ -23,12 +23,13 @@ This file is the authoritative source for infrastructure counts. All other docum
 | 11 | `/website_download_text_content` | POST | Content Processing |
 | 12 | `/website_text_remove_not_needed` | POST | Content Processing |
 | 13 | `/website_split_for_embedding` | POST | Content Processing |
-| 14 | `/healthz` | GET | Health & Info |
-| 15 | `/metrics` | GET | Health & Info |
-| 16 | `/startup` | GET | Health & Info |
-| 17 | `/readiness` | GET | Health & Info |
-| 18 | `/liveness` | GET | Health & Info |
-| 19 | `/version` | GET | Health & Info |
+| 14 | `/document_states` | GET | Metadata |
+| 15 | `/healthz` | GET | Health & Info |
+| 16 | `/metrics` | GET | Health & Info |
+| 17 | `/startup` | GET | Health & Info |
+| 18 | `/readiness` | GET | Health & Info |
+| 19 | `/liveness` | GET | Health & Info |
+| 20 | `/version` | GET | Health & Info |
 
 All routes except `/startup`, `/readiness`, `/liveness`, `/version` require `x-api-key` header.
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -23,7 +23,7 @@ The system consists of a Python/Flask REST API backend, a React frontend applica
 ## Parts Summary
 
 ### Backend API (`backend/`)
-Flask REST API with 19 endpoints for document CRUD, AI operations (embedding generation, similarity search), and content processing (webpage download, text cleanup, YouTube transcription). Multi-provider LLM abstraction supporting OpenAI, AWS Bedrock, Google Vertex AI, and CloudFerro Bielik.
+Flask REST API with 20 endpoints for document CRUD, AI operations (embedding generation, similarity search), and content processing (webpage download, text cleanup, YouTube transcription). Multi-provider LLM abstraction supporting OpenAI, AWS Bedrock, Google Vertex AI, and CloudFerro Bielik.
 
 ### Main Frontend (`web_interface_react/`)
 React 18 SPA with 7 pages for document management. Features include document list with filtering, vector similarity search, and per-type editors (link, webpage, youtube, movie) with AI tools (split for embedding, clean text). Supports two backend modes: AWS Serverless and Docker.

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -16,7 +16,7 @@ lenie-server-2025/
 ├── Jenkinsfile                        # Jenkins pipeline (AWS EC2, Semgrep)
 │
 ├── backend/                    ★ Flask REST API (Python 3.11)
-│   ├── server.py                      # Main Flask application (19 endpoints)
+│   ├── server.py                      # Main Flask application (20 endpoints)
 │   ├── pyproject.toml                 # Dependencies & build config (uv)
 │   ├── uv.lock                        # Frozen dependency lock
 │   ├── Dockerfile                     # Docker build (python:3.11-slim + uv)
@@ -175,7 +175,7 @@ lenie-server-2025/
 ## Integration Points
 
 ```
-web_interface_react ──(REST API, axios)──→ backend/server.py (19 endpoints)
+web_interface_react ──(REST API, axios)──→ backend/server.py (20 endpoints)
 web_chrome_extension ──(POST /url_add)──→ AWS API Gateway → sqs-weblink-put-into Lambda
 infra/docker ──(deploys)──→ backend + web_interface_react + PostgreSQL
 infra/aws/cloudformation ──(provisions)──→ VPC, RDS, Lambda, API Gateway, SQS, DynamoDB

--- a/web_interface_react/src/modules/shared/hooks/useDocumentStates.ts
+++ b/web_interface_react/src/modules/shared/hooks/useDocumentStates.ts
@@ -24,18 +24,21 @@ export const useDocumentStates = () => {
   const [states, setStates] = React.useState<string[]>(cached?.states ?? []);
   const [types, setTypes] = React.useState<string[]>(cached?.types ?? []);
   const [errors, setErrors] = React.useState<string[]>(cached?.errors ?? []);
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = React.useState(!cached);
   const [error, setError] = React.useState<string | null>(null);
   const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
 
   React.useEffect(() => {
     if (!apiUrl || !apiKey) return;
 
+    const controller = new AbortController();
+
     const fetchStates = async () => {
       setLoading(true);
       try {
         const response = await axios.get(`${apiUrl}/document_states`, {
           headers: { "x-api-key": `${apiKey}` },
+          signal: controller.signal,
         });
         const data: DocumentStatesData = response.data;
         setStates(data.states);
@@ -43,20 +46,17 @@ export const useDocumentStates = () => {
         setErrors(data.errors);
         setError(null);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-      } catch (err: any) {
+      } catch (err: unknown) {
+        if (axios.isCancel(err)) return;
+        const message = err instanceof Error ? err.message : "Unknown error";
         console.error("Failed to fetch document states:", err);
-        setError(err.message);
+        setError(message);
         // Fallback to cached values
-        const cached = localStorage.getItem(STORAGE_KEY);
-        if (cached) {
-          try {
-            const data: DocumentStatesData = JSON.parse(cached);
-            setStates(data.states);
-            setTypes(data.types);
-            setErrors(data.errors);
-          } catch {
-            // Invalid cache, use empty arrays
-          }
+        const fallback = loadCached();
+        if (fallback) {
+          setStates(fallback.states);
+          setTypes(fallback.types);
+          setErrors(fallback.errors);
         }
       } finally {
         setLoading(false);
@@ -64,6 +64,8 @@ export const useDocumentStates = () => {
     };
 
     fetchStates();
+
+    return () => controller.abort();
   }, [apiUrl, apiKey]);
 
   return { states, types, errors, loading, error };


### PR DESCRIPTION
## Summary

- **useDocumentStates.ts**: Added `AbortController` cleanup, fixed `err: any` → `err: unknown` with type narrowing, corrected `loading` initialization for cache-less state
- **Documentation (8 files)**: Updated endpoint count 19→20, added `/document_states` to infrastructure-metrics SSOT table and backend/CLAUDE.md Metadata category
- **Sprint tracking**: B-93 status updated review → done

## Code Review Findings

| Issue | Severity | Status |
|-------|----------|--------|
| H1: Endpoint count 19→20 in docs | HIGH | Fixed |
| M1: `err: any` TypeScript anti-pattern | MEDIUM | Fixed |
| M2: No AbortController cleanup | MEDIUM | Fixed |
| M3: `loading` init without cache | MEDIUM | Fixed |
| L1: Unused `errors` field | LOW | Accepted |
| L2: Redundant localStorage re-read | LOW | Refactored |

## Test plan

- [x] TypeScript type check passes (`npx tsc --noEmit` — 0 errors)
- [x] Pre-commit hooks pass (gitleaks + TruffleHog)
- [ ] Verify frontend dropdowns still populate correctly
- [ ] Verify AbortController doesn't interfere with normal fetch flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)