### PR TITLE
feat: scheduled health checks with proactive Slack alerts (Story 25.1)

### DIFF
--- a/_bmad-output/implementation-artifacts/25-1-scheduled-health-checks-proactive-alerts.md
+++ b/_bmad-output/implementation-artifacts/25-1-scheduled-health-checks-proactive-alerts.md
@@ -1,0 +1,207 @@
+# Story 25.1: Scheduled Health Checks & Proactive Alerts
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **system administrator (single user)**,
+I want the Slack bot to periodically check backend health and proactively alert me via DM when infrastructure problems occur,
+so that I am immediately aware of failures without having to manually query the system.
+
+## Acceptance Criteria
+
+1. **Scheduled health checks run on a configurable interval** (default: 5 minutes)
+   - Given the Slack bot is running
+   - When the configured interval elapses
+   - Then the bot executes health checks against the backend API
+   - And health checks do NOT block normal Slack event handling (commands, DMs, mentions)
+
+2. **Backend API reachability is monitored**
+   - Given a scheduled health check runs
+   - When the bot calls `GET /healthz` on the backend
+   - Then the result is recorded as `healthy` (2xx response) or `down` (timeout/connection error/non-2xx)
+
+3. **Database connectivity is monitored**
+   - Given a scheduled health check runs
+   - When the bot calls a DB-dependent endpoint (`GET /version` or `GET /website_list?type=ALL`)
+   - Then the result confirms the database is reachable through the backend
+
+4. **Bot sends DM alert on new failure**
+   - Given a health check detects a failure (transition from `healthy` → `down`)
+   - When the failure is new (not previously reported and still unresolved)
+   - Then the bot sends a direct message to the configured user with:
+     - Affected component name
+     - Failure reason in plain language (no stack traces)
+     - Timestamp of the failed check
+     - Actionable suggestion (e.g., "Check if lenie-ai-server container is running on NAS")
+
+5. **Alert deduplication prevents alert fatigue**
+   - Given an alert was sent for a specific failure
+   - When the same health check fails again before recovery
+   - Then no duplicate alert is sent
+   - And when the failure resolves, a recovery notification IS sent
+
+6. **Recovery notification on resolution**
+   - Given a component was in `down` state and an alert was sent
+   - When the health check succeeds again (transition from `down` → `healthy`)
+   - Then the bot sends a recovery DM with:
+     - Component name
+     - Recovery timestamp
+     - Approximate downtime duration
+
+7. **Health check does not crash the bot**
+   - Given the backend is completely unreachable
+   - When the health check runs
+   - Then the bot catches all exceptions gracefully
+   - And remains connected to Slack and responsive to user commands
+
+8. **Configuration via environment variables**
+   - `HEALTH_CHECK_ENABLED` (default: `false`) — enable/disable scheduled checks
+   - `HEALTH_CHECK_INTERVAL` (default: `300` seconds / 5 minutes)
+   - `HEALTH_CHECK_USER_ID` — Slack user ID to receive alerts (required if enabled)
+   - All variables managed via `unified_config_loader` (Vault/SSM/env)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create `src/health_monitor.py` module (AC: #1, #2, #3, #7)
+  - [x] 1.1: Define `HealthStatus` enum (`healthy`, `down`) and `ComponentState` dataclass (component name, status, last_check, last_alert_sent)
+  - [x] 1.2: Implement `HealthMonitor` class with state tracking per component
+  - [x] 1.3: Implement `check_backend_api()` — calls `client.check_health()` (GET /healthz)
+  - [x] 1.4: Implement `check_database_connectivity()` — calls `client.get_version()` (GET /version, requires DB)
+  - [x] 1.5: Implement `run_all_checks()` — executes all checks, returns list of state changes
+  - [x] 1.6: Wrap all check methods in try/except to prevent crashes (AC #7)
+
+- [x] Task 2: Implement alert delivery (AC: #4, #5, #6)
+  - [x] 2.1: Implement `send_alert(component, reason, suggestion)` — DM via Slack `chat.postMessage` to `HEALTH_CHECK_USER_ID`
+  - [x] 2.2: Implement `send_recovery(component, downtime_duration)` — recovery DM
+  - [x] 2.3: Implement state-transition-based deduplication (only alert on `healthy→down`, only recover on `down→healthy`)
+  - [x] 2.4: Format messages with user-friendly text (FR18/FR20 patterns from dm_handler.py)
+
+- [x] Task 3: Implement scheduler integration (AC: #1, #8)
+  - [x] 3.1: Add `threading.Timer` based recurring execution (stdlib, no new dependency)
+  - [x] 3.2: Ensure scheduler runs in background thread (daemon timer, does not block Socket Mode event loop)
+  - [x] 3.3: Add graceful shutdown (cancel timer on SIGTERM/SIGINT via KeyboardInterrupt handler in main.py)
+
+- [x] Task 4: Integrate into `src/main.py` (AC: #8)
+  - [x] 4.1: Read `HEALTH_CHECK_ENABLED`, `HEALTH_CHECK_INTERVAL`, `HEALTH_CHECK_USER_ID` from config
+  - [x] 4.2: If enabled, create `HealthMonitor` instance and start scheduler after Socket Mode connect
+  - [x] 4.3: Add shutdown hook to stop scheduler
+
+- [x] Task 5: Add environment variables to configuration (AC: #8)
+  - [x] 5.1: Add `HEALTH_CHECK_ENABLED`, `HEALTH_CHECK_INTERVAL`, `HEALTH_CHECK_USER_ID` to `scripts/vars-classification.yaml`
+  - [x] 5.2: Add variables to `slack-app-manifest.yaml` documentation comment (if applicable) — N/A, manifest does not list env vars
+
+- [x] Task 6: Unit tests (all ACs)
+  - [x] 6.1: Test `HealthMonitor` state tracking — initial state, healthy→down transition, down→healthy transition
+  - [x] 6.2: Test alert deduplication — no duplicate alerts for same ongoing failure
+  - [x] 6.3: Test recovery notification — sent only on down→healthy transition
+  - [x] 6.4: Test graceful error handling — check doesn't crash on ConnectionError, Timeout
+  - [x] 6.5: Test scheduler start/stop lifecycle
+  - [x] 6.6: Test configuration loading — enabled/disabled, default values
+
+## Dev Notes
+
+### Architecture Patterns & Constraints
+
+- **Slack Bot runs on Docker/NAS only** (Socket Mode = persistent process, not serverless). Scheduler fits naturally.
+- **Existing health check at startup**: `main.py:check_backend_connectivity()` calls `client.check_health()` + `client.get_version()`. Reuse this pattern.
+- **API client already has health methods**: `api_client.py` provides `check_health()` (GET /healthz) and `get_version()` (GET /version). No new API endpoints needed.
+- **5-second timeout on all API calls** (NFR3) — health checks inherit this timeout from `api_client.py`.
+- **NFR16**: Bot MUST remain running and connected to Slack even when backend is unreachable. Health check failures must never crash the process.
+- **NFR17**: Slack Bolt SDK auto-reconnect handles Socket Mode disconnections. Health monitor must not interfere.
+
+### Implementation Guidance
+
+- **Scheduler choice**: Prefer `threading.Timer` (stdlib) over `APScheduler` to avoid adding a new dependency. Recurring timer pattern:
+  ```python
+  def _schedule_next(self):
+      self._timer = threading.Timer(self.interval, self._run_and_reschedule)
+      self._timer.daemon = True
+      self._timer.start()
+  ```
+- **State tracking**: In-memory dict keyed by component name. No persistence needed — state resets on restart (acceptable for single-container deployment).
+- **DM delivery**: Use Slack Web API `client.chat_postMessage(channel=user_id, text=...)`. The bot already has `chat:write` scope.
+- **Alert format**: Follow existing error message patterns from `dm_handler.py` and `mention_handler.py` (plain text, no stack traces, actionable suggestions).
+- **Deduplication**: Track previous state per component. Only send alert when state transitions (not on every failed check). This is simpler and more reliable than cooldown timers.
+
+### Error Handling Patterns (from existing codebase)
+
+```python
+# From dm_handler.py / mention_handler.py
+try:
+    client.check_health()
+except ApiConnectionError:
+    # Backend unreachable — record as "down"
+except ApiResponseError as exc:
+    # Backend returned error — record as "down" with status code
+except ApiError as exc:
+    # Unexpected — record as "down"
+```
+
+### Project Structure Notes
+
+- New file: `slack_bot/src/health_monitor.py` — health monitoring logic + scheduler
+- Modified file: `slack_bot/src/main.py` — integration (config reading, monitor start/stop)
+- New test file: `slack_bot/tests/unit/test_health_monitor.py`
+- Modified file: `scripts/vars-classification.yaml` — new env vars
+- **No changes to backend** — all monitoring uses existing API endpoints
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/archive/prd-sprint5-slack-bot-2026-03-04.md` — FR15, FR16, FR17, NFR16, NFR17]
+- [Source: `slack_bot/src/main.py` — `check_backend_connectivity()` startup health check pattern]
+- [Source: `slack_bot/src/api_client.py` — `check_health()`, `get_version()`, exception hierarchy]
+- [Source: `slack_bot/src/dm_handler.py` — error handling and message formatting patterns]
+- [Source: `slack_bot/pyproject.toml` — current dependencies (no APScheduler)]
+- [Source: `CLAUDE.md` — Slack Bot Docker deployment, Socket Mode, config_loader]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+None — all tests passed on first run.
+
+### Completion Notes List
+
+- Implemented `HealthMonitor` class in `slack_bot/src/health_monitor.py` with:
+  - `HealthStatus` enum (healthy/down) and `ComponentState` dataclass for per-component state tracking
+  - `check_backend_api()` — calls GET /healthz via existing `api_client.check_health()`
+  - `check_database_connectivity()` — calls GET /version via existing `api_client.get_version()`
+  - `run_all_checks()` — runs all checks and returns state transitions (component, old→new status)
+  - `send_alert()` / `send_recovery()` — DM delivery via Slack `chat.postMessage`
+  - `process_transitions()` — dispatches alerts on healthy→down, recovery on down→healthy
+  - State-transition-based deduplication — no duplicate alerts for ongoing failures
+  - `threading.Timer` based scheduler with daemon threads (stdlib, no new dependencies)
+  - Graceful error handling — all exceptions caught, monitor never crashes the bot
+- Integrated into `main.py` — reads config, starts monitor after Socket Mode connect, stops on shutdown
+- Added 3 env vars to `vars-classification.yaml`: HEALTH_CHECK_ENABLED, HEALTH_CHECK_INTERVAL, HEALTH_CHECK_USER_ID
+- 33 new unit tests covering all ACs (state tracking, deduplication, recovery, error handling, scheduler lifecycle)
+- 283 total tests pass, 0 regressions, ruff clean
+
+**Code Review Fixes (2026-03-10):**
+- H1: Fixed recovery downtime calculation — uses `down_since` instead of `last_alert_sent`; transition tuples now include `down_since` field
+- H2: Fixed `test_alert_deduplication_via_run_all_checks` — now properly calls `process_transitions` on first transitions and asserts `chat_postMessage` call count
+- M1: Protected `HEALTH_CHECK_INTERVAL` parsing against `ValueError` with fallback to 300s default
+- M2: Added interval validation in `HealthMonitor.__init__` — raises `ValueError` for zero/negative interval
+- M3: `down_since` field now properly consumed in recovery flow (resolved by H1 fix)
+- 4 new tests added: interval validation (2), recovery downtime calculation (2)
+- 287 total tests pass, 0 regressions, ruff clean
+
+### Change Log
+
+- 2026-03-10: Story 25.1 implemented — scheduled health checks with proactive Slack alerts
+- 2026-03-10: Code review — 5 issues fixed (2H/3M), 4 new tests added
+
+### File List
+
+- `slack_bot/src/health_monitor.py` — NEW: health monitoring module (HealthStatus, ComponentState, HealthMonitor)
+- `slack_bot/src/main.py` — MODIFIED: health monitor integration (config reading, start/stop)
+- `slack_bot/tests/unit/test_health_monitor.py` — NEW: 37 unit tests for health monitoring
+- `scripts/vars-classification.yaml` — MODIFIED: added HEALTH_CHECK_ENABLED, HEALTH_CHECK_INTERVAL, HEALTH_CHECK_USER_ID
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` — MODIFIED: story status updated

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -294,8 +294,8 @@ development_status:
   epic-24-retrospective: optional
 
   # --- Epic 25: Proactive Health Monitoring ---
-  epic-25: backlog
-  25-1-scheduled-health-checks-proactive-alerts: backlog
+  epic-25: in-progress
+  25-1-scheduled-health-checks-proactive-alerts: done
   epic-25-retrospective: optional
 
   # --- Phase 6: Obsidian Integration ---

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -324,6 +324,26 @@ groups:
         default: "#general"
         example: "#lenie-bot"
         used_by: [docker]
+      HEALTH_CHECK_ENABLED:
+        description: "Enable/disable scheduled health checks with proactive alerts"
+        type: config
+        required: false
+        default: "false"
+        example: "false"
+        used_by: [docker]
+      HEALTH_CHECK_INTERVAL:
+        description: "Health check interval in seconds"
+        type: config
+        required: false
+        default: "300"
+        example: "300"
+        used_by: [docker]
+      HEALTH_CHECK_USER_ID:
+        description: "Slack user ID to receive health alert DMs (required when HEALTH_CHECK_ENABLED=true)"
+        type: config
+        required_when: "HEALTH_CHECK_ENABLED=true"
+        example: "U0123456789"
+        used_by: [docker]
 
   integrations:
     description: "Third-party service API keys and endpoints"

--- a/slack_bot/src/health_monitor.py
+++ b/slack_bot/src/health_monitor.py
@@ -1,0 +1,214 @@
+"""Scheduled health monitoring with proactive Slack alerts.
+
+Periodically checks backend API and database connectivity,
+sends DM alerts on failures and recovery notifications.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from src.api_client import ApiConnectionError, ApiResponseError
+
+if TYPE_CHECKING:
+    from src.api_client import LenieApiClient
+
+logger = logging.getLogger(__name__)
+
+
+class HealthStatus(Enum):
+    HEALTHY = "healthy"
+    DOWN = "down"
+
+
+@dataclass
+class ComponentState:
+    name: str
+    status: HealthStatus = HealthStatus.HEALTHY
+    last_check: datetime | None = None
+    last_alert_sent: datetime | None = None
+    failure_reason: str | None = None
+    down_since: datetime | None = None
+
+
+class HealthMonitor:
+    """Monitors backend health and sends Slack alerts on state transitions."""
+
+    def __init__(
+        self,
+        api_client: LenieApiClient,
+        slack_client: object,
+        alert_user_id: str,
+        interval: float = 300,
+    ):
+        if interval <= 0:
+            raise ValueError(f"Health check interval must be positive, got {interval}")
+        self._client = api_client
+        self._slack = slack_client
+        self._user_id = alert_user_id
+        self._interval = interval
+        self._states: dict[str, ComponentState] = {
+            "backend_api": ComponentState(name="backend_api"),
+            "database": ComponentState(name="database"),
+        }
+        self._timer: threading.Timer | None = None
+        self._running = False
+
+    # --- Individual check methods (Task 1.3, 1.4) ---
+
+    def check_backend_api(self) -> tuple[HealthStatus, str | None]:
+        """Check backend API reachability via GET /healthz."""
+        try:
+            self._client.check_health()
+            return HealthStatus.HEALTHY, None
+        except ApiConnectionError as exc:
+            return HealthStatus.DOWN, exc.message
+        except ApiResponseError as exc:
+            return HealthStatus.DOWN, exc.message
+        except Exception as exc:
+            return HealthStatus.DOWN, f"Unexpected error: {exc}"
+
+    def check_database_connectivity(self) -> tuple[HealthStatus, str | None]:
+        """Check database connectivity via GET /version (requires DB)."""
+        try:
+            self._client.get_version()
+            return HealthStatus.HEALTHY, None
+        except ApiConnectionError as exc:
+            return HealthStatus.DOWN, exc.message
+        except ApiResponseError as exc:
+            return HealthStatus.DOWN, exc.message
+        except Exception as exc:
+            return HealthStatus.DOWN, f"Unexpected error: {exc}"
+
+    # --- Aggregate check (Task 1.5) ---
+
+    def run_all_checks(self) -> list[tuple[str, HealthStatus, HealthStatus, str | None, datetime | None]]:
+        """Run all health checks and return list of state transitions.
+
+        Returns list of (component_name, old_status, new_status, reason, down_since) tuples
+        for components that changed state.
+        """
+        now = datetime.now(tz=timezone.utc)
+        checks = {
+            "backend_api": self.check_backend_api,
+            "database": self.check_database_connectivity,
+        }
+        transitions: list[tuple[str, HealthStatus, HealthStatus, str | None, datetime | None]] = []
+
+        for component_name, check_fn in checks.items():
+            state = self._states[component_name]
+            new_status, reason = check_fn()
+            old_status = state.status
+
+            state.last_check = now
+
+            if old_status != new_status:
+                state.status = new_status
+                state.failure_reason = reason
+                down_since = state.down_since
+                if new_status == HealthStatus.DOWN:
+                    state.down_since = now
+                    down_since = now
+                elif new_status == HealthStatus.HEALTHY:
+                    state.down_since = None
+                transitions.append((component_name, old_status, new_status, reason, down_since))
+
+        return transitions
+
+    # --- Alert delivery (Task 2) ---
+
+    def send_alert(self, component: str, reason: str, suggestion: str) -> None:
+        """Send failure alert DM to configured user."""
+        now = datetime.now(tz=timezone.utc)
+        text = (
+            f"Health Check Alert: {component}\n\n"
+            f"Status: DOWN\n"
+            f"Reason: {reason}\n"
+            f"Time: {now.strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n"
+            f"Suggestion: {suggestion}"
+        )
+        try:
+            self._slack.chat_postMessage(channel=self._user_id, text=text)
+            self._states[component].last_alert_sent = now
+            logger.info("Alert sent for %s: %s", component, reason)
+        except Exception:
+            logger.exception("Failed to send alert for %s", component)
+
+    def send_recovery(self, component: str, downtime_seconds: float) -> None:
+        """Send recovery notification DM to configured user."""
+        now = datetime.now(tz=timezone.utc)
+        minutes = int(downtime_seconds // 60)
+        seconds = int(downtime_seconds % 60)
+        duration = f"{minutes}m {seconds}s" if minutes > 0 else f"{seconds}s"
+        text = (
+            f"Recovery: {component} is back online\n\n"
+            f"Status: HEALTHY\n"
+            f"Recovery time: {now.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
+            f"Approximate downtime: {duration}"
+        )
+        try:
+            self._slack.chat_postMessage(channel=self._user_id, text=text)
+            logger.info("Recovery notification sent for %s (downtime: %s)", component, duration)
+        except Exception:
+            logger.exception("Failed to send recovery notification for %s", component)
+
+    def process_transitions(
+        self, transitions: list[tuple[str, HealthStatus, HealthStatus, str | None, datetime | None]]
+    ) -> None:
+        """Process state transitions — send alerts or recovery notifications."""
+        suggestions = {
+            "backend_api": "Check if lenie-ai-server container is running on NAS",
+            "database": "Check if lenie-ai-db container is running and PostgreSQL is accepting connections",
+        }
+        for component, old_status, new_status, reason, down_since in transitions:
+            if old_status == HealthStatus.HEALTHY and new_status == HealthStatus.DOWN:
+                self.send_alert(component, reason or "Unknown", suggestions.get(component, "Check system logs"))
+            elif old_status == HealthStatus.DOWN and new_status == HealthStatus.HEALTHY:
+                now = datetime.now(tz=timezone.utc)
+                downtime = 0.0
+                if down_since:
+                    downtime = (now - down_since).total_seconds()
+                self.send_recovery(component, downtime)
+
+    # --- Scheduler (Task 3) ---
+
+    def _run_and_reschedule(self) -> None:
+        """Execute checks, process transitions, and schedule next run."""
+        if not self._running:
+            return
+        try:
+            transitions = self.run_all_checks()
+            self.process_transitions(transitions)
+        except Exception:
+            logger.exception("Health check cycle failed")
+        finally:
+            if self._running:
+                self._schedule_next()
+
+    def _schedule_next(self) -> None:
+        """Schedule the next health check run."""
+        self._timer = threading.Timer(self._interval, self._run_and_reschedule)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def start(self) -> None:
+        """Start the health check scheduler."""
+        if self._running:
+            logger.warning("Health monitor already running")
+            return
+        self._running = True
+        logger.info("Health monitor started (interval: %ss)", self._interval)
+        self._schedule_next()
+
+    def stop(self) -> None:
+        """Stop the health check scheduler."""
+        self._running = False
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+        logger.info("Health monitor stopped")

--- a/slack_bot/src/main.py
+++ b/slack_bot/src/main.py
@@ -17,6 +17,7 @@ from src import __version__
 from src.api_client import ApiConnectionError, ApiError, LenieApiClient, create_client
 from src.commands import register_commands
 from src.dm_handler import register_dm_handler
+from src.health_monitor import HealthMonitor
 from src.mention_handler import register_mention_handler
 from src.config import Config, load_config
 
@@ -113,11 +114,35 @@ def main() -> None:
     check_backend_connectivity(api_client)
     post_startup_message(app, cfg)
 
+    # Start health monitor if enabled
+    health_monitor = None
+    health_enabled = cfg.get("HEALTH_CHECK_ENABLED", "false").lower() == "true"
+    if health_enabled:
+        health_user_id = cfg.get("HEALTH_CHECK_USER_ID", "")
+        if not health_user_id:
+            logger.warning("HEALTH_CHECK_ENABLED=true but HEALTH_CHECK_USER_ID not set — health monitor disabled")
+        else:
+            try:
+                health_interval = int(cfg.get("HEALTH_CHECK_INTERVAL", "300"))
+            except ValueError:
+                logger.warning("HEALTH_CHECK_INTERVAL is not a valid integer, using default 300s")
+                health_interval = 300
+            health_monitor = HealthMonitor(
+                api_client=api_client,
+                slack_client=app.client,
+                alert_user_id=health_user_id,
+                interval=health_interval,
+            )
+            health_monitor.start()
+            logger.info("Health monitor started (interval: %ds, user: %s)", health_interval, health_user_id)
+
     logger.info("Bot is running. Press Ctrl+C to stop.")
     try:
         Event().wait()
     except KeyboardInterrupt:
         logger.info("Shutting down...")
+        if health_monitor is not None:
+            health_monitor.stop()
         handler.close()
 
 

--- a/slack_bot/tests/unit/test_health_monitor.py
+++ b/slack_bot/tests/unit/test_health_monitor.py
@@ -1,0 +1,419 @@
+"""Unit tests for health_monitor module."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.api_client import ApiConnectionError, ApiResponseError
+from src.health_monitor import (
+    ComponentState,
+    HealthMonitor,
+    HealthStatus,
+)
+
+
+# --- HealthStatus enum tests ---
+
+
+class TestHealthStatus:
+    def test_healthy_value(self):
+        assert HealthStatus.HEALTHY.value == "healthy"
+
+    def test_down_value(self):
+        assert HealthStatus.DOWN.value == "down"
+
+
+# --- ComponentState dataclass tests ---
+
+
+class TestComponentState:
+    def test_default_state_is_healthy(self):
+        state = ComponentState(name="backend_api")
+        assert state.status == HealthStatus.HEALTHY
+        assert state.last_check is None
+        assert state.last_alert_sent is None
+        assert state.failure_reason is None
+
+    def test_state_with_values(self):
+        now = datetime.now(tz=timezone.utc)
+        state = ComponentState(
+            name="database",
+            status=HealthStatus.DOWN,
+            last_check=now,
+            last_alert_sent=now,
+            failure_reason="Connection refused",
+        )
+        assert state.name == "database"
+        assert state.status == HealthStatus.DOWN
+        assert state.failure_reason == "Connection refused"
+
+
+# --- HealthMonitor state tracking tests (Task 1.2) ---
+
+
+class TestHealthMonitorStateTracking:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_initial_state_all_healthy(self):
+        for state in self.monitor._states.values():
+            assert state.status == HealthStatus.HEALTHY
+
+    def test_components_tracked(self):
+        assert "backend_api" in self.monitor._states
+        assert "database" in self.monitor._states
+
+
+# --- check_backend_api tests (Task 1.3) ---
+
+
+class TestCheckBackendApi:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_healthy_check(self):
+        self.mock_client.check_health.return_value = {"status": "ok"}
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.HEALTHY
+        assert reason is None
+
+    def test_connection_error_returns_down(self):
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.DOWN
+        assert "timeout" in reason
+
+    def test_response_error_returns_down(self):
+        self.mock_client.check_health.side_effect = ApiResponseError("500", 500)
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.DOWN
+        assert "500" in reason
+
+    def test_unexpected_exception_returns_down(self):
+        self.mock_client.check_health.side_effect = RuntimeError("unexpected")
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.DOWN
+        assert "unexpected" in reason.lower() or "Unexpected" in reason
+
+
+# --- check_database_connectivity tests (Task 1.4) ---
+
+
+class TestCheckDatabaseConnectivity:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_healthy_db_check(self):
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        status, reason = self.monitor.check_database_connectivity()
+        assert status == HealthStatus.HEALTHY
+        assert reason is None
+
+    def test_connection_error_returns_down(self):
+        self.mock_client.get_version.side_effect = ApiConnectionError("no connection")
+        status, reason = self.monitor.check_database_connectivity()
+        assert status == HealthStatus.DOWN
+        assert reason is not None
+
+    def test_response_error_returns_down(self):
+        self.mock_client.get_version.side_effect = ApiResponseError("DB error", 500)
+        status, reason = self.monitor.check_database_connectivity()
+        assert status == HealthStatus.DOWN
+
+    def test_unexpected_exception_returns_down(self):
+        self.mock_client.get_version.side_effect = Exception("boom")
+        status, reason = self.monitor.check_database_connectivity()
+        assert status == HealthStatus.DOWN
+
+
+# --- run_all_checks tests (Task 1.5) ---
+
+
+class TestRunAllChecks:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_all_healthy_no_transitions(self):
+        self.mock_client.check_health.return_value = {"status": "ok"}
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        transitions = self.monitor.run_all_checks()
+        assert transitions == []
+
+    def test_backend_goes_down_returns_transition(self):
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        transitions = self.monitor.run_all_checks()
+        assert len(transitions) == 1
+        assert transitions[0][0] == "backend_api"
+        assert transitions[0][1] == HealthStatus.HEALTHY  # old
+        assert transitions[0][2] == HealthStatus.DOWN  # new
+        assert transitions[0][4] is not None  # down_since is set
+
+    def test_recovery_returns_transition(self):
+        # First: go down
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        self.monitor.run_all_checks()
+
+        # Then: recover
+        self.mock_client.check_health.side_effect = None
+        self.mock_client.check_health.return_value = {"status": "ok"}
+        transitions = self.monitor.run_all_checks()
+        assert len(transitions) == 1
+        assert transitions[0][0] == "backend_api"
+        assert transitions[0][1] == HealthStatus.DOWN  # old
+        assert transitions[0][2] == HealthStatus.HEALTHY  # new
+
+    def test_no_duplicate_transition_on_repeated_failure(self):
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        self.monitor.run_all_checks()  # first failure → transition
+        transitions = self.monitor.run_all_checks()  # second failure → no transition
+        assert transitions == []
+
+
+# --- Alert delivery tests (Task 2) ---
+
+
+class TestAlertDelivery:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_send_alert_calls_slack(self):
+        self.monitor.send_alert("backend_api", "Connection timeout", "Check if lenie-ai-server container is running")
+        self.mock_slack_client.chat_postMessage.assert_called_once()
+        call_kwargs = self.mock_slack_client.chat_postMessage.call_args[1]
+        assert call_kwargs["channel"] == "U12345"
+        assert "backend_api" in call_kwargs["text"]
+        assert "Connection timeout" in call_kwargs["text"]
+
+    def test_send_recovery_calls_slack(self):
+        self.monitor.send_recovery("backend_api", 120.0)
+        self.mock_slack_client.chat_postMessage.assert_called_once()
+        call_kwargs = self.mock_slack_client.chat_postMessage.call_args[1]
+        assert call_kwargs["channel"] == "U12345"
+        assert "backend_api" in call_kwargs["text"]
+        assert "recover" in call_kwargs["text"].lower() or "back" in call_kwargs["text"].lower()
+
+    def test_alert_deduplication_via_run_all_checks(self):
+        """Verify that repeated failures only trigger one alert."""
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+
+        # First failure → transition → alert sent
+        transitions = self.monitor.run_all_checks()
+        self.monitor.process_transitions(transitions)
+        assert self.mock_slack_client.chat_postMessage.call_count == 1
+
+        # Second failure → no transition → no additional alert
+        transitions = self.monitor.run_all_checks()
+        assert transitions == []
+        self.monitor.process_transitions(transitions)
+        assert self.mock_slack_client.chat_postMessage.call_count == 1  # still 1
+
+    def test_recovery_notification_after_failure(self):
+        """Full cycle: healthy → down → healthy triggers alert then recovery."""
+        # Go down
+        self.mock_client.check_health.side_effect = ApiConnectionError("timeout")
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        transitions = self.monitor.run_all_checks()
+        self.monitor.process_transitions(transitions)
+        assert self.mock_slack_client.chat_postMessage.call_count == 1  # alert
+
+        # Recover
+        self.mock_client.check_health.side_effect = None
+        self.mock_client.check_health.return_value = {"status": "ok"}
+        transitions = self.monitor.run_all_checks()
+        self.monitor.process_transitions(transitions)
+        assert self.mock_slack_client.chat_postMessage.call_count == 2  # alert + recovery
+
+    def test_send_alert_handles_slack_error(self):
+        """Alert delivery failure doesn't crash the monitor."""
+        self.mock_slack_client.chat_postMessage.side_effect = Exception("Slack error")
+        # Should not raise
+        self.monitor.send_alert("backend_api", "timeout", "suggestion")
+
+    def test_send_recovery_handles_slack_error(self):
+        """Recovery delivery failure doesn't crash the monitor."""
+        self.mock_slack_client.chat_postMessage.side_effect = Exception("Slack error")
+        self.monitor.send_recovery("backend_api", 60.0)
+
+
+# --- Scheduler tests (Task 3) ---
+
+
+class TestScheduler:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_client.check_health.return_value = {"status": "ok"}
+        self.mock_client.get_version.return_value = {"app_version": "1.0"}
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=0.1,  # 100ms for test speed
+        )
+
+    def test_start_creates_daemon_timer(self):
+        self.monitor.start()
+        assert self.monitor._timer is not None
+        assert self.monitor._timer.daemon is True
+        self.monitor.stop()
+
+    def test_stop_cancels_timer(self):
+        self.monitor.start()
+        self.monitor.stop()
+        assert self.monitor._running is False
+
+    def test_scheduler_runs_checks(self):
+        """Verify scheduler actually executes health checks."""
+        self.monitor.start()
+        time.sleep(0.3)  # Let at least 1 check run
+        self.monitor.stop()
+        assert self.mock_client.check_health.call_count >= 1
+
+    def test_double_start_is_safe(self):
+        self.monitor.start()
+        self.monitor.start()  # Should not crash or create duplicate timers
+        self.monitor.stop()
+
+    def test_double_stop_is_safe(self):
+        self.monitor.start()
+        self.monitor.stop()
+        self.monitor.stop()  # Should not crash
+
+
+# --- Graceful error handling tests (Task 1.6) ---
+
+
+class TestGracefulErrorHandling:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_check_backend_catches_connection_error(self):
+        self.mock_client.check_health.side_effect = ConnectionError("refused")
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.DOWN
+
+    def test_check_backend_catches_timeout(self):
+        self.mock_client.check_health.side_effect = TimeoutError("timed out")
+        status, reason = self.monitor.check_backend_api()
+        assert status == HealthStatus.DOWN
+
+    def test_check_db_catches_any_exception(self):
+        self.mock_client.get_version.side_effect = Exception("unknown error")
+        status, reason = self.monitor.check_database_connectivity()
+        assert status == HealthStatus.DOWN
+
+    def test_run_all_checks_never_raises(self):
+        """Even if everything explodes, run_all_checks should not crash."""
+        self.mock_client.check_health.side_effect = Exception("total failure")
+        self.mock_client.get_version.side_effect = Exception("total failure")
+        # Should not raise
+        transitions = self.monitor.run_all_checks()
+        assert isinstance(transitions, list)
+
+
+# --- Interval validation tests (M2 fix) ---
+
+
+class TestIntervalValidation:
+    def test_zero_interval_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            HealthMonitor(
+                api_client=MagicMock(),
+                slack_client=MagicMock(),
+                alert_user_id="U12345",
+                interval=0,
+            )
+
+    def test_negative_interval_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            HealthMonitor(
+                api_client=MagicMock(),
+                slack_client=MagicMock(),
+                alert_user_id="U12345",
+                interval=-10,
+            )
+
+
+# --- Recovery downtime calculation tests (H1 fix) ---
+
+
+class TestRecoveryDowntimeCalculation:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.mock_slack_client = MagicMock()
+        self.monitor = HealthMonitor(
+            api_client=self.mock_client,
+            slack_client=self.mock_slack_client,
+            alert_user_id="U12345",
+            interval=60,
+        )
+
+    def test_recovery_uses_down_since_for_downtime(self):
+        """Recovery downtime should be calculated from down_since, not last_alert_sent."""
+        down_time = datetime.now(tz=timezone.utc) - timedelta(minutes=10)
+
+        # Simulate a transition from DOWN → HEALTHY with known down_since
+        transitions = [("backend_api", HealthStatus.DOWN, HealthStatus.HEALTHY, None, down_time)]
+        self.monitor.process_transitions(transitions)
+
+        call_kwargs = self.mock_slack_client.chat_postMessage.call_args[1]
+        # Downtime should be ~10 minutes, not 0
+        assert "10m" in call_kwargs["text"]
+
+    def test_recovery_with_no_down_since_uses_zero(self):
+        """If down_since is None, downtime should be 0."""
+        transitions = [("backend_api", HealthStatus.DOWN, HealthStatus.HEALTHY, None, None)]
+        self.monitor.process_transitions(transitions)
+
+        call_kwargs = self.mock_slack_client.chat_postMessage.call_args[1]
+        assert "0s" in call_kwargs["text"]


### PR DESCRIPTION
## Summary
- New `slack_bot/src/health_monitor.py` — `HealthMonitor` class with `threading.Timer` scheduler that periodically checks backend API (`GET /healthz`) and database connectivity (`GET /version`)
- Sends DM alerts on failure (healthy→down) with actionable suggestions, recovery notifications (down→healthy) with downtime duration
- State-transition-based deduplication — no duplicate alerts for ongoing failures
- Integrated into `slack_bot/src/main.py` — config-driven enable/disable, graceful shutdown
- 3 new env vars in `vars-classification.yaml`: `HEALTH_CHECK_ENABLED`, `HEALTH_CHECK_INTERVAL`, `HEALTH_CHECK_USER_ID`
- Code review: 5 issues fixed (2 HIGH, 3 MEDIUM) — recovery downtime calculation, test assertions, interval validation, config parsing protection
- 37 unit tests, 287 total suite pass, ruff clean

## Test plan
- [x] 37 unit tests covering all 8 Acceptance Criteria
- [x] State tracking, deduplication, recovery, error handling, scheduler lifecycle
- [x] Interval validation (zero/negative rejected)
- [x] Recovery downtime calculated from `down_since` (not `last_alert_sent`)
- [x] Full test suite: 287 passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)