### PR TITLE
docs: combined retrospective for ORM migration (Epics 26-30)

### DIFF
--- a/_bmad-output/implementation-artifacts/epic-26-27-29-30-retro-2026-03-11.md
+++ b/_bmad-output/implementation-artifacts/epic-26-27-29-30-retro-2026-03-11.md
@@ -1,0 +1,102 @@
+# Combined Retrospective: Epics 26, 27, 29, 30 — SQLAlchemy ORM Migration
+
+**Date:** 2026-03-11
+**Scope:** Sprint 9 (Epics 26-29) + Sprint 10 (Epic 30) — Full ORM migration
+**Stories completed:** 15/15 (100%)
+**Facilitator:** Bob (Scrum Master, AI)
+
+## Executive Summary
+
+Complete migration of Project Lenie backend from raw psycopg2 to SQLAlchemy ORM across 4 epics (15 stories). Zero production regressions, 3 SQL injection vulnerabilities fixed as side effect, ~1000 lines of legacy code removed.
+
+## What Went Well
+
+### 1. Incremental Migration Strategy
+The dual-mode constructor pattern (`WebsitesDBPostgreSQL(session=None)`) allowed parallel operation of old/new code without forced big-bang rewrites. Each story could migrate one layer at a time while keeping the system running.
+
+### 2. Strong Foundation (Epic 26)
+Excellent architecture decisions in Epic 26 — engine singleton with thread-safe initialization, dual session strategy (scoped for Flask, plain for scripts), `pool_pre_ping=True`, URL.create() for safe password encoding — made Epics 27-30 straightforward.
+
+### 3. Pattern Reusability
+ORM branches, session mocking, `pytest.importorskip("sqlalchemy")`, enum `.name` comparisons — patterns established in early stories were copied consistently. By Epic 29, new stories were essentially fill-in-the-blanks.
+
+### 4. Zero New Dependencies Beyond Foundation
+Only 3 packages added (SQLAlchemy 2.0.48, pgvector 0.4.2, Alembic 1.18.4), all in Epic 26.1. Epics 27-30 required no additional dependencies.
+
+### 5. Security Improvements as Side Effect
+3 SQL injection vulnerabilities fixed via ORM parameterization:
+- `get_next_to_correct()` — f-string interpolation
+- `get_similar()` — model + project parameters
+- `get_documents_needing_embedding()` — embedding_model parameter
+
+## What Could Be Improved
+
+### 1. Test Environment Limitation
+`uvx pytest` doesn't include SQLAlchemy → ORM tests skip or error. Story 26.2 introduced `pytest.importorskip()` but B-96 code review found 2 test files still missing it (30 errors → fixed). **Action:** Ensure all SQLAlchemy-dependent tests use `importorskip` guard from day one.
+
+### 2. Enum Serialization Confusion
+ORM returns enum members, legacy returns `.name` strings. Multiple code review findings related to this mismatch. B-96 finally resolved it by switching to `String` columns, but the transition period was error-prone. **Action:** When migrating column types, create a checklist of all consumers that read/write the column.
+
+### 3. Incomplete Setter Coverage
+B-96 code review found 5 missing enum values in setter methods (`set_document_state()` and `set_document_state_error()`). These were pre-existing gaps but should have been caught during the SAEnum→String rewrite. **Action:** When rewriting validation logic, always enumerate ALL enum values and verify 1:1 coverage.
+
+### 4. File List Tracking
+B-96 code review found 10 files changed in git but not documented in the story's File List. This was a pattern across multiple stories. **Action:** Run `git diff --name-only` before marking story as "review" and cross-check with File List.
+
+### 5. Story Scope Creep
+Story 29.3 ("old code removal") also deleted re-export stubs, which B-96 then had to handle differently. Story boundaries could be cleaner. **Action:** Define explicit "do not touch" boundaries in story Dev Notes.
+
+## Key Metrics
+
+| Metric | Value |
+|--------|-------|
+| Stories completed | 15/15 |
+| Unit tests added | 300+ |
+| Test files created | 20+ |
+| Production files modified | 30+ |
+| Legacy code removed | ~1000 lines |
+| SQL injection fixes | 3 |
+| Pre-existing bugs found & fixed | 3 |
+| Code review rounds | 15 (one per story) |
+| Code review issues found | ~60 total |
+| Code review issues fixed | ~50 (H+M) |
+
+## Architecture Decisions Validated
+
+1. **Repository pattern** — methods never commit, caller owns transactions. Proved correct across Flask endpoints and batch scripts.
+2. **Session lifecycle split** — `get_scoped_session()` for Flask (teardown cleanup), `get_session()` for scripts (explicit close). No session leaks found.
+3. **Enum as source of truth** — Python enums validate, DB lookup tables enforce via FK. Setter methods bridge the gap. Clean separation.
+4. **STI for document types** — polymorphic_on=document_type works correctly with String column after B-96 migration.
+5. **Alembic baseline approach** — `stamp head` instead of "create from scratch" migration. Avoids drift between init scripts and migration history.
+
+## Technical Debt Status
+
+### Cleared
+- [x] All psycopg2 code removed from production
+- [x] Global database connection singletons eliminated
+- [x] Session management standardized
+- [x] SQL injection in 3 methods fixed
+- [x] Legacy re-export stubs removed (B-96)
+
+### Remaining (Tracked in Backlog)
+- [ ] B-86: 3 more methods with f-string SQL interpolation (`get_similar()`, `get_documents_by_url()`, `get_documents_md_needed()`) — now ORM-parameterized but backlog item still open for review
+- [ ] `document_state_error` type drift (TEXT vs VARCHAR) — suppressed in `include_object()`, needs standardization
+- [ ] Test isolation: `sys.modules` mock ordering issue in full suite (low priority)
+- [ ] AC #6 (autogenerate = empty migration) not verified against live DB
+
+## Action Items
+
+| # | Action | Owner | Priority |
+|---|--------|-------|----------|
+| 1 | Always use `pytest.importorskip("sqlalchemy")` in new ORM test files | Dev | High |
+| 2 | Cross-check `git diff --name-only` vs story File List before review | Dev | Medium |
+| 3 | Enumerate ALL enum values when rewriting validation logic | Dev | Medium |
+| 4 | Standardize `document_state_error` column type (TEXT vs VARCHAR) | Backlog | Low |
+| 5 | Verify Alembic autogenerate produces empty migration on NAS DB | Dev | Low |
+
+## Conclusion
+
+The ORM migration was a well-executed, methodical modernization. The incremental strategy (dual-mode constructor → feature parity → legacy removal) minimized risk and maintained system stability throughout. Code review caught meaningful issues in every story, and the test coverage is comprehensive. The codebase is now in a clean, maintainable state with consistent ORM patterns.
+
+---
+_Retrospective conducted 2026-03-11 by Bob (Scrum Master, AI) with Ziutus (Project Lead)._

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -335,14 +335,14 @@ development_status:
   26-1-dependencies-engine-session-factories: done  # DONE 2026-03-08. SQLAlchemy 2.0.48 + pgvector 0.4.2 + Alembic 1.18.4. Engine singleton (URL.create), Base (DeclarativeBase), get_session/get_scoped_session/dispose_engine. 15 unit tests. Code review: 5 issues fixed (H2 URL encoding + defaults, M3 weak tests + dispose API).
   26-2-orm-models-web-document-website-embedding: done  # WebDocument (26 cols, STI, domain methods, dict()), 6 STI subclasses, WebsiteEmbedding (8 cols, Vector(), cascade). 104 unit tests. Code review #2: H1 pytest.importorskip, M2 full state test coverage, M3 logging. WSL sync verified.
   26-3-alembic-initialization-flask-session-integration: done  # Code review: 8 issues (1H/4M/3L), all H+M fixed. include_object: table-name check + 5 behavioral tests. 20 tests total, ruff clean.
-  epic-26-retrospective: optional
+  epic-26-retrospective: done  # Combined retro with epics 27, 29, 30: epic-26-27-29-30-retro-2026-03-11.md
 
   # --- Epic 27: Document CRUD & API Serving ---
   epic-27: done
   27-1-document-persistence-crud-via-orm: done
   27-2-repository-queries-list-count-state-lookups: done
   27-3-flask-api-endpoints-crud-routes-via-repository: done
-  epic-27-retrospective: optional
+  epic-27-retrospective: done  # Combined retro: epic-26-27-29-30-retro-2026-03-11.md
 
   # --- Epic 28: Vector Embeddings & Similarity Search ---
   epic-28: done
@@ -355,7 +355,7 @@ development_status:
   29-1-import-scripts-migration: done
   29-2-batch-pipeline-youtube-processing-migration: done
   29-3-old-code-removal-final-verification: done  # DONE 2026-03-10. Removed all legacy psycopg2 branches from WebsitesDBPostgreSQL (630→270 lines). Replaced stalker_web_document.py + stalker_web_document_db.py with ORM re-exports. Migrated 3 experimental scripts. Zero cursor.execute() in production code. 386 tests pass, ruff clean.
-  epic-29-retrospective: optional
+  epic-29-retrospective: done  # Combined retro: epic-26-27-29-30-retro-2026-03-11.md
 
   # ============================================================
   # SPRINT 10: Database Lookup Tables & Search Extensions
@@ -368,7 +368,7 @@ development_status:
   B-95-add-foreign-key-constraints-to-web-documents-and-websites-embeddings: done  # FK constraints on document_state, document_state_error, document_type, embedding model. Depends on B-94. Code review: 5M/3L, 2 fixed (test coverage + schema prefix), 1 deferred (integration test).
   B-96-update-sqlalchemy-orm-models-for-lookup-table-relationships: done  # ORM models for lookup tables, ForeignKey + relationship() instead of SAEnum. Depends on B-95. Includes: B-95/M5 FK constraint integration tests. Code review: 4M/2L fixed (missing setter states, importorskip, File List, CLAUDE.md).
   B-97-install-unaccent-and-pg-trgm-extensions-on-existing-databases: done  # DONE 2026-03-10 (NAS). unaccent('Łódź')→'Lodz', similarity('Warszawa','Warszawie')→0.58. AWS RDS deferred. ADR-009.
-  epic-30-retrospective: optional
+  epic-30-retrospective: done  # Combined retro: epic-26-27-29-30-retro-2026-03-11.md
 
   # ============================================================
   # DONE (completed backlog items — historical record)


### PR DESCRIPTION
## Summary
- Combined retrospective for Epics 26, 27, 29, 30 (SQLAlchemy ORM migration)
- 15 stories, 300+ tests, ~1000 lines legacy code removed, 3 SQL injection fixes
- Sprint-status updated: all 4 epic retrospectives marked as done

## Test plan
- [x] No code changes — documentation only
- [x] Pre-commit hooks passed (gitleaks, TruffleHog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)