### PR TITLE
feat: add Business Source License 1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Project Lenie is a personal AI assistant for collecting, managing, and searching data using LLMs. Named after the protagonist from Peter Watts' novel "Starfish," it helps users collect links/references, download and store webpage content, transcribe YouTube videos, and assess information reliability.
 
-**Current version**: 0.3.13.0 | **Status**: Active development
+**Current version**: 0.3.13.0 | **Status**: Active development | **License**: [BSL 1.1](LICENSE) (converts to Apache 2.0 on 2030-03-12)
 
 ## Common Commands
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,69 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             Krzysztof Jozwiak
+Licensed Work:        lenie-server-2025
+                      A personal AI assistant for collecting, managing, and
+                      searching data using LLMs. The Licensed Work is (c) 2025-2026
+                      Krzysztof Jozwiak.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      such use does not include offering the Licensed Work to
+                      third parties on a hosted or embedded basis which is
+                      competitive with Krzysztof Jozwiak's products or services.
+                      "Hosted or embedded basis" means providing the functionality
+                      of the Licensed Work to third parties as a managed service,
+                      platform service, or as part of a "software as a service"
+                      (SaaS) offering, where the service provides users with
+                      access to any substantial set of the features or
+                      functionality of the Licensed Work.
+Change Date:          2030-03-12
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact the Licensor at krzysztof@lenie-ai.eu.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently
+in effect as described in this License, you must purchase a commercial license
+from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of
+the Licensed Work. If you receive the Licensed Work in original or modified form
+from a third party, the terms and conditions set forth in this License apply to
+your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ See [Current Architecture](#current-architecture) for a detailed breakdown of wh
 
 See [CLAUDE.md](CLAUDE.md) for the full architecture reference.
 
+## License
+
+This project is licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
+
+- **What this means:** You can freely view, copy, modify, and use the code. Production use is permitted as long as you are not offering it as a competing managed/hosted service.
+- **Anti-cloud-provider clause:** Providing the functionality of this software to third parties as a managed service, platform service, or SaaS offering is not permitted under this license.
+- **Change Date:** On **2030-03-12**, the license automatically converts to the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), a fully permissive open-source license.
+
+BSL 1.1 is a "source-available" license created by MariaDB and adopted by companies such as HashiCorp, Sentry, and CockroachDB. It is not OSI-approved as "open-source." For details, see the [BSL 1.1 FAQ](https://mariadb.com/bsl-faq-mariadb/).
+
 ## Supported Platforms
 
 | Platform | Support |

--- a/_bmad-output/implementation-artifacts/31-1-add-bsl-1-1-license.md
+++ b/_bmad-output/implementation-artifacts/31-1-add-bsl-1-1-license.md
@@ -1,0 +1,96 @@
+# Story 31.1: Add Business Source License 1.1 to Repository
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **project owner**,
+I want to add a Business Source License 1.1 (BSL 1.1) to the repository,
+so that the project is protected from unauthorized commercial use by cloud providers while remaining open for community use and automatically converting to a permissive open-source license after a defined period.
+
+## Acceptance Criteria
+
+1. **Given** the repository has no LICENSE file, **when** BSL 1.1 is added, **then** a `LICENSE` file exists in the repository root containing the full BSL 1.1 text.
+2. **Given** the BSL 1.1 license is applied, **when** a cloud provider attempts to offer the software as a managed service, **then** the Additional Use Grant explicitly prohibits this use case (anti-cloud-provider clause).
+3. **Given** the BSL 1.1 license includes a Change Date, **when** the Change Date is reached (4 years from initial commit), **then** the license automatically converts to Apache 2.0 (or MPL 2.0 — confirm with project owner).
+4. **Given** the LICENSE file is created, **when** the project README is reviewed, **then** a license section/badge references BSL 1.1 with a brief explanation of the terms.
+5. **Given** the BSL 1.1 license is applied, **when** any source file header is reviewed, **then** no per-file license headers are required (license applies at repository level via LICENSE file).
+
+## Tasks / Subtasks
+
+- [x] Task 1: Create LICENSE file with BSL 1.1 text (AC: #1, #2, #3)
+  - [x] 1.1 Use the official BSL 1.1 template from MariaDB/Hashicorp examples
+  - [x] 1.2 Fill in Licensor: Krzysztof Jozwiak
+  - [x] 1.3 Fill in Licensed Work: "lenie-server-2025" with description
+  - [x] 1.4 Fill in Additional Use Grant: explicitly prohibit offering as managed/hosted service (anti-cloud-provider clause)
+  - [x] 1.5 Fill in Change Date: 2030-03-12
+  - [x] 1.6 Fill in Change License: Apache License, Version 2.0
+- [x] Task 2: Update README.md with license information (AC: #4)
+  - [x] 2.1 Add "License" section to README.md referencing BSL 1.1
+  - [x] 2.2 Briefly explain: what BSL 1.1 means, what the anti-cloud clause covers, when it converts to open-source
+
+## Dev Notes
+
+- **BSL 1.1** was created by MariaDB and is used by companies like HashiCorp (Terraform, Vault), Sentry, CockroachDB, and others to protect against cloud provider exploitation while keeping code source-available.
+- The license is **not OSI-approved** — it is a "source-available" license, not "open-source" per OSI definition. This distinction should be noted in README.
+- The **Additional Use Grant** is the key customizable clause — it defines what additional uses are permitted beyond non-production use. For Lenie, the restriction should focus on preventing cloud providers from offering it as a competing managed service.
+- The **Change Date** triggers automatic conversion to a fully permissive license (Apache 2.0 or MPL 2.0). 4 years is a common choice (HashiCorp uses 4 years).
+- No code changes required — this is a documentation/governance task only.
+- The `shared_python/unified-config-loader/` package has its own identity but is part of this repo — BSL 1.1 at the repo root covers all contents.
+
+### Project Structure Notes
+
+- LICENSE file goes in the repository root (`/LICENSE`)
+- README.md is in the repository root (`/README.md`)
+- No per-file headers needed — single LICENSE file covers the entire repository
+- No impact on build, CI/CD, or runtime behavior
+
+### References
+
+- [BSL 1.1 Official FAQ](https://mariadb.com/bsl-faq-mariadb/)
+- [BSL 1.1 License Template](https://mariadb.com/bsl11/)
+- [HashiCorp BSL adoption](https://www.hashicorp.com/license-faq) — reference for anti-cloud-provider clause wording
+- [Source: sprint-status.yaml] — story 31-1-add-bsl-1-1-license definition
+- [Source: CLAUDE.md] — project overview and structure
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+No debug issues encountered.
+
+### Completion Notes List
+
+- Created LICENSE file with full BSL 1.1 text. Licensor: Krzysztof Jozwiak. Licensed Work: lenie-server-2025. Additional Use Grant: anti-cloud-provider clause prohibiting managed/hosted/SaaS offerings. Change Date: 2030-03-12. Change License: Apache License 2.0.
+- Added "License" section to README.md before "Supported Platforms" section. Explains BSL 1.1 terms, anti-cloud clause, Change Date, and notes it is source-available (not OSI open-source).
+- No code changes — documentation/governance only. All existing tests pass (49 passed, 20 skipped).
+
+### Senior Developer Review (AI)
+
+- **Review Date:** 2026-03-12
+- **Review Outcome:** Approve (after fixes)
+- **Issues Found:** 0 High, 3 Medium, 1 Low — all fixed
+- **Action Items:**
+  - [x] M1: Added contact email (krzysztof@lenie-ai.eu) to LICENSE
+  - [x] M2: Fixed copyright year to 2025-2026
+  - [x] M3: Fixed README License section — production use is permitted (not restricted to non-production)
+  - [x] L1: Added license reference to CLAUDE.md project overview line
+
+### Change Log
+
+- 2026-03-12: Created LICENSE (BSL 1.1) and updated README.md with license section.
+- 2026-03-12: Code review fixes — added contact email, fixed copyright year, corrected README wording, added license to CLAUDE.md.
+
+### File List
+
+- LICENSE (new)
+- README.md (modified)
+- CLAUDE.md (modified)
+- _bmad-output/implementation-artifacts/31-1-add-bsl-1-1-license.md (modified)
+- _bmad-output/implementation-artifacts/sprint-status.yaml (modified)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-03-10
+# generated: 2026-03-12
 # project: lenie-server-2025
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-03-10
+generated: 2026-03-12
 project: lenie-server-2025
 project_key: NOKEY
 tracking_system: file-system
@@ -236,13 +236,13 @@ development_status:
   # ============================================================
 
   # --- Bug Fixes ---
-  B-85-website-get-returns-500-for-nonexistent-id: backlog  # GET /website_get?id=<nonexistent> returns HTTP 500 instead of 404. Backend should return 404 with clear error message when document ID does not exist. Found during Story 22.1 verification.
+  # B-85: moved to Sprint 11, Epic 31 (story 31-2)
 
   # --- Project Governance ---
-  B-87-add-bsl-1-1-license: backlog  # Add Business Source License 1.1 (BUSL-1.1) to the repository. Allows personal/internal use, modification, and redistribution. Prohibits offering the software as a competing commercial hosted/managed service (anti-cloud-provider clause, similar to Elastic/HashiCorp model). After 4 years each version auto-converts to open-source (Change License: Apache 2.0 or MPL 2.0 — TBD). GitHub natively supports BUSL-1.1 in choosealicense.com and license detection. Steps: (1) choose Additional Use Grant wording and Change License, (2) create LICENSE file with BSL 1.1 text and project-specific parameters, (3) add license headers to source files, (4) update README with license section.
+  # B-87: moved to Sprint 11, Epic 31 (story 31-1)
 
   # --- Code Quality ---
-  B-86-parameterize-sql-in-remaining-db-methods: backlog  # SQL injection: get_similar(), get_documents_by_url(), get_documents_md_needed() use f-string interpolation instead of %s parameterized queries. get_next_to_correct() fixed in Story 27.2 code review. Same vulnerability pattern fixed in get_list() (Story 22.2). Found during code review.
+  # B-86: moved to Sprint 11, Epic 31 (story 31-3)
   B-81-expand-code-duplication-control: backlog  # pylint duplicate-code added to Makefile (make duplicate-check). Next: jscpd for cross-language (Python+TS), expand scope, CI integration, fix known duplicates (connect_kwargs, serialization).
 
   # --- Phase 2.5: API Contract & Type Safety ---
@@ -261,7 +261,7 @@ development_status:
   B-55-remove-stale-api-gateway-deployments: backlog  # Remove 36 stale API Gateway deployments left from manual/ad-hoc deploys.
 
   # --- Phase 4: MCP Server Foundation ---
-  B-56-database-abstraction-layer: backlog  # Separate raw psycopg2 queries from business logic. Prerequisite for MCP server and testability.
+  # B-56: moved to Sprint 11, Epic 32 (stories 32-1, 32-2, 32-3)
   B-57-implement-mcp-server-protocol: backlog  # Expose search/retrieve endpoints as MCP tools. Follow MCP specification.
   B-58-claude-desktop-integration: backlog  # Configure Lenie-AI as MCP server in Claude Desktop. Test search and retrieve workflows.
   B-59-api-adaptation-for-mcp-tool-consumption: backlog  # Adapt API response formats for MCP tool consumption patterns.
@@ -280,23 +280,23 @@ development_status:
   22-1-nas-deployment-end-to-end-verification: done
   22-2-backend-api-response-fixes-conditional: done
   22-3-dm-text-command-parsing-simplified: done
-  epic-22-retrospective: optional
+  epic-22-retrospective: done  # Combined retro: epic-22-23-24-25-retro-2026-03-12.md
 
   # --- Epic 23: Channel App Mentions ---
   epic-23: done
   23-1-app-mention-event-handler-thread-responses: done  # DONE 2026-03-04. Implemented in PR #64 (commit c9d01c5). mention_handler.py with thread responses, shared command handlers from dm_handler.py, 21 unit tests, manifest updated (app_mentions:read scope + app_mention event). Version bumped to 0.2.0.
-  epic-23-retrospective: optional
+  epic-23-retrospective: done  # Combined retro: epic-22-23-24-25-retro-2026-03-12.md
 
   # --- Epic 24: Conversational LLM Intelligence ---
   epic-24: done
   24-1-llm-intent-parser: done  # DONE 2026-03-05. Backend /ai_parse_intent endpoint + slack_bot intent_parser.py + DM/mention handler LLM fallback chain. 27 backend tests, 214 slack_bot tests (22 new). Version 0.3.0. Code review: 6 issues fixed (H1 unused import, H2 dead param, M1 unimplemented cmd UX, M3 input sanitization, M4 missing test).
   24-2-semantic-search-via-natural-language: done  # DONE. Code review: 7 issues (0H/4M/3L). M1 sprint-status fixed. M2-M4, L1-L3 as follow-up action items. 250 tests, ruff clean.
-  epic-24-retrospective: optional
+  epic-24-retrospective: done  # Combined retro: epic-22-23-24-25-retro-2026-03-12.md
 
   # --- Epic 25: Proactive Health Monitoring ---
   epic-25: done
   25-1-scheduled-health-checks-proactive-alerts: done
-  epic-25-retrospective: optional
+  epic-25-retrospective: done  # Combined retro: epic-22-23-24-25-retro-2026-03-12.md
 
   # --- Phase 6: Obsidian Integration ---
   B-60-obsidian-vault-integration: backlog  # Synchronization between Lenie-AI and Obsidian vault — linking, note creation, bidirectional sync.
@@ -369,6 +369,24 @@ development_status:
   B-96-update-sqlalchemy-orm-models-for-lookup-table-relationships: done  # ORM models for lookup tables, ForeignKey + relationship() instead of SAEnum. Depends on B-95. Includes: B-95/M5 FK constraint integration tests. Code review: 4M/2L fixed (missing setter states, importorskip, File List, CLAUDE.md).
   B-97-install-unaccent-and-pg-trgm-extensions-on-existing-databases: done  # DONE 2026-03-10 (NAS). unaccent('Łódź')→'Lodz', similarity('Warszawa','Warszawie')→0.58. AWS RDS deferred. ADR-009.
   epic-30-retrospective: done  # Combined retro: epic-26-27-29-30-retro-2026-03-11.md
+
+  # ============================================================
+  # SPRINT 11: Code Quality, Security & Service Layer
+  # ============================================================
+
+  # --- Epic 31: Security Fixes & Project Governance ---
+  epic-31: in-progress
+  31-1-add-bsl-1-1-license: done  # B-87: Add Business Source License 1.1 to repository. Anti-cloud-provider clause, auto-converts to Apache 2.0/MPL 2.0 after 4 years.
+  31-2-fix-website-get-404-for-nonexistent-id: backlog  # B-85: GET /website_get?id=<nonexistent> returns 500 instead of 404. Return proper 404 with clear error message.
+  31-3-parameterize-sql-in-remaining-db-methods: backlog  # B-86: SQL injection fix in get_similar(), get_documents_by_url(), get_documents_md_needed(). Replace f-string interpolation with %s parameterized queries.
+  epic-31-retrospective: optional
+
+  # --- Epic 32: Service Layer Extraction ---
+  epic-32: backlog
+  32-1-extract-document-service-from-flask-routes: backlog  # B-56: Extract business logic (save, delete, download flow) from server.py routes into DocumentService. Eliminates duplication for MCP server.
+  32-2-extract-search-service-for-similarity-queries: backlog  # B-56: Extract search/similarity logic into SearchService. Prepares clean interface for MCP (B-57).
+  32-3-migrate-import-scripts-to-service-layer: backlog  # B-56: Migrate import scripts (dynamodb_sync, unknown_news_import, batch pipeline) to use service layer instead of direct ORM.
+  epic-32-retrospective: optional
 
   # ============================================================
   # DONE (completed backlog items — historical record)


### PR DESCRIPTION
## Summary

- Add BSL 1.1 license with anti-cloud-provider clause (prohibits offering as managed/hosted/SaaS service)
- Licensor: Krzysztof Jozwiak, Change Date: 2030-03-12, auto-converts to Apache License 2.0
- README.md updated with License section explaining terms
- CLAUDE.md updated with license reference

## Test plan

- [x] LICENSE file exists in repo root with correct BSL 1.1 text
- [x] Additional Use Grant contains anti-cloud-provider clause
- [x] Change Date and Change License fields are correct
- [x] README.md License section accurately describes terms
- [x] Contact email included in LICENSE
- [x] No regressions — backend unit tests pass (49 passed, 20 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)