### PR TITLE
fix: validate S3 bucket exists before processing loop

### DIFF
--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -64,11 +64,19 @@ if __name__ == '__main__':
 
     print(f"Using >{cfg.get('EMBEDDING_MODEL')}< for embedding")
 
+    aws_session = boto3.Session(region_name=cfg.get("AWS_REGION"))
+    try:
+        sts = aws_session.client("sts")
+        identity = sts.get_caller_identity()
+        print(f"AWS account: {identity['Account']}, identity: {identity['Arn']}")
+    except Exception as e:
+        print(f"WARNING: Could not determine AWS identity: {e}")
+
     if not cfg.get("AWS_S3_WEBSITE_CONTENT"):
         print("The S3 bucket for text and html files is not set, exiting.")
         exit(1)
 
-    s3_check = boto3.Session(region_name=cfg.get("AWS_REGION")).client("s3")
+    s3_check = aws_session.client("s3")
     try:
         s3_check.head_bucket(Bucket=cfg.get("AWS_S3_WEBSITE_CONTENT"))
     except Exception as e:

--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -68,6 +68,13 @@ if __name__ == '__main__':
         print("The S3 bucket for text and html files is not set, exiting.")
         exit(1)
 
+    s3_check = boto3.Session(region_name=cfg.get("AWS_REGION")).client("s3")
+    try:
+        s3_check.head_bucket(Bucket=cfg.get("AWS_S3_WEBSITE_CONTENT"))
+    except Exception as e:
+        print(f"S3 bucket '{cfg.get('AWS_S3_WEBSITE_CONTENT')}' is not accessible: {e}")
+        exit(1)
+
     if not os.path.exists(cfg.get('CACHE_DIR')):
         os.makedirs(cfg.get('CACHE_DIR'))
 

--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -68,7 +68,12 @@ if __name__ == '__main__':
     try:
         sts = aws_session.client("sts")
         identity = sts.get_caller_identity()
-        print(f"AWS account: {identity['Account']}, identity: {identity['Arn']}")
+        actual_account = identity['Account']
+        print(f"AWS account: {actual_account}, identity: {identity['Arn']}")
+        expected_account = cfg.get("AWS_ACCOUNT_ID")
+        if expected_account and actual_account != expected_account:
+            print(f"ERROR: AWS account mismatch! Expected: {expected_account}, got: {actual_account}")
+            exit(1)
     except Exception as e:
         print(f"WARNING: Could not determine AWS identity: {e}")
 

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -200,6 +200,11 @@ groups:
   aws:
     description: "AWS credentials and resource identifiers"
     variables:
+      AWS_ACCOUNT_ID:
+        description: "Expected AWS account ID — validated at startup to prevent using wrong credentials"
+        type: config
+        required: false
+        used_by: [docker, local]
       AWS_ACCESS_KEY_ID:
         description: "AWS access key ID for SDK calls"
         type: secret


### PR DESCRIPTION
## Summary

- Add `head_bucket` validation at startup in `web_documents_do_the_needful_new.py`
- Fails fast with a clear error message when the S3 bucket is missing or inaccessible
- Prevents the script from running through hundreds of documents, each hitting `NoSuchBucket` error

## Test plan

- [x] Run script with non-existent bucket — should exit immediately with clear message
- [ ] Run script with valid bucket — should proceed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)