### PR TITLE
feat: add Webshare proxy for YouTube captions

### DIFF
--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 import assemblyai as aai
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled
+from youtube_transcript_api.proxies import WebshareProxyConfig
 
 from sqlalchemy.orm import Session
 
@@ -144,7 +145,17 @@ def process_youtube_url(
             if yt_language == 'pl-PL':
                 yt_language = 'pl'
 
-            ytt_api = YouTubeTranscriptApi()
+            proxy_user = os.environ.get("WEBSHARE_PROXY_USERNAME")
+            proxy_pass = os.environ.get("WEBSHARE_PROXY_PASSWORD")
+            if proxy_user and proxy_pass:
+                proxy_config = WebshareProxyConfig(
+                    proxy_username=proxy_user,
+                    proxy_password=proxy_pass,
+                )
+                ytt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
+                logger.info("Using Webshare proxy for YouTube captions")
+            else:
+                ytt_api = YouTubeTranscriptApi()
             transcript_list = ytt_api.list(youtube_file.video_id)
             available_languages = [trans.language_code for trans in transcript_list]
 

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -354,6 +354,16 @@ groups:
         type: secret
         required: false
         used_by: [docker, local]
+      WEBSHARE_PROXY_USERNAME:
+        description: "Webshare rotating residential proxy username for YouTube captions"
+        type: secret
+        required: false
+        used_by: [docker, local]
+      WEBSHARE_PROXY_PASSWORD:
+        description: "Webshare rotating residential proxy password for YouTube captions"
+        type: secret
+        required: false
+        used_by: [docker, local]
       FIRECRAWL_API_KEY:
         description: "Firecrawl API key for web scraping"
         type: secret


### PR DESCRIPTION
## Summary

- Add optional Webshare rotating residential proxy support for fetching YouTube captions
- When `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD` are set (e.g. in Vault), captions are fetched through Webshare proxy with automatic IP rotation and retry on blocking
- Without these variables, behavior is unchanged (direct connection)
- Uses built-in `WebshareProxyConfig` from `youtube-transcript-api` library (no new dependencies)

## Test plan

- [x] All 91 tests pass (70 passed, 21 skipped)
- [x] Ruff linting passes
- [ ] Manual: Set `WEBSHARE_PROXY_USERNAME` and `WEBSHARE_PROXY_PASSWORD` in Vault
- [ ] Manual: Run `web_documents_do_the_needful_new.py` and verify YouTube captions are fetched via proxy (log: "Using Webshare proxy for YouTube captions")
- [ ] Manual: Verify multiple videos can fetch captions without IP blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)