### PR TITLE
docs: add cleaned BMad Method examples and cleaning script

### DIFF
--- a/docs/bmad-examples/PRD_arch_clean.txt
+++ b/docs/bmad-examples/PRD_arch_clean.txt
@@ -1,0 +1,1476 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯ /bmad-bmm-create-architecture                                                 
+
+
+● Rozumiem. Rozpoczynam workflow tworzenia architektury. Najpierw sprawdzę, czy
+  istnieje już dokument architektury, a następnie odkryję dokumenty wejściowe.
+
+
+● Znalazłem istniejący dokument architektury. Sprawdzam jego zawartość i
+  frontmatter.
+
+
+● Dokument architektury istnieje i ma frontmatter z stepsCompleted. Zgodnie z
+  instrukcjami, ładuję plik kontynuacji.
+
+
+● Dokument jest kompletny (1309 linii). Przeanalizowałem cały plik. Oto
+  podsumowanie:
+
+  ---
+  Witaj ponownie, Ziutus! Znalazłem Twój dokument Architecture dla
+  lenie-server-2025.
+
+  Aktualny stan:
+
+  - Kroki ukończone: [1, 2, 3, 4, 5, 6, 7, 8] — wszystkie kroki
+  - Ostatni krok: 8
+  - Status: complete (ukończony 2026-02-13)
+  - Dokumenty wejściowe: 11 plików załadowanych
+  - Dodatkowo: Sprint 4 architektura ukończona (2026-02-19)
+
+  Sekcje w dokumencie:
+
+  1. Project Context Analysis — przegląd wymagań, ograniczenia techniczne,
+  cross-cutting concerns
+  2. Starter Template Evaluation — analiza wzorców Gen 1 vs Gen 2, wybrany
+  pattern Gen 2+
+  3. Core Architectural Decisions — 6 decyzji krytycznych + 2 ważne (template
+  organization, API GW strategy, CloudFront OAC, Lambda Layers, legacy cleanup)
+  4. Implementation Patterns & Consistency Rules — 7 enforcement rules, naming
+  patterns, process patterns
+  5. Project Structure & Boundaries — directory structure, deploy.ini, layer
+  dependencies
+  6. Architecture Validation Results — coherence, requirements coverage, gap
+  analysis
+  7. Sprint 4 — AWS Infrastructure Consolidation & Tooling — pełna architektura
+  dla 6 historyjek (B-4, B-5, B-11, B-12, B-14, B-19) z API GW consolidation
+  jako najważniejszą
+
+  Architektura jest oznaczona jako READY FOR IMPLEMENTATION — zarówno Sprint 1
+  jak i Sprint 4.
+
+  Co chciałbyś zrobić?
+
+  - [R] Wznowienie — kontynuuj od miejsca gdzie skończyliśmy
+  - [C] Kontynuuj do następnego logicznego kroku (np. nowy sprint/iteracja)
+  - [O] Przegląd wszystkich kroków workflow
+  - [X] Zacznij od nowa (nadpisze istniejącą pracę)
+
+
+❯ C                                                                             
+
+● Architektura jest kompletna (Sprint 1 + Sprint 4). Sprawdzam aktualny PRD,
+  żeby zrozumieć kontekst następnego sprintu.
+
+
+● Przeczytałem cały aktualny PRD. To jest Sprint 6 — migracja z psycopg2 na 
+  SQLAlchemy 2.x ORM z Alembic. Dokument jest kompletny (wszystkie 12 kroków
+  ukończone).
+
+  Teraz załaduję pozostałe dokumenty kontekstowe i przystąpię do tworzenia nowej
+   iteracji architektury. Najpierw załaduję template i dodatkowe dokumenty
+  projektowe.
+
+
+● Teraz załaduję kluczowe dokumenty kontekstowe dla tego PRD — plan migracji
+  SQLAlchemy, data models, i architecture decisions.
+
+
+● Mam teraz pełny obraz kontekstu. Znalazłem następujące dokumenty wejściowe:
+
+  Odkryte dokumenty:
+
+  Typ: PRD
+  Plik: _bmad-output/planning-artifacts/prd.md
+  Status: Sprint 6 — migracja SQLAlchemy ORM
+  ────────────────────────────────────────
+  Typ: PRD Validation
+  Plik: _bmad-output/planning-artifacts/prd-validation-report.md
+  Status: Istnieje
+  ────────────────────────────────────────
+  Typ: Istniejąca architektura
+  Plik: _bmad-output/planning-artifacts/architecture.md
+  Status: Sprint 1 + Sprint 4 (kompletna)
+  ────────────────────────────────────────
+  Typ: Project docs
+  Plik: docs/index.md
+  Status: Indeks dokumentacji
+  ────────────────────────────────────────
+  Typ: Project docs
+  Plik: docs/architecture-backend.md
+  Status: Architektura backendu
+  ────────────────────────────────────────
+  Typ: Project docs
+  Plik: docs/data-models-backend.md
+  Status: Modele danych (PostgreSQL)
+  ────────────────────────────────────────
+  Typ: Project docs
+  Plik: docs/architecture-decisions.md
+  Status: ADR (8 decyzji, w tym ADR-004a o SQLAlchemy)
+
+  Brak (nieznalezione):
+  - Product Brief — brak
+  - UX Design — brak (nie dotyczy — backend refactor)
+  - Research — brak (ale plan migracji jest jednym z inputDocuments w PRD)
+
+  Aktualny PRD dotyczy migracji z raw psycopg2 na SQLAlchemy 2.x ORM z Alembic —
+   to jest sprint 6 (backend data access layer migration). Architektura musi
+  objąć decyzje dotyczące ORM, sesji, repozytoriów, embeddingów pgvector, i
+  migracji Alembic.
+
+  Czy chcesz, żebym załadował jeszcze jakieś dodatkowe dokumenty, zanim przejdę
+  do tworzenia nowej iteracji architektury?
+
+  [C] Kontynuuj do analizy kontekstu projektu
+
+
+❯ C                                                                             
+
+
+● Teraz muszę załadować plan migracji, który jest wskazany jako inputDocument
+  PRD.
+
+
+● Teraz załaduję kluczowe pliki źródłowe, żeby zrozumieć obecną architekturę
+  kodu, który będzie przepisywany.
+
+  (ctrl+o to expand)
+
+● Mam teraz pełny obraz projektu. Przygotowałem analizę kontekstu dla
+  architektury migracji SQLAlchemy.
+
+  ---
+  Ziutus, przejrzałem dokumentację projektu dla lenie-server-2025.
+
+  Znalazłem 43 wymagania funkcjonalne (FR1-FR43) zorganizowane w 7 grup oraz 12 
+  wymagań niefunkcjonalnych (NFR1-NFR12) w 4 kategoriach.
+
+  Kluczowe aspekty architektoniczne, które zauważam:
+
+  - Big-bang rewrite warstwy dostępu do danych — z raw psycopg2 na SQLAlchemy
+  2.x ORM. Trzy klasy (StalkerWebDocument + StalkerWebDocumentDB +
+  WebsitesDBPostgreSQL) → dwie warstwy (ORM model + repository)
+  - Krytyczne NFR: zero raw cursor.execute() w kodzie produkcyjnym, backward
+  compatibility API responses, zachowanie enumów
+  - pgvector integration: cosine_distance() via pgvector-python musi zastąpić
+  ręczny operator <=>
+  - Wielokontekstowe zarządzanie sesjami: Flask (scoped/thread-local) vs skrypty
+   importu (script-scoped) vs batch pipeline
+  - Singleton connection anti-pattern: obecna klasa StalkerWebDocumentDB używa
+  class-level db_conn — thread-unsafe
+  - Pydantic explicite out of scope: PRD jasno definiuje, że schemas Pydantic są
+   odroczone do Phase 2
+
+  Wskaźniki skali:
+
+  - Złożoność projektu: Low (single user, brownfield, brak produkcji)
+  - Domena techniczna: Backend refactor (database access layer)
+  - Cross-cutting concerns: zarządzanie sesjami, backward compatibility API,
+  enum preservation, Alembic baseline
+
+  ---
+  Oto treść, którą dodam do dokumentu architektury:
+
+  # Sprint 6 — SQLAlchemy ORM Migration
+
+  _Continuation of architecture decisions for Sprint 6. Sprint 1 and Sprint 4 
+  decisions remain as foundational context._
+
+  ## Sprint 6 — Project Context Analysis
+
+  ### Requirements Overview
+
+  **Functional Requirements:**
+  43 FRs organized in 7 capability groups:
+  1. **ORM Model Definition (FR1-FR5):** Define `WebDocument` (STI base with
+  document type discriminator) and `WebsiteEmbedding` (dimensionless `Vector()`)
+   as SQLAlchemy 2.x declarative models with domain methods (validate, analyze,
+  set_document_type, set_document_state)
+  2. **Schema Migration (FR6-FR9):** Initialize Alembic, auto-generate migration
+   scripts from model diffs, apply/rollback migrations, stamp existing database
+  as baseline
+  3. **Session & Connection Management (FR10-FR13):** Thread-local scoped
+  sessions for Flask (`get_scoped_session()`), script-scoped sessions for
+  imports/batch (`get_session()`), `pool_pre_ping` for stale connection
+  recovery, `@app.teardown_appcontext` cleanup
+  4. **Document Persistence (FR14-FR19):** CRUD operations via ORM (create,
+  update, delete with cascade, lookup by URL/ID, dict serialization for API
+  responses)
+  5. **Embedding Operations (FR20-FR23):** Add/delete embeddings via ORM
+  relationship, find documents needing embeddings (outer join), similarity
+  search via `pgvector-python` `cosine_distance()`
+  6. **Repository Queries (FR24-FR30):** Dynamic filtered lists, count by
+  type/state, documents ready for download/transcription/correction, last import
+   date — all via SQLAlchemy `select()` queries
+  7. **Consumer Compatibility (FR31-FR43):** Import scripts (`dynamodb_sync.py`,
+   `unknown_news_import.py`), batch pipeline
+  (`web_documents_do_the_needful_new.py`), and Flask API endpoints must produce
+  identical behavior and data formats
+
+  **Non-Functional Requirements:**
+  12 NFRs in 4 categories:
+  - **Code Quality (NFR1-NFR4):** Zero raw `cursor.execute()` in production
+  code, ruff clean, existing unit tests pass, type hints via `Mapped[]`
+  - **Backward Compatibility (NFR5-NFR6):** Enum classes preserved with
+  identical values, database schema identical after migration (Alembic baseline
+  = no diff)
+  - **Maintainability (NFR7-NFR9):** Adding column = 1 file change, adding table
+   = 1 file + 1 Alembic command, no dead code from old architecture
+  - **Dependency Management (NFR10-NFR12):** New deps in `pyproject.toml` with
+  version pins, valid `uv lock`, `.venv_wsl` synchronized
+
+  **Scale & Complexity:**
+
+  - Primary domain: Backend refactor (database access layer migration)
+  - Complexity level: Low (single user, no production data, brownfield rewrite)
+  - Estimated architectural components: 3 new files (engine, models, alembic
+  config) + 2 rewritten files (wrapper, query layer) + 5 updated consumers
+  - Project context: Brownfield — rewriting data layer within existing Flask
+  backend, preserving API contracts
+
+  ### Technical Constraints & Dependencies
+
+  1. **Three-class architecture to two-layer** — current: `StalkerWebDocument`
+  (base) → `StalkerWebDocumentDB` (persistence) → `WebsitesDBPostgreSQL`
+  (queries). Target: ORM model (data + domain methods) + repository (complex
+  queries). The intermediate `StalkerWebDocumentDB` wrapper is eliminated.
+
+  2. **Singleton connection anti-pattern** — `StalkerWebDocumentDB` uses
+  class-level `db_conn = None` shared across all instances. Thread-unsafe for
+  Flask. Must be replaced by SQLAlchemy session factory with proper scoping.
+
+  3. **pgvector partial HNSW indexes** — 5 model-specific partial indexes exist
+  on `websites_embeddings.embedding` (ada-002: 1536, titan-v1: 1536, titan-v2:
+  1024, stella: 1024, bge-m3: 1024). These cannot be defined in the ORM model —
+  must be managed by Alembic migrations.
+
+  4. **`langauge` typo already fixed** — migration `08-fix-language-typo.sql`
+  corrected the column name to `language`. ORM model uses correct spelling.
+
+  5. **Enum storage as varchar** — `document_type`, `document_state`,
+  `document_state_error` stored as string values in the database (not PostgreSQL
+   enum types). ORM model must use string-backed enum mapping.
+
+  6. **Pydantic explicitly out of scope** — PRD defers Pydantic v2 schemas to
+  Phase 2. `dict()` serialization stays on the ORM model for now.
+
+  7. **Lambda compatibility deferred** — SQLAlchemy adds ~30MB to Lambda layers.
+   Lambda/AWS deployment compatibility is not in scope.
+
+  8. **Navigation fields are computed** — `next_id`, `next_type`, `previous_id`,
+   `previous_type` are loaded on construction in
+  `StalkerWebDocumentDB.__init__()` via additional SQL queries. Must become
+  repository-level logic or lazy-loaded transient attributes.
+
+  9. **Mixed SQL safety** — some queries use `psycopg2.sql.SQL` for safe
+  parameterization, others embed strings directly. SQLAlchemy eliminates this
+  inconsistency by default (parameterized queries).
+
+  10. **28 columns in `web_documents`** (including `transcript_needed` added 
+  recently) — ORM model must map all columns exactly to match existing schema 
+  for Alembic baseline.
+
+  ### Cross-Cutting Concerns Identified
+
+  1. **Session lifecycle management** — three distinct contexts (Flask 
+  request-scoped, script-scoped, batch per-document commit) require a unified 
+  session factory with different instantiation patterns. Incorrect scoping 
+  causes connection pool exhaustion or data inconsistency.
+
+  2. **Backward compatibility of API responses** — `dict()` output from ORM 
+  model must produce identical keys and value formats as current 
+  `StalkerWebDocumentDB.dict()`. Consumers (React frontend, import scripts) 
+  depend on exact field names and date formatting (`"YYYY-MM-DD HH:MM:SS"`).
+
+  3. **Enum preservation** — `StalkerDocumentStatus`, `StalkerDocumentType`, 
+  `StalkerDocumentStatusError` are imported across 15+ files. Class names, 
+  member names, and values must remain identical. Re-export from original module
+   paths for zero-change consumer imports.
+
+  4. **Alembic baseline integrity** — ORM model must exactly match existing DDL 
+  (`03-create-table.sql`, `04-create-table.sql`) including column types, 
+  defaults, constraints, and indexes. Any drift causes `alembic revision 
+  --autogenerate` to generate unwanted changes.
+
+  5. **pgvector operator compatibility** — `get_similar()` uses raw SQL with 
+  `<=>` operator. `pgvector-python`'s `cosine_distance()` must produce identical
+   similarity scores and ranking. Verification required with known test vectors.
+
+  ---
+  Co chciałbyś zrobić?
+
+  - [A] Advanced Elicitation — pogłębmy analizę implikacji architektonicznych
+  - [P] Party Mode — przeanalizujmy wymagania z różnych perspektyw
+  architektonicznych
+  - [C] Kontynuuj — zapisz tę analizę i przejdź do oceny starter template
+
+
+❯ C                                                                             
+
+● Zapisuję analizę kontekstu do dokumentu architektury i aktualizuję
+  frontmatter.
+
+  [--- Update: architecture.md — diff removed for readability ---]
+
+● Teraz dopisuję treść Sprint 6 na końcu dokumentu.
+
+
+  [--- Update: architecture.md — diff removed for readability ---]
+
+● Treść zapisana. Ładuję następny krok workflow.
+
+
+● Przeczytałem krok 3 w całości. Ten krok dotyczy oceny starter templates, ale
+  Sprint 6 to brownfield migration wewnątrz istniejącego backendu — nie tworzymy
+   nowego projektu od zera. Podobnie jak Sprint 4, nie ma tu tradycyjnego
+  "starter template" do wyboru.
+
+  Oto moja analiza i treść, którą dodam do dokumentu:
+
+  ---
+  Oto treść, którą dodam do dokumentu:
+
+  ## Sprint 6 — Starter Template Evaluation
+
+  ### Primary Technology Domain
+
+  Backend database access layer migration (Python 3.11, Flask, PostgreSQL +
+  pgvector). No new project or framework — Sprint 6 rewrites the data access
+  layer within the existing Flask backend.
+
+  ### Existing Pattern Reuse
+
+  **Decision:** No external starter template. Use SQLAlchemy 2.x conventions
+  directly, following the project's existing patterns and SQLAlchemy
+  documentation.
+
+  **Rationale:** Sprint 6 does not create a new application. It replaces the
+  internal data access layer (raw psycopg2 → SQLAlchemy ORM) within an
+  established Flask backend. The "starter" is the combination of:
+  1. SQLAlchemy 2.x declarative model conventions (`mapped_column()`,
+  `Mapped[]`, `DeclarativeBase`)
+  2. pgvector-python integration patterns (`Vector()` type, `cosine_distance()`
+  operator)
+  3. Alembic initialization conventions (`alembic init`, `env.py` with engine
+  integration)
+  4. Existing project structure (files live in `backend/library/db/`)
+
+  ### Technology Decisions Already Established
+
+  | Decision | Choice | Source |
+  |----------|--------|--------|
+  | ORM | SQLAlchemy 2.x (`mapped_column()` declarative) | ADR-004a, PRD |
+  | Vector operations | `pgvector-python` native integration | PRD |
+  | Migration tool | Alembic with autogenerate | PRD |
+  | Inheritance | Single Table Inheritance on `web_documents` | PRD |
+  | DB driver | `psycopg2-binary` (retained) | PRD |
+  | Session management | Plain SQLAlchemy (not Flask-SQLAlchemy) | PRD |
+  | Pydantic | Deferred (out of scope) | PRD |
+
+  ### Sprint 6-Specific Pattern Notes
+
+  1. **ORM model file** (`backend/library/db/models.py`) follows SQLAlchemy 2.x
+  declarative style with `Mapped[]` type hints — not the older `Column()` style.
+
+  2. **Engine file** (`backend/library/db/engine.py`) provides factory functions
+   (`get_engine()`, `get_session()`, `get_scoped_session()`) — not a global
+  session object.
+
+  3. **Repository file**
+  (`backend/library/stalker_web_documents_db_postgresql.py`) is rewritten to use
+   `session.execute(select(...))` — preserving existing method signatures and
+  return formats.
+
+  4. **Alembic configuration** follows standard layout: `backend/alembic.ini` +
+  `backend/alembic/env.py` + `backend/alembic/versions/`.
+
+  No starter template evaluation needed — all work builds on established
+  SQLAlchemy conventions within the existing project structure.
+
+  ---
+  Co chciałbyś zrobić?
+
+  - [A] Advanced Elicitation — zbadajmy niestandardowe podejścia
+  - [P] Party Mode — oceńmy kompromisy z różnych perspektyw
+  - [C] Kontynuuj — zapisz i przejdź do decyzji architektonicznych
+
+
+❯ C                                                                             
+
+  [--- Update: architecture.md — diff removed for readability ---]
+
+● Aktualizuję frontmatter.
+
+  [--- Update: architecture.md — diff removed for readability ---]
+
+● Ładuję krok 4 — decyzje architektoniczne.
+
+
+● Przeczytałem krok 4 w całości. Teraz — bazując na PRD, planie migracji,
+  eksploracji kodu i kontekście projektu — identyfikuję decyzje architektoniczne
+   specyficzne dla Sprint 6.
+
+  Wiele decyzji jest już ustalonych (przez PRD i ADR-004a). Skupiam się na
+  pozostałych decyzjach, które muszą być podjęte:
+
+  ---
+  Ziutus, mamy już ustalone przez PRD i ADR-004a:
+  - SQLAlchemy 2.x z mapped_column() declarative
+  - pgvector-python dla operacji wektorowych
+  - Alembic dla migracji
+  - STI na web_documents
+  - Plain SQLAlchemy (nie Flask-SQLAlchemy)
+  - Pydantic odroczone
+
+  Pozostałe decyzje architektoniczne, które musimy podjąć:
+
+  1. Strategia wrapperów — eliminacja vs thin wrapper (Krytyczna)
+
+  Obecna architektura: StalkerWebDocument → StalkerWebDocumentDB →
+  WebsitesDBPostgreSQL
+
+  PRD mówi o eliminacji StalkerWebDocumentDB, ale plan migracji proponuje thin 
+  wrapper delegujący do ORM modelu (z __getattr__/__setattr__).
+
+  Opcje:
+  - (A) Thin wrapper — StalkerWebDocumentDB zostaje jako fasada nad WebDocument
+  ORM. Minimalizuje zmiany w konsumentach (importy się nie zmieniają). Wrapper
+  deleguje do self._model.
+  - (B) Pełna eliminacja — StalkerWebDocumentDB usunięty, konsumenci importują
+  WebDocument bezpośrednio. Re-export StalkerWebDocumentDB = WebDocument w
+  starym module dla backward compatibility.
+  - (C) Re-export tylko — stalker_web_document_db.py zawiera from 
+  library.db.models import WebDocument as StalkerWebDocumentDB. Zero wrappera,
+  zero nowego kodu.
+
+  Dla projektu z jednym developerem, bez produkcji — skłaniam się ku (C) —
+  najprostsze, czyste, zero dead code. Jak Ty to widzisz?
+
+  2. Sesja w repository — parametr vs wewnętrzna (Krytyczna)
+
+  WebsitesDBPostgreSQL musi dostawać sesję SQLAlchemy. Dwie opcje:
+
+  - (A) Sesja jako parametr konstruktora — WebsitesDBPostgreSQL(session). Czyste
+   dependency injection, łatwe testowanie. Flask tworzy sesję per-request i
+  przekazuje.
+  - (B) Repository tworzy sesję sam — WebsitesDBPostgreSQL() wywołuje
+  get_session() wewnętrznie. Mniej zmian w server.py, ale trudniejsze
+  testowanie.
+
+  Dla tego projektu skłaniam się ku (A) — czystsze i przygotowuje na przyszłe
+  testy. Twoja opinia?
+
+  3. Sesja w ORM modelu — metody klasowe vs repository (Ważna)
+
+  PRD definiuje class methods na WebDocument: get_by_id(session, id),
+  get_by_url(session, url). To łączy logikę query z modelem ORM.
+
+  - (A) Classmethods na modelu — WebDocument.get_by_id(session, 5). Wygodne dla
+  prostych lookupów.
+  - (B) Wszystko w repository — model jest czystym data objectem, wszelkie query
+   przechodzą przez repository.
+  - (C) Hybrydowo — proste lookupy jako classmethods, złożone query w
+  repository.
+
+  PRD wyraźnie preferuje (C), co wydaje się rozsądne. Zgadzasz się?
+
+  4. dict() — metoda na modelu vs osobna funkcja (Ważna)
+
+  - (A) Metoda dict() na ORM modelu — jak w PRD. Proste, ale łączy serializację
+  z modelem.
+  - (B) Osobna funkcja to_api_dict(doc) — czysta separacja, przygotowuje na
+  Pydantic w Phase 2.
+
+  PRD jasno definiuje (A) — dict() na modelu. Pydantic przejmie serializację w
+  Phase 2. Trzymamy się tego?
+
+  5. get_similar() — pgvector-python vs raw SQL (Ważna)
+
+  PRD mówi o pgvector-python cosine_distance(), ale plan migracji sugeruje
+  text() raw SQL dla operatora <=>.
+
+  - (A) pgvector-python natywnie —
+  WebsiteEmbedding.embedding.cosine_distance(query_vector) — czyste, typowane,
+  zero raw SQL.
+  - (B) SQLAlchemy text() z raw SQL — text("embedding <=> :vec") — prostsze gdy
+  pgvector-python nie wspiera wszystkich operacji (partial indexes,
+  dimension-specific queries).
+
+  Potrzebuję Twojego wkładu: czy ważniejsze jest zero raw SQL (NFR1), czy
+  prostota implementacji? Proponuję (A) z fallback na text() jeśli natywny
+  operator nie obsługuje partial index filtering.
+
+  6. Obsługa navigation fields (Ważna)
+
+  next_id, previous_id etc. — obecnie ładowane w
+  StalkerWebDocumentDB.__init__().
+
+  - (A) Metoda repository — repo.load_neighbors(doc) wypełnia transient
+  atrybuty.
+  - (B) Lazy property na modelu — @property z dodatkowym query (wymaga sesji w
+  modelu — anty-pattern).
+  - (C) Oddzielne query w route handler — Flask route wywołuje
+  repo.get_neighbors(id, type) osobno.
+
+  Skłaniam się ku (A) — repository wypełnia transient atrybuty, model nie wie o
+  sesji. Twoja preferencja?
+
+
+❯ 4. czy migracja w Pydantic bedzie problematyczna w tym przypadku czy nie? w   
+pozostalych zgadzam sie z Toba                                                  
+
+● Dobre pytanie. Migracja z dict() na modelu do Pydantic nie będzie 
+  problematyczna. Oto dlaczego:
+
+  Ścieżka migracji (Phase 2):
+  # Teraz (Phase 1) — dict() na modelu ORM:
+  return doc.dict()
+
+  # Później (Phase 2) — Pydantic schema:
+  return WebDocumentResponse.model_validate(doc).model_dump()
+
+  Pydantic v2 ma wbudowane from_attributes=True, które czyta atrybuty
+  bezpośrednio z ORM instancji. Nie musisz przechodzić przez dict() — Pydantic
+  czyta pola z obiektu SQLAlchemy wprost. Migracja to:
+  1. Utwórz WebDocumentResponse(BaseModel) z model_config = 
+  ConfigDict(from_attributes=True)
+  2. Zamień doc.dict() → WebDocumentResponse.model_validate(doc).model_dump() w
+  route handlerach
+  3. Usuń dict() z ORM modelu
+
+  Formatowanie dat ("YYYY-MM-DD HH:MM:SS") przeniesie się z dict() do Pydantic
+  field_serializer. Żadnych skomplikowanych refaktorów — czysta podmiana.
+
+  Opcja (B) z osobną funkcją nie ułatwia tego procesu — i tak byś ją zastępował
+  schematem Pydantic. Trzymamy się (A).
+
+  ---
+  Mamy więc wszystkie decyzje ustalone. Oto pełna treść do dokumentu:
+
+  ## Sprint 6 — Core Architectural Decisions
+
+  ### Decision Priority Analysis
+
+  **Critical Decisions (Block Implementation):**
+  1. Wrapper elimination strategy: Re-export only (option C)
+  2. Session in repository: Dependency injection via constructor parameter
+  3. ORM model style: SQLAlchemy 2.x `mapped_column()` with `Mapped[]` type
+  hints (from PRD)
+  4. Vector operations: `pgvector-python` native `cosine_distance()` with
+  `text()` fallback for partial index filtering
+
+  **Important Decisions (Shape Architecture):**
+  5. Query location: Hybrid — simple lookups as classmethods on model, complex
+  queries in repository
+  6. API serialization: `dict()` method on ORM model (clean migration path to
+  Pydantic in Phase 2)
+  7. Navigation fields: Repository method `load_neighbors(doc)` populates
+  transient attributes on model
+
+  **Deferred Decisions (Post-MVP):**
+  - Pydantic v2 schemas for API serialization (Phase 2 —
+  `model_validate(orm_instance)` with `from_attributes=True`)
+  - TypeScript type synchronization via Pydantic -> OpenAPI ->
+  `openapi-typescript` (Phase 2)
+  - Joined Table Inheritance split of `web_documents` by document type (Phase 3)
+  - Lambda/AWS deployment compatibility with SQLAlchemy (separate sprint)
+
+  ### Wrapper Elimination Strategy
+
+  **Decision:** Re-export only — no wrapper class, no delegation layer.
+
+  **Implementation:**
+  - `stalker_web_document.py` becomes: `from library.db.models import
+  WebDocument as StalkerWebDocument`
+  - `stalker_web_document_db.py` becomes: `from library.db.models import
+  WebDocument as StalkerWebDocumentDB`
+  - Consumers that import `StalkerWebDocumentDB` or `StalkerWebDocument`
+  continue working without import changes
+  - Over time, consumers migrate to direct `from library.db.models import
+  WebDocument` imports
+
+  **Rationale:** Single developer, no production code, no need for gradual
+  migration. Re-export provides backward compatibility at zero maintenance cost.
+   The wrapper pattern (`__getattr__`/`__setattr__` delegation) adds complexity
+  without value in this context.
+
+  ### Session Management Strategy
+
+  **Decision:** Dependency injection — session passed as constructor parameter
+  to repository.
+
+  **Implementation:**
+  ```python
+  # Flask (request-scoped):
+  @app.teardown_appcontext
+  def shutdown_session(exception=None):
+      scoped_session.remove()
+
+  # Route handler:
+  session = scoped_session()
+  repo = WebsitesDBPostgreSQL(session)
+  results = repo.get_list(...)
+
+  # Scripts (script-scoped):
+  session = get_session()
+  repo = WebsitesDBPostgreSQL(session)
+  try:
+      # ... work ...
+      session.commit()
+  finally:
+      session.close()
+
+  Rationale: Clean dependency injection makes the repository testable (mock
+  session) and explicit about its database dependency. Flask creates the scoped
+  session, scripts create their own — the repository doesn't care which.
+
+  Query Location Strategy
+
+  Decision: Hybrid — simple lookups as classmethods, complex queries in
+  repository.
+
+  Classmethods on WebDocument:
+  - get_by_id(session, id, reach=False) — single document lookup
+  - get_by_url(session, url) — duplicate detection
+
+  Repository methods (WebsitesDBPostgreSQL):
+  - get_list(...) — dynamic filtered, paginated lists
+  - get_similar(...) — pgvector cosine similarity search
+  - get_count(...), get_count_by_type() — aggregations
+  - get_ready_for_download(), get_youtube_just_added(), get_transcription_done()
+   — state-based queries
+  - get_documents_needing_embedding(model) — outer join query
+  - get_next_to_correct(...) — navigation query
+  - get_last_unknown_news() — source-specific query
+  - load_neighbors(doc) — populates next_id, next_type, previous_id,
+  previous_type
+
+  Rationale: Simple lookups are natural as classmethods (standard SQLAlchemy
+  pattern). Complex queries with joins, dynamic filters, and aggregations belong
+   in the repository to keep the model focused on data definition and domain
+  logic.
+
+  API Serialization Strategy
+
+  Decision: dict() method on ORM model, with clean migration path to Pydantic in
+   Phase 2.
+
+  Implementation: WebDocument.dict() produces identical output to current
+  StalkerWebDocumentDB.dict():
+  - Enum fields serialized as .name (string)
+  - created_at formatted as "YYYY-MM-DD HH:MM:SS" string
+  - Navigation fields (next_id, next_type, previous_id, previous_type) included
+  when populated
+  - All existing dict keys preserved for frontend backward compatibility
+
+  Phase 2 migration path: dict() replaced by
+  WebDocumentResponse.model_validate(doc).model_dump() using Pydantic v2's
+  from_attributes=True. Date formatting moves to field_serializer. No complex
+  refactoring required.
+
+  Vector Operations Strategy
+
+  Decision: pgvector-python native operators as primary approach, SQLAlchemy
+  text() as fallback for edge cases.
+
+  Primary (native):
+  select(WebsiteEmbedding)
+      .order_by(WebsiteEmbedding.embedding.cosine_distance(query_vector))
+      .limit(limit)
+
+  Fallback (text()) — for similarity score calculation and partial index 
+  filtering:
+  similarity = (1 - func.cast(
+      WebsiteEmbedding.embedding.cosine_distance(query_vector),
+      Float
+  )).label("similarity")
+
+  Rationale: NFR1 requires zero raw cursor.execute(). pgvector-python provides
+  native SQLAlchemy operators for cosine_distance(), satisfying this
+  requirement. The text() fallback is only for cases where native operators
+  don't support the full query pattern (e.g., combining similarity with minimum
+  threshold filtering).
+
+  Navigation Fields Strategy
+
+  Decision: Repository method load_neighbors(doc) populates transient
+  attributes.
+
+  Implementation:
+  # On WebDocument model — transient (not mapped to DB):
+  next_id: int | None = None  # not a mapped_column
+  next_type: str | None = None
+  previous_id: int | None = None
+  previous_type: str | None = None
+
+  # In repository:
+  def load_neighbors(self, doc: WebDocument) -> None:
+      # Query for next/previous documents by ID and type
+      # Populate doc.next_id, doc.next_type, etc.
+
+  Rationale: The ORM model should not contain session-dependent logic.
+  Navigation is a query concern — the repository knows how to find neighbors.
+  The model provides transient attributes as data slots. Route handlers call
+  repo.load_neighbors(doc) only when needed (e.g., /website_get endpoint, not
+  /website_list).
+
+  Decision Impact Analysis
+
+  Implementation Sequence:
+  1. Dependencies + engine + session factories (foundation)
+  2. ORM models (WebDocument STI + WebsiteEmbedding with Vector())
+  3. Repository rewrite (WebsitesDBPostgreSQL with SQLAlchemy queries)
+  4. Re-exports (stalker_web_document.py, stalker_web_document_db.py)
+  5. Flask integration (@app.teardown_appcontext, scoped session in route
+  handlers)
+  6. Consumer updates (import scripts, batch pipeline)
+  7. Alembic initialization + baseline stamp
+  8. Old code removal + cleanup
+  9. Verification (unit tests, ruff, manual testing)
+
+  Cross-Component Dependencies:
+  - Engine must exist before models (models import Base)
+  - Models must exist before repository (repository queries ORM models)
+  - Repository must exist before Flask integration (route handlers use
+  repository)
+  - Re-exports must exist before consumer updates (backward compatibility)
+  - Alembic baseline requires models to be complete and matching DDL
+  - Old code removal is last — only after all consumers are migrated and
+  verified
+
+  ---
+
+  **Co chciałbyś zrobić?**
+
+  - **[A]** Advanced Elicitation — zbadajmy innowacyjne podejścia do konkretnych
+   decyzji
+  - **[P]** Party Mode — przejrzyjmy decyzje z wielu perspektyw
+  - **[C]** Kontynuuj — zapisz decyzje i przejdź do wzorców implementacji
+
+
+❯ C                                                                             
+
+
+  [--- Update: architecture.md — 2 edits, diffs removed for readability ---]
+
+● Decyzje zapisane. Ładuję krok 5 — wzorce implementacji.
+
+
+● Przeczytałem krok 5 w całości. Teraz identyfikuję punkty konfliktu specyficzne
+   dla migracji SQLAlchemy — miejsca, gdzie agenci AI mogliby podjąć różne
+  decyzje.
+
+  ---
+  Ziutus, zidentyfikowałem 6 krytycznych punktów konfliktu dla Sprint 6, gdzie
+  agenci AI mogliby implementować niekonsystentnie:
+
+  Oto treść, którą dodam do dokumentu:
+
+  ## Sprint 6 — Implementation Patterns & Consistency Rules
+
+  ### Critical Conflict Points Identified
+
+  6 areas where AI agents could make different choices when implementing the
+  SQLAlchemy migration.
+
+  ### Naming Patterns
+
+  **ORM Model Class Names:**
+  - `WebDocument` (not `WebDocumentModel`, `Document`, `StalkerWebDocument`)
+  - `WebsiteEmbedding` (not `Embedding`, `WebDocumentEmbedding`,
+  `VectorEmbedding`)
+  - Match existing table names exactly: `__tablename__ = "web_documents"`,
+  `__tablename__ = "websites_embeddings"`
+
+  **Column Mapping:**
+  - Use exact database column names in `mapped_column()` — no renaming
+  - Python attribute names = database column names (e.g., `document_type`,
+  `created_at`, `ai_summary_needed`)
+  - Exception: `language` attribute maps to `language` column (typo `langauge`
+  already fixed by migration 08)
+
+  **Module Paths:**
+  - Engine: `backend/library/db/engine.py`
+  - Models: `backend/library/db/models.py`
+  - Repository: `backend/library/stalker_web_documents_db_postgresql.py` (same
+  file, rewritten)
+  - Re-exports: `backend/library/stalker_web_document.py`,
+  `backend/library/stalker_web_document_db.py`
+  - Anti-pattern: Creating `backend/library/db/repository.py` (keep the existing
+   filename)
+
+  ### Structure Patterns
+
+  **ORM Model File Organization (`models.py`):**
+  ```python
+  # 1. Imports (sqlalchemy, pgvector, enums)
+  # 2. Base declaration
+  # 3. WebDocument model (with STI configuration)
+  #    - __tablename__, __mapper_args__
+  #    - Mapped columns (same order as DDL: id, url, document_type, ...)
+  #    - Relationships
+  #    - Transient attributes (next_id, next_type, etc.)
+  #    - Domain methods (set_document_type, set_document_state, validate,
+  analyze)
+  #    - Classmethods (get_by_id, get_by_url)
+  #    - Serialization (dict)
+  # 4. WebsiteEmbedding model
+  #    - __tablename__
+  #    - Mapped columns
+  #    - Relationships
+
+  Engine File Organization (engine.py):
+  # 1. Imports
+  # 2. Module-level engine variable (lazy init)
+  # 3. get_engine() — creates/returns engine singleton
+  # 4. get_session() — returns new Session (for scripts)
+  # 5. get_scoped_session() — returns scoped_session (for Flask)
+
+  Enum Preservation:
+  - Enums stay in their original files:
+  backend/library/models/stalker_document_status.py, etc.
+  - Import path unchanged: from library.models.stalker_document_status import 
+  StalkerDocumentStatus
+  - ORM model imports enums from their original location
+  - Anti-pattern: Moving enums into models.py or creating new enum files
+
+  Format Patterns
+
+  dict() Output Format — Exact Match Required:
+  {
+      "id": 42,
+      "url": "https://...",
+      "title": "...",
+      "document_type": "link",           # enum .name, not .value
+      "document_state": "URL_ADDED",     # enum .name
+      "document_state_error": "NONE",    # enum .name
+      "created_at": "2026-03-07 14:30:00",  # NOT ISO format, NOT datetime 
+  object
+      "language": "pl",
+      "summary": "...",
+      "tags": "...",
+      "text": "...",
+      "paywall": False,                  # Python bool, not 0/1
+      "date_from": "2026-03-07",         # date as string, or None
+      "ai_summary_needed": False,
+      "author": None,
+      "note": None,
+      "s3_uuid": None,
+      "project": None,
+      "text_md": None,
+      "transcript_needed": False,
+      "next_id": 43,                     # transient, only when loaded
+      "next_type": "webpage",
+      "previous_id": 41,
+      "previous_type": "link"
+  }
+  - Anti-pattern: Using datetime.isoformat(), returning enum objects, omitting
+  None fields
+
+  get_list() Return Format — Subset Dict:
+  {
+      "id": 42,
+      "url": "https://...",
+      "title": "...",
+      "document_type": "link",
+      "created_at": "2026-03-07 14:30:00",
+      "document_state": "URL_ADDED",
+      "document_state_error": "NONE",
+      "note": None,
+      "project": None,
+      "s3_uuid": None
+  }
+
+  get_similar() Return Format:
+  {
+      "website_id": 42,
+      "text": "embedded text",
+      "similarity": 0.87,               # float, 1 - cosine_distance
+      "id": 42,
+      "url": "https://...",
+      "language": "pl",
+      "text_original": "original text",
+      "websites_text_length": 1500,
+      "embeddings_text_length": 500,
+      "title": "...",
+      "document_type": "link",
+      "project": None
+  }
+
+  Process Patterns
+
+  Session Lifecycle in Flask Route Handlers:
+  # CORRECT:
+  @app.route("/website_list")
+  def website_list():
+      session = scoped_session()
+      repo = WebsitesDBPostgreSQL(session)
+      results = repo.get_list(...)
+      return jsonify(results)
+  # Session cleaned up by @app.teardown_appcontext
+
+  # WRONG — do NOT:
+  # - Create engine per request
+  # - Call session.close() in route handler (teardown handles it)
+  # - Use global session variable
+  # - Pass session through function parameters chain
+
+  Session Lifecycle in Scripts:
+  # CORRECT:
+  from library.db.engine import get_session
+
+  session = get_session()
+  try:
+      repo = WebsitesDBPostgreSQL(session)
+      # ... work ...
+      session.commit()
+  finally:
+      session.close()
+
+  # WRONG — do NOT:
+  # - Use scoped_session in scripts
+  # - Forget session.close()
+  # - Commit inside repository methods (caller controls transaction)
+
+  Transaction Boundaries:
+  - Repository methods NEVER commit or rollback — caller controls transactions
+  - Flask: implicit commit via scoped session lifecycle
+  - Scripts: explicit session.commit() at logical boundaries
+  - Anti-pattern: session.commit() inside repo.get_list() or
+  repo.embedding_add()
+
+  ORM Model Save/Delete Pattern:
+  # CORRECT — via session directly:
+  doc = WebDocument(url="https://...")
+  session.add(doc)
+  session.commit()
+
+  # Update:
+  doc.title = "New title"
+  session.commit()  # SQLAlchemy dirty tracking handles UPDATE
+
+  # Delete:
+  session.delete(doc)
+  session.commit()  # CASCADE deletes embeddings
+
+  # WRONG — do NOT:
+  # - Add save()/delete() methods to WebDocument model
+  # - Use session.merge() when session.add() suffices
+  # - Manually delete embeddings before document (CASCADE handles it)
+
+  Enforcement Guidelines
+
+  All AI Agents implementing Sprint 6 MUST:
+  1. Use exact database column names in ORM model — no renaming attributes
+  2. Preserve enum imports from original module paths (library.models.*)
+  3. Match dict() output format exactly (date as "YYYY-MM-DD HH:MM:SS" string,
+  enums as .name)
+  4. Pass session as constructor parameter to repository — never create session
+  inside repository
+  5. Never commit/rollback inside repository methods — caller controls
+  transactions
+  6. Use mapped_column() with Mapped[] type hints — not older Column() style
+  7. Keep pgvector HNSW indexes out of ORM model — managed by Alembic only
+
+  Anti-Patterns (NEVER do this):
+  - Move enums into models.py (breaks 15+ import locations)
+  - Add session attribute to ORM model (session belongs to caller)
+  - Use datetime.isoformat() in dict() (frontend expects "YYYY-MM-DD HH:MM:SS")
+  - Create backend/library/db/repository.py (reuse existing filename)
+  - Add save() or delete() methods to ORM model (use
+  session.add()/session.delete())
+  - Call session.commit() inside repository query methods
+
+  ---
+
+  **Co chciałbyś zrobić?**
+
+  - **[A]** Advanced Elicitation — zbadajmy dodatkowe wzorce spójności
+  - **[P]** Party Mode — przejrzyjmy wzorce z różnych perspektyw
+  implementacyjnych
+  - **[C]** Kontynuuj — zapisz wzorce i przejdź do struktury projektu
+
+
+❯ C                                                                             
+
+
+● Linia 1579 to koniec pliku. Dopisuję wzorce implementacji.
+
+  [--- Update: architecture.md — 2 edits, diffs removed for readability ---]
+
+● Wzorce zapisane. Ładuję krok 6 — struktura projektu.
+
+
+● Przeczytałem krok 6. Teraz definiuję strukturę projektu i granice
+  architektoniczne dla Sprint 6.
+
+  ---
+  Oto treść, którą dodam do dokumentu:
+
+  ## Sprint 6 — Project Structure & Boundaries
+
+  ### Complete Directory Structure (Changes Only)
+
+  Files to create (NEW), modify (MOD), or delete (DEL):
+
+  backend/
+  ├── library/
+  │   ├── db/
+  │   │   ├── init.py                                    [NEW] Package init
+  (empty)
+  │   │   ├── engine.py                                      [NEW] get_engine(),
+   get_session(), get_scoped_session(), Base
+  │   │   └── models.py                                      [NEW] WebDocument
+  (STI), WebsiteEmbedding
+  │   ├── stalker_web_document.py                            [MOD] Re-export:
+  WebDocument as StalkerWebDocument
+  │   ├── stalker_web_document_db.py                         [MOD] Re-export:
+  WebDocument as StalkerWebDocumentDB
+  │   ├── stalker_web_documents_db_postgresql.py             [MOD] Rewrite:
+  SQLAlchemy session queries
+  │   ├── models/
+  │   │   ├── stalker_document_status.py                     [NO CHANGE] Enum
+  preserved
+  │   │   ├── stalker_document_type.py                       [NO CHANGE] Enum
+  preserved
+  │   │   └── stalker_document_status_error.py               [NO CHANGE] Enum
+  preserved
+  │   └── ... (other library files unchanged)
+  ├── alembic.ini                                            [NEW] Alembic
+  configuration
+  ├── alembic/
+  │   ├── env.py                                             [NEW] Alembic env
+  (imports Base.metadata, get_engine())
+  │   ├── script.py.mako                                     [NEW] Alembic
+  migration template
+  │   └── versions/                                          [NEW] Migration
+  scripts directory
+  ├── server.py                                              [MOD] Add
+  teardown_appcontext, scoped_session, update route handlers
+  ├── pyproject.toml                                         [MOD] Add
+  sqlalchemy, pgvector, alembic dependencies
+  ├── imports/
+  │   ├── dynamodb_sync.py                                   [MOD] Use ORM model
+   + session instead of wrapper
+  │   └── unknown_news_import.py                             [MOD] Use ORM model
+   + session instead of wrapper
+  ├── web_documents_do_the_needful_new.py                    [MOD] Use ORM model
+   + session instead of wrapper
+  ├── database/
+  │   └── init/
+  │       ├── 03-create-table.sql                            [NO CHANGE]
+  Reference DDL (Alembic baseline source)
+  │       └── 04-create-table.sql                            [NO CHANGE]
+  Reference DDL (Alembic baseline source)
+  └── tests/
+      └── unit/                                              [NO CHANGE]
+  Existing tests must pass
+
+  **File count summary:**
+  - New files: 6 (db/__init__.py, engine.py, models.py, alembic.ini,
+  alembic/env.py, script.py.mako)
+  - Modified files: 8 (stalker_web_document.py, stalker_web_document_db.py,
+  stalker_web_documents_db_postgresql.py, server.py, pyproject.toml,
+  dynamodb_sync.py, unknown_news_import.py, web_documents_do_the_needful_new.py)
+  - Deleted files: 0 (re-export files replace content, not deleted)
+  - New directories: 2 (library/db/, alembic/versions/)
+
+  ### Requirements to Structure Mapping
+
+  | FR Group | Files Affected |
+  |----------|---------------|
+  | FR1-FR5 (ORM Models) | `library/db/models.py` [NEW] |
+  | FR6-FR9 (Alembic) | `alembic.ini` [NEW], `alembic/env.py` [NEW],
+  `alembic/versions/` [NEW] |
+  | FR10-FR13 (Session Management) | `library/db/engine.py` [NEW], `server.py`
+  [MOD] |
+  | FR14-FR19 (Document Persistence) | `library/db/models.py` [NEW]
+  (classmethods + dict) |
+  | FR20-FR23 (Embedding Operations) | `library/db/models.py` [NEW],
+  `stalker_web_documents_db_postgresql.py` [MOD] |
+  | FR24-FR30 (Repository Queries) | `stalker_web_documents_db_postgresql.py`
+  [MOD] |
+  | FR31-FR34 (Import Scripts) | `imports/dynamodb_sync.py` [MOD],
+  `imports/unknown_news_import.py` [MOD] |
+  | FR35-FR38 (Batch Pipeline) | `web_documents_do_the_needful_new.py` [MOD] |
+  | FR39-FR43 (Flask API) | `server.py` [MOD] |
+
+  ### Architectural Boundaries
+
+  **Data Access Boundary:**
+  All database operations are mediated through two paths:
+  Flask Route / Script
+    |
+    v
+  WebDocument.get_by_id(session, id)  ──or──
+  WebsitesDBPostgreSQL(session).get_list(...)
+    |                                            |
+    v                                            v
+  SQLAlchemy Session                          SQLAlchemy Session
+    |                                            |
+    v                                            v
+  PostgreSQL 18 + pgvector
+
+  No direct `psycopg2` cursor usage anywhere in production code. All database
+  access flows through SQLAlchemy session.
+
+  **Model Boundary:**
+  - `library/db/models.py` — defines data structure, domain methods, simple
+  lookups
+  - `stalker_web_documents_db_postgresql.py` — complex queries, aggregations,
+  vector search
+  - Models know nothing about HTTP, Flask, or API response formats (except
+  `dict()` for backward compat)
+  - Repository knows nothing about Flask routes or request handling
+
+  **Session Boundary:**
+  - `library/db/engine.py` — the ONLY place that creates sessions and engines
+  - `server.py` — the ONLY place that creates scoped sessions for Flask
+  - Scripts — each creates its own session via `get_session()`
+  - No session creation inside models or repository
+
+  **Enum Boundary:**
+  - Enums live in `library/models/` — unchanged
+  - ORM model imports enums from their original location
+  - No enum definitions inside `library/db/models.py`
+
+  ### Development Workflow
+
+  **For the migration, the agent workflow is:**
+  1. Add dependencies to `pyproject.toml`, run `uv lock`
+  2. Create `library/db/__init__.py`, `engine.py`, `models.py`
+  3. Verify model matches DDL: `python -c "from library.db.models import
+  WebDocument, WebsiteEmbedding; print('OK')"`
+  4. Rewrite `stalker_web_documents_db_postgresql.py` with SQLAlchemy queries
+  5. Create re-exports in `stalker_web_document.py` and
+  `stalker_web_document_db.py`
+  6. Update `server.py` (teardown, scoped session, route handlers)
+  7. Update import scripts and batch pipeline
+  8. Initialize Alembic: `alembic init alembic`, configure `env.py`
+  9. Stamp baseline: `alembic stamp head`
+  10. Run tests: `cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v`
+  11. Run linter: `uvx ruff check backend/`
+  12. Sync `.venv_wsl`
+
+  ---
+  Co chciałbyś zrobić?
+
+  - [A] Advanced Elicitation — zbadajmy innowacyjne podejścia do organizacji
+  projektu
+  - [P] Party Mode — przejrzyjmy strukturę z różnych perspektyw
+  - [C] Kontynuuj — zapisz strukturę i przejdź do walidacji architektury
+
+
+❯ c                                                                             
+
+
+  [--- Update: architecture.md — 2 edits, diffs removed for readability ---]
+
+● Struktura zapisana. Ładuję krok 7 — walidacja architektury.
+
+
+● Przeczytałem krok 7. Przeprowadzam walidację architektury Sprint 6.
+
+  ---
+  Podsumowanie walidacji:
+
+  - ✅ Koherencja: Wszystkie decyzje współpracują ze sobą
+  - ✅ Pokrycie: Wszystkie 43 FR i 12 NFR mają wsparcie architektoniczne
+  - ✅ Gotowość: Agenci AI mogą implementować konsystentnie
+
+  Oto treść walidacji:
+
+  ## Sprint 6 — Architecture Validation Results
+
+  ### Coherence Validation
+
+  **Decision Compatibility:**
+  All Sprint 6 architectural decisions work together without conflicts.
+  Re-export strategy (decision 1) is compatible with session injection (decision
+   2) — re-exported classes are the same ORM model that receives sessions via
+  repository. Hybrid query location (decision 3) aligns with session injection —
+   classmethods accept session parameter, repository receives session in
+  constructor. The `dict()` on model (decision 4) is self-contained and does not
+   conflict with any other decision. pgvector-python native operators (decision
+  5) work with SQLAlchemy session-based queries. Navigation fields via
+  repository (decision 6) respect the session boundary — model has no session
+  dependency.
+
+  **Pattern Consistency:**
+  Implementation patterns fully support the architectural decisions. Naming
+  patterns (exact column names, existing module paths) ensure backward
+  compatibility required by the re-export strategy. Format patterns (exact
+  `dict()` output) preserve API contracts. Process patterns (transaction
+  boundaries, session lifecycle) enforce the session injection decision
+  consistently across Flask and script contexts. No contradictions between
+  patterns and decisions.
+
+  **Structure Alignment:**
+  The project structure supports all decisions. New files
+  (`library/db/engine.py`, `library/db/models.py`) align with the two-layer
+  architecture (ORM model + repository). Re-export files
+  (`stalker_web_document.py`, `stalker_web_document_db.py`) stay at their
+  existing paths for backward compatibility. Repository stays in its existing
+  file. Alembic configuration follows standard layout. All boundaries (data
+  access, model, session, enum) are structurally enforced by file organization.
+
+  ### Requirements Coverage Validation
+
+  **Functional Requirements Coverage:**
+
+  | FR Group | Status | Architectural Support |
+  |----------|--------|----------------------|
+  | FR1-FR5 (ORM Models) | Covered | `library/db/models.py`: WebDocument (STI) +
+   WebsiteEmbedding (Vector) |
+  | FR6-FR9 (Alembic) | Covered | `alembic.ini` + `alembic/env.py` + baseline
+  stamp |
+  | FR10-FR13 (Session Management) | Covered | `engine.py`:
+  get_engine/session/scoped_session, server.py: teardown |
+  | FR14-FR19 (Document Persistence) | Covered | ORM session.add/commit/delete,
+  WebDocument.get_by_id/url, dict() |
+  | FR20-FR23 (Embedding Operations) | Covered | WebsiteEmbedding ORM model,
+  cosine_distance() in repository |
+  | FR24-FR30 (Repository Queries) | Covered | WebsitesDBPostgreSQL rewritten 
+  with SQLAlchemy select() |
+  | FR31-FR34 (Import Scripts) | Covered | dynamodb_sync.py,
+  unknown_news_import.py use ORM + session |
+  | FR35-FR38 (Batch Pipeline) | Covered | web_documents_do_the_needful_new.py 
+  uses ORM + session |
+  | FR39-FR43 (Flask API) | Covered | server.py with scoped_session, repository
+  per request |
+
+  **Non-Functional Requirements Coverage:**
+
+  | NFR | Status | Architectural Support |
+  |-----|--------|----------------------|
+  | NFR1 (Zero cursor.execute) | Covered | All queries via SQLAlchemy session,
+  pgvector-python operators |
+  | NFR2 (ruff clean) | Covered | Enforcement guideline: run ruff before marking
+   complete |
+  | NFR3 (Unit tests pass) | Covered | Tests don't touch DB layer — no changes
+  needed |
+  | NFR4 (Type hints) | Covered | Mapped[] type hints on all ORM columns |
+  | NFR5 (Enum preservation) | Covered | Enums unchanged in original files,
+  re-exported |
+  | NFR6 (Schema identical) | Covered | Alembic baseline = no diff against DDL |
+  | NFR7 (1-file column add) | Covered | mapped_column() in models.py only |
+  | NFR8 (1-file table add) | Covered | New model class in models.py + alembic 
+  autogenerate |
+  | NFR9 (No dead code) | Covered | Re-export files replace old code, no wrapper
+   remnants |
+  | NFR10 (Dependencies pinned) | Covered | pyproject.toml with version ranges |
+  | NFR11 (uv lock valid) | Covered | Development workflow step 1 |
+  | NFR12 (.venv_wsl synced) | Covered | Development workflow step 12 |
+
+  ### Implementation Readiness Validation
+
+  **Decision Completeness:**
+  All 7 architectural decisions are documented with rationale and code examples.
+   Session management has examples for both Flask and script contexts. Vector
+  operations show both native and fallback patterns. Re-export strategy shows
+  exact import statements. No ambiguity in any decision.
+
+  **Structure Completeness:**
+  Project structure lists all 6 new files, 8 modified files, and 2 new
+  directories with [NEW]/[MOD] annotations. Requirements-to-structure mapping
+  covers every FR group. Architectural boundaries (data access, model, session,
+  enum) are defined with diagrams.
+
+  **Pattern Completeness:**
+  6 conflict points identified and resolved. Naming patterns cover model
+  classes, column mapping, and module paths. Format patterns include exact
+  dict() output for all three return types (full, list, similar). Process
+  patterns cover session lifecycle, transaction boundaries, and save/delete
+  operations. 7 enforcement rules and 6 anti-patterns documented.
+
+  ### Gap Analysis Results
+
+  **Critical Gaps:** None found.
+
+  **Important Gaps (Addressed):**
+
+  1. **`get_similar()` similarity score calculation** — the formula `1 - 
+  cosine_distance` must be computed in SQLAlchemy, not Python. The 
+  pgvector-python `cosine_distance()` returns distance (0=identical, 
+  2=opposite). The similarity score `1 - distance` must be computed as a SQL 
+  expression for correct sorting. *Resolution: Documented in Vector Operations 
+  Strategy with `func.cast` example.*
+
+  2. **Transient attributes on ORM model** — `next_id`, `next_type`, 
+  `previous_id`, `previous_type` must NOT be `mapped_column()`. They should be 
+  plain Python attributes with `__init__` defaults or class-level defaults. 
+  SQLAlchemy's `__init__` behavior with declarative models requires care. 
+  *Resolution: Documented in Navigation Fields Strategy with explicit `= None` 
+  class-level defaults.*
+
+  **Nice-to-Have Gaps (Deferred):**
+
+  3. Unit tests for ORM model `dict()` output — verifying backward compatibility
+   with known test data. Useful but belongs in implementation, not architecture.
+  4. Performance benchmarks for SQLAlchemy vs raw psycopg2 — informational but 
+  not blocking. Single-user system with no performance-sensitive workload.
+
+  ### Architecture Completeness Checklist
+
+  **Requirements Analysis**
+
+  - [x] Project context thoroughly analyzed (brownfield backend refactor, single
+   dev)
+  - [x] Scale and complexity assessed (low — 6 new + 8 modified files)
+  - [x] Technical constraints identified (10 constraints including singleton 
+  anti-pattern, pgvector indexes, enum storage)
+  - [x] Cross-cutting concerns mapped (session lifecycle, backward compat, enum 
+  preservation, Alembic baseline, pgvector compat)
+
+  **Architectural Decisions**
+
+  - [x] Critical decisions documented with rationale (4 critical + 3 important)
+  - [x] Technology stack fully specified (SQLAlchemy 2.x, pgvector-python, 
+  Alembic, psycopg2-binary driver)
+  - [x] Integration patterns defined (session injection, re-exports, hybrid 
+  query location)
+  - [x] Deferred decisions explicitly listed with rationale (Pydantic, 
+  TypeScript sync, JTI, Lambda)
+
+  **Implementation Patterns**
+
+  - [x] Naming conventions established (model classes, column mapping, module 
+  paths)
+  - [x] Structure patterns defined (model file organization, engine file 
+  organization, enum preservation)
+  - [x] Format patterns specified (dict() output, get_list() format, 
+  get_similar() format)
+  - [x] Process patterns documented (session lifecycle Flask/scripts, 
+  transaction boundaries, save/delete)
+
+  **Project Structure**
+
+  - [x] Complete directory structure defined (NEW/MOD annotations)
+  - [x] Component boundaries established (data access, model, session, enum)
+  - [x] Integration points mapped (two data access paths diagram)
+  - [x] Requirements to structure mapping complete (FR -> file table)
+
+  ### Architecture Readiness Assessment
+
+  **Overall Status:** READY FOR IMPLEMENTATION
+
+  **Confidence Level:** High — all critical decisions made, no blocking gaps, 
+  patterns comprehensive with code examples, backward compatibility explicitly 
+  addressed.
+
+  **Key Strengths:**
+
+  1. **Clean two-layer architecture** — ORM model + repository replaces 
+  three-class hierarchy with zero wrapper overhead
+  2. **Explicit backward compatibility** — re-exports preserve all existing 
+  import paths, dict() format exact match documented
+  3. **Session injection** — testable, explicit, supports all three contexts 
+  (Flask, scripts, batch)
+  4. **Comprehensive anti-patterns** — 6 explicitly forbidden patterns prevent 
+  common SQLAlchemy migration mistakes
+  5. **Clear migration path to Pydantic** — dict() on model today, Pydantic 
+  model_validate() tomorrow, no refactoring needed
+
+  **Areas for Future Enhancement:**
+
+  1. Pydantic v2 schemas for API serialization (Phase 2)
+  2. TypeScript type synchronization via Pydantic -> OpenAPI (Phase 2)
+  3. Joined Table Inheritance split of web_documents (Phase 3)
+  4. Lambda/AWS deployment compatibility with SQLAlchemy (separate sprint)
+  5. Repository unit tests with mock sessions
+
+  ### Implementation Handoff
+
+  **AI Agent Guidelines:**
+
+  - Follow all Sprint 6 architectural decisions exactly as documented
+  - Use implementation patterns consistently: naming, structure, format, process
+  - Respect all 4 architectural boundaries (data access, model, session, enum)
+  - Match dict() output format exactly for backward compatibility
+  - Never commit inside repository methods — caller controls transactions
+  - Verify Alembic baseline produces no diff against existing DDL
+
+  **First Implementation Priority:**
+
+  1. Dependencies + engine (foundation — everything depends on this)
+  2. ORM models (WebDocument STI + WebsiteEmbedding with Vector())
+  3. Repository rewrite (SQLAlchemy queries preserving signatures)
+
+  **Implementation Sequence (Full):**
+
+  Phase A (foundation):  pyproject.toml -> uv lock -> library/db/init.py ->
+  engine.py
+  Phase B (models):      models.py (WebDocument + WebsiteEmbedding)
+  Phase C (repository):  stalker_web_documents_db_postgresql.py rewrite
+  Phase D (compat):      stalker_web_document.py + stalker_web_document_db.py
+  re-exports
+  Phase E (Flask):       server.py (teardown, scoped session, route handlers)
+  Phase F (consumers):   dynamodb_sync.py + unknown_news_import.py +
+  web_documents_do_the_needful_new.py
+  Phase G (Alembic):     alembic init + env.py config + stamp head
+  Phase H (verify):      pytest + ruff + manual test + .venv_wsl sync
+
+
+  ---
+  Co chciałbyś zrobić?
+
+  - [A] Advanced Elicitation — rozwiążmy złożone problemy architektoniczne
+  - [P] Party Mode — przejrzyjmy walidację z różnych perspektyw
+  - [C] Kontynuuj — zapisz walidację i zakończ workflow
+
+
+❯ C                                                                             
+
+
+  [--- Update: architecture.md — 2 edits, diffs removed for readability ---]
+
+● Walidacja zapisana. Ładuję krok 8 — zakończenie workflow.
+
+
+● Aktualizuję frontmatter na status kompletny.
+
+  [--- Update: architecture.md — diff removed for readability ---]
+
+● Teraz ładuję instrukcje help.
+
+
+● Ziutus, architektura Sprint 6 jest kompletna!
+
+  ---
+  Wspólnie stworzyliśmy kompleksowy dokument architektury dla migracji z raw
+  psycopg2 na SQLAlchemy 2.x ORM. Oto co osiągnęliśmy:
+
+  Podsumowanie:
+  - 7 decyzji architektonicznych — re-export, session injection, hybrid queries,
+   dict() na modelu, pgvector-python native, navigation via repository
+  - 6 wzorców implementacji z konkretnymi przykładami kodu i anti-patternami
+  - 43 FR + 12 NFR — wszystkie pokryte architektonicznie
+  - 8 faz implementacji (A-H) z jasną kolejnością zależności
+  - 4 granice architektoniczne (data access, model, session, enum)
+  - Dokument gotowy do użycia przez agentów AI jako single source of truth
+
+  ---
+  Następne kroki w workflow BMad:
+
+  Jesteś w fazie 3-solutioning. Architektura jest gotowa. Kolejne wymagane kroki
+   to:
+
+  1. Create Epics and Stories (wymagane)
+  /bmad-bmm-create-epics-and-stories
+  John (Product Manager) — stworzenie epików i historyjek na podstawie PRD i
+  architektury
+  2. Check Implementation Readiness (wymagane)
+  /bmad-bmm-check-implementation-readiness
+  Winston (Architect) — walidacja spójności PRD, architektury i epików
+  3. Następnie faza 4-implementation: Sprint Planning → Create Story → Dev Story
+
+  Zalecenie: każdy workflow uruchamiaj w nowym oknie kontekstowym dla
+  najlepszych wyników.
+
+  Masz pytania dotyczące dokumentu architektury?
+

--- a/docs/bmad-examples/PRD_example_2_clean.txt
+++ b/docs/bmad-examples/PRD_example_2_clean.txt
@@ -1,0 +1,361 @@
+
+
+  ⎿  Referenced file _bmad-output\planning-artifacts\prd.md
+  ⎿  Read backend\imports\CLAUDE.md (126 lines)
+  ⎿  Read backend\CLAUDE.md (163 lines)
+  ⎿  Read _bmad-output\planning-artifacts\archive\prd-sprint6-notion-changelog-2
+     026-03-07.md (270 lines)
+  ⎿  Referenced file backend\web_documents_do_the_needful_new.py
+  ⎿  Skills restored (bmad-agent-bmm-pm)
+
+
+● 🎯 Advanced Elicitation — PRD Polish
+
+  Wybieram 5 metod najlepiej dopasowanych do polishing PRD migracji SQLAlchemy:
+
+  #: 1
+  Metoda: Pre-mortem Analysis
+  Kategoria: risk
+  Dlaczego pasuje: Wyobraź sobie, że migracja się nie udała — co poszło nie tak?
+
+    Doskonałe do identyfikacji ryzyk, których nie uwzględniliśmy
+  ────────────────────────────────────────
+  #: 2
+  Metoda: Cross-Functional War Room
+  Kategoria: collaboration
+  Dlaczego pasuje: PM + inżynier + architekt omawiają trade-offy między
+    feasibility, desirability i viability migracji
+  ────────────────────────────────────────
+  #: 3
+  Metoda: Challenge from Critical Perspective
+  Kategoria: risk
+  Dlaczego pasuje: Advocatus diaboli atakuje założenia PRD — eliminuje
+  groupthink
+    i wzmacnia dokument
+  ────────────────────────────────────────
+  #: 4
+  Metoda: What If Scenarios
+  Kategoria: creative
+  Dlaczego pasuje: "Co jeśli pgvector-python nie wspiera naszego use case?", "Co
+
+    jeśli Alembic autogenerate nie wykrywa zmian?" — kontyngencje
+  ────────────────────────────────────────
+  #: 5
+  Metoda: Self-Consistency Validation
+  Kategoria: advanced
+  Dlaczego pasuje: Sprawdza spójność PRD: czy wymagania funkcjonalne pokrywają
+    się z journey, czy sukces jest mierzalny, czy nic nie jest sprzeczne
+
+  ---
+  Wybierz: numer (1-5), [r] Przetasuj, [a] Pokaż wszystkie 50, [x] Zakończ
+  elicitation i wróć do menu
+
+
+❯ a                                                                             
+
+● 📋 Wszystkie 50 metod Advanced Elicitation
+
+  Collaboration (1-10)
+
+  ┌─────┬────────────────────┬──────────────────────────────────────────────┐
+  │  #  │       Metoda       │                     Opis                     │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 1   │ Stakeholder Round  │ Wiele person wnosi różne perspektywy —       │
+  │     │ Table              │ balansowanie konkurujących interesów         │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 2   │ Expert Panel       │ Eksperci domenowi prowadzą głęboką analizę   │
+  │     │ Review             │ specjalistyczną                              │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 3   │ Debate Club        │ Dwie persony argumentują przeciwne pozycje,  │
+  │     │ Showdown           │ moderator punktuje                           │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 4   │ User Persona Focus │ Persony użytkowników reagują na propozycje,  │
+  │     │  Group             │ dzielą się frustracjami                      │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 5   │ Time Traveler      │ Przeszły-ty i przyszły-ty doradzają          │
+  │     │ Council            │ obecnemu-tobie                               │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 6   │ Cross-Functional   │ PM + inżynier + designer — trade-offy        │
+  │     │ War Room           │ feasibility/desirability/viability           │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 7   │ Mentor and         │ Senior uczy juniora, junior zadaje naiwne    │
+  │     │ Apprentice         │ pytania — ujawnia ukryte założenia           │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 8   │ Good Cop Bad Cop   │ Wspierająca i krytyczna persona na zmianę    │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 9   │ Improv Yes-And     │ Persony budują na pomysłach innych bez       │
+  │     │                    │ blokowania                                   │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 10  │ Customer Support   │ Zły klient + support — ujawnia prawdziwe     │
+  │     │ Theater            │ frustracje                                   │
+  └─────┴────────────────────┴──────────────────────────────────────────────┘
+
+  Advanced (11-16)
+
+  ┌─────┬─────────────────────────┬──────────────────────────────────────────┐
+  │  #  │         Metoda          │                   Opis                   │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 11  │ Tree of Thoughts        │ Eksploracja wielu ścieżek rozumowania    │
+  │     │                         │ jednocześnie                             │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 12  │ Graph of Thoughts       │ Sieć połączonych idei ujawnia ukryte     │
+  │     │                         │ relacje                                  │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 13  │ Thread of Thought       │ Spójna narracja przez długi kontekst     │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 14  │ Self-Consistency        │ Wiele niezależnych podejść → porównanie  │
+  │     │ Validation              │ spójności                                │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 15  │ Meta-Prompting Analysis │ Analiza samej metodologii i podejścia    │
+  ├─────┼─────────────────────────┼──────────────────────────────────────────┤
+  │ 16  │ Reasoning via Planning  │ Drzewo rozumowania z modelem świata i    │
+  │     │                         │ stanami docelowymi                       │
+  └─────┴─────────────────────────┴──────────────────────────────────────────┘
+
+  Competitive (17-19)
+
+  ┌─────┬─────────────────┬─────────────────────────────────────────────────┐
+  │  #  │     Metoda      │                      Opis                       │
+  ├─────┼─────────────────┼─────────────────────────────────────────────────┤
+  │ 17  │ Red Team vs     │ Atak-obrona — szukanie luk bezpieczeństwa       │
+  │     │ Blue Team       │                                                 │
+  ├─────┼─────────────────┼─────────────────────────────────────────────────┤
+  │ 18  │ Shark Tank      │ Pitch przed sceptycznymi inwestorami —          │
+  │     │ Pitch           │ stress-test wartości biznesowej                 │
+  ├─────┼─────────────────┼─────────────────────────────────────────────────┤
+  │ 19  │ Code Review     │ Seniorzy z różnymi filozofiami recenzują ten    │
+  │     │ Gauntlet        │ sam kod                                         │
+  └─────┴─────────────────┴─────────────────────────────────────────────────┘
+
+  Technical (20-24)
+
+  ┌─────┬─────────────────────────┬─────────────────────────────────────────┐
+  │  #  │         Metoda          │                  Opis                   │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 20  │ Architecture Decision   │ Architekci proponują i debatują wybory  │
+  │     │ Records                 │ z trade-offami                          │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 21  │ Rubber Duck Debugging   │ Tłumaczenie na coraz bardziej           │
+  │     │ Evolved                 │ technicznych poziomach                  │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 22  │ Algorithm Olympics      │ Podejścia rywalizują na benchmarkach    │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 23  │ Security Audit Personas │ Haker + obrońca + audytor z różnych     │
+  │     │                         │ modeli zagrożeń                         │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 24  │ Performance Profiler    │ DB expert + frontend + DevOps           │
+  │     │ Panel                   │ diagnozują wydajność                    │
+  └─────┴─────────────────────────┴─────────────────────────────────────────┘
+
+  Creative (25-30)
+
+  ┌─────┬────────────┬──────────────────────────────────────────────────────┐
+  │  #  │   Metoda   │                         Opis                         │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │ 25  │ SCAMPER    │ 7 soczewek kreatywności: Substitute/Combine/Adapt/Mo │
+  │     │ Method     │ dify/Put/Eliminate/Reverse                           │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │ 26  │ Reverse En │ Od pożądanego wyniku wstecz do implementacji         │
+  │     │ gineering  │                                                      │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │ 27  │ What If    │ Alternatywne rzeczywistości — kontyngencje i         │
+  │     │ Scenarios  │ eksploracja                                          │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │     │ Random     │                                                      │
+  │ 28  │ Input      │ Losowe koncepty burzą blokady kreatywne              │
+  │     │ Stimulus   │                                                      │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │     │ Exquisite  │                                                      │
+  │ 29  │ Corpse     │ Każda persona dodaje widząc tylko poprzedni wkład    │
+  │     │ Brainstorm │                                                      │
+  ├─────┼────────────┼──────────────────────────────────────────────────────┤
+  │ 30  │ Genre      │ Łączenie niepowiązanych domen — innowacja przez      │
+  │     │ Mashup     │ krzyżowanie                                          │
+  └─────┴────────────┴──────────────────────────────────────────────────────┘
+
+  Research (31-33)
+
+  ┌─────┬─────────────────────────┬─────────────────────────────────────────┐
+  │  #  │         Metoda          │                  Opis                   │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 31  │ Literature Review       │ Optymista + sceptyk + syntezator        │
+  │     │ Personas                │ oceniają źródła                         │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 32  │ Thesis Defense          │ Student broni hipotezy przed komisją    │
+  │     │ Simulation              │                                         │
+  ├─────┼─────────────────────────┼─────────────────────────────────────────┤
+  │ 33  │ Comparative Analysis    │ Analitycy oceniają opcje wg ważonych    │
+  │     │ Matrix                  │ kryteriów                               │
+  └─────┴─────────────────────────┴─────────────────────────────────────────┘
+
+  Risk (34-38)
+
+  ┌─────┬───────────────────────────┬───────────────────────────────────────┐
+  │  #  │          Metoda           │                 Opis                  │
+  ├─────┼───────────────────────────┼───────────────────────────────────────┤
+  │ 34  │ Pre-mortem Analysis       │ Wyobraź sobie porażkę i zapobiegaj    │
+  │     │                           │ jej                                   │
+  ├─────┼───────────────────────────┼───────────────────────────────────────┤
+  │ 35  │ Failure Mode Analysis     │ Systematyczna analiza jak każdy       │
+  │     │                           │ komponent może zawieść                │
+  ├─────┼───────────────────────────┼───────────────────────────────────────┤
+  │ 36  │ Challenge from Critical   │ Advocatus diaboli stress-testuje      │
+  │     │ Perspective               │ pomysły                               │
+  ├─────┼───────────────────────────┼───────────────────────────────────────┤
+  │ 37  │ Identify Potential Risks  │ Brainstorm ryzyk we wszystkich        │
+  │     │                           │ kategoriach                           │
+  ├─────┼───────────────────────────┼───────────────────────────────────────┤
+  │ 38  │ Chaos Monkey Scenarios    │ Celowo psuj rzeczy, testuj odporność  │
+  └─────┴───────────────────────────┴───────────────────────────────────────┘
+
+  Core (39-44)
+
+  ┌─────┬──────────────────────────┬────────────────────────────────────────┐
+  │  #  │          Metoda          │                  Opis                  │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 39  │ First Principles         │ Od fundamentalnych prawd, bez założeń  │
+  │     │ Analysis                 │                                        │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 40  │ 5 Whys Deep Dive         │ Powtarzaj "dlaczego" aż do root cause  │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 41  │ Socratic Questioning     │ Pytania ujawniające ukryte założenia   │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 42  │ Critique and Refine      │ Systematyczna identyfikacja            │
+  │     │                          │ mocnych/słabych stron                  │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 43  │ Explain Reasoning        │ Krok po kroku pokazanie logiki         │
+  │     │                          │ wniosków                               │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 44  │ Expand or Contract for   │ Dostosowanie głębokości do odbiorcy    │
+  │     │ Audience                 │                                        │
+  └─────┴──────────────────────────┴────────────────────────────────────────┘
+
+  Learning (45-46)
+
+  ┌─────┬────────────────────┬──────────────────────────────────────────────┐
+  │  #  │       Metoda       │                     Opis                     │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 45  │ Feynman Technique  │ Wytłumacz jak dziecku — test prawdziwego     │
+  │     │                    │ zrozumienia                                  │
+  ├─────┼────────────────────┼──────────────────────────────────────────────┤
+  │ 46  │ Active Recall      │ Test bez podglądania — identyfikacja luk     │
+  │     │ Testing            │                                              │
+  └─────┴────────────────────┴──────────────────────────────────────────────┘
+
+  Philosophical (47-48)
+
+  ┌─────┬──────────────────────────┬────────────────────────────────────────┐
+  │  #  │          Metoda          │                  Opis                  │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 47  │ Occam's Razor            │ Najprostsze wystarczające wyjaśnienie  │
+  │     │ Application              │                                        │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 48  │ Trolley Problem          │ Etyczne trade-offy przez dylematy      │
+  │     │ Variations               │ moralne                                │
+  └─────┴──────────────────────────┴────────────────────────────────────────┘
+
+  Retrospective (49-50)
+
+  ┌─────┬──────────────────────────┬────────────────────────────────────────┐
+  │  #  │          Metoda          │                  Opis                  │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 49  │ Hindsight Reflection     │ Spojrzenie z przyszłości na obecne     │
+  │     │                          │ decyzje                                │
+  ├─────┼──────────────────────────┼────────────────────────────────────────┤
+  │ 50  │ Lessons Learned          │ Systematyczne wyciąganie wniosków      │
+  │     │ Extraction               │                                        │
+  └─────┴──────────────────────────┴────────────────────────────────────────┘
+
+  ---
+  Wybierz: numer (1-50), [r] Przetasuj 5 rekomendowanych, [x] Zakończ
+  elicitation i wróć do menu
+
+
+❯ x                                                                             
+
+● 📋 Krok 11/12 — Polish (menu)
+
+  Elicitation zakończona. Wracamy do menu polish.
+
+  PRD przeszło już poprawki w tej fazie:
+  - Usunięcie duplikatu Product Scope
+  - Aktualizacja referencji pgvector → pgvector-python
+  - Korekta języka kompatybilności API ("functionally equivalent")
+  - Korekta Measurable Outcomes (usunięcie wyjątku text())
+
+  ---
+  Wybierz: [P] Party Mode | [C] Kontynuuj do finalizacji PRD (Krok 12/12)
+
+❯ c                                                                             
+
+
+● Teraz zaktualizuję frontmatter PRD, dodając step-12-complete.
+
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● ---
+  ✅ Krok 12/12 — PRD Zakończony!
+
+  Product Requirements Document dla migracji SQLAlchemy jest kompletny i
+  wypolerowany.
+
+  Co zawiera PRD:
+
+  ┌────────────────────────┬────────────────────────────────────────────────┐
+  │         Sekcja         │                   Zawartość                    │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ Executive Summary      │ Cel migracji, kontekst brownfield, podejście   │
+  │                        │ big-bang                                       │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ Project Classification │ api_backend, personal AI knowledge management, │
+  │                        │  medium complexity                             │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ Success Criteria       │ User/Business/Technical success + mierzalne    │
+  │                        │ outcomes                                       │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ 4 User Journeys        │ Nowa tabela źródeł, modyfikacja schematu,      │
+  │                        │ import danych, REST API                        │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ Technical Context      │ Architektura 2-warstwowa, session management,  │
+  │                        │ pgvector-python, zależności                    │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ Project Scoping & Risk │ MVP (5 epików), big-bang strategy, 4 ryzyka z  │
+  │  Mitigation            │ mitigacją                                      │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ 43 Functional          │ FR1-FR43 pokrywające ORM, Alembic, Repository, │
+  │ Requirements           │  pgvector, konsumentów                         │
+  ├────────────────────────┼────────────────────────────────────────────────┤
+  │ 12 Non-Functional      │ NFR1-NFR12: wydajność, bezpieczeństwo, jakość  │
+  │ Requirements           │ kodu, kompatybilność                           │
+  └────────────────────────┴────────────────────────────────────────────────┘
+
+  Co dalej?
+
+  Oto rekomendowane następne kroki w workflow BMad:
+
+  1. Walidacja PRD (opcjonalna, zalecana)
+  - /bmad-bmm-validate-prd — 📋 John (Product Manager)
+  - Sprawdza kompletność, spójność i gotowość do implementacji
+  - Rekomendacja: uruchom w nowym oknie kontekstowym, najlepiej z innym LLM
+
+  2. Create Architecture (wymagany)
+  - /bmad-bmm-create-architecture — 🏗️ Winston (Architect)
+  - Dokumentacja decyzji technicznych, diagramy, wzorce
+  - Bazuje na PRD — szczegóły ORM modeli, session management, repository pattern
+
+  3. Create Epics and Stories (wymagany)
+  - /bmad-bmm-create-epics-and-stories — 📋 John (Product Manager)
+  - Rozbicie 5 epików MVP na implementowalne stories
+
+  4. Check Implementation Readiness (wymagany)
+  - /bmad-bmm-check-implementation-readiness — 🏗️ Winston (Architect)
+  - Walidacja że PRD + Architecture + Epics są spójne i gotowe do developmentu
+
+  ---
+  Wypolerowane PRD służy jako fundament dla całej dalszej pracy. Architektura,
+  design i development powinny się odwoływać do wymagań i wizji udokumentowanych
+   w tym PRD. Aktualizuj go w miarę potrzeb w trakcie dalszego planowania.
+
+  Czy chcesz uruchomić walidację PRD, przejść do architektury, czy coś innego?
+

--- a/docs/bmad-examples/PRD_example_clean.txt
+++ b/docs/bmad-examples/PRD_example_clean.txt
@@ -1,0 +1,1559 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯ /bmad-agent-bmm-pm @.claude/exports/plan-sqlalchemy-migration.md              
+  ⎿  Read .claude\exports\plan-sqlalchemy-migration.md (149 lines)
+
+
+● ---
+  📋 Cześć, Ziutus!
+
+  Jestem John, Twój Product Manager. Widzę, że przekazałeś mi plan migracji na
+  SQLAlchemy ORM + Pydantic Schemas (B-92) — solidny dokument techniczny.
+
+  Oto co mogę dla Ciebie zrobić:
+
+  1. [MH] Wyświetl ponownie menu pomocy
+  2. [CH] Porozmawiaj z agentem o czymkolwiek
+  3. [CP] Stwórz PRD — ekspercka facylitacja tworzenia dokumentu wymagań
+  produktowych
+  4. [VP] Walidacja PRD — sprawdź kompletność, spójność i organizację PRD
+  5. [EP] Edytuj PRD — zaktualizuj istniejący dokument wymagań
+  6. [CE] Stwórz Epiki i Stories — specyfikacje napędzające development
+  7. [IR] Gotowość do implementacji — upewnij się, że PRD, UX, architektura i
+  epiki są zsynchronizowane
+  8. [CC] Korekta kursu — co robić gdy w trakcie implementacji pojawia się
+  potrzeba dużych zmian
+  9. [PM] Party Mode
+  10. [DA] Pożegnaj agenta
+
+  W każdej chwili możesz wpisać /bmad-help, żeby uzyskać poradę co robić dalej.
+  Np. /bmad-help gdzie powinienem zacząć z tym planem migracji na SQLAlchemy.
+
+  Co chciałbyś zrobić?
+
+❯ chce omowic bardzo duza zmiane: @.claude/exports/plan-sqlalchemy-migration.md 
+  ⎿  Read .claude\exports\plan-sqlalchemy-migration.md (149 lines)
+
+● Świetnie, Ziutus — porozmawiajmy o tym planie migracji. Przeczytałem go już na
+   wejściu.
+
+  Zanim wejdziemy w szczegóły, muszę zadać kilka kluczowych pytań, bo ten plan
+  to poważna zmiana architektury — dotyka warstwy danych, która jest kręgosłupem
+   całego systemu.
+
+  ---
+  Pytania na start:
+
+  1. DLACZEGO teraz?
+  Plan mówi, że "dodanie kolumny wymaga zmian w 5+ miejscach". Ile razy w
+  ostatnich 2-3 miesiącach faktycznie dodawałeś kolumny? Czy ten ból jest realny
+   i częsty, czy raczej przewidywany? Bo jeśli to się zdarza raz na kwartał, to
+  koszt migracji może nie być uzasadniony.
+
+  2. Zakres vs. ryzyko:
+  Plan dotyka praktycznie każdego pliku w warstwie danych —
+  stalker_web_document_db.py, stalker_web_documents_db_postgresql.py,
+  stalker_web_document.py, server.py, plus nowe pliki. To nie jest refactor — to
+   przepisanie core'u. Jakie masz zabezpieczenia? Testy integracyjne pokrywają
+  obecne zachowanie?
+
+  3. Trzy cele naraz:
+  Plan łączy:
+  - SQLAlchemy ORM (eliminacja redundancji)
+  - Pydantic schemas (serializacja API)
+  - Alembic (migracje schematu)
+
+  Czy rozważałeś robienie tego sekwencyjnie zamiast w jednym wielkim epiku? Np.
+  najpierw Pydantic schemas na istniejącym kodzie, potem ORM, potem Alembic?
+
+  4. Lambda cold start:
+  Sam plan wspomina ryzyko wzrostu rozmiaru paczki Lambda. Mierzyłeś obecny
+  rozmiar? SQLAlchemy to ~30MB — to może być deal-breaker dla cold startów.
+
+  ---
+  Co jest Twoją główną motywacją — redukcja boilerplate'u, Pydantic dla
+  OpenAPI/TypeScript, czy coś innego? Zacznijmy od DLACZEGO, a potem ocenimy czy
+   plan jest właściwą odpowiedzią.
+
+❯ 1. spodziewam sie dodania nowych tabel, dodania lub usuwania kolumn (np.      
+kazdy dokument w bazie moze miec autora, teraz nie sliedzimy autorow w osobnej  
+tabeli, nie mamy jego biografii itp)  2. jestesmy na etapie pisania kodu od     
+nowa, kod zostanie sprawdzony przez dodawanie nowych danych. 3. nie wiem,       
+przedyskutujmy to 4. lambdy schodza na dalszy plan. najwazniejsze jest by       
+projekt dzialal na loklanym labie czyli NAS. zdalny setup na AWS w chwili       
+obecnej to glownie proxy pozwalajace zbierac dane z komputera, telefonu lub     
+tabletu. Analiza danych jednak bedzie odbywac sie lokalnie na NAS (a raczej nas 
+ bedzie baza danych a claude dekstop i obsydian bedzie glownym uzyciem). AWS    
+zostaje na przyszlosc jako ostatni etap czyli wspoldzielenie rozwiazania z      
+innymi chcacymi placic.                                                         
+
+● Dzięki, Ziutus — to zmienia obraz znacząco. Podsumowuję co słyszę:
+
+  - Ból jest realny i rośnie — nowe tabele (autorzy, biografie) są na horyzoncie
+  - Kod jest przepisywany — więc ryzyko regresji jest niższe, bo nie
+  refaktorujesz "działającej produkcji"
+  - NAS + Claude Desktop + Obsidian to główny use case — AWS to drugorzędny
+  kanał zbierania danych
+
+  ---
+  Dyskusja o sekwencji (punkt 3)
+
+  Masz trzy narzędzia w tym planie, każde rozwiązuje inny problem:
+
+  ┌─────────────────┬───────────────────────────────────────────────────────┐
+  │    Narzędzie    │               Problem który rozwiązuje                │
+  ├─────────────────┼───────────────────────────────────────────────────────┤
+  │ SQLAlchemy ORM  │ Redundancja przy dodawaniu/usuwaniu kolumn            │
+  ├─────────────────┼───────────────────────────────────────────────────────┤
+  │ Pydantic        │ Serializacja API, OpenAPI → TypeScript, structured    │
+  │ schemas         │ outputs AI                                            │
+  ├─────────────────┼───────────────────────────────────────────────────────┤
+  │ Alembic         │ Wersjonowanie zmian schematu DB                       │
+  └─────────────────┴───────────────────────────────────────────────────────┘
+
+  Pytanie: Czy musisz je wdrażać razem, czy mogą iść niezależnie?
+
+  Moja analiza:
+
+  Opcja A — Wszystko naraz (jak w planie):
+  - Zaleta: jedno przepisanie, spójna architektura od razu
+  - Ryzyko: duży scope, trudniej debugować jeśli coś nie gra
+
+  Opcja B — Sekwencyjnie:
+  1. Faza 1: SQLAlchemy ORM + Alembic — to naturalna para, bo Alembic czyta
+  modele ORM. Rozwiązuje Twój główny ból (kolumny w jednym miejscu + migracje)
+  2. Faza 2: Pydantic schemas — dodajesz później, kiedy API stabilizuje się i
+  faktycznie potrzebujesz OpenAPI → TypeScript
+
+  Opcja C — Odwrócona:
+  1. Faza 1: Pydantic schemas na istniejącym kodzie — natychmiast zyskujesz
+  structured outputs dla Claude Desktop
+  2. Faza 2: SQLAlchemy + Alembic — później
+
+  ---
+  Kluczowe pytanie:
+
+  Powiedziałeś, że Claude Desktop + Obsidian to główne użycie. To znaczy, że
+  Pydantic structured outputs (punkt 3 w planie — response format dla AI) mogą
+  być ważniejsze niż myślałem.
+
+  Jak dokładnie Claude Desktop komunikuje się z Twoim systemem? Przez API Flask?
+   Przez MCP? Bezpośrednio z bazą? Bo to wpływa na to, co powinno iść pierwsze:
+
+  - Jeśli Claude Desktop → Flask API → DB — to ORM + Pydantic razem mają sens
+  - Jeśli Claude Desktop → bezpośrednio baza/pliki — to Pydantic dla structured
+  outputs jest ważniejsze niż ORM
+
+  Co wybierasz i jak wygląda ten flow z Claude Desktop?
+
+❯ flow na razie nie ma bo nie mamy danych w bazie danych. czeka nas jeszcze     
+duza praca z oczyszczaniem artykulow z stron inernetowych z zbednych rzeczy     
+(linki na gorze strony jak zobacz inne dzialy serwisu, czy noty prawne i        
+komnetarze na dole), na razie dzialamy z testowymi danymi typu linki oraz       
+zaczynamy prace z tesktami z youtube (co jest raczej bez reklam i zbedych       
+tresci).                                                                        
+
+● OK, rozumiem — jesteście na wczesnym etapie. Dane dopiero wchodzą, pipeline
+  czyszczenia treści jeszcze przed wami. To ważny kontekst.
+
+  Co to zmienia w priorytetach:
+
+  Skoro nie ma jeszcze ustalonego flow z Claude Desktop i dane dopiero się 
+  zbierają, to:
+
+  1. Pydantic structured outputs — nie pilne, bo nie ma jeszcze z czym rozmawiać
+   przez AI
+  2. Pydantic → OpenAPI → TypeScript — nie pilne, bo frontend jest drugorzędny
+  wobec NAS/Obsidian
+  3. SQLAlchemy ORM — to jest Twój realny ból, bo schemat bazy będzie się często
+   zmieniał w miarę jak odkrywasz co trzeba przechowywać (autorzy, biografie,
+  czyszczenie treści pewnie doda nowe kolumny/flagi)
+  4. Alembic — naturalny partner ORM, szczególnie gdy schemat jest niestabilny
+
+  Moja rekomendacja:
+
+  Opcja B — SQLAlchemy ORM + Alembic najpierw, Pydantic później.
+
+  Powody:
+  - Schemat będzie się zmieniał często (nowe tabele, kolumny) — to jest
+  dokładnie ten ból który ORM + Alembic rozwiązuje
+  - Pydantic możesz dodać w dowolnym momencie obok ORM — nie wymaga
+  przepisywania
+  - Mniejszy scope = szybciej skończysz i wrócisz do właściwej pracy
+  (czyszczenie treści, YouTube)
+
+  Pytania zanim zamkniemy temat scope'u:
+
+  1. Plan wspomina nową tabelę autorów. Czy masz już pomysł jakie inne nowe 
+  tabele mogą się pojawić? (tagi, kategorie, źródła, oceny wiarygodności?) To
+  wpływa na to jak zaprojektować Base i relacje.
+
+  2. Obecny kod ma dwie klasy: StalkerWebDocument (model) i StalkerWebDocumentDB
+   (wrapper DB) i stalker_web_documents_db_postgresql (query functions). Plan
+  proponuje utrzymać wrapper. Czy naprawdę potrzebujesz tę warstwę pośrednią,
+  czy to dobry moment żeby ją wyeliminować i mieć po prostu ORM model +
+  repository?
+
+  3. Ile masz teraz testów jednostkowych pokrywających warstwę danych? Zero,
+  kilka, dużo? To determinuje jak agresywnie możesz przepisywać.
+
+❯ nie mam na razie pomyslow, zastanawiam sie nawet czy glowna tabela nie        
+powinna zostac podzielona ze wzgledu na typy danych (np. linki niepotrzebuja    
+spisu tresci i rozdzialow).  2. Kiedys byl pomysl aby oprocz bazy danych        
+postgresql wspierac np. elastic search bo podobno on fajnie pracuje z tekstem.  
+natomiast jest do dalszy plan, obecnie postgresql to jedyna baza danych, ktora  
+planuje uzywac. stad jest osobna klasa na DB i osobna abstrakcja na dokument.   
+
+● Dwa bardzo ważne tematy. Rozpakujmy je:
+
+  ---
+  Temat 1: Podział tabeli web_documents po typach
+
+  To jest klasyczny dylemat: single-table vs. table-per-type. Masz 28 kolumn, z
+  których część ma sens tylko dla pewnych typów (np. transcript_needed tylko dla
+   YouTube, spis treści tylko dla webpage).
+
+  Ale uwaga — to decyzja, którą SQLAlchemy ORM obsługuje elegancko przez
+  dziedziczenie:
+
+  - Single Table Inheritance — jedna tabela, kolumna type jako dyskryminator,
+  nieużywane kolumny = NULL
+  - Joined Table Inheritance — wspólna tabela documents + podtabele
+  youtube_documents, link_documents itd.
+
+  Nie musisz decydować teraz. Jeśli zaczniesz od Single Table Inheritance (czyli
+   jak jest dziś), to przejście na Joined Table to migracja Alembic + zmiana w 
+  modelu ORM, bez przepisywania logiki biznesowej. Właśnie po to robimy tę
+  migrację.
+
+  Moja rekomendacja: zacznij jak jest (jedna tabela), ale w modelu ORM od razu
+  użyj dziedziczenia — WebDocument jako bazowa klasa, LinkDocument,
+  YouTubeDocument itd. jako podklasy. Wtedy podział tabeli w przyszłości to
+  zmiana konfiguracji, nie architektury.
+
+  ---
+  Temat 2: Warstwa abstrakcji na DB
+
+  Mówisz, że wrapper istnieje na wypadek zmiany backendu (ElasticSearch). Ale
+  sam mówisz, że to daleki plan i PostgreSQL to jedyna baza.
+
+  Zasada YAGNI — You Ain't Gonna Need It. Utrzymywanie abstrakcji "na wszelki
+  wypadek" to koszt który płacisz przy każdej zmianie, teraz:
+  - Każda nowa kolumna = zmiana w ORM modelu + zmiana w wrapperze
+  - Każda nowa metoda = implementacja w dwóch miejscach
+  - Debugowanie przez dodatkową warstwę
+
+  Moja rekomendacja: Wyrzuć wrapper. Zostaw:
+  - ORM model (WebDocument) — definicja danych + metody domenowe
+  - Repository (obecny stalker_web_documents_db_postgresql.py) — złożone query
+  (listy, wyszukiwanie, statystyki)
+
+  Jeśli kiedyś ElasticSearch wejdzie do gry, wyciągniesz interfejs wtedy — mając
+   już dojrzały kod łatwiej zrobić abstrakcję niż wymyślać ją z góry.
+
+  ---
+  Podsumowując dotychczasową dyskusję:
+
+  Wyłania się zrewidowany plan:
+
+  1. SQLAlchemy ORM z dziedziczeniem modeli (przygotowanie na podział tabeli)
+  2. Alembic (migracje schematu)
+  3. Eliminacja wrappera StalkerWebDocumentDB — ORM model + repository
+  bezpośrednio
+  4. Pydantic — odłożone na później
+
+  Zanim zapiszę to jako zrewidowany plan, jedno ostatnie pytanie: Nie zapytałem 
+  o testy (pytanie 3 z poprzedniej rundy). Ile masz testów pokrywających obecną
+  warstwę danych? To determinuje czy możemy agresywnie wyrzucić wrapper, czy
+  trzeba zachować ostrożność.
+
+❯ testom nie ufam natomiast to jest wczesny etap, mozemy zadzialac agresywanie  
+bo rozwiazanie nigdy tak naprawde nie dzialalo                                  
+
+● Idealnie — to jest najlepszy moment na agresywne zmiany. Czyste pole.
+
+  Finalna rekomendacja scope'u B-92:
+
+  W scope:
+  1. SQLAlchemy ORM z dziedziczeniem modeli (WebDocument → LinkDocument,
+  YouTubeDocument itd.)
+  2. Alembic do migracji schematu
+  3. Eliminacja wrappera StalkerWebDocumentDB — zostaje ORM model + repository
+  4. Uproszczenie warstwy — z 3 klas (model + wrapper + queries) do 2 (ORM model
+   + repository)
+
+  Poza scope (osobny ticket na później):
+  - Pydantic schemas (API serializacja, OpenAPI → TypeScript, structured AI
+  outputs)
+  - Podział tabeli na podtypy (Joined Table Inheritance) — ORM będzie gotowe,
+  migracja gdy pojawi się realna potrzeba
+  - ElasticSearch — jeśli kiedykolwiek
+
+  ---
+  Co dalej?
+
+  Mogę Ci pomóc na kilka sposobów:
+
+  1. [CP] Stworzyć PRD dla tej zrewidowanej wersji B-92 — formalny dokument z
+  wymaganiami, kryteriami akceptacji, ryzykami
+  2. [CE] Stworzyć Epiki i Stories — rozbić to na konkretne zadania
+  implementacyjne
+  3. [CH] Kontynuować dyskusję — jeśli chcesz jeszcze coś doprecyzować
+
+  Co wolisz? Jeśli chcesz szybko przejść do kodu, to epiki i stories mogą być
+  wystarczające. Jeśli chcesz mieć pełną dokumentację decyzji (szczególnie
+  dlaczego wyrzucamy wrapper, dlaczego Pydantic odłożone), to PRD najpierw.
+
+❯ CP                                                                            
+
+
+● Świetnie, Ziutus! Uruchamiam workflow tworzenia PRD.
+
+  Create Mode: Tworzenie nowego PRD od podstaw.
+
+  ---
+  Krok 1 z 11 — Inicjalizacja
+
+  Sprawdzam stan workflow i szukam dokumentów wejściowych...
+
+
+● Znalazłem istniejący stan. Oto raport:
+
+  ---
+  Ziutus, analiza stanu workspace:
+
+  Istniejący PRD: _bmad-output/planning-artifacts/prd.md — UKOŃCZONY
+  (step-12-complete)
+  - Dotyczy: Notion Changelog (skrypt PoC)
+  - To jest inny temat niż migracja SQLAlchemy
+
+  Dokumenty wejściowe odkryte:
+  - Product briefs: 0 plików (nie znaleziono)
+  - Research: 0 plików (nie znaleziono)
+  - Project docs: 42 pliki w docs/ ✓ (brownfield project)
+  - Plan migracji: .claude/exports/plan-sqlalchemy-migration.md ✓ (przekazany
+  jako argument)
+
+  📋 Uwaga: To jest brownfield project — istniejąca dokumentacja projektowa jest
+   dostępna.
+
+  ---
+  Kwestia do rozstrzygnięcia:
+
+  Mamy ukończony PRD dla Notion Changelog. Zgodnie z konwencją projektu,
+  powinienem go zarchiwizować do _bmad-output/planning-artifacts/archive/ przed
+  utworzeniem nowego PRD dla migracji SQLAlchemy.
+
+  Proponuję archiwizację jako:
+  _bmad-output/planning-artifacts/archive/prd-sprint6-notion-changelog-2026-03-0
+  7.md
+
+  Dla nowego PRD załaduję jako kontekst:
+  - .claude/exports/plan-sqlalchemy-migration.md (plan migracji — już wczytany)
+  - docs/architecture-backend.md (architektura backendu)
+  - docs/data-models-backend.md (modele danych)
+  - docs/architecture-decisions.md (ADR-y, w tym ADR-004 o raw psycopg2)
+
+  Czy chcesz dodać jakieś inne dokumenty, albo masz uwagi do powyższego zanim
+  przejdę dalej?
+
+  [C] Continue — Zarchiwizuj stary PRD, załaduj dokumenty i utwórz nowy PRD
+
+
+❯ C                                                                             
+
+● Archiwizuję stary PRD i ładuję dokumenty kontekstowe.
+
+
+● Kontekst załadowany. Archiwizuję stary PRD i tworzę nowy dokument.
+
+  [--- Write: prd-sprint6-notion-changelog-2026-03-07.md — diff removed for readability ---]
+
+  [--- Write: prd.md — diff removed for readability ---]
+
+● Witaj Ziutus! Przygotowałem Twój workspace PRD dla lenie-server-2025.
+
+  Setup dokumentu:
+  - Utworzono: _bmad-output/planning-artifacts/prd.md z szablonu
+  - Zarchiwizowano: poprzedni PRD (Notion Changelog) do
+  archive/prd-sprint6-notion-changelog-2026-03-07.md
+  - Zainicjalizowano frontmatter ze stanem workflow
+
+  Dokumenty wejściowe odkryte:
+  - Product briefs: 0 plików (nie znaleziono)
+  - Research: 1 plik — .claude/exports/plan-sqlalchemy-migration.md (plan
+  migracji)
+  - Project docs: 3 pliki — architecture-backend.md, data-models-backend.md,
+  architecture-decisions.md (w tym ADR-004 i ADR-004a)
+
+  Pliki zaladowane:
+  - .claude/exports/plan-sqlalchemy-migration.md — oryginalny plan migracji
+  (referencja)
+  - docs/architecture-backend.md — obecna architektura warstwy danych
+  - docs/data-models-backend.md — schemat DB (28 kolumn web_documents, 8 kolumn
+  websites_embeddings)
+  - docs/architecture-decisions.md — ADR-004 (raw psycopg2) superseded by
+  ADR-004a (SQLAlchemy)
+
+  Uwaga: To jest brownfield project. Istniejąca dokumentacja projektowa została
+  załadowana. W następnym kroku zapytam konkretnie o zmiany, które chcesz
+  wprowadzić do istniejącego systemu.
+
+  Masz inne dokumenty, które chciałbyś dołączyć, albo przechodzimy dalej?
+
+  [C] Continue — Zapisz i przejdź do Project Discovery (Krok 2 z 11)
+
+
+❯ C                                                                             
+
+
+● Krok 2 z 13 — Project Discovery
+
+  ---
+  Z kroku 1 mam załadowane:
+  - Product briefs: 0
+  - Research: 1 (plan migracji SQLAlchemy)
+  - Brainstorming: 0
+  - Project docs: 3 (architektura, modele danych, ADR-y)
+
+  To jest brownfield project — skupiam się na zrozumieniu co chcesz zmienić.
+
+  ---
+  Ziutus, na podstawie naszej wcześniejszej rozmowy i załadowanych dokumentów,
+  mam już dość dobre zrozumienie tego co robisz. Pozwól, że podsumuję co
+  słyszałem i potwierdzimy klasyfikację.
+
+  Co robisz: Przepisujesz warstwę dostępu do danych w backendzie Lenie. Zamiast
+  ręcznych zapytań psycopg2 z redundancją w 5+ miejscach, wprowadzasz SQLAlchemy
+   ORM z Alembic do migracji schematu. Przy okazji upraszczasz architekturę — z
+  3 klas (model + wrapper DB + query layer) do 2 (ORM model + repository).
+  Wrapper StalkerWebDocumentDB znika, bo jego jedynym uzasadnieniem była
+  abstrakcja na wypadek zmiany backendu (ElasticSearch), co nie jest aktualnym
+  priorytetem.
+
+  Dlaczego teraz: Schemat bazy będzie się szybko zmieniał — nowe tabele
+  (autorzy), nowe/usuwane kolumny, ewentualny podział tabeli po typach
+  dokumentów. Obecna architektura sprawia, że każda zmiana to ręczna edycja w
+  wielu miejscach. Kod jest na wczesnym etapie — nigdy tak naprawdę nie działał
+  produkcyjnie — więc to najlepszy moment na agresywne zmiany.
+
+  Scope zrewidowany (vs. oryginalny plan):
+  - W scope: SQLAlchemy ORM (z dziedziczeniem modeli), Alembic, eliminacja
+  wrappera
+  - Poza scope: Pydantic schemas (odłożone), podział tabeli (ORM gotowe, ale
+  migracja gdy potrzeba)
+
+  ---
+  Słyszę to jako:
+
+  - Project Type: api_backend — migracja warstwy DB w Flask REST API
+  - Domain: Personal AI knowledge management
+  - Complexity: Low — jeden użytkownik, brak wymogów regulacyjnych, wczesny etap
+  - Project Context: Brownfield — przepisanie istniejącej warstwy danych
+  - Deployment Scope: Backend refactor (Docker + NAS jako primary)
+
+  Zgadza się? Chcesz coś doprecyzować?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Product Vision
+   (Step 2b of 13)
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Krok 2b z 13 — Product Vision Discovery
+
+  ---
+  Ustaliliśmy, że to api_backend w domenie personal AI knowledge management, o
+  niskiej złożoności, w kontekście brownfield. Teraz odkryjmy co czyni tę zmianę
+   wyjątkową.
+
+  Ziutus, mam kilka pytań, żeby zrozumieć wizję stojącą za tą migracją:
+
+  1. Co sprawia, że ta zmiana jest naprawdę wartościowa?
+  Wiem, że chodzi o eliminację redundancji przy zmianie schematu. Ale głębiej —
+  co ta migracja Ci odblokuje? Czy chodzi głównie o szybkość dodawania nowych
+  tabel/kolumn, czy jest coś większego — np. możliwość szybszego
+  eksperymentowania z nowymi typami danych, łatwiejsze onboardowanie nowych
+  źródeł wiedzy?
+
+  2. Jak wygląda "sukces" tej migracji?
+  Wyobraź sobie, że migracja jest skończona. Dostajesz pomysł: "chcę śledzić
+  autorów artykułów w osobnej tabeli z biografiami". Co się wtedy dzieje? Jak
+  wygląda Twoja praca krok po kroku?
+
+  3. Dlaczego teraz, a nie za 3 miesiące?
+  Powiedziałeś, że kod nigdy naprawdę nie działał. Ale czy jest coś konkretnego,
+   co Cię pcha do zrobienia tego teraz — zanim np. zajmiesz się czyszczeniem
+  treści z artykułów?
+
+
+❯ szybsze wprowadzanie zmian opisujacych rzeczywistosc, chcialbym np. dodac     
+tabele z zrodlami danych, tak aby przy dodawaniu nowego dokumentu moc wybierac  
+i edytowac liste zrodel a nie miec na sztywno zapisanych kilku wyborow 2.       
+suckces to bezproblemowe modyfikowanie tabel w bazie danych, teraz martwie sie  
+czy poprawnie policze ktore pole w wyniku select jest np. autorem 3. dzisiaj    
+przy eleminacji niepotrzebnych kolumn w bazie danych martwilem sie czy wsystkie 
+ select update i insert beda dzialac poprawnie                                  
+
+● Ziutus, to jest bardzo czytelne. Słyszę trzy rzeczy:
+
+  Problem powierzchniowy: Ręczne liczenie pozycji kolumn w SELECT, ręczne
+  synchronizowanie INSERT/UPDATE/SELECT przy każdej zmianie schematu. To jest
+  kruche i stresujące.
+
+  Problem głębszy: Baza danych nie opisuje rzeczywistości tak, jak byś chciał.
+  Chcesz modelować świat (źródła danych, autorzy, dynamiczne listy) ale obecna
+  architektura sprawia, że każda nowa tabela czy kolumna to ryzyko i stres
+  zamiast kreatywnej pracy.
+
+  Wizja: Baza danych jako elastyczny model rzeczywistości, który łatwo
+  rozszerzasz w miarę jak odkrywasz nowe wymiary wiedzy. Dodanie tabeli źródeł,
+  autorów z biografiami, dynamicznych list — to powinny być proste, bezstresowe
+  operacje: definiujesz model ORM, Alembic generuje migrację, gotowe.
+
+  ---
+  Oto co rozumiem jako wizję i wyróżnik:
+
+  Wizja: Warstwa danych, która rośnie razem z Twoim rozumieniem domeny — bez
+  strachu, że zmiana schematu zepsuje istniejący kod. Dodajesz tabelę, kolumnę
+  lub relację w jednym miejscu (model ORM), a reszta się dopasowuje.
+
+  Co czyni to wyjątkowym: To nie jest typowa migracja "bo ORM jest lepszy". To
+  odblokowanie zdolności do eksperymentowania z modelem danych — źródła,
+  autorzy, typy dokumentów — bez kosztu mentalnego ręcznego zarządzania SQL-em.
+
+  Rdzeń: Eliminacja strachu przed zmianą schematu. Dziś każda zmiana to "czy
+  policzyłem dobrze kolumny w SELECT?". Po migracji to "dodaję pole w modelu,
+  Alembic robi resztę".
+
+  Trafia to w sedno? Czegoś brakuje?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Executive
+  Summary (Step 2c of 13)
+
+❯ C                                                                             
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Krok 2c z 13 — Executive Summary Generation
+
+  ---
+  Na podstawie naszej klasyfikacji (krok 2) i odkrycia wizji (krok 2b),
+  przygotowałem Executive Summary. Przejrzyj i daj znać czy chcesz coś zmienić:
+
+  ---
+  Executive Summary
+
+  The backend data access layer of Project Lenie currently uses raw psycopg2
+  queries with manual SQL construction. Adding or removing a column requires
+  synchronized changes in 5+ locations: SELECT column lists, INSERT statements,
+  UPDATE clauses, dict() serialization, __clean_values(), and the domain model
+  constructor. Column positions are counted by hand — a single miscount silently
+   corrupts data mapping. This fragility blocks the evolution of the data model:
+   new tables (data sources, authors with biographies) and schema changes
+  (splitting web_documents by document type) carry disproportionate risk and
+  mental overhead.
+
+  This PRD defines the migration from raw psycopg2 to SQLAlchemy 2.x ORM with
+  Alembic schema migrations. Columns are defined once in a declarative ORM model
+   — SQLAlchemy generates all SQL automatically. Alembic auto-generates
+  migration scripts from model diffs, replacing unversioned DDL scripts. The
+  existing three-class architecture (StalkerWebDocument base model +
+  StalkerWebDocumentDB persistence wrapper + WebsitesDBPostgreSQL query layer)
+  is simplified to two layers: ORM model (data definition + domain methods) and
+  repository (complex queries). The intermediate StalkerWebDocumentDB wrapper —
+  originally designed to abstract over potential future database backends
+  (ElasticSearch) — is eliminated, as PostgreSQL is the only planned backend.
+
+  ORM model inheritance (Single Table Inheritance) prepares for future table
+  splitting by document type without requiring architectural changes — the split
+   becomes an Alembic migration, not a rewrite. Pydantic v2 schemas for API
+  serialization and structured AI outputs are explicitly out of scope and
+  deferred to a future sprint.
+
+  What Makes This Special
+
+  This is not a technology upgrade for its own sake. The migration eliminates
+  the fear of changing the database schema. Today, every schema change triggers
+  anxiety: "did I count the columns correctly in SELECT?" After the migration,
+  adding a table, column, or relationship is a single-location change in the ORM
+   model — Alembic handles the rest. This unblocks rapid experimentation with
+  the data model at a stage where the project is actively discovering what
+  reality it needs to represent (data sources, authors, document type
+  hierarchies). The code has never run in production, making this the
+  lowest-risk moment for an aggressive rewrite.
+
+  Project Classification
+
+  ┌────────────────┬────────────────────────────────────────────────────────┐
+  │   Dimension    │                         Value                          │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Project Type   │ API backend (database access layer migration)          │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Domain         │ Personal AI knowledge management                       │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Complexity     │ Low (single user, no regulatory requirements,          │
+  │                │ early-stage codebase)                                  │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Project        │ Brownfield — rewriting existing data layer in Flask    │
+  │ Context        │ backend                                                │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Deployment     │ Backend refactor (Docker + NAS primary, AWS secondary) │
+  │ Scope          │                                                        │
+  └────────────────┴────────────────────────────────────────────────────────┘
+
+  ---
+  Jak oceniasz ten draft? Chcesz coś zmienić, dodać lub wyciąć?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Success
+  Criteria (Step 3 of 13)
+
+
+❯ C                                                                             
+
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 3 z 11 — Success Criteria Definition
+
+  ---
+  Mamy Executive Summary i klasyfikację. Teraz definiujemy co znaczy "sukces" —
+  dla Ciebie jako użytkownika, dla projektu, i technicznie.
+
+  Z naszej wcześniejszej rozmowy wyłapałem już silne sygnały sukcesu. Pozwól, że
+   je potwierdzę i pogłębimy:
+
+  Sukces użytkownika — co słyszałem:
+  - Dodanie nowej tabeli/kolumny = zmiana w jednym miejscu (model ORM), bez
+  strachu
+  - Koniec z ręcznym liczeniem pozycji kolumn w SELECT
+  - Bezproblemowe modyfikowanie schematu (Twoje słowa: "bezproblemowe
+  modyfikowanie tabel")
+
+  Pytania pogłębiające:
+
+  1. Wyobraź sobie, że za miesiąc chcesz dodać tabelę data_sources z relacją do
+  web_documents. Jak wygląda sukces? Czy wystarczy "zdefiniowałem model, Alembic
+   wygenerował migrację, działa" — czy jest coś więcej? Np. "i od razu mogę
+  wybrać źródło z listy w UI"?
+
+  2. Business success — w tym projekcie to raczej osobisty ROI. Czy główna
+  metryka to "ile czasu oszczędzam na zmianach schematu" czy raczej "ile nowych
+  tabel/kolumn mogę dodać w danym tygodniu bez ryzyka"?
+
+  3. Technical success — co musi przejść, żebyś uznał migrację za ukończoną?
+  Np.:
+  - Wszystkie istniejące endpointy Flask działają jak wcześniej?
+  - Alembic potrafi wygenerować migrację z modelu?
+  - Stare klasy (StalkerWebDocument, StalkerWebDocumentDB) usunięte?
+  - Testy przechodzą?
+
+
+❯ 2. ile czasu oszczedzam, najwiekszym limitem w rozwoju tego projektu to moj   
+wlasny czas. 1. i od razu moge wybrac zrodlo z listy w UI, stad w zalozeniach   
+jest synchronizacja python i typescript w przyszlosci, szybsze i dokladniejsze  
+wprowadzanie zmian w wielu miejscach. 3. dane pobrane przez skrypty importujace 
+ @backend/imports/dynamodb_sync.py oraz @backend/imports/unknown_news_import.py 
+ poprawnie laduja dane do bazy danych a skrypt                                  
+@backend/web_documents_do_the_needful_new.py poprwnie tworzy embedingi (teraz   
+dla links bo tylko to jest teraz do konca wspierane). poprawnie sa tez          
+pobieranie i wkladane do bazy danych teksty z filmow youtube                    
+  ⎿  Read backend\imports\dynamodb_sync.py (333 lines)
+  ⎿  Read backend\imports\unknown_news_import.py (210 lines)
+  ⎿  Read backend\web_documents_do_the_needful_new.py (445 lines)
+  ⎿  Loaded backend\CLAUDE.md
+  ⎿  Loaded backend\imports\CLAUDE.md
+
+● Doskonałe odpowiedzi, Ziutus. Mam teraz pełny obraz sukcesu. Oto draft sekcji
+  Success Criteria i Product Scope:
+
+  ---
+  Success Criteria
+
+  User Success
+
+  - Adding a new table or column is a single-location change in the ORM model —
+  no manual SQL synchronization across SELECT/INSERT/UPDATE/dict/clean
+  - Alembic generates the migration script automatically from model diff — no
+  hand-written DDL
+  - The developer (Ziutus) can modify the schema without anxiety about
+  miscounted column positions or broken queries
+
+  Business Success
+
+  - Developer time is the primary constraint. The migration must reduce time
+  spent on schema changes from "careful manual work across 5+ files" to "one
+  field in a model, one Alembic command"
+  - Unblocks future work: new tables (data sources, authors), TypeScript type
+  synchronization (Pydantic → OpenAPI → TypeScript), and UI-driven data entry
+  (e.g., selecting a source from a dynamic list)
+
+  Technical Success
+
+  - Import scripts function correctly after migration:
+    - backend/imports/dynamodb_sync.py — loads documents from DynamoDB + S3 into
+   PostgreSQL
+    - backend/imports/unknown_news_import.py — imports curated links from
+  unknow.news
+  - Batch processing pipeline works end-to-end:
+    - backend/web_documents_do_the_needful_new.py — correctly creates embeddings
+   for link documents (currently the only fully supported type)
+    - YouTube video text is correctly fetched and stored in the database
+  - Flask API endpoints (/website_list, /website_get, /website_save,
+  /website_delete, /website_similar) return identical data formats as before the
+   migration
+  - All existing unit tests pass
+  - ruff check backend/ reports zero warnings
+  - Old classes (StalkerWebDocument, StalkerWebDocumentDB, StalkerWebDocumentDB
+  wrapper layer) are removed — no dead code left behind
+
+  Measurable Outcomes
+
+  - Lines of code to add a new column: 1 (ORM model field) + 1 (Alembic
+  autogenerate) vs. current 5+ manual edits
+  - Import scripts run end-to-end with exit code 0 on test data
+  - Zero raw cursor.execute() calls remaining in production code (except
+  pgvector <=> operator via text())
+
+  Product Scope
+
+  MVP
+
+  1. SQLAlchemy 2.x ORM models for web_documents and websites_embeddings tables
+  with Single Table Inheritance on web_documents
+  2. Alembic initialized with baseline migration (existing schema = model)
+  3. StalkerWebDocumentDB wrapper eliminated — ORM model handles persistence
+  directly
+  4. Repository layer (stalker_web_documents_db_postgresql.py) rewritten to use
+  SQLAlchemy sessions
+  5. All Flask API endpoints functional with identical response formats
+  6. All import and batch scripts functional (dynamodb_sync.py,
+  unknown_news_import.py, web_documents_do_the_needful_new.py)
+  7. YouTube processing pipeline functional (transcript fetch + DB storage)
+
+  Growth Features (Post-MVP)
+
+  - Pydantic v2 schemas for API serialization and OpenAPI generation
+  - TypeScript type synchronization pipeline (Pydantic → OpenAPI →
+  openapi-typescript)
+  - Pydantic structured outputs for LLM calls (Claude Desktop, OpenAI, Bedrock)
+  - New tables: data_sources (dynamic source list), authors (with biographies)
+
+  Vision (Future)
+
+  - Joined Table Inheritance — split web_documents by document type (links,
+  webpages, YouTube) with type-specific columns
+  - Full MCP server exposing Lenie data to Claude Desktop via SQLAlchemy queries
+  - ElasticSearch as secondary search backend (if needed — repository pattern
+  enables this)
+
+  ---
+  Jak oceniasz? Chcesz coś doprecyzować lub zmienić?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to User Journey
+  Mapping (Step 4 of 11)
+
+
+❯ C                                                                             
+
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 4 z 11 — User Journey Mapping
+
+  ---
+  To jest migracja warstwy danych — "użytkownikami" są głównie Ty (developer) i
+  istniejące skrypty/endpointy, które konsumują tę warstwę. Zidentyfikowałem
+  następujących "aktorów" w systemie:
+
+  1. Ziutus — developer modyfikujący schemat bazy (główna persona)
+  2. Ziutus — operator uruchamiający skrypty importu (dynamodb_sync.py,
+  unknown_news_import.py)
+  3. Batch pipeline (web_documents_do_the_needful_new.py) — automatyczny
+  konsument
+  4. Flask API — endpointy obsługujące frontend React
+
+  Czy powinienem uwzględnić jeszcze kogoś? Np. przyszły MCP server dla Claude
+  Desktop? Albo Lambda functions w AWS?
+
+  Zanim napiszę narracje — chcę się upewnić, że mam komplet aktorów. Kto jeszcze
+   wchodzi w interakcję z warstwą danych?
+
+
+❯ teraz to komplet                                                              
+
+● Świetnie. Oto draft User Journeys:
+
+  ---
+  User Journeys
+
+  Journey 1: "New Column Without Fear" — Developer Modifying the Schema
+
+  Persona: Ziutus — sole developer of Project Lenie, working evenings and
+  weekends on a personal AI knowledge management system.
+
+  Opening Scene: Ziutus decides that documents need an author field linked to a
+  new authors table with biographies. In the old world, this meant: add column
+  to SQL init script, update SELECT column list (count positions carefully),
+  update INSERT, update UPDATE, update dict(), update __clean_values(), update
+  the domain model constructor, and pray nothing was miscounted.
+
+  Rising Action: Ziutus opens backend/library/db/models.py and adds a single
+  field: author_id: Mapped[int | None] = 
+  mapped_column(ForeignKey("authors.id")). He creates a new Author model class
+  with name, bio, url fields. He runs alembic revision --autogenerate -m "add 
+  authors table" — Alembic inspects the model diff and generates the migration
+  script with CREATE TABLE authors and ALTER TABLE web_documents ADD COLUMN 
+  author_id.
+
+  Climax: alembic upgrade head — the database schema matches the model. No
+  manual column counting. No cross-referencing 5 files. The ORM handles SELECT,
+  INSERT, UPDATE automatically. Ziutus writes zero SQL.
+
+  Resolution: The entire operation took minutes instead of an anxious hour.
+  Ziutus moves on to building the UI for selecting authors from a list — the
+  part he actually cares about — instead of wrestling with SQL plumbing.
+
+  Journey 2: "The Import Run" — Operator Running Data Import Scripts
+
+  Persona: Ziutus — running the weekly unknow.news import to pull curated Polish
+   tech links into the knowledge base.
+
+  Opening Scene: Ziutus runs cd backend && ./imports/unknown_news_import.py 
+  --since 2026-03-01. The script starts, connects to PostgreSQL, downloads the
+  unknow.news archive JSON, and begins processing entries.
+
+  Rising Action: For each new URL, the script creates an ORM model instance via
+  WebDocument(url=entry['url']). The session queries the database to check for
+  duplicates. New documents are populated with fields (title, summary, language,
+   source, date_from, document_type, document_state) and added to the session.
+  session.commit() persists them — SQLAlchemy generates the INSERT with exactly
+  the right columns.
+
+  Climax: The script processes 47 new entries. Summary: "Added: 47, Exist: 112,
+  Ignored: 1,834." Exit code 0. The output format is identical to before the
+  migration — Ziutus notices no difference in behavior.
+
+  Resolution: The import works exactly as before but the underlying code is
+  simpler. If Ziutus later adds an author column to web_documents, the import
+  script doesn't need any changes — the new column defaults to NULL and the ORM
+  handles the rest.
+
+  Journey 3: "Embeddings Pipeline" — Batch Processing End-to-End
+
+  Persona: web_documents_do_the_needful_new.py — the batch pipeline script,
+  orchestrated by Ziutus.
+
+  Opening Scene: Ziutus runs the pipeline with --only-links. The script needs
+  to: find link documents in READY_FOR_EMBEDDING state, generate embeddings via
+  the configured model, and store vectors in websites_embeddings.
+
+  Rising Action: The repository method get_documents_needing_embedding(model)
+  executes a SQLAlchemy query with an outer join on websites_embeddings —
+  replacing a hand-written SQL string with a composable query object. For each
+  document, the script loads the ORM model by ID, calls embedding_add(model),
+  which creates a WebsiteEmbedding instance and adds it to the document's
+  embeddings relationship. session.commit() persists both the embedding and the
+  document state update in a single transaction.
+
+  Climax: 23 link documents processed, embeddings generated and stored. The
+  pgvector <=> operator for similarity search still works via text() raw SQL
+  within SQLAlchemy — the one place where raw SQL is intentionally preserved.
+
+  Resolution: The pipeline produces identical results. The embedding storage
+  code is shorter and safer — no manual cursor.execute() with hand-built INSERT
+  statements. The websites_embeddings table is managed through the ORM
+  relationship, so cascade deletes work automatically.
+
+  Journey 4: "API Request" — Flask Endpoint Serving the Frontend
+
+  Persona: React frontend making a GET /website_list?document_type=link&limit=20
+   request.
+
+  Opening Scene: A user opens the Lenie React UI and navigates to the document
+  list filtered by "links." The frontend sends an authenticated request to the
+  Flask backend.
+
+  Rising Action: The Flask route handler calls the repository method
+  get_list(document_type='link', limit=20). The repository builds a SQLAlchemy
+  select() query with dynamic filters — where(WebDocument.document_type == 
+  'link'), .limit(20), .order_by(WebDocument.created_at.desc()). The session
+  executes the query and returns ORM model instances.
+
+  Climax: Each WebDocument instance is serialized via its dict() method —
+  producing the exact same JSON structure as the old
+  StalkerWebDocumentDB.dict(). The API response format is byte-for-byte
+  compatible with the frontend's expectations.
+
+  Resolution: The frontend displays the list. Zero changes needed in the React
+  code. The API contract is preserved while the implementation underneath is
+  completely rewritten.
+
+  Journey Requirements Summary
+
+  ┌────────────────┬────────────────────────────────────────────────────────┐
+  │    Journey     │                 Capabilities Required                  │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Schema         │ ORM model definition, Alembic autogenerate, migration  │
+  │ Modification   │ execution                                              │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │                │ ORM instance creation, session-based persistence,      │
+  │ Data Import    │ duplicate detection by URL, backward-compatible field  │
+  │                │ mapping                                                │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ Embeddings     │ Repository queries with joins, ORM relationship        │
+  │ Pipeline       │ management (document → embeddings), pgvector           │
+  │                │ integration via text(), transaction management         │
+  ├────────────────┼────────────────────────────────────────────────────────┤
+  │ API Request    │ Repository with dynamic filters, ORM-to-dict           │
+  │                │ serialization, response format backward compatibility  │
+  └────────────────┴────────────────────────────────────────────────────────┘
+
+  ---
+  Jak oceniasz te journey? Pokrywają Twoje scenariusze użycia?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Domain
+  Requirements (Step 5 of 11)
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Złożoność domeny z kroku 2 to low. Ten krok jest opcjonalny dla domen o
+  niskiej złożoności.
+
+  Ziutus, nie mamy wymogów regulacyjnych, certyfikacji ani złożonych integracji
+  domenowych. Proponuję pominąć ten krok.
+
+  Select: [C] Pomiń i przejdź do Innovation Focus (Step 6 of 13) [D] Przeprowadź
+   eksplorację domeny mimo to
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Ten krok dotyczy odkrywania innowacyjnych aspektów produktu. Skanuję sygnały
+  innowacji...
+
+  Ziutus, ta migracja to doskonałe wykonanie sprawdzonego podejścia (SQLAlchemy
+  ORM to standard branżowy), nie przełomowa innowacja. Nie ma tu nowego
+  protokołu, nowej kompozycji API ani nowatorskiego wzorca — i to jest w
+  porządku. Wiele udanych zmian to solidna egzekucja, nie wynalazek.
+
+  Nie wykryłem sygnałów innowacji wymagających głębszej eksploracji. Proponuję
+  pominąć tę sekcję.
+
+  Select: [A] Advanced Elicitation — spróbujmy znaleźć innowacyjne kąty [C]
+  Continue — pomiń i przejdź do Project Type Analysis (Step 7 of 11)
+
+❯ C                                                                             
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Krok 7 z 11 — Project-Type Deep Dive (API Backend)
+
+  ---
+  Dla typu api_backend CSV wskazuje kluczowe pytania: Endpoints? Authentication?
+   Data formats? Rate limits? Versioning? SDK? Oraz sekcje do pominięcia: ux_ui,
+   visual_design, user_journeys (już mamy).
+
+  Ale w naszym przypadku to nie jest nowe API — to migracja warstwy danych pod
+  istniejącym API. Dlatego dostosuję pytania do kontekstu. Kilka rzeczy chcę
+  potwierdzić:
+
+  1. Architektura docelowa:
+  Z naszej rozmowy wynika dwuwarstwowa struktura:
+  - ORM model (backend/library/db/models.py) — WebDocument, WebsiteEmbedding,
+  dziedziczenie STI
+  - Repository (backend/library/stalker_web_documents_db_postgresql.py) —
+  złożone query
+
+  Sesja SQLAlchemy zarządzana w Flask przez @app.teardown_appcontext. Skrypty
+  batch tworzą własne sesje.
+
+  Czy to zgadza się z Twoją wizją, czy widzisz to inaczej?
+
+  2. pgvector:
+  Similarity search (get_similar()) używa operatora <=>. Plan zakłada użycie
+  text() raw SQL w SQLAlchemy dla tego operatora. Alternatywa: pgvector-python
+  daje natywny cosine_distance() w SQLAlchemy. Które podejście wolisz?
+
+  3. Kompatybilność API:
+  Endpointy Flask muszą zwracać identyczne formaty JSON. Czy planujesz
+  jakiekolwiek zmiany w formacie odpowiedzi przy okazji migracji, czy ściśle
+  backward-compatible?
+
+❯ porozmawiajmy o pgvector-python, czy nie byloby lepsze tutaj? 2. nie planuje  
+zmian ale z drugiej strony fronted mozna dostosowac. na razie najwazniejsze     
+jest by konsumencji czyli skrypty importujace i modyfikujace dane dzialaly, API 
+ mozna poprawiac nawet pozniej                                                  
+
+● pgvector-python — zdecydowanie lepszy wybór
+
+  pgvector-python daje Ci natywną integrację z SQLAlchemy:
+
+  Co zyskujesz:
+  - Typ kolumny: Vector(1536) zamiast ręcznego definiowania typu
+  - Operator cosine distance:
+  WebsiteEmbedding.embedding.cosine_distance(query_vector) zamiast
+  text("embedding <=> :vec")
+  - Indeksy: index = Index('...', embedding, postgresql_using='ivfflat', 
+  postgresql_with={'lists': 100}, postgresql_ops={'embedding': 
+  'vector_cosine_ops'}) — definicja w modelu ORM, Alembic zarządza
+  - Brak text() raw SQL — cały kod jest czystym SQLAlchemy, zero wyjątków
+
+  Przykład query:
+
+  # Zamiast raw SQL:
+  # cursor.execute("SELECT ... FROM websites_embeddings ORDER BY embedding <=> 
+  %s LIMIT %s", [vector, limit])
+
+  # Masz:
+  stmt = (
+      select(WebsiteEmbedding)
+      .order_by(WebsiteEmbedding.embedding.cosine_distance(query_vector))
+      .limit(limit)
+  )
+  results = session.execute(stmt).scalars().all()
+
+  Koszt: jedna dodatkowa zależność (pgvector>=0.3.0), ~50KB.
+
+  Moja rekomendacja: Użyj pgvector-python. Eliminujesz jedyny planowany wyjątek
+  od reguły "zero raw SQL". Cała warstwa danych jest spójna — czyste SQLAlchemy,
+   zero text(), zero cursor.execute().
+
+  Zgadzasz się?
+
+  ---
+  Kompatybilność API — zrewidowana
+
+  Rozumiem — priorytet to:
+  1. Skrypty importu i batch — muszą działać identycznie (to jest warunek
+  konieczny)
+  2. Flask API — może ewoluować, frontend się dostosuje (to jest nice-to-have
+  backward compatibility)
+
+  To upraszcza sprawę — dict() na modelu ORM nie musi być byte-for-byte
+  kompatybilny ze starym formatem. Może zwracać czystszą strukturę, a frontend
+  się dostosuje.
+
+  Chcesz jeszcze coś doprecyzować w kwestii architektury technicznej, czy mogę
+  przygotować draft sekcji Technical Context?
+
+❯ uzyjmy pgvector-python i idziemy do draft-u                                   
+
+● Świetnie. Oto draft sekcji Technical Context:
+
+  ---
+  Technical Context
+
+  Architectural Position
+
+  Database access layer migration within the existing Flask backend. Replaces
+  raw psycopg2 queries with SQLAlchemy 2.x ORM. All consumers (Flask API, import
+   scripts, batch pipeline) use the same ORM models and session management.
+
+  Target Architecture
+
+  Flask Route / Script
+    |
+    v
+  Repository (stalker_web_documents_db_postgresql.py)
+    |  - complex queries: get_list(), get_similar(), get_count()
+    |  - uses SQLAlchemy select(), func.count(), joins
+    |
+    v
+  ORM Models (library/db/models.py)
+    |  - WebDocument (STI base) -> LinkDocument, YouTubeDocument, etc.
+    |  - WebsiteEmbedding (Vector(1536), cosine_distance())
+    |  - domain methods: set_document_type(), validate(), analyze(), dict()
+    |
+    v
+  SQLAlchemy Engine (library/db/engine.py)
+    |  - get_engine() with pool_pre_ping=True
+    |  - get_session() for scripts
+    |  - get_scoped_session() for Flask (thread-local)
+    |
+    v
+  PostgreSQL 18 + pgvector
+
+  Session Management
+
+  ┌─────────────┬───────────────────────────────────────────────────────────┐
+  │   Context   │                         Strategy                          │
+  ├─────────────┼───────────────────────────────────────────────────────────┤
+  │ Flask API   │ get_scoped_session() — thread-local,                      │
+  │             │ @app.teardown_appcontext calls session.remove()           │
+  ├─────────────┼───────────────────────────────────────────────────────────┤
+  │ Import      │ get_session() — script-scoped, explicit session.close()   │
+  │ scripts     │ at exit                                                   │
+  ├─────────────┼───────────────────────────────────────────────────────────┤
+  │ Batch       │ get_session() — script-scoped, commit per document        │
+  │ pipeline    │                                                           │
+  └─────────────┴───────────────────────────────────────────────────────────┘
+
+  Key Technology Decisions
+
+  ┌──────────────┬───────────────────────┬──────────────────────────────────┐
+  │   Decision   │        Choice         │            Rationale             │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │              │ SQLAlchemy 2.x        │ Modern, type-hint native, best   │
+  │ ORM style    │ mapped_column()       │ IDE support                      │
+  │              │ declarative           │                                  │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │ Vector       │ pgvector-python       │ cosine_distance() operator,      │
+  │ operations   │ native integration    │ Vector(1536) type — zero raw SQL │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │              │ Single Table          │ Matches current schema (one      │
+  │ Inheritance  │ Inheritance on        │ table), prepares for future      │
+  │              │ web_documents         │ Joined Table split               │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │ Migration    │ Alembic with          │ Reads ORM model diffs, generates │
+  │ tool         │ autogenerate          │  migration scripts               │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │              │                       │ StalkerWebDocumentDB wrapper     │
+  │ DB wrapper   │ Eliminated            │ removed — ORM model + repository │
+  │              │                       │  directly                        │
+  ├──────────────┼───────────────────────┼──────────────────────────────────┤
+  │              │ Deferred (out of      │ Not needed until API             │
+  │ Pydantic     │ scope)                │ serialization or structured AI   │
+  │              │                       │ outputs become priority          │
+  └──────────────┴───────────────────────┴──────────────────────────────────┘
+
+  Data Flow — Import Script
+
+  DynamoDB/JSON feed
+    -> Script creates WebDocument(url=...)
+    -> session.add(doc) + session.commit()
+    -> SQLAlchemy generates INSERT with correct columns
+    -> New columns auto-default to NULL (no script changes needed)
+
+  Data Flow — Similarity Search
+
+  Query vector (1536 dims)
+    -> Repository: select(WebsiteEmbedding)
+         .order_by(WebsiteEmbedding.embedding.cosine_distance(query_vector))
+         .limit(limit)
+    -> pgvector IVFFlat index (cosine similarity)
+    -> ORM instances returned
+
+  Dependencies (new)
+
+  ┌────────────┬────────────┬────────────────────────────────────────┐
+  │  Package   │  Version   │                Purpose                 │
+  ├────────────┼────────────┼────────────────────────────────────────┤
+  │ sqlalchemy │ >=2.0,<3.0 │ ORM, query builder, session management │
+  ├────────────┼────────────┼────────────────────────────────────────┤
+  │ pgvector   │ >=0.3.0    │ Vector type, cosine_distance operator  │
+  ├────────────┼────────────┼────────────────────────────────────────┤
+  │ alembic    │ >=1.13     │ Schema migration management            │
+  └────────────┴────────────┴────────────────────────────────────────┘
+
+  Existing psycopg2-binary retained as SQLAlchemy driver.
+
+  Files — Summary
+
+  New:
+  - backend/library/db/__init__.py
+  - backend/library/db/engine.py — engine, session factories, Base
+  - backend/library/db/models.py — WebDocument (STI), WebsiteEmbedding
+  - backend/alembic.ini
+  - backend/alembic/env.py
+  - backend/alembic/versions/ — migration scripts
+
+  Rewritten:
+  - backend/library/stalker_web_documents_db_postgresql.py — SQLAlchemy session
+  queries
+  - backend/imports/dynamodb_sync.py — ORM model instead of wrapper
+  - backend/imports/unknown_news_import.py — ORM model instead of wrapper
+  - backend/web_documents_do_the_needful_new.py — ORM model instead of wrapper
+  - backend/server.py — add teardown_appcontext, update route handlers
+
+  Removed:
+  - backend/library/stalker_web_document_db.py — wrapper eliminated
+  - backend/library/stalker_web_document.py — replaced by ORM model (re-export
+  enums only)
+
+  Implementation Considerations
+
+  - StalkerDocumentStatus, StalkerDocumentType, StalkerDocumentStatusError enums
+   are preserved as-is — they are used across the codebase and stored as strings
+   in the database
+  - The langauge typo in websites_embeddings has been fixed in migration
+  08-fix-language-typo.sql — ORM model uses correct language spelling
+  - dynamodb_sync.py has a direct SQL UPDATE for created_at and chapter_list
+  (line 210) — this becomes a normal ORM attribute assignment + commit
+  - pgvector HNSW/IVFFlat partial indexes: managed by Alembic migrations, not
+  defined in ORM model
+
+  ---
+  Jak oceniasz? Coś do zmiany lub dodania?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Scoping (Step
+  8 of 11)
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 8 z 11 — Scoping Exercise
+
+  ---
+  Ziutus, mamy już solidne MVP zdefiniowane w kroku 3 (Product Scope).
+  Przeglądam całe PRD do tej pory i widzę, że scope jest dość jasny. Zanim
+  wygeneruję sekcję, jedno pytanie o ryzyka:
+
+  Największe ryzyko techniczne jakie widzę to ten moment, kiedy wszystkie
+  konsumencji (3 skrypty + Flask API) muszą przejść na nową warstwę
+  jednocześnie. Nie da się tego robić plik po pliku, bo stare klasy i nowe ORM
+  nie mogą współistnieć łatwo (dwa sposoby zarządzania połączeniami DB).
+
+  Pytanie: Czy akceptujesz podejście "big bang" — przepisujemy wszystko naraz,
+  testujemy na świeżych danych, i jeśli coś nie działa, debugujemy? Biorąc pod
+  uwagę, że kod "nigdy naprawdę nie działał", to wydaje się bezpieczne. Ale chcę
+   to potwierdzić.
+
+
+❯ akceptuje                                                                     
+
+● Oto draft sekcji Scoping & Risk Mitigation:
+
+  ---
+  Project Scoping & Risk Mitigation
+
+  MVP Strategy
+
+  Approach: Big-bang rewrite of the data access layer. All consumers (Flask API,
+   import scripts, batch pipeline) migrate to SQLAlchemy ORM simultaneously. The
+   codebase has never run in production, so there is no live system to break —
+  this is the safest moment for an aggressive rewrite.
+
+  Resource Requirements: Solo developer (Ziutus), Claude Code as implementation
+  partner.
+
+  MVP Feature Set (Phase 1)
+
+  Core Journeys Supported:
+  - All four journeys: schema modification, data import, embeddings pipeline,
+  API request
+
+  Must-Have Capabilities:
+  1. ORM models (WebDocument with STI, WebsiteEmbedding with Vector(1536))
+  2. Engine + session management (get_engine(), get_session(),
+  get_scoped_session())
+  3. Alembic initialized with baseline migration
+  4. Repository rewritten with SQLAlchemy queries
+  5. All import scripts (dynamodb_sync.py, unknown_news_import.py) working with
+  ORM
+  6. Batch pipeline (web_documents_do_the_needful_new.py) working with ORM
+  7. Flask endpoints functional
+  8. Old wrapper classes removed
+
+  Post-MVP Features
+
+  Phase 2 (Growth):
+  - Pydantic v2 schemas for API serialization
+  - TypeScript type synchronization (Pydantic → OpenAPI → openapi-typescript)
+  - New tables: data_sources, authors
+  - Pydantic structured outputs for LLM calls
+
+  Phase 3 (Expansion):
+  - Joined Table Inheritance (split web_documents by document type)
+  - MCP server for Claude Desktop backed by SQLAlchemy queries
+  - ElasticSearch as secondary search backend (if needed)
+
+  Risk Mitigation Strategy
+
+  Technical Risk — Big-Bang Migration:
+  All consumers switch to SQLAlchemy simultaneously. No gradual migration path.
+  Mitigation: The code has never run in production. Verification is done by
+  running import scripts on test data and confirming correct database state. If
+  something breaks, the old code is in git history.
+
+  Technical Risk — pgvector Compatibility:
+  pgvector-python must produce identical similarity search results to the
+  current raw SQL <=> operator. Mitigation: Run get_similar() with known test
+  vectors before and after migration, compare results.
+
+  Technical Risk — Session Lifecycle:
+  SQLAlchemy sessions in Flask must be properly scoped (thread-local) and
+  cleaned up. Leaked sessions cause connection pool exhaustion. Mitigation:
+  @app.teardown_appcontext with session.remove() — standard Flask-SQLAlchemy
+  pattern.
+
+  Technical Risk — Alembic Baseline:
+  Existing database schema must match the ORM model exactly for alembic stamp 
+  head to work. Any drift causes migration failures. Mitigation: Compare alembic
+   revision --autogenerate output against existing DDL scripts
+  (backend/database/init/03-create-table.sql, 04-create-table.sql). Fix any
+  discrepancies before stamping.
+
+  Dependency Risk — Lambda Package Size:
+  SQLAlchemy adds ~30MB to Lambda layers. Mitigation: Deferred — Lambda/AWS is
+  secondary. NAS deployment has no package size constraints. Lambda
+  compatibility addressed in a future sprint if needed.
+
+  ---
+  Jak oceniasz? Coś do zmiany?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Functional
+  Requirements (Step 9 of 11)
+
+❯ C                                                                             
+
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 9 z 11 — Functional Requirements
+
+  ---
+  Ziutus, to jest kluczowa sekcja — kontrakt na zdolności systemu. Syntezuję
+  wszystkie odkrycia z poprzednich kroków. Oto draft:
+
+  ---
+  Functional Requirements
+
+  ORM Model Definition
+
+  - FR1: Developer can define database table structure as a Python ORM model
+  class in a single file
+  - FR2: Developer can define column types, constraints, defaults, and
+  nullability as model field attributes
+  - FR3: Developer can define relationships between models (one-to-many,
+  many-to-one) using ORM relationship declarations
+  - FR4: Developer can define Single Table Inheritance hierarchy on
+  web_documents with document type as discriminator
+  - FR5: Developer can add domain methods (validate, analyze, set_document_type,
+   set_document_state) directly on the ORM model
+
+  Schema Migration
+
+  - FR6: Developer can auto-generate migration scripts from ORM model changes
+  via Alembic
+  - FR7: Developer can apply migrations to the database with a single command
+  (alembic upgrade head)
+  - FR8: Developer can roll back migrations to a previous version (alembic 
+  downgrade)
+  - FR9: Developer can initialize Alembic on an existing database by stamping
+  the current state as baseline
+
+  Session & Connection Management
+
+  - FR10: Flask application can obtain thread-local database sessions scoped to
+  the request lifecycle
+  - FR11: Flask application can automatically clean up sessions on request
+  teardown
+  - FR12: Standalone scripts can obtain and manage their own database sessions
+  - FR13: Engine can detect and recover from stale database connections
+  (pool_pre_ping)
+
+  Document Persistence
+
+  - FR14: Consumer can create a new document by instantiating an ORM model and
+  committing to session
+  - FR15: Consumer can update an existing document by modifying ORM model
+  attributes and committing
+  - FR16: Consumer can delete a document via session, with cascade deletion of
+  related embeddings
+  - FR17: Consumer can look up a document by URL for duplicate detection
+  - FR18: Consumer can look up a document by ID
+  - FR19: Consumer can serialize a document to a dictionary for API responses
+
+  Embedding Operations
+
+  - FR20: Consumer can add a vector embedding to a document via ORM relationship
+  - FR21: Consumer can delete embeddings for a document filtered by model name
+  - FR22: Repository can find documents needing embeddings (outer join on
+  websites_embeddings)
+  - FR23: Repository can perform similarity search using pgvector-python
+  cosine_distance() operator
+
+  Repository Queries
+
+  - FR24: Repository can list documents with dynamic filters (document_type,
+  document_state, source, project, limit, offset)
+  - FR25: Repository can count documents by type and/or state
+  - FR26: Repository can find documents ready for download (URL_ADDED state,
+  webpage/link type)
+  - FR27: Repository can find YouTube documents just added (URL_ADDED state,
+  youtube type)
+  - FR28: Repository can find documents with completed transcriptions
+  - FR29: Repository can find the next document to correct (navigation by ID and
+   type)
+  - FR30: Repository can retrieve the last imported date for a given source
+
+  Import Script Compatibility
+
+  - FR31: dynamodb_sync.py can create documents from DynamoDB items using ORM
+  models
+  - FR32: dynamodb_sync.py can set created_at and chapter_list via normal ORM
+  attribute assignment (no direct SQL)
+  - FR33: unknown_news_import.py can create documents from JSON feed entries
+  using ORM models
+  - FR34: unknown_news_import.py can detect and skip duplicate URLs via ORM
+  query
+
+  Batch Pipeline Compatibility
+
+  - FR35: web_documents_do_the_needful_new.py can process SQS messages and
+  create documents via ORM
+  - FR36: web_documents_do_the_needful_new.py can generate and store embeddings
+  via ORM relationship
+  - FR37: web_documents_do_the_needful_new.py can update document state through
+  the processing lifecycle
+  - FR38: YouTube processing pipeline can store transcript text and metadata via
+   ORM
+
+  Flask API Compatibility
+
+  - FR39: /website_list endpoint can return filtered, paginated document lists
+  via repository
+  - FR40: /website_get endpoint can return a single document with neighbor
+  navigation via repository
+  - FR41: /website_save endpoint can create or update documents via ORM model
+  - FR42: /website_delete endpoint can remove documents with cascade embedding
+  deletion via ORM
+  - FR43: /website_similar endpoint can perform vector similarity search via
+  pgvector-python
+
+  ---
+  To jest kontrakt zdolności — wszystko co nie jest tu wymienione, nie zostanie
+  zaimplementowane. Widzisz jakieś braki? Coś czego potrzebujesz a co tu nie
+  jest?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Non-Functional
+   Requirements (Step 10 of 11)
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 10 z 12 — Non-Functional Requirements
+
+  ---
+  Ocena kontekstu NFR dla tej migracji:
+
+  - Performance: Nie dotyczy — nie zmieniamy wymagań wydajnościowych, SQLAlchemy
+   generuje podobne SQL
+  - Security: Minimalne — sekrety DB już zarządzane przez config_loader, nic się
+   nie zmienia
+  - Scalability: Nie dotyczy — jeden użytkownik, NAS
+  - Accessibility: Nie dotyczy — warstwa danych
+  - Integration: Nie dotyczy — te same systemy zewnętrzne
+
+  Ale widzę kilka NFR-ów specyficznych dla tej migracji. Oto draft:
+
+  ---
+  Non-Functional Requirements
+
+  Code Quality
+
+  - NFR1: Zero raw cursor.execute() calls in production code — all database
+  operations via SQLAlchemy ORM or pgvector-python operators
+  - NFR2: Code passes ruff check backend/ with zero warnings (line-length=120)
+  - NFR3: All existing unit tests pass without modification (tests that don't
+  touch DB layer)
+  - NFR4: ORM models use type hints (Mapped[type]) for IDE autocompletion and
+  static analysis
+
+  Backward Compatibility
+
+  - NFR5: Enum classes (StalkerDocumentStatus, StalkerDocumentType,
+  StalkerDocumentStatusError) are preserved with identical values — no import
+  changes needed in consumers
+  - NFR6: Database schema after migration is identical to before — Alembic
+  baseline produces no diff against existing DDL scripts
+
+  Maintainability
+
+  - NFR7: Adding a new column requires changes in exactly one file
+  (backend/library/db/models.py)
+  - NFR8: Adding a new table requires changes in exactly one file plus one
+  Alembic migration command
+  - NFR9: No dead code from old architecture remains (stalker_web_document_db.py
+   wrapper fully removed)
+
+  Dependency Management
+
+  - NFR10: New dependencies (sqlalchemy, pgvector, alembic) added to
+  pyproject.toml with version pins
+  - NFR11: uv lock produces a valid lock file after dependency changes
+  - NFR12: .venv_wsl synchronized after dependency changes
+
+  ---
+  Jak oceniasz? Chcesz coś dodać lub zmienić?
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Polish
+  Document (Step 11 of 12)
+
+
+❯ C                                                                             
+
+  [--- Update: prd.md — 2 edits, diffs removed for readability ---]
+
+● Krok 11 z 12 — Document Polish
+
+  ---
+  Załadowałem cały dokument PRD i wytyczne jakości. Przeprowadzam przegląd:
+
+  Znalezione problemy:
+
+  1. Duplikacja scope: Product Scope (krok 3) i MVP Feature Set (krok 8)
+  częściowo się pokrywają — obie sekcje definiują MVP, Growth i Vision.
+  Skonsoliduję w jedną sekcję Project Scoping & Risk Mitigation (krok 8 jest
+  pełniejsza).
+  2. Journey 3 nieaktualna: Wspomina text() raw SQL dla pgvector, ale
+  zdecydowaliśmy się na pgvector-python native. Poprawię.
+  3. Journey 4 nieaktualna: Mówi o "byte-for-byte compatible" API, ale
+  ustaliliśmy że API może ewoluować. Poprawię.
+  4. Journey Requirements Summary: Wspomina pgvector integration via text() —
+  poprawię na pgvector-python cosine_distance().
+  5. Measurable Outcomes: Mówi "except pgvector <=> operator via text()" — to
+  już nieaktualne.
+
+  Przygotowuję spoliszowany dokument z tymi poprawkami. Chwilę...
+
+
+● Teraz aplikuję poprawki — usuwam duplikację Product Scope (sekcja z kroku 3
+  pokrywa się z Project Scoping z kroku 8) i aktualizuję nieaktualne odniesienia
+   do text() raw SQL.
+
+  [--- Update: prd.md — 4 edits, diffs removed for readability ---]
+
+● Now update frontmatter:
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Gotowe. Oto podsumowanie zmian w polishu:
+
+  Usunięta duplikacja:
+  - Sekcja "Product Scope" (MVP/Growth/Vision) usunięta — ta sama treść istnieje
+   pełniej w "Project Scoping & Risk Mitigation" → "MVP Feature Set", "Post-MVP
+  Features"
+
+  Zaktualizowane odniesienia (pgvector):
+  - Journey 3 (Embeddings Pipeline): text() raw SQL → pgvector-python native
+  cosine_distance()
+  - Journey Requirements Summary: pgvector integration via text() →
+  pgvector-python cosine_distance()
+  - Measurable Outcomes: usunięty wyjątek "except pgvector <=> via text()"
+
+  Zaktualizowana kompatybilność API (Journey 4):
+  - "byte-for-byte compatible" → "functionally equivalent, frontend may need
+  minor adjustments"
+
+  Zachowane: Wszystkie FR-y (43), NFR-y (12), success criteria, risk mitigation,
+   technical context — zero utraty informacji.
+
+  Select: [A] Advanced Elicitation [P] Party Mode [C] Continue to Complete PRD
+  (Step 12 of 12)
+

--- a/docs/bmad-examples/PRD_example_epics_clean.txt
+++ b/docs/bmad-examples/PRD_example_epics_clean.txt
@@ -1,0 +1,194 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯  /bmad-bmm-check-implementation-readiness                                     
+
+     Skill tool due to disable-model-invocation
+
+● Skill bmad-bmm-check-implementation-readiness ma flagę
+  disable-model-invocation, więc nie mogę go uruchomić bezpośrednio. Sprawdzę
+  jego definicję i wykonam sprawdzenie ręcznie.
+
+
+● Rozumiem. Rozpoczynam workflow Check Implementation Readiness zgodnie z
+  instrukcjami.
+
+  ---
+  Rozpoczynam Document Discovery — inwentaryzację wszystkich plików
+  projektowych.
+
+  Będę:
+  1. Szukać wszystkich wymaganych dokumentów (PRD, Architecture, Epics, UX)
+  2. Grupować shardowane dokumenty razem
+  3. Identyfikować duplikaty (wersje pełne + shardowane)
+  4. Przedstawić wyniki do potwierdzenia
+
+
+● Sprawdzam jeszcze archiwum PRD.
+
+
+● ---
+  Document Discovery Complete
+
+  PRD Documents
+
+  Whole Documents:
+  - prd.md (aktualny)
+  - prd-validation-report.md (raport walidacyjny)
+
+  Archived PRDs:
+  - 6 zarchiwizowanych wersji PRD w archive/ (sprint 1–6)
+
+  Brak duplikatów — PRD nie jest shardowany.
+
+  Architecture Documents
+
+  Whole Documents:
+  - architecture.md
+
+  Brak duplikatów — brak wersji shardowanej.
+
+  Epics & Stories Documents
+
+  Whole Documents:
+  - epics.md
+
+  Sharded Documents:
+  - Folder: epics/
+    - index.md
+    - epic-20.md
+    - backlog.md
+
+  ⚠️ CRITICAL ISSUE: Duplikat formatu dokumentu Epics
+  - Epics istnieje zarówno jako epics.md (pełny dokument) ORAZ folder epics/
+  (shardowany)
+  - Musisz wybrać, której wersji użyć do oceny
+
+  Archived Epics:
+  - 3 zarchiwizowane wersje w archive/
+
+  UX Design Documents
+
+  ⚠️ WARNING: Brak dokumentu UX
+  - Dokument UX Design nie został znaleziony
+  - Wpłynie to na kompletność oceny
+
+  ---
+  Wymagane działania:
+  1. Duplikat Epics — który format jest aktualny? epics.md czy folder epics/?
+  Proszę wskazać, lub usunąć/przenieść nieaktualną wersję.
+  2. Brak UX — czy dokument UX Design istnieje w innej lokalizacji, czy projekt
+  nie wymaga tego dokumentu?
+
+  Gotowy do kontynuacji? [C] Kontynuuj po rozwiązaniu powyższych kwestii
+
+
+❯ epics.md jest aktualny, w epics/ jest backlog, trzeba go zostawic, index.md   
+zawiera informacje  o dawnych sprintach. to jest chyba stary ipcs               
+@_bmad-output/planning-artifacts/epics/epic-20.md                               
+  ⎿  Read _bmad-output\planning-artifacts\epics\epic-20.md (211 lines)
+
+● Rozumiem. Podsumowując sytuację z Epics:
+
+  - epics.md — aktualny dokument do oceny ✅
+  - epics/backlog.md — backlog, zostaje (dokument uzupełniający)
+  - epics/index.md — stare sprinty (archiwalne)
+  - epics/epic-20.md — stary/nieaktualny plik
+
+  Do oceny implementation readiness użyję epics.md jako główny dokument Epics, z
+   epics/backlog.md jako uzupełnienie.
+
+  Zostaje jeszcze kwestia dokumentu UX Design — nie został znaleziony. Czy:
+  - Projekt nie wymaga dokumentu UX?
+  - Istnieje w innej lokalizacji?
+
+  Select an Option: [C] Kontynuuj do File Validation
+
+❯ na razie pracujemy na backend, UX nie jest potrzebny na razie. bedziemy o tym 
+ rozmawiac pozniej                                                              
+
+● Rozumiem — UX pomijamy na tym etapie.
+
+  Zapisuję inwentarz dokumentów i przechodzę do następnego kroku.
+
+
+  [--- Write: implementation-readiness-report-2026-03-07.md — diff removed for readability ---]
+
+● Inwentarz zapisany. Ładuję krok 2 — analiza PRD.
+
+
+● Rozpoczynam Analizę PRD — ekstrakcję wszystkich wymagań.
+
+  Wczytuję kompletny dokument PRD.
+
+
+● PRD przeczytany w całości. Teraz wyodrębniam wymagania i dodaję je do raportu.
+
+
+  [--- Update: implementation-readiness-report-2026-03-07.md — 2 edits, diffs removed for readability ---]
+
+● Analiza PRD zakończona. Wyodrębniono 43 FR i 12 NFR. Przechodzę do kroku 3 —
+  walidacja pokrycia epics.
+
+
+● Rozpoczynam Walidację Pokrycia Epics. Wczytuję dokument epics.
+
+
+● Doskonale. Dokument epics zawiera kompletną mapę pokrycia FR. Wszystkie 43 FR
+  są pokryte w epicach. Aktualizuję raport.
+
+
+  [--- Update: implementation-readiness-report-2026-03-07.md — 2 edits, diffs removed for readability ---]
+
+● Pokrycie epics zwalidowane — 100% FR i NFR pokryte. Przechodzę do kroku 4 (UX
+  alignment). Ponieważ UX nie jest potrzebny, sprawdzę co krok mówi i przeskoczę
+   do następnego.
+
+
+● PRD dotyczy migracji backendu (bazy danych), nie ma komponentów UI w zakresie
+  tego sprintu. Dodaję krótką notę i przechodzę dalej.
+
+
+  [--- Update: implementation-readiness-report-2026-03-07.md — 2 edits, diffs removed for readability ---]
+
+● Przechodzę do kroku 5 — przegląd jakości epics.
+
+
+● Przeprowadzam przegląd jakości epics — rygorystyczna walidacja przeciwko
+  najlepszym praktykom.
+
+  Mam już pełny dokument epics w pamięci. Przeczytam jeszcze architekturę dla
+  kontekstu.
+
+
+● Mam wystarczający kontekst. Architektura potwierdza: brownfield, brak starter
+  template, praca w istniejącym backendzie Flask. Teraz przeprowadzam
+  rygorystyczny przegląd jakości epics.
+
+  [--- Update: implementation-readiness-report-2026-03-07.md — 2 edits, diffs removed for readability ---]
+
+● Przegląd jakości epics zakończony — brak krytycznych ani poważnych problemów.
+  3 drobne uwagi. Przechodzę do kroku 6 — końcowa ocena gotowości.
+
+
+  [--- Update: implementation-readiness-report-2026-03-07.md — 2 edits, diffs removed for readability ---]
+
+● ---
+  Implementation Readiness Assessment Complete
+
+  Raport wygenerowany:
+  _bmad-output/planning-artifacts/implementation-readiness-report-2026-03-07.md
+
+  Podsumowanie:
+
+  - Status: READY — projekt gotowy do implementacji
+  - 0 krytycznych i 0 poważnych problemów
+  - 3 drobne uwagi (opcjonalne ulepszenia — nie blokują implementacji)
+  - 100% pokrycie FR (43/43) i 100% pokrycie NFR (12/12)
+  - Epics dobrze ustrukturyzowane z pełną tracabilnością
+
+  Następny krok: Rozpocząć implementację od Epic 1, Story 1.1 (Dependencies,
+  Engine & Session Factories).
+

--- a/docs/bmad-examples/PRD_help_co_dalej_1_clean.txt
+++ b/docs/bmad-examples/PRD_help_co_dalej_1_clean.txt
@@ -1,0 +1,109 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯ /bmad-agent-bmm-pm skonczylem przeglad PRD co teraz?                          
+
+
+● Cześć Ziutus! 👋 Tu John, Twój Product Manager.
+
+  Widzę, że skończyłeś przegląd PRD — świetnie! Zanim przejdziemy dalej, powiem
+  Ci co masz do dyspozycji. Oto moje menu:
+
+  ---
+  1. [MH] Wyświetl ponownie menu pomocy
+  2. [CH] Porozmawiaj ze mną o czymkolwiek
+  3. [CP] Stwórz PRD — prowadzone tworzenie dokumentu wymagań produktowych
+  4. [VP] Walidacja PRD — sprawdzenie czy PRD jest kompletny, spójny i dobrze
+  zorganizowany
+  5. [EP] Edytuj PRD — aktualizacja istniejącego dokumentu wymagań
+  6. [CE] Stwórz Epiki i Stories — specyfikacje napędzające development
+  7. [IR] Gotowość do implementacji — sprawdzenie czy PRD, UX, architektura i
+  epiki są ze sobą zsynchronizowane
+  8. [CC] Korekta kursu — gdy w trakcie implementacji odkryjesz potrzebę dużych
+  zmian
+  9. [PM] Party Mode
+  10. [DA] Zwolnij agenta
+
+  ---
+  Skoro skończyłeś przegląd PRD, naturalnym następnym krokiem byłoby:
+  - [VP] Walidacja PRD — jeśli chcesz upewnić się, że PRD jest kompletny i
+  spójny przed przejściem dalej
+  - [EP] Edytuj PRD — jeśli podczas przeglądu znalazłeś rzeczy do poprawienia
+  - [CE] Stwórz Epiki i Stories — jeśli PRD jest gotowy i chcesz przejść do
+  planowania implementacji
+
+  W każdej chwili możesz wpisać /bmad-help, np. /bmad-help co powinienem zrobić 
+  po przeglądzie PRD?
+
+  Co wybierasz?
+
+❯ po walidacji PRD nie trzeba architektury robic? bo wlasnie walidacje          
+skonczylem                                                                      
+
+● Masz absolutną rację, Ziutus! Standardowy flow BMad wygląda tak:
+
+  1. ✅ Stwórz PRD — zrobione
+  2. ✅ Walidacja PRD — właśnie skończone
+  3. 👉 Architektura — to jest następny krok!
+  4. Epiki i Stories
+  5. Sprawdzenie gotowości do implementacji
+
+  Architektura to jednak nie moja działka jako PM-a. Do tego potrzebujesz agenta
+   Architekta, który zaprojektuje rozwiązanie techniczne w oparciu o Twój PRD.
+
+  Proponuję:
+  - Zwolnij mnie (DA) i wywołaj agenta Architekta — to on przeprowadzi Cię przez
+   tworzenie dokumentu architektury
+  - Prawdopodobnie komenda to /bmad-agent-bmm-architect lub podobna
+
+  Jeśli nie jesteś pewien jak go wywołać, wpisz /bmad-help — podpowie Ci
+  następny krok i dokładną komendę.
+
+  Chcesz żebym Cię zwolnił, czy masz jeszcze jakieś pytania do mnie jako PM-a?
+
+❯ /bmad-help zrobilem PRD i walidacje PRD, jakim poleceniem zrobic Arcitektura  
+teraz?                                                                          
+
+
+● Znalazłem odpowiedź! Oto Twój następny krok:
+
+  ---
+  Następny krok: Stworzenie Architektury (wymagane ✅)
+
+  To jest krok wymagany (required=true) w fazie 3 (solutioning), sekwencja 10 —
+  czyli pierwszy krok po zakończeniu planowania PRD.
+
+  Komenda:
+  /bmad-bmm-create-architecture
+
+  Agent: 🏗️ Winston (Architect)
+
+  Opis: Prowadzony workflow do udokumentowania decyzji technicznych —
+  architektura, wybory technologiczne, infrastruktura.
+
+  ---
+  Pełna ścieżka dalej (faza 3 - solutioning):
+
+  #: 1
+  Krok: Stworzenie Architektury
+  Komenda: /bmad-bmm-create-architecture
+  Agent: 🏗️ Winston
+  Wymagany: ✅ tak
+  ────────────────────────────────────────
+  #: 2
+  Krok: Stworzenie Epików i Stories
+  Komenda: /bmad-bmm-create-epics-and-stories
+  Agent: 📋 John (PM)
+  Wymagany: ✅ tak
+  ────────────────────────────────────────
+  #: 3
+  Krok: Sprawdzenie gotowości do implementacji
+  Komenda: /bmad-bmm-check-implementation-readiness
+  Agent: 🏗️ Winston
+  Wymagany: ✅ tak
+
+  ---
+  Ważne: Uruchom architekturę w nowym oknie kontekstu (nowa konwersacja). Jeśli
+  masz dostęp do innego LLM wysokiej jakości, rozważ użycie go do walidacji.

--- a/docs/bmad-examples/PRD_to_EPICS_clean.txt
+++ b/docs/bmad-examples/PRD_to_EPICS_clean.txt
@@ -1,0 +1,1119 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯ /bmad-bmm-create-epics-and-stories                                            
+
+
+● Rozumiem konfigurację. Teraz wczytuję pierwszy krok workflow.
+
+
+● Cześć Ziutus! Witaj w procesie tworzenia epików i historyjek użytkownika!
+
+  Jestem tu jako strateg produktowy i specjalista od specyfikacji technicznych —
+   będziemy wspólnie przekształcać wymagania z PRD i architektury w gotowe do
+  implementacji historyjki.
+
+  Zaczynam od walidacji wymaganych dokumentów. Szukam PRD, Architecture i UX...
+
+
+● Znalazłem wymagane dokumenty:
+
+  ┌─────────────┬───────────┬──────────────────────────────────────────────┐
+  │  Dokument   │  Status   │                   Ścieżka                    │
+  ├─────────────┼───────────┼──────────────────────────────────────────────┤
+  │ PRD         │ ✅ Znalez │ _bmad-output/planning-artifacts/prd.md       │
+  │             │ iony      │                                              │
+  ├─────────────┼───────────┼──────────────────────────────────────────────┤
+  │ Architectur │ ✅ Znalez │ _bmad-output/planning-artifacts/architecture │
+  │ e           │ iony      │ .md                                          │
+  ├─────────────┼───────────┼──────────────────────────────────────────────┤
+  │ UX Design   │ ❌ Brak   │ (nie znaleziono — OK, opcjonalny)            │
+  └─────────────┴───────────┴──────────────────────────────────────────────┘
+
+  Znalazłem też prd-validation-report.md — mogę go uwzględnić jako dodatkowe
+  źródło.
+
+  Zanim przejdę dalej — czy chcesz:
+  - Dodać jakieś inne dokumenty do analizy?
+  - Wykluczyć któryś ze znalezionych?
+  - Czy prd-validation-report.md też powinien być uwzględniony?
+
+  Czekam na Twoje potwierdzenie, żebym mógł przejść do ekstrakcji wymagań.
+
+
+❯ dodaj prd-validation-report.md, nic wiecej nie mam                            
+
+● Świetnie, uwzględniam wszystkie trzy dokumenty. Teraz wczytuję je w całości,
+  żeby wyekstrahować wymagania.
+
+
+● Architektura jest za duża — wczytam ją w częściach.
+
+
+● Widzę, że architektura jest duża. Sprawdzę, czy zawiera sekcje dotyczące
+  migracji SQLAlchemy (sprint 6).
+
+
+● Znalazłem sekcję Sprint 6 w architekturze (od linii 1322). Wczytam ją w
+  całości.
+
+
+● Mam teraz pełny obraz wszystkich trzech dokumentów. Przechodzę do ekstrakcji
+  wymagań.
+
+  ---
+  Wyekstrahowane wymagania
+
+  Wymagania funkcjonalne (FR) — 43 znalezione
+
+  PRD zawiera 43 FR zorganizowane w 9 grup:
+
+  ORM Model Definition (FR1-FR5):
+  - FR1: Developer can define database table structure as a Python ORM model
+  class in a single file
+  - FR2: Developer can define column types, constraints, defaults, and
+  nullability as model field attributes
+  - FR3: Developer can define relationships between models (one-to-many,
+  many-to-one) using ORM relationship declarations
+  - FR4: Developer can define Single Table Inheritance hierarchy on
+  web_documents with document type as discriminator
+  - FR5: Developer can add domain methods directly on the ORM model
+
+  Schema Migration (FR6-FR9):
+  - FR6: Developer can auto-generate migration scripts from ORM model changes
+  via Alembic
+  - FR7: Developer can apply migrations with a single command
+  - FR8: Developer can roll back migrations to a previous version
+  - FR9: Developer can initialize Alembic on an existing database by stamping
+  baseline
+
+  Session & Connection Management (FR10-FR13):
+  - FR10-FR13: Thread-local sessions for Flask, teardown cleanup, script-scoped
+  sessions, pool_pre_ping recovery
+
+  Document Persistence (FR14-FR19):
+  - FR14-FR19: CRUD via ORM, cascade deletion, lookup by URL/ID, dict
+  serialization
+
+  Embedding Operations (FR20-FR23):
+  - FR20-FR23: Add/delete embeddings via relationship, find documents needing
+  embeddings, similarity search via cosine_distance()
+
+  Repository Queries (FR24-FR30):
+  - FR24-FR30: Dynamic filtered lists, count by type/state, ready for
+  download/transcription, next to correct, last import date
+
+  Import Script Compatibility (FR31-FR34):
+  - FR31-FR34: dynamodb_sync.py and unknown_news_import.py work with ORM
+
+  Batch Pipeline Compatibility (FR35-FR38):
+  - FR35-FR38: web_documents_do_the_needful_new.py with ORM for embeddings and
+  state transitions
+
+  Flask API Compatibility (FR39-FR43):
+  - FR39-FR43: All 5 endpoints (/website_list, /website_get, /website_save,
+  /website_delete, /website_similar) work via repository
+
+  ---
+  Wymagania niefunkcjonalne (NFR) — 12 znalezionych
+
+  Code Quality (NFR1-NFR4):
+  - NFR1: Zero raw cursor.execute() in production code
+  - NFR2: ruff check backend/ zero warnings
+  - NFR3: All existing unit tests pass
+  - NFR4: ORM models use Mapped[type] type hints
+
+  Backward Compatibility (NFR5-NFR6):
+  - NFR5: Enum classes preserved with identical values
+  - NFR6: Database schema identical after migration (Alembic baseline = no diff)
+
+  Maintainability (NFR7-NFR9):
+  - NFR7: Adding column = 1 file change
+  - NFR8: Adding table = 1 file + 1 Alembic command
+  - NFR9: No dead code from old architecture
+
+  Dependency Management (NFR10-NFR12):
+  - NFR10: New deps in pyproject.toml with version pins
+  - NFR11: uv lock valid
+  - NFR12: .venv_wsl synchronized
+
+  ---
+  Dodatkowe wymagania z Architecture (Sprint 6)
+
+  - Brak starter template — praca w ramach istniejącego Flask backend
+  - Wrapper elimination — re-export StalkerWebDocument i StalkerWebDocumentDB z
+  library.db.models
+  - Session injection — session przekazywany jako parametr konstruktora
+  repository
+  - Hybrid query location — proste lookupy jako classmethods, złożone queries w
+  repository
+  - dict() backward compatibility — format "YYYY-MM-DD HH:MM:SS", enum .name,
+  nawigacja jako transient attributes
+  - pgvector-python native operators — cosine_distance() jako primary, text()
+  jako fallback
+  - Navigation fields — repository load_neighbors(doc) populuje transient
+  attributes
+  - Implementation sequence — 9-fazowa kolejność: dependencies → models →
+  repository → re-exports → Flask → consumers → Alembic → cleanup → verification
+  - Enum preservation — enumy zostają w library/models/, bez zmian
+  - Transaction boundaries — repository NIGDY nie commituje — caller kontroluje
+  transakcje
+  - pgvector HNSW indexes — zarządzane tylko przez Alembic, nie w ORM model
+
+  ---
+  Dodatkowe wymagania z PRD Validation Report
+
+  Raport walidacyjny potwierdził PRD jako 5/5 Excellent — brak krytycznych
+  problemów. Post-validation fixes już zostały zastosowane:
+  - FR12 poprawione (dodano szczegółowość)
+  - Dodano sekcję "Out of Scope" (9 wykluczeń)
+  - Dodano sekcję "Assumptions & Dependencies"
+  - Poprawiono Vector() na dimensionless
+
+  Brak dodatkowych wymagań z validation report — pełni rolę potwierdzającą, nie
+  rozszerzającą.
+
+  ---
+  Czy te wyekstrahowane wymagania dokładnie odzwierciedlają to, co ma być
+  zbudowane? Jakieś uzupełnienia lub korekty?
+
+
+❯ tak, zrobmy to                                                                
+
+● Tworzę plik wyjściowy z wyekstrahowanymi wymaganiami.
+
+  [--- Write: epics.md — diff removed for readability ---]
+
+● Plik jeszcze nie istnieje, ale narzędzie wymaga wcześniejszego odczytu.
+  Spróbuję inaczej — plik jest nowy, więc odczytam go (otrzymam błąd), a potem
+  zapiszę.
+
+
+● Plik epics.md istnieje z poprzedniego sprintu (Slack Bot). Nadpiszę go nową
+  zawartością dla Sprint 6 — migracji SQLAlchemy ORM.
+
+  [--- Write: epics.md — diff removed for readability ---]
+
+● Plik epics.md został utworzony z pełną listą wymagań. Oto podsumowanie:
+
+  Wyekstrahowano:
+  - 43 FR w 9 grupach (ORM Models, Schema Migration, Session Management,
+  Document Persistence, Embedding Operations, Repository Queries, Import
+  Scripts, Batch Pipeline, Flask API)
+  - 12 NFR w 4 grupach (Code Quality, Backward Compatibility, Maintainability,
+  Dependency Management)
+  - 15 dodatkowych wymagań z Architecture Sprint 6 (wrapper elimination, session
+   injection, dict() backward compat, pgvector operators, transaction
+  boundaries, etc.)
+  - 0 dodatkowych wymagań z PRD Validation Report (potwierdzenie jakości)
+
+  Placeholdery {{requirements_coverage_map}} i {{epics_list}} zostaną wypełnione
+   w następnych krokach.
+
+  ---
+  Potwierdź, że wymagania są kompletne i poprawne, aby przejść dalej: [C] 
+  continue
+
+
+❯ C                                                                             
+
+
+● Wczytuję plik wyjściowy, aby mieć kontekst wymagań, i przechodzę do
+  projektowania epików.
+
+  Zanim zaproponuję strukturę, wyjaśnię zasady projektowania epików:
+
+  1. User-Value First — każdy epik umożliwia użytkownikowi (tu: deweloperowi
+  Ziutus) osiągnięcie czegoś wartościowego
+  2. Standalone — każdy epik działa samodzielnie po ukończeniu
+  3. Incremental Delivery — naturalna progresja od fundamentów do pełnej
+  migracji
+  4. Dependency-Free Within Epic — historyjki w epiku nie zależą od przyszłych
+  historyjek
+
+  PRD definiuje 4 user journeys, które dają naturalne grupowanie tematyczne:
+  - Journey 1: Schema Modification (definiowanie modeli, Alembic)
+  - Journey 2: Import Run (skrypty importu)
+  - Journey 3: Embeddings Pipeline (embeddingowy batch)
+  - Journey 4: API Request (Flask API serwuje frontend)
+
+  ---
+  Propozycja struktury epików
+
+  Epic 1: ORM Foundation & Schema Management
+
+  Developer can define database schema as SQLAlchemy 2.x ORM models, manage
+  database sessions for Flask and scripts, and use Alembic for schema migrations
+   — eliminating the fear of schema changes.
+
+  FRs covered: FR1, FR2, FR3, FR4, FR5, FR6, FR7, FR8, FR9, FR10, FR11, FR12,
+  FR13
+  User value: Schema changes become single-file edits with auto-generated
+  migrations. Session management replaces the singleton anti-pattern.
+  Standalone: ORM models importable, sessions work, Alembic initialized —
+  foundation for all subsequent epics.
+
+  Epic 2: Document CRUD & API Serving
+
+  Developer can create, update, delete, and query documents through the ORM
+  repository, and all Flask API endpoints (/website_list, /website_get,
+  /website_save, /website_delete) return identical data formats as before. Old
+  wrapper classes replaced with re-exports.
+
+  FRs covered: FR14, FR15, FR16, FR17, FR18, FR19, FR24, FR25, FR26, FR27, FR28,
+   FR29, FR30, FR39, FR40, FR41, FR42
+  User value: Complete document management through API — frontend works
+  identically after migration.
+  Standalone: Full CRUD + query API operational via ORM. Builds on Epic 1.
+
+  Epic 3: Vector Embeddings & Similarity Search
+
+  Developer can manage vector embeddings via ORM relationship and perform
+  similarity search using pgvector-python native cosine_distance() operator —
+  zero raw SQL for vector operations.
+
+  FRs covered: FR20, FR21, FR22, FR23, FR43
+  User value: Similarity search works through ORM with native operators.
+  /website_similar endpoint functional.
+  Standalone: Complete embedding management + vector search. Builds on Epic 1 +
+  2.
+
+  Epic 4: Data Pipeline Migration & Cleanup
+
+  Import scripts and batch pipeline work with ORM models and sessions. YouTube
+  pipeline stores transcripts via ORM. Old wrapper code fully removed, all
+  quality gates pass.
+
+  FRs covered: FR31, FR32, FR33, FR34, FR35, FR36, FR37, FR38
+  NFRs addressed: NFR1 (zero cursor.execute), NFR2 (ruff clean), NFR3 (tests
+  pass), NFR9 (no dead code), NFR10-NFR12 (dependencies)
+  User value: All data ingestion paths work through ORM. Migration is complete —
+   zero legacy code remains.
+  Standalone: All consumers migrated. Builds on Epic 1 + 2 + 3.
+
+  ---
+  Podsumowanie:
+
+  ┌─────────────────────────┬─────────────────────┬────────────────────────┐
+  │          Epic           │         FRs         │       User Value       │
+  ├─────────────────────────┼─────────────────────┼────────────────────────┤
+  │ Epic 1: ORM Foundation  │ FR1-FR13 (13)       │ Schema bez strachu,    │
+  │ & Schema Management     │                     │ sesje, Alembic         │
+  ├─────────────────────────┼─────────────────────┼────────────────────────┤
+  │ Epic 2: Document CRUD & │ FR14-FR19,          │ CRUD + API działa      │
+  │  API Serving            │ FR24-FR30,          │ identycznie            │
+  │                         │ FR39-FR42 (17)      │                        │
+  ├─────────────────────────┼─────────────────────┼────────────────────────┤
+  │ Epic 3: Vector          │                     │ Wektorowy search via   │
+  │ Embeddings & Similarity │ FR20-FR23, FR43 (5) │ pgvector-python        │
+  │  Search                 │                     │                        │
+  ├─────────────────────────┼─────────────────────┼────────────────────────┤
+  │ Epic 4: Data Pipeline   │ FR31-FR38 (8)       │ Importy + batch +      │
+  │ Migration & Cleanup     │                     │ cleanup                │
+  ├─────────────────────────┼─────────────────────┼────────────────────────┤
+  │ Total                   │ 43 FRs — 100%       │                        │
+  └─────────────────────────┴─────────────────────┴────────────────────────┘
+
+  Zależności: Epic 1 → Epic 2 → Epic 3 → Epic 4 (naturalna progresja, każdy
+  standalone po ukończeniu)
+
+  ---
+  Czy ta struktura epików pasuje do Twojej wizji produktu? Czy chcesz zmienić
+  jakieś grupowanie?
+
+
+❯ jest ok                                                                       
+
+● Świetnie! Zapisuję zatwierdzoną strukturę epików do pliku.
+
+  [--- Update: epics.md — 2 edits, diffs removed for readability ---]
+
+● Zatwierdzona struktura epików i mapa pokrycia FR zapisane do epics.md.
+
+  Wybierz opcję: [A] Advanced Elicitation [P] Party Mode [C] Continue
+
+
+❯ C                                                                             
+
+
+● Zaczynam tworzenie historyjek. Przetwarzam epiki sekwencyjnie, zaczynając od
+  Epic 1.
+
+  ---
+  Epic 1: ORM Foundation & Schema Management
+
+  Cel: Developer can define database schema as SQLAlchemy 2.x ORM models, manage
+   database sessions, and use Alembic for schema migrations.
+
+  FRs: FR1-FR13 | NFRs: NFR4, NFR5, NFR6, NFR7, NFR8, NFR10, NFR11, NFR12
+
+  Dodatkowe wymagania z Architecture:
+  - SQLAlchemy 2.x mapped_column() z Mapped[] type hints
+  - WebDocument (STI) + WebsiteEmbedding (dimensionless Vector())
+  - Engine: get_engine(), get_session(), get_scoped_session()
+  - Enum preservation — importy z library/models/ bez zmian
+  - 28 kolumn w web_documents — wszystkie zmapowane
+  - pool_pre_ping=True dla recovery stale connections
+  - Flask: @app.teardown_appcontext z session.remove()
+
+  Proponuję 3 historyjki dla tego epika:
+
+  Story 1.1: Dependencies, Engine & Session Factories
+
+  As a developer,
+  I want SQLAlchemy engine and session factory functions (get_engine,
+  get_session, get_scoped_session),
+  So that all consumers have a unified, thread-safe way to access the database.
+
+  AC:
+  - Given pyproject.toml is updated with sqlalchemy>=2.0,<3.0, pgvector>=0.3.0,
+  alembic>=1.13
+  - When uv lock is run
+  - Then lock file is valid and dependencies resolve
+  - Given library/db/engine.py exists
+  - When get_engine() is called
+  - Then returns a SQLAlchemy engine with pool_pre_ping=True using POSTGRESQL_*
+  env vars
+  - Given engine is initialized
+  - When get_session() is called
+  - Then returns a new Session bound to the engine (for scripts)
+  - Given engine is initialized
+  - When get_scoped_session() is called
+  - Then returns a thread-local scoped_session (for Flask)
+  - Given .venv_wsl exists
+  - When dependencies change
+  - Then .venv_wsl is synchronized
+
+  Covers: FR10, FR12, FR13 | NFR10, NFR11, NFR12
+
+  ---
+  Story 1.2: ORM Models — WebDocument (STI) & WebsiteEmbedding
+
+  As a developer,
+  I want WebDocument and WebsiteEmbedding defined as SQLAlchemy 2.x ORM models
+  in library/db/models.py,
+  So that database schema is defined once in Python and I can add columns/tables
+   with a single-file change.
+
+  AC:
+  - Given library/db/models.py exists
+  - When WebDocument model is inspected
+  - Then it maps all 28 columns from web_documents table with exact column names
+   and types matching DDL (03-create-table.sql)
+  - Given WebDocument has STI configured
+  - When __mapper_args__ is inspected
+  - Then document_type is the polymorphic discriminator
+  - Given WebDocument has domain methods
+  - When set_document_type(), set_document_state(), validate(), dict() are
+  called
+  - Then they behave identically to current StalkerWebDocumentDB methods
+  - Given dict() is called on a WebDocument instance
+  - When the result is inspected
+  - Then dates are formatted as "YYYY-MM-DD HH:MM:SS", enums as .name, all
+  existing keys preserved
+  - Given WebsiteEmbedding model exists
+  - When inspected
+  - Then it has dimensionless Vector() column, web_document_id FK, language,
+  model, text columns matching DDL (04-create-table.sql)
+  - Given WebDocument has a relationship to WebsiteEmbedding
+  - When relationship is inspected
+  - Then cascade="all, delete-orphan" is configured
+  - Given enums are needed by ORM model
+  - When imports are inspected
+  - Then enums are imported from library.models.stalker_document_status
+  (original location, not moved)
+  - Given all ORM model columns use type hints
+  - When code is inspected
+  - Then all columns use Mapped[type] with mapped_column() (not older Column()
+  style)
+  - Given navigation fields exist
+  - When next_id, next_type, previous_id, previous_type are inspected
+  - Then they are plain Python class attributes (= None), NOT mapped_column()
+
+  Covers: FR1, FR2, FR3, FR4, FR5 | NFR4, NFR5, NFR7
+
+  ---
+  Story 1.3: Alembic Initialization & Flask Session Integration
+
+  As a developer,
+  I want Alembic initialized with a baseline migration and Flask session
+  teardown configured,
+  So that I can auto-generate migration scripts from model changes and Flask
+  sessions are properly scoped.
+
+  AC:
+  - Given backend/alembic.ini and backend/alembic/env.py exist
+  - When alembic revision --autogenerate -m "test" is run against existing
+  database
+  - Then the generated migration is empty (no diff — model matches DDL exactly)
+  - Given Alembic is initialized
+  - When alembic stamp head is run
+  - Then existing database is marked as baseline (no migrations needed)
+  - Given developer adds a new column to the ORM model
+  - When alembic revision --autogenerate -m "add column" is run
+  - Then Alembic generates correct ALTER TABLE migration script
+  - Given a migration exists
+  - When alembic upgrade head is run
+  - Then database schema is updated
+  - Given a migration was applied
+  - When alembic downgrade -1 is run
+  - Then migration is rolled back
+  - Given server.py has @app.teardown_appcontext
+  - When a Flask request completes
+  - Then scoped_session.remove() is called, releasing the session
+  - Given re-export files exist
+  - When from library.stalker_web_document import StalkerWebDocument is used
+  - Then it returns the WebDocument ORM model (backward compatibility)
+  - Given re-export files exist
+  - When from library.stalker_web_document_db import StalkerWebDocumentDB is
+  used
+  - Then it returns the WebDocument ORM model (backward compatibility)
+
+  Covers: FR6, FR7, FR8, FR9, FR10, FR11 | NFR5, NFR6, NFR8
+
+  ---
+  Podsumowanie Epic 1: 3 historyjki, 13 FR pokrytych (FR1-FR13), naturalna
+  progresja: dependencies → models → Alembic + Flask.
+
+  Czy te historyjki poprawnie oddają wymagania? Czy zakres każdej jest
+  odpowiedni?
+
+
+❯ jest ok                                                                       
+
+● Zapisuję Epic 1 i przechodzę do Epic 2.
+
+  ---
+  Epic 2: Document CRUD & API Serving
+
+  Cel: Developer can create, update, delete, and query documents through the ORM
+   repository, and all Flask API endpoints return identical data formats. Old
+  wrapper classes replaced with re-exports.
+
+  FRs: FR14-FR19, FR24-FR30, FR39-FR42 | NFRs: NFR1 (partial), NFR5
+
+  Dodatkowe wymagania z Architecture:
+  - Session injection — WebsitesDBPostgreSQL(session) constructor
+  - Hybrid query location — get_by_id(), get_by_url() jako classmethods na
+  modelu
+  - Repository NIGDY nie commituje — caller kontroluje transakcje
+  - dict() backward compat — exact match (dates, enums, navigation fields)
+  - get_list() zwraca subset dict (10 pól)
+  - load_neighbors(doc) populuje transient attributes
+  - Plik stalker_web_documents_db_postgresql.py — ten sam plik, przepisany
+
+  Proponuję 3 historyjki:
+
+  Story 2.1: Document Persistence — CRUD via ORM
+
+  As a developer,
+  I want to create, read, update, and delete documents via ORM session
+  operations and classmethods,
+  So that I no longer need manual SQL for basic document operations.
+
+  AC:
+  - Given a session and document data
+  - When WebDocument(url="https://...") is created and session.add(doc) +
+  session.commit() is called
+  - Then the document is persisted in web_documents table
+  - Given an existing document in the database
+  - When doc.title = "New title" is set and session.commit() is called
+  - Then SQLAlchemy dirty tracking generates UPDATE for the changed column only
+  - Given a document with related embeddings
+  - When session.delete(doc) + session.commit() is called
+  - Then the document AND all related embeddings are deleted (cascade)
+  - Given a URL string
+  - When WebDocument.get_by_url(session, url) is called
+  - Then returns the matching document or None (for duplicate detection)
+  - Given a document ID
+  - When WebDocument.get_by_id(session, id) is called
+  - Then returns the matching document or None
+  - Given a WebDocument instance
+  - When doc.dict() is called
+  - Then output matches exact format: dates as "YYYY-MM-DD HH:MM:SS", enums as
+  .name, all existing keys preserved including transient navigation fields when
+  populated
+
+  Covers: FR14, FR15, FR16, FR17, FR18, FR19 | NFR5
+
+  ---
+  Story 2.2: Repository Queries — List, Count, State-Based Lookups
+
+  As a developer,
+  I want all repository query methods rewritten with SQLAlchemy select()
+  queries,
+  So that document listing, counting, and state-based lookups work without raw
+  SQL.
+
+  AC:
+  - Given WebsitesDBPostgreSQL receives session via constructor
+  (WebsitesDBPostgreSQL(session))
+  - When any query method is called
+  - Then it uses session.execute(select(...)) — no raw cursor.execute()
+  - Given repository method get_list(document_type='link', limit=20)
+  - When called
+  - Then returns list of subset dicts (id, url, title, document_type,
+  created_at, document_state, document_state_error, note, project, s3_uuid) with
+   dynamic filters applied
+  - Given repository method get_count(document_type='link')
+  - When called
+  - Then returns integer count using func.count()
+  - Given repository method get_count_by_type()
+  - When called
+  - Then returns dict with counts per document type
+  - Given repository method get_ready_for_download()
+  - When called
+  - Then returns documents in URL_ADDED state with webpage/link type
+  - Given repository method get_youtube_just_added()
+  - When called
+  - Then returns YouTube documents in URL_ADDED state
+  - Given repository method get_transcription_done()
+  - When called
+  - Then returns documents with completed transcriptions
+  - Given repository method get_next_to_correct(id, document_type)
+  - When called
+  - Then returns the next document for navigation
+  - Given repository method get_last_unknown_news()
+  - When called
+  - Then returns the last imported date for unknow.news source
+  - Given repository method load_neighbors(doc)
+  - When called
+  - Then populates doc.next_id, doc.next_type, doc.previous_id,
+  doc.previous_type transient attributes
+  - Given any repository method
+  - When inspected
+  - Then it NEVER calls session.commit() or session.rollback() — caller controls
+   transactions
+
+  Covers: FR24, FR25, FR26, FR27, FR28, FR29, FR30
+
+  ---
+  Story 2.3: Flask API Endpoints — CRUD Routes via Repository
+
+  As a developer,
+  I want Flask route handlers updated to use the ORM repository with scoped
+  session,
+  So that the React frontend receives identical API responses after the
+  migration.
+
+  AC:
+  - Given Flask app with scoped session
+  - When GET /website_list?document_type=link&limit=20 is called
+  - Then route creates WebsitesDBPostgreSQL(scoped_session()), calls get_list(),
+   returns JSON response identical to pre-migration format
+  - Given a document with ID exists
+  - When GET /website_get?id=42 is called
+  - Then route returns full document dict with navigation fields (next_id,
+  next_type, previous_id, previous_type) populated via load_neighbors()
+  - Given valid document data in request body
+  - When POST /website_save is called
+  - Then route creates or updates document via ORM model and session.commit(),
+  returns success response
+  - Given a document ID
+  - When DELETE /website_delete?id=42 is called
+  - Then route deletes document via session.delete() with cascade (embeddings
+  removed), returns success response
+  - Given any Flask endpoint completes (success or error)
+  - When request teardown occurs
+  - Then scoped_session.remove() is called via @app.teardown_appcontext
+  - Given frontend makes API calls before and after migration
+  - When response JSON is compared
+  - Then field names, value types, and date formats are identical
+
+  Covers: FR39, FR40, FR41, FR42 | NFR1 (partial)
+
+  ---
+  Podsumowanie Epic 2: 3 historyjki, 17 FR pokrytych (FR14-FR19, FR24-FR30,
+  FR39-FR42). Progresja: CRUD → queries → Flask endpoints.
+
+  Czy historyjki Epic 2 są OK?
+
+
+❯ ok                                                                            
+
+● Przechodzę do Epic 3.
+
+  ---
+  Epic 3: Vector Embeddings & Similarity Search
+
+  Cel: Developer can manage vector embeddings via ORM relationship and perform
+  similarity search using pgvector-python native cosine_distance() operator —
+  zero raw SQL for vector operations.
+
+  FRs: FR20-FR23, FR43 | NFRs: NFR1 (partial)
+
+  Dodatkowe wymagania z Architecture:
+  - pgvector-python native cosine_distance() jako primary, text() fallback dla
+  edge cases
+  - Similarity score = 1 - cosine_distance computed jako SQL expression
+  - pgvector HNSW partial indexes — zarządzane przez Alembic, nie w ORM model
+  - get_similar() return format: website_id, text, similarity, id, url,
+  language, text_original, websites_text_length, embeddings_text_length, title,
+  document_type, project
+  - find documents needing embeddings — outer join na websites_embeddings
+
+  Proponuję 2 historyjki:
+
+  Story 3.1: Embedding CRUD & Documents Needing Embeddings
+
+  As a developer,
+  I want to add, delete, and query embeddings via ORM relationship and
+  repository,
+  So that embedding management no longer requires hand-written INSERT/DELETE
+  SQL.
+
+  AC:
+  - Given a WebDocument instance and an embedding vector
+  - When a WebsiteEmbedding is created and added via ORM relationship
+  (doc.embeddings.append(embedding)) and session.commit() is called
+  - Then the embedding is persisted in websites_embeddings table with correct
+  web_document_id FK
+  - Given a document with embeddings for multiple models
+  - When embeddings are deleted filtered by model name via repository
+  - Then only embeddings for the specified model are removed, others remain
+  - Given documents exist with and without embeddings
+  - When repository method get_documents_needing_embedding(model) is called
+  - Then returns documents that have no embedding for the specified model (outer
+   join on websites_embeddings)
+  - Given the query uses SQLAlchemy
+  - When get_documents_needing_embedding() is inspected
+  - Then it uses select() with outerjoin() — no raw cursor.execute()
+
+  Covers: FR20, FR21, FR22
+
+  ---
+  Story 3.2: Similarity Search via pgvector-python & API Endpoint
+
+  As a developer,
+  I want similarity search implemented with pgvector-python native
+  cosine_distance() operator and the /website_similar endpoint functional,
+  So that vector search works through ORM with zero raw SQL.
+
+  AC:
+  - Given a query vector and a limit
+  - When repository method get_similar(vector, limit, model) is called
+  - Then it uses WebsiteEmbedding.embedding.cosine_distance(query_vector) for
+  ordering
+  - Given similarity search results
+  - When similarity score is computed
+  - Then it is calculated as 1 - cosine_distance using a SQLAlchemy SQL
+  expression (func.cast), not Python-side computation
+  - Given get_similar() returns results
+  - When result format is inspected
+  - Then each result is a dict with: website_id, text, similarity (float), id,
+  url, language, text_original, websites_text_length, embeddings_text_length,
+  title, document_type, project
+  - Given a query vector
+  - When GET /website_similar endpoint is called with vector and model
+  parameters
+  - Then Flask route creates repository, calls get_similar(), returns JSON
+  response
+  - Given no similar documents exist above threshold
+  - When similarity search is performed
+  - Then returns empty list (no error)
+  - Given pgvector HNSW partial indexes exist in the database
+  - When ORM model is inspected
+  - Then indexes are NOT defined in the model — they are managed by Alembic
+  migrations only
+
+  Covers: FR23, FR43 | NFR1 (partial)
+
+  ---
+  Podsumowanie Epic 3: 2 historyjki, 5 FR pokrytych (FR20-FR23, FR43).
+  Progresja: embedding CRUD → similarity search + endpoint.
+
+  Czy historyjki Epic 3 są OK?
+
+❯ ok                                                                            
+
+● Przechodzę do Epic 4 — ostatni epik.
+
+  ---
+  Epic 4: Data Pipeline Migration & Cleanup
+
+  Cel: Import scripts and batch pipeline work with ORM models and sessions. Old
+  wrapper code fully removed, all quality gates pass.
+
+  FRs: FR31-FR38 | NFRs: NFR1 (complete), NFR2, NFR3, NFR9
+
+  Dodatkowe wymagania z Architecture:
+  - dynamodb_sync.py — created_at i chapter_list via ORM attribute assignment
+  (nie direct SQL)
+  - unknown_news_import.py — duplicate detection via WebDocument.get_by_url()
+  - web_documents_do_the_needful_new.py — commit per document, script-scoped
+  session
+  - YouTube pipeline — transcript text i metadata via ORM
+  - Session lifecycle w skryptach: get_session() → try/commit/finally/close
+  - Old code removal: stalker_web_document_db.py wrapper content replaced, no
+  dead code
+  - NFR1 final verification: zero cursor.execute() in production code
+
+  Proponuję 3 historyjki:
+
+  Story 4.1: Import Scripts Migration (dynamodb_sync & unknown_news_import)
+
+  As a developer,
+  I want import scripts to use ORM models and sessions instead of the old
+  wrapper,
+  So that data imports work through the same ORM layer as the rest of the
+  application.
+
+  AC:
+  - Given dynamodb_sync.py is updated
+  - When it processes a DynamoDB item
+  - Then it creates WebDocument(url=item['url']) via ORM, sets attributes, and
+  session.commit()
+  - Given dynamodb_sync.py needs to set created_at and chapter_list
+  - When these fields are updated
+  - Then they are set via normal ORM attribute assignment (doc.created_at = 
+  value) — no direct SQL UPDATE
+  - Given unknown_news_import.py is updated
+  - When it processes a JSON feed entry
+  - Then it creates WebDocument via ORM with fields: title, summary, language,
+  source, date_from, document_type, document_state
+  - Given unknown_news_import.py processes a URL that already exists
+  - When WebDocument.get_by_url(session, url) returns a match
+  - Then the duplicate is skipped (not inserted)
+  - Given either import script
+  - When session lifecycle is inspected
+  - Then it follows the pattern: session = get_session() → try →
+  session.commit() → finally → session.close()
+  - Given import scripts use no raw SQL
+  - When code is inspected
+  - Then zero cursor.execute() calls remain in import scripts
+
+  Covers: FR31, FR32, FR33, FR34
+
+  ---
+  Story 4.2: Batch Pipeline & YouTube Processing Migration
+
+  As a developer,
+  I want web_documents_do_the_needful_new.py and YouTube processing to use ORM
+  models,
+  So that the batch pipeline and transcript storage work through the same ORM
+  layer.
+
+  AC:
+  - Given web_documents_do_the_needful_new.py is updated
+  - When it processes an SQS message
+  - Then it creates/retrieves WebDocument via ORM and session.commit()
+  - Given batch pipeline needs to generate embeddings
+  - When embeddings are created
+  - Then they are stored via ORM relationship (WebsiteEmbedding added to
+  document's embeddings collection)
+  - Given batch pipeline processes a document through its lifecycle
+  - When document state changes (e.g., URL_ADDED → DOCUMENT_INTO_DATABASE →
+  EMBEDDING_EXIST)
+  - Then state is updated via ORM attribute assignment (doc.document_state = 
+  StalkerDocumentStatus.EMBEDDING_EXIST) and session.commit()
+  - Given YouTube processing pipeline receives transcript
+  - When transcript text and metadata are stored
+  - Then they are set via ORM attributes on WebDocument (not direct SQL)
+  - Given batch pipeline session lifecycle
+  - When inspected
+  - Then uses script-scoped get_session() with commit per document
+  - Given batch pipeline uses no raw SQL
+  - When code is inspected
+  - Then zero cursor.execute() calls remain
+
+  Covers: FR35, FR36, FR37, FR38
+
+  ---
+  Story 4.3: Old Code Removal & Final Verification
+
+  As a developer,
+  I want all old wrapper code removed and all quality gates verified,
+  So that the migration is complete with zero legacy code and a clean codebase.
+
+  AC:
+  - Given all consumers are migrated to ORM
+  - When stalker_web_document.py is inspected
+  - Then it contains only: from library.db.models import WebDocument as 
+  StalkerWebDocument (re-export)
+  - Given all consumers are migrated
+  - When stalker_web_document_db.py is inspected
+  - Then it contains only: from library.db.models import WebDocument as 
+  StalkerWebDocumentDB (re-export)
+  - Given old wrapper code
+  - When codebase is searched for cursor.execute()
+  - Then zero occurrences found in production code (NFR1 complete)
+  - Given updated codebase
+  - When ruff check backend/ is run
+  - Then zero warnings reported (line-length=120)
+  - Given existing unit tests
+  - When cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v is run
+  - Then all tests pass without modification
+  - Given the complete migration
+  - When codebase is searched for dead code from old architecture
+  - Then no remnants of StalkerWebDocumentDB class definition, db_conn
+  singleton, or __clean_values() method remain
+
+  Covers: NFR1 (complete), NFR2, NFR3, NFR9
+
+  ---
+  Podsumowanie Epic 4: 3 historyjki, 8 FR pokrytych (FR31-FR38) + NFR1, NFR2,
+  NFR3, NFR9. Progresja: import scripts → batch pipeline → cleanup &
+  verification.
+
+  Czy historyjki Epic 4 są OK?
+
+❯ ok                                                                            
+
+● Zapisuję wszystkie epiki i historyjki do pliku.
+
+
+  [--- Update: epics.md — 2 edits, diffs removed for readability ---]
+
+● Wszystkie 4 epiki z 11 historyjkami zapisane do epics.md. Podsumowanie:
+
+  ┌───────────────────────┬────────────┬──────────────────┬────────────────┐
+  │         Epic          │  Stories   │       FRs        │      NFRs      │
+  ├───────────────────────┼────────────┼──────────────────┼────────────────┤
+  │ Epic 1: ORM           │ 3 (1.1,    │                  │ NFR4-NFR8,     │
+  │ Foundation & Schema   │ 1.2, 1.3)  │ FR1-FR13         │ NFR10-NFR12    │
+  │ Management            │            │                  │                │
+  ├───────────────────────┼────────────┼──────────────────┼────────────────┤
+  │ Epic 2: Document CRUD │ 3 (2.1,    │ FR14-FR19,       │                │
+  │  & API Serving        │ 2.2, 2.3)  │ FR24-FR30,       │ NFR1, NFR5     │
+  │                       │            │ FR39-FR42        │                │
+  ├───────────────────────┼────────────┼──────────────────┼────────────────┤
+  │ Epic 3: Vector        │ 2 (3.1,    │                  │                │
+  │ Embeddings &          │ 3.2)       │ FR20-FR23, FR43  │ NFR1           │
+  │ Similarity Search     │            │                  │                │
+  ├───────────────────────┼────────────┼──────────────────┼────────────────┤
+  │ Epic 4: Data Pipeline │ 3 (4.1,    │ FR31-FR38        │ NFR1-NFR3,     │
+  │  Migration & Cleanup  │ 4.2, 4.3)  │                  │ NFR9           │
+  ├───────────────────────┼────────────┼──────────────────┼────────────────┤
+  │ Total                 │ 11 stories │ 43/43 FRs — 100% │ 12/12 NFRs     │
+  └───────────────────────┴────────────┴──────────────────┴────────────────┘
+
+  Wybierz opcję: [A] Advanced Elicitation [P] Party Mode [C] Continue
+
+
+❯ c                                                                             
+
+
+● Przechodzę do walidacji końcowej. Sprawdzam systematycznie wszystkie
+  wymagania.
+
+  ---
+  1. FR Coverage Validation
+
+  Sprawdzam każdy FR:
+
+  ┌──────┬─────────────────────────────────────────────────────────┬─────────┐
+  │  FR  │                          Story                          │ Status  │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR1  │ Story 1.2 (ORM model definition)                        │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR2  │ Story 1.2 (column types, constraints)                   │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR3  │ Story 1.2 (relationships)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR4  │ Story 1.2 (STI hierarchy)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR5  │ Story 1.2 (domain methods)                              │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR6  │ Story 1.3 (Alembic autogenerate)                        │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR7  │ Story 1.3 (alembic upgrade head)                        │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR8  │ Story 1.3 (alembic downgrade)                           │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR9  │ Story 1.3 (stamp baseline)                              │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR10 │ Story 1.1 + 1.3 (thread-local session + Flask teardown) │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR11 │ Story 1.3 (teardown_appcontext)                         │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR12 │ Story 1.1 (get_session for scripts)                     │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR13 │ Story 1.1 (pool_pre_ping)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR14 │ Story 2.1 (create via ORM)                              │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR15 │ Story 2.1 (update via ORM)                              │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR16 │ Story 2.1 (delete with cascade)                         │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR17 │ Story 2.1 (lookup by URL)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR18 │ Story 2.1 (lookup by ID)                                │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR19 │ Story 2.1 (dict serialization)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR20 │ Story 3.1 (add embedding)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR21 │ Story 3.1 (delete by model)                             │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR22 │ Story 3.1 (documents needing embeddings)                │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR23 │ Story 3.2 (cosine_distance)                             │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR24 │ Story 2.2 (dynamic filtered list)                       │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR25 │ Story 2.2 (count by type/state)                         │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR26 │ Story 2.2 (ready for download)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR27 │ Story 2.2 (YouTube just added)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR28 │ Story 2.2 (transcription done)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR29 │ Story 2.2 (next to correct)                             │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR30 │ Story 2.2 (last import date)                            │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR31 │ Story 4.1 (dynamodb_sync ORM)                           │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR32 │ Story 4.1 (created_at via ORM)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR33 │ Story 4.1 (unknown_news ORM)                            │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR34 │ Story 4.1 (duplicate detection)                         │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR35 │ Story 4.2 (SQS processing)                              │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR36 │ Story 4.2 (embeddings via ORM)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR37 │ Story 4.2 (document state updates)                      │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR38 │ Story 4.2 (YouTube transcript)                          │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR39 │ Story 2.3 (/website_list)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR40 │ Story 2.3 (/website_get)                                │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR41 │ Story 2.3 (/website_save)                               │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR42 │ Story 2.3 (/website_delete)                             │ Covered │
+  ├──────┼─────────────────────────────────────────────────────────┼─────────┤
+  │ FR43 │ Story 3.2 (/website_similar)                            │ Covered │
+  └──────┴─────────────────────────────────────────────────────────┴─────────┘
+
+  Wynik: 43/43 FRs covered — 100%
+
+  ---
+  2. Architecture Implementation Validation
+
+  - Starter template: Architecture says "No external starter template" —
+  poprawnie, Story 1.1 tworzy engine/session foundation, nie klonuje starter
+  template
+  - Database/entity creation: Tabele NIE są tworzone upfront — ORM modele
+  definiują mapowanie do istniejących tabel, Alembic stamp baseline w Story 1.3.
+   Poprawne.
+
+  Wynik: PASS
+
+  ---
+  3. Story Quality Validation
+
+  ┌───────┬───────────────┬─────────┬─────────────┬────────────────────────┐
+  │ Story │  Single Dev   │ Clear   │     FR      │    No Forward Deps     │
+  │       │     Agent     │   AC    │  Reference  │                        │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 1.1   │ Yes           │ 5 AC    │ FR10,12,13  │ Standalone             │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 1.2   │ Yes           │ 9 AC    │ FR1-5       │ Depends on 1.1 only    │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 1.3   │ Yes           │ 8 AC    │ FR6-9,10,11 │ Depends on 1.1, 1.2    │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 2.1   │ Yes           │ 6 AC    │ FR14-19     │ Depends on Epic 1      │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 2.2   │ Yes           │ 11 AC   │ FR24-30     │ Depends on Epic 1, 2.1 │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 2.3   │ Yes           │ 6 AC    │ FR39-42     │ Depends on Epic 1,     │
+  │       │               │         │             │ 2.1, 2.2               │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 3.1   │ Yes           │ 4 AC    │ FR20-22     │ Depends on Epic 1, 2   │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 3.2   │ Yes           │ 6 AC    │ FR23, FR43  │ Depends on Epic 1, 2,  │
+  │       │               │         │             │ 3.1                    │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 4.1   │ Yes           │ 6 AC    │ FR31-34     │ Depends on Epic 1, 2   │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 4.2   │ Yes           │ 6 AC    │ FR35-38     │ Depends on Epic 1, 2,  │
+  │       │               │         │             │ 3                      │
+  ├───────┼───────────────┼─────────┼─────────────┼────────────────────────┤
+  │ 4.3   │ Yes           │ 6 AC    │ NFR1-3,     │ Depends on all         │
+  │       │               │         │ NFR9        │ previous               │
+  └───────┴───────────────┴─────────┴─────────────┴────────────────────────┘
+
+  Wynik: PASS — all stories completable sequentially, no forward dependencies
+
+  ---
+  4. Epic Structure Validation
+
+  - Epic 1: User value — "schema changes without fear" (Journey 1)
+  - Epic 2: User value — "frontend works identically" (Journey 4)
+  - Epic 3: User value — "vector search via ORM" (Journey 3)
+  - Epic 4: User value — "all data pipelines work, migration complete" (Journey
+  2+3)
+
+  Żaden epik nie jest czysto techniczną warstwą. Każdy dostarcza konkretną
+  capability.
+
+  Wynik: PASS
+
+  ---
+  5. Dependency Validation
+
+  Epic Independence:
+  - Epic 1 — standalone (foundation)
+  - Epic 2 — działa bez Epic 3/4 (CRUD + API serwuje frontend)
+  - Epic 3 — działa bez Epic 4 (embeddings + search functional)
+  - Epic 4 — wymaga Epic 1+2+3, ale jest ostatni w sekwencji
+
+  Within-Epic Stories:
+  - Epic 1: 1.1 → 1.2 → 1.3 (linear, no forward deps)
+  - Epic 2: 2.1 → 2.2 → 2.3 (linear, no forward deps)
+  - Epic 3: 3.1 → 3.2 (linear, no forward deps)
+  - Epic 4: 4.1 → 4.2 → 4.3 (linear, no forward deps)
+
+  Wynik: PASS — all dependencies flow forward only
+
+  ---
+  Podsumowanie walidacji
+
+  ┌─────────────────────────┬────────────────────────────────┐
+  │          Check          │             Result             │
+  ├─────────────────────────┼────────────────────────────────┤
+  │ FR Coverage             │ 43/43 — 100%                   │
+  ├─────────────────────────┼────────────────────────────────┤
+  │ Architecture Compliance │ PASS                           │
+  ├─────────────────────────┼────────────────────────────────┤
+  │ Story Quality           │ PASS — 11 stories, 73 AC total │
+  ├─────────────────────────┼────────────────────────────────┤
+  │ Epic Structure          │ PASS — user-value focused      │
+  ├─────────────────────────┼────────────────────────────────┤
+  │ Dependency Validation   │ PASS — no forward deps         │
+  └─────────────────────────┴────────────────────────────────┘
+
+  Dokument jest gotowy do implementacji.
+
+  Walidacja zakończona! [C] Complete Workflow
+
+
+❯ /export PRD_to_EPICS                                                          
+  ⎿  Conversation exported to: PRD_to_EPICS.txt
+
+❯ C                                                                             
+
+  [--- Update: epics.md — diff removed for readability ---]
+
+● Workflow Create Epics and Stories zakończony!
+
+  Wynik końcowy:
+  - 4 epiki zorganizowane wokół wartości użytkownika (developer journeys)
+  - 11 historyjek z 73 kryteriami akceptacji w formacie Given/When/Then
+  - 43/43 FR pokryte (100%)
+  - 12/12 NFR zaadresowane
+  - Dokument: _bmad-output/planning-artifacts/epics.md
+
+  Następny krok w BMAD workflow to implementacja — możesz użyć tych epików i
+  historyjek jako specyfikacji dla agentów implementacyjnych. Epiki są
+  zaprojektowane do realizacji sekwencyjnej: Epic 1 → 2 → 3 → 4.
+
+  Masz pytania dotyczące epików lub historyjek?

--- a/docs/bmad-examples/PRD_validation_clean.txt
+++ b/docs/bmad-examples/PRD_validation_clean.txt
@@ -1,0 +1,792 @@
+
+
+❯ /clear                                                                        
+  ⎿  (no content)
+
+❯ /bmad-bmm-validate-prd                                                        
+
+
+● Teraz wczytam plik z PRD purpose oraz wyszukam PRD do walidacji.
+
+
+● Tryb walidacji: Walidacja istniejącego PRD według standardów BMAD.
+
+  Znalazłem PRD: _bmad-output/planning-artifacts/prd.md — używam go do
+  walidacji.
+
+  Wczytuję PRD...
+
+
+● Teraz wczytam dokumenty wejściowe z frontmattera PRD.
+
+
+● Wszystkie dokumenty wejściowe zostały załadowane pomyślnie. Oto podsumowanie:
+
+  Załadowałem następujące dokumenty z frontmattera PRD:
+
+  - .claude/exports/plan-sqlalchemy-migration.md — plan migracji SQLAlchemy
+  (research) ✓
+  - docs/architecture-backend.md — architektura backendu ✓
+  - docs/data-models-backend.md — modele danych ✓
+  - docs/architecture-decisions.md — decyzje architektoniczne (ADR-001 do
+  ADR-008) ✓
+
+  Czy chcesz dołączyć dodatkowe dokumenty referencyjne do tej walidacji?
+
+  Mogą to być:
+  - Dodatkowe dokumenty z badań lub kontekstu
+  - Dokumentacja projektu nie wymieniona w frontmatterze
+  - Standardy lub wymagania compliance
+  - Analiza konkurencyjna lub benchmarki
+
+  Podaj ścieżki do dodatkowych dokumentów lub wpisz none aby kontynuować.
+
+
+❯ none                                                                          
+
+  [--- Write: prd-validation-report.md — diff removed for readability ---]
+
+● Istnieje już poprzedni raport walidacji (z 2026-02-27) dla innej wersji PRD.
+  Nadpiszę go nowym raportem dla aktualnego PRD (migracja SQLAlchemy).
+
+  [--- Write: prd-validation-report.md — diff removed for readability ---]
+
+● Setup zakończony!
+
+  PRD do walidacji: _bmad-output/planning-artifacts/prd.md
+
+  Załadowane dokumenty wejściowe:
+  - PRD: prd.md (SQLAlchemy ORM Migration) ✓
+  - Research: 1 (plan-sqlalchemy-migration.md) ✓
+  - Project Docs: 3 (architecture-backend.md, data-models-backend.md,
+  architecture-decisions.md) ✓
+  - Dodatkowe referencje: 0 (none)
+
+  Raport walidacji: _bmad-output/planning-artifacts/prd-validation-report.md
+
+  Gotowy do rozpoczęcia walidacji.
+
+  ---
+  Wybierz opcję: [A] Advanced Elicitation [P] Party Mode [C] Kontynuuj do Format
+   Detection
+
+❯ C                                                                             
+
+
+● Analizuję strukturę PRD...
+
+  Struktura PRD (nagłówki ## Level 2):
+  1. Executive Summary
+  2. Project Classification
+  3. Success Criteria
+  4. User Journeys
+  5. Technical Context
+  6. Project Scoping & Risk Mitigation
+  7. Functional Requirements
+  8. Non-Functional Requirements
+
+  Sprawdzanie sekcji BMAD Core:
+
+  ┌─────────────────────┬───────────────────────────────────────────────────┐
+  │     Sekcja BMAD     │                      Status                       │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │ Executive Summary   │ Present ✓                                         │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │ Success Criteria    │ Present ✓                                         │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │                     │ Present ✓ (jako "Project Scoping & Risk           │
+  │ Product Scope       │ Mitigation" — zawiera MVP Strategy, Feature Set,  │
+  │                     │ Post-MVP phases)                                  │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │ User Journeys       │ Present ✓                                         │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │ Functional          │ Present ✓                                         │
+  │ Requirements        │                                                   │
+  ├─────────────────────┼───────────────────────────────────────────────────┤
+  │ Non-Functional      │ Present ✓                                         │
+  │ Requirements        │                                                   │
+  └─────────────────────┴───────────────────────────────────────────────────┘
+
+  Klasyfikacja: BMAD Standard — 6/6 sekcji core obecnych. Sekcja "Product Scope"
+   występuje pod wariantem nazwy "Project Scoping & Risk Mitigation" z pełną
+  zawartością (MVP strategy, feature set, post-MVP phases, risk mitigation).
+
+  Dodatkowe sekcje (poza core):
+  - Project Classification — typ projektu, domena, złożoność, kontekst
+  - Technical Context — architektura docelowa, session management, decyzje
+  technologiczne, data flow, zależności, pliki
+
+  Aktualizuję raport walidacji i przechodzę do systematycznych sprawdzeń...
+
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Format wykryty: BMAD Standard (6/6 sekcji core)
+
+  Przechodzę do systematycznych sprawdzeń walidacyjnych...
+
+
+● Skanowanie PRD pod kątem anti-patternów gęstości informacyjnej...
+
+  Wyniki skanowania:
+
+  Conversational filler: Przeskanowano wzorce "The system will allow users
+  to...", "It is important to note that...", "In order to", "For the purpose
+  of", "With regard to" — 0 wystąpień. PRD konsekwentnie używa aktywnej formy:
+  "Developer can...", "Consumer can...", "Repository can...".
+
+  Wordy phrases: Przeskanowano wzorce "Due to the fact that", "In the event of",
+   "At this point in time", "In a manner that" — 0 wystąpień.
+
+  Redundant phrases: Przeskanowano wzorce "Future plans", "Past history",
+  "Absolutely essential", "Completely finish" — 0 wystąpień.
+
+  Total violations: 0 | Severity: Pass
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Walidacja gęstości informacyjnej zakończona — Pass
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Brak Product Brief wśród dokumentów wejściowych (frontmatter PRD: briefs: 0).
+
+  Product Brief Coverage: Pominięto (brak Product Brief)
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Przechodzę do następnego sprawdzenia...
+
+
+● Analizuję mierzalność wszystkich wymagań funkcjonalnych i niefunkcjonalnych...
+
+  Analiza Functional Requirements (FR1-FR43):
+
+  Sprawdzenie: Format "[Actor] can [capability]"
+  Wynik: 43/43 zgodne — "Developer can...", "Consumer can...", "Repository
+    can...", "Flask application can..."
+  ────────────────────────────────────────
+  Sprawdzenie: Subjective adjectives (easy, fast, intuitive...)
+  Wynik: 0 wystąpień
+  ────────────────────────────────────────
+  Sprawdzenie: Vague quantifiers (multiple, several, some...)
+  Wynik: 0 wystąpień
+  ────────────────────────────────────────
+  Sprawdzenie: Implementation leakage
+  Wynik: 0 true violations — technology names (SQLAlchemy, pgvector-python,
+    Alembic, cosine_distance()) are domain vocabulary for a migration PRD;
+  script
+     filenames (FR31-FR38) define migration scope
+
+  Analiza Non-Functional Requirements (NFR1-NFR12):
+
+  ┌───────┬─────────────────────────────────────┬───────────────────────────┐
+  │  NFR  │               Metric                │         Testable?         │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR1  │ "Zero raw cursor.execute() calls"   │ Yes — code search         │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR2  │ "ruff check backend/ with zero      │ Yes — tool exit code      │
+  │       │ warnings"                           │                           │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR3  │ "All existing unit tests pass"      │ Yes — pytest exit code    │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR4  │ "type hints (Mapped[type])"         │ Yes — code inspection     │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR5  │ "Enum classes preserved with        │ Yes — import test         │
+  │       │ identical values"                   │                           │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR6  │ "Database schema identical to       │ Yes — Alembic diff        │
+  │       │ before"                             │                           │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR7  │ "Changes in exactly one file"       │ Yes — count files         │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR8  │ "One file plus one Alembic command" │ Yes — count steps         │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR9  │ "No dead code remains"              │ Yes — grep for old        │
+  │       │                                     │ classes                   │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR10 │ "Dependencies added with version    │ Yes — pyproject.toml      │
+  │       │ pins"                               │ inspection                │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR11 │ "uv lock produces valid lock file"  │ Yes — exit code           │
+  ├───────┼─────────────────────────────────────┼───────────────────────────┤
+  │ NFR12 │ ".venv_wsl synchronized"            │ Yes — import test         │
+  └───────┴─────────────────────────────────────┴───────────────────────────┘
+
+  Missing metrics: 0 | Incomplete template: 0 | Missing context: 0
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Walidacja mierzalności zakończona — Total Violations: 0 (Pass)
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Analizuję łańcuch traceability...
+
+  Executive Summary → Success Criteria: Intact ✓
+  - "Adding or removing a column requires 5+ changes" → User Success:
+  "single-location change"
+  - "Alembic generates migration scripts" → User Success: "auto-generated
+  migration"
+  - "Eliminates fear of changing schema" → User Success: "without anxiety"
+  - "Unblocks evolution of the data model" → Business Success: "unblocks future
+  work"
+  - "Three-class simplified to two layers" → Technical Success: "old classes
+  removed"
+
+  Success Criteria → User Journeys: Intact ✓
+  - User Success (single-location, no anxiety) → Journey 1 (Schema Modification)
+  - Technical Success (import scripts work) → Journey 2 (Import Run)
+  - Technical Success (batch pipeline works) → Journey 3 (Embeddings Pipeline)
+  - Technical Success (Flask endpoints identical) → Journey 4 (API Request)
+  - Measurable (zero cursor.execute()) → Journeys 2-4
+
+  User Journeys → FRs: Intact ✓
+  - Journey 1 → FR1-FR9 (ORM Model + Schema Migration)
+  - Journey 2 → FR14-FR19, FR31-FR34 (Persistence + Import)
+  - Journey 3 → FR20-FR23, FR24-FR30, FR35-FR38 (Embeddings + Repository +
+  Pipeline)
+  - Journey 4 → FR10-FR13, FR24, FR39-FR43 (Session + Repository + Flask API)
+
+  Scope → FR Alignment: Intact ✓
+  All 8 MVP feature set items map to FRs.
+
+  Orphan FRs: 0 | Unsupported Success Criteria: 0 | Journeys without FRs: 0
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Walidacja traceability zakończona — Total Issues: 0 (Pass)
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Skanowanie FRs i NFRs pod kątem implementation leakage...
+
+  Kontekst domenowy:
+  Ten PRD definiuje migrację technologiczną. Technologie docelowe (SQLAlchemy,
+  Alembic, pgvector-python) stanowią słownictwo domenowe — to CZEGO dotyczy PRD,
+   nie JAK to zbudować. Analogicznie do PRD integracji Slack Bot wymieniającego
+  Slack.
+
+  Wyniki skanowania FRs:
+
+  ┌────────────────────┬────────────┬───────────────────────────────────────┐
+  │     Kategoria      │ Violations │              Borderline               │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Frontend           │ 0          │ 0                                     │
+  │ Frameworks         │            │                                       │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Backend Frameworks │ 0          │ 0 (Flask in FR10-FR11 = existing      │
+  │                    │            │ context)                              │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Databases          │ 0          │ 0                                     │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Cloud Platforms    │ 0          │ 0                                     │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Infrastructure     │ 0          │ 0                                     │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Libraries          │ 0          │ 2                                     │
+  ├────────────────────┼────────────┼───────────────────────────────────────┤
+  │ Other              │ 0          │ 3                                     │
+  └────────────────────┴────────────┴───────────────────────────────────────┘
+
+  Borderline instances w FRs (nie true violations):
+  - FR7: "alembic upgrade head" — specific command syntax; could be "apply
+  migrations with a single command"
+  - FR8: "alembic downgrade" — specific command syntax
+  - FR23: "pgvector-python cosine_distance() operator" — specific library +
+  method name; could be "native vector similarity search operator"
+  - FR31-FR38: Specific script filenames — define migration scope, acceptable
+  for brownfield project
+  - FR39-FR43: Endpoint names — API contract identifiers, acceptable
+
+  Wyniki skanowania NFRs:
+
+  ┌───────┬────────────────────┬────────────────────────────────────────────┐
+  │  NFR  │  Implementation    │                 Assessment                 │
+  │       │        term        │                                            │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR1  │ cursor.execute()   │ Naming the anti-pattern to eliminate —     │
+  │       │                    │ acceptable                                 │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR2  │ ruff check         │ Established project standard — borderline  │
+  │       │ backend/           │                                            │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR4  │ Mapped[type]       │ SQLAlchemy-specific — borderline           │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR5  │ Class names        │ Specific classes being preserved —         │
+  │       │                    │ borderline                                 │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR10 │ pyproject.toml     │ Specific file — borderline                 │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR11 │ uv lock            │ Specific tool command — borderline         │
+  ├───────┼────────────────────┼────────────────────────────────────────────┤
+  │ NFR12 │ .venv_wsl          │ Specific file — borderline                 │
+  └───────┴────────────────────┴────────────────────────────────────────────┘
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Walidacja implementation leakage zakończona — 0 true violations (Pass)
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● PRD frontmatter: domain: personal_ai_knowledge_management, complexity: low.
+  Domena niskozłożonościowa — pomijam szczegółowe sprawdzenia compliance.
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Domain Compliance Validation: Pominięto (low complexity)
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Project type z frontmattera: api_backend
+
+  Analizuję zgodność z wymaganiami dla api_backend...
+
+  Required sections (z project-types.csv):
+
+  ┌────────────────┬─────────────┬──────────────────────────────────────────┐
+  │     Sekcja     │   Status    │                  Uwagi                   │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │                │ Present     │ FR39-FR43 specyfikują endpointy Flask    │
+  │ endpoint_specs │ (partial)   │ API; Technical Context opisuje target    │
+  │                │             │ architecture                             │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │ auth_model     │ N/A         │ Auth (x-api-key) nie zmienia się w tej   │
+  │                │             │ migracji — nie jest przedmiotem PRD      │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │                │             │ Technical Context opisuje architekturę   │
+  │ data_schemas   │ Present     │ ORM; PRD referencuje 28-kolumnowy        │
+  │                │             │ schemat                                  │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │ error_codes    │ N/A         │ Wewnętrzna migracja — error codes nie są │
+  │                │             │  przedmiotem                             │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │ rate_limits    │ N/A         │ Wewnętrzna migracja — rate limits się    │
+  │                │             │ nie zmieniają                            │
+  ├────────────────┼─────────────┼──────────────────────────────────────────┤
+  │ api_docs       │ N/A         │ Wewnętrzna migracja — API docs nie są    │
+  │                │             │ przedmiotem                              │
+  └────────────────┴─────────────┴──────────────────────────────────────────┘
+
+  Skip sections (z project-types.csv):
+
+  ┌───────────────┬──────────────────────────────────────────────────────────┐
+  │    Sekcja     │                          Status                          │
+  ├───────────────┼──────────────────────────────────────────────────────────┤
+  │ ux_ui         │ Absent ✓                                                 │
+  ├───────────────┼──────────────────────────────────────────────────────────┤
+  │ visual_design │ Absent ✓                                                 │
+  ├───────────────┼──────────────────────────────────────────────────────────┤
+  │               │ Present — ale opisują workflow developera (schema        │
+  │ user_journeys │ modification, import run, embeddings pipeline, API       │
+  │               │ request), nie end-user UX                                │
+  └───────────────┴──────────────────────────────────────────────────────────┘
+
+  Uwaga kontekstowa: CSV definiuje user_journeys jako skip dla api_backend, ale
+  BMAD PRD core wymaga User Journeys jako obowiązkowej sekcji (6/6 core). W tym
+  PRD User Journeys opisują scenariusze operacyjne developera/operatora — nie
+  tradycyjne ścieżki użytkownika UI. Jest to napięcie w frameworku, nie
+  naruszenie w PRD.
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Project-Type Compliance Validation zakończona — Pass
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Oceniam 43 wymagania funkcjonalne wg kryteriów SMART...
+
+  Wszystkie FRs przeanalizowane. Wyniki:
+
+  - All scores >= 3: 100% (43/43)
+  - All scores >= 4: 100% (43/43)
+  - Overall Average Score: 4.98/5.0
+
+  Jedyny FR poniżej perfect score:
+  - FR12 (S:4, M:4) — "Standalone scripts can obtain and manage their own
+  database sessions" — "standalone scripts" nieco ogólne (które skrypty?),
+  "manage" nieco nieprecyzyjne
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● SMART Requirements Validation zakończona — 100% acceptable, avg 4.98/5.0 
+  (Pass)
+
+  Przechodzę do następnego sprawdzenia...
+
+
+● Przeprowadzam holistyczną ocenę jakości PRD...
+
+  Document Flow & Coherence: Excellent
+
+  Dokument buduje klarowną narrację: problem (5+ ręcznych zmian przy każdej
+  kolumnie) → rozwiązanie (SQLAlchemy ORM) → scenariusze użycia (4 vivid
+  journeys) → szczegółowe wymagania (43 FRs + 12 NFRs). Sekcja "What Makes This
+  Special" krystalizuje wartość: "eliminates the fear of changing the database
+  schema."
+
+  Dual Audience: 5/5
+
+  Dla ludzi: Executive-level narrative compelling, developer clarity exceptional
+   (architecture diagrams, file inventory, session management strategies).
+  Dla LLM: Clean ## headers, consistent FR/NFR numbering, YAML frontmatter, 9 FR
+   groups map directly to implementation epics.
+
+  BMAD Principles: 7/7 Met
+
+  Rating: 5/5 — Excellent
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Holistic Quality Assessment zakończona — Rating: 5/5 Excellent
+
+  Przechodzę do finalnych sprawdzeń...
+
+
+● Przeprowadzam finalną walidację kompletności...
+
+  Template variables: 0 — brak pozostałych zmiennych szablonowych.
+
+  Content completeness: Wszystkie 8 sekcji complete.
+
+  Section-specific: Wszystkie kryteria spełnione.
+
+  Frontmatter: 5/5 pól wypełnionych.
+
+  [--- Update: prd-validation-report.md — 2 edits, diffs removed for readability ---]
+
+● Completeness Validation zakończona — 100% Complete (Pass)
+
+  Przechodzę do finalnego kroku...
+
+
+● Finalizuję raport walidacji...
+
+  [--- Update: prd-validation-report.md — diff removed for readability ---]
+
+● Now let me append the final summary section.
+
+  [--- Update: prd-validation-report.md — diff removed for readability ---]
+
+● ---
+  Walidacja PRD zakończona!
+
+  Overall Status: Pass
+
+  Szybkie wyniki:
+
+  ┌────────────────────────┬──────────────────────────────────────┐
+  │      Sprawdzenie       │                Wynik                 │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Format                 │ BMAD Standard (6/6)                  │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Gęstość informacji     │ Pass (0 violations)                  │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Mierzalność            │ Pass (0 violations, 55 requirements) │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Traceability           │ Pass (0 orphans, all chains intact)  │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Implementation Leakage │ Pass (0 true violations)             │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ SMART Quality          │ Pass (avg 4.98/5.0)                  │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Holistic Quality       │ 5/5 — Excellent                      │
+  ├────────────────────────┼──────────────────────────────────────┤
+  │ Kompletność            │ 100%                                 │
+  └────────────────────────┴──────────────────────────────────────┘
+
+  Critical Issues: 0 | Warnings: 0
+
+  Top 3 ulepszeń (opcjonalnych):
+  1. Dodaj sekcję "Out of Scope" — skonsoliduj rozproszone informacje o
+  odroczonym Pydantic, Lambda, ElasticSearch
+  2. Dodaj sekcję "Assumptions & Dependencies" — udokumentuj założenia (schemat
+  DB = DDL scripts, pgvector identyczne wyniki, brak danych produkcyjnych)
+  3. Rozważ ekstrakcję szczegółów architektury do osobnego tech spec — Technical
+   Context (~80 linii) zawiera treści na poziomie dokumentu architektonicznego
+
+  Raport zapisany: _bmad-output/planning-artifacts/prd-validation-report.md
+
+  PRD jest gotowy do dalszej pracy (architektura, epiki, stories).
+
+  ---
+  Co chcesz zrobić dalej?
+
+  [R] Review Detailed Findings — przejście przez raport sekcja po sekcji
+  [E] Use Edit Workflow — systematyczne poprawki na podstawie raportu
+  [F] Fix Simpler Items — natychmiastowe poprawki prostych elementów
+  [X] Exit — zakończ walidację
+
+
+❯ F                                                                             
+
+● Na podstawie raportu walidacji, oto proste poprawki do zastosowania:
+
+  1. FR12 — doprecyzowanie — zmienić "Standalone scripts" na konkretne skrypty i
+   zdefiniować "manage"
+  2. Dodanie sekcji "Out of Scope" — skonsolidować rozproszone informacje o
+  Pydantic, Lambda, ElasticSearch, JTI
+  3. Dodanie sekcji "Assumptions & Dependencies" — udokumentować 4 kluczowe
+  założenia
+
+  Które poprawki chcesz zastosować? Możesz wybrać numery (np. 1,2,3 dla
+  wszystkich, 2 dla samego Out of Scope, itp.)
+
+❯ 1,2,3                                                                         
+
+
+● Teraz stosuję 3 poprawki.
+
+  Poprawka 1: FR12 — doprecyzowanie
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Poprawka 2: Sekcja "Out of Scope"
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Poprawka 3: Sekcja "Assumptions & Dependencies"
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Wszystkie 3 poprawki zastosowane:
+
+  1. FR12 — doprecyzowano: "Import scripts and batch pipeline can obtain,
+  commit, and close their own database sessions (script-scoped lifecycle)"
+  2. Out of Scope — dodano sekcję z 9 wyraźnie wykluczonych elementów (Pydantic,
+   TypeScript sync, nowe tabele, JTI, MCP, ElasticSearch, Lambda,
+  Flask-SQLAlchemy, zmiany schematu)
+  3. Assumptions & Dependencies — dodano sekcję z 5 założeniami i 4
+  zależnościami
+
+  ---
+  Co dalej?
+
+  [R] Review Detailed Findings — przejście przez raport sekcja po sekcji
+  [E] Use Edit Workflow — systematyczne poprawki na podstawie raportu
+  [F] Fix Simpler Items — więcej natychmiastowych poprawek
+  [X] Exit — zakończ walidację
+
+
+❯ postgres 17 na NAS zostal dzisiaj zmigrowany do Postgres 18                   
+
+  [--- Update: prd.md — diff removed for readability ---]
+
+● Zaktualizowałem. Przy okazji — chcesz żebym zaktualizował też CLAUDE.md, gdzie
+   jest wzmianka o wersji PostgreSQL?
+
+  Database: PostgreSQL 18 with pgvector extension [...] (RDS: 18.1, Docker/NAS: 
+  17 — pending upgrade via B-69)
+
+
+❯ tak                                                                           
+
+
+  [--- Update: CLAUDE.md — diff removed for readability ---]
+
+● Gotowe. Usunąłem wzmiankę o wersji 17 i oczekującej migracji B-69 — teraz
+  wszędzie PostgreSQL 18.
+
+  Sprawdzę jeszcze czy są inne odniesienia do pg 17.
+
+
+● Sporo odniesień. Chcesz żebym zaktualizował te dokumenty teraz, czy wolisz to
+  zrobić osobnym commitem/zadaniem? To ~15 plików z referencjami do PostgreSQL
+  17.
+
+❯ teraz                                                                         
+
+● Zaktualizuję aktywne dokumenty (pomijam archiwalne pliki w archive/ i
+  implementation-artifacts/ — to historyczne snapshoty).
+
+
+● Teraz stosuję wszystkie edycje:
+
+  [--- Update: CLAUDE.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: project-overview.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: development-guide.md — diff removed for readability ---]
+
+  [--- Update: NAS_Deployment.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: Docker_Local.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: architecture-infra.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: architecture-backend.md — diff removed for readability ---]
+
+● Teraz zaktualizuję backlog — B-69 powinien być oznaczony jako done.
+
+
+  [--- Update: backlog.md — diff removed for readability ---]
+
+● Gotowe. Zaktualizowane pliki (12 edycji w 8 plikach):
+
+  ┌──────────────────────────────┬───────────────────────────────────────────┐
+  │             Plik             │                  Zmiana                   │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ CLAUDE.md                    │ Usunięto "(RDS: 18.1, Docker/NAS: 17 —    │
+  │                              │ pending upgrade via B-69)"                │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ backend/database/CLAUDE.md   │ 17 → 18 (opis + Docker image)             │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/project-overview.md     │ 17 → 18 (2 miejsca)                       │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/development-guide.md    │ 17 → 18                                   │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/CICD/NAS_Deployment.md  │ 17 → 18 (tabela + Docker setup)           │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/CICD/Docker_Local.md    │ pg17 → pg18 (pull + run)                  │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/architecture-infra.md   │ 17 → 18 (tabela + opis Dockerfile)        │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/architecture-backend.md │ 17 → 18                                   │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ backlog.md                   │ B-69 status: backlog → done (2026-03-07)  │
+  └──────────────────────────────┴───────────────────────────────────────────┘
+
+  Pominąłem pliki archiwalne (archive/, implementation-artifacts/) — to
+  historyczne snapshoty.
+
+  ---
+  Co dalej?
+
+  [R] Review Detailed Findings
+  [E] Use Edit Workflow
+  [F] Fix Simpler Items
+  [X] Exit
+
+
+❯ sprawdz jeszcze informacje o vectorach, teraz nie powinno byc szywtno         
+1536-dim vector, teraz to jest zalezne od uzytego embedingu                     
+
+
+● Widzę problem — wiele dokumentów traktuje 1536 jako stały wymiar, ale
+  backend/database/CLAUDE.md:130 już poprawnie opisuje kolumnę jako bezwymiarową
+   (vector bez wymiaru) z osobnymi indeksami per model. Sprawdzę jeszcze DDL.
+
+
+● Potwierdzam — kolumna embedding jest bezwymiarowa, a modele mają różne wymiary
+   (1536, 1024). Aktualizuję dokumenty:
+
+  [--- Update: project-overview.md — diff removed for readability ---]
+
+  [--- Update: index.md — diff removed for readability ---]
+
+  [--- Update: data-models-backend.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: architecture-backend.md — 2 edits, diffs removed for readability ---]
+
+  [--- Update: CLAUDE.md — diff removed for readability ---]
+
+  [--- Update: README.md — diff removed for readability ---]
+
+  [--- Update: index.md — diff removed for readability ---]
+
+  [--- Update: README.md — diff removed for readability ---]
+
+● Teraz PRD — tam jest kilka referencji do Vector(1536):
+
+  [--- Update: prd.md — 4 edits, diffs removed for readability ---]
+
+● Sprawdzę jeszcze plan migracji i docs/embeddings.md — tam referencje do 1536
+  dotyczą konkretnych modeli (ada-002, Titan v1), więc są poprawne. Ale
+  docs/architecture-backend.md ma jeszcze tabelę modeli:
+
+
+● Titan v2 ma faktycznie 1024 wymiarów, nie 1536. Poprawię:
+
+  [--- Update: architecture-backend.md — diff removed for readability ---]
+
+● Gotowe. Podsumowanie zmian wektorowych (10 edycji w 8 plikach):
+
+  ┌──────────────────────────────┬───────────────────────────────────────────┐
+  │             Plik             │                  Zmiana                   │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ CLAUDE.md                    │ "1536 dimensions" → "dimensionless        │
+  │                              │ column, per-model HNSW partial indexes"   │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ README.md                    │ "1536-dim" → "multi-model,                │
+  │                              │ variable-dimension"                       │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/index.md                │ Usunięto "1536-dim"                       │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/project-overview.md     │ "1536-dim vectors" → "variable-dimension  │
+  │                              │ vectors per embedding model"              │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ docs/data-models-backend.md  │ vector(1536) → vector (dimensionless) +   │
+  │                              │ wymiary per model                         │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │                              │ "1536-dim" → "1024-1536 dim               │
+  │ docs/architecture-backend.md │ (model-dependent)", Titan v2: 1536→1024,  │
+  │                              │ pipeline: "vary by model"                 │
+  ├──────────────────────────────┼───────────────────────────────────────────┤
+  │ prd.md                       │ 4x Vector(1536) → Vector() dimensionless  │
+  └──────────────────────────────┴───────────────────────────────────────────┘
+
+  Nie ruszałem docs/embeddings.md — tam wymiary są przypisane do konkretnych
+  modeli (poprawne) i indeksy HNSW z castami ::vector(1536) / ::vector(1024)
+  odzwierciedlają faktyczną definicję DDL.
+
+  ---
+  Co dalej?
+
+  [R] Review Detailed Findings
+  [E] Use Edit Workflow
+  [F] Fix Simpler Items
+  [X] Exit
+
+
+❯ czy to wplywa teraz na nasz prd i validacje jego?                             
+
+● Nie wpływa na wynik walidacji. Wyjaśnienie:
+
+  - Overall Status: Pass — bez zmian
+  - Holistic Quality: 5/5 — bez zmian
+  - Wszystkie sprawdzenia (density, measurability, traceability, SMART) — wyniki
+   identyczne
+
+  Zmiany które zastosowaliśmy (FR12, Out of Scope, Assumptions, Vector
+  dimensions) to poprawki po walidacji — one wzmacniają PRD, nie wprowadzają
+  nowych problemów. PRD był już oceniony jako Excellent, a teraz jest jeszcze
+  lepszy.
+
+  Jedyne co warto zrobić to dodać notatkę w raporcie walidacji, że po walidacji
+  zastosowano poprawki. Chcesz żebym to dodał?
+
+❯ tak                                                                           
+
+
+  [--- Update: prd-validation-report.md — diff removed for readability ---]
+
+● Dodałem sekcję "Post-Validation Fixes Applied" na końcu raportu z opisem
+  wszystkich 4 poprawek i notatką że nie wpływają na wyniki walidacji.
+
+  ---
+  Co dalej?
+
+  [R] Review Detailed Findings
+  [E] Use Edit Workflow
+  [F] Fix Simpler Items
+  [X] Exit
+
+❯ X                                                                             
+
+● Raport walidacji zapisany:
+  _bmad-output/planning-artifacts/prd-validation-report.md
+
+  Podsumowanie: Pass — PRD jest exemplary (5/5 Excellent) i gotowy do dalszej
+  pracy (architektura, epiki, stories). Po walidacji zastosowano 4 poprawki
+  wzmacniające dokument.
+
+  Sugerowane następne kroki:
+  - Utworzenie architektury technicznej na podstawie PRD
+  - Breakdown na epiki i stories
+  - Rozpoczęcie implementacji migracji SQLAlchemy

--- a/docs/bmad-examples/clean_examples.py
+++ b/docs/bmad-examples/clean_examples.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Cleans BMad Method example files by removing Claude Code tool noise
+(file diffs, read/search/explore output) and replacing it with short comments.
+
+Usage:
+    python clean_examples.py                    # Process all .txt files in this directory
+    python clean_examples.py file1.txt file2.txt  # Process specific files
+
+Output files are saved with _clean suffix (e.g. PRD_arch_clean.txt).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def is_new_block_start(line: str) -> bool:
+    """Check if line starts a new logical block (user prompt, tool call, or AI response)."""
+    stripped = line.strip()
+    if stripped.startswith('❯'):
+        return True
+    if stripped.startswith('●'):
+        return True
+    if stripped.startswith('✻'):
+        return True
+    return False
+
+
+def is_continuation_line(line: str) -> bool:
+    """Check if line is a ⎿ continuation from a tool call."""
+    return '⎿' in line
+
+
+def is_tool_single_line(line: str) -> bool:
+    """Check if line is a single-line tool output (Read, Searched, Explore, etc.)."""
+    patterns = [
+        r'^● Read \d+ files?\s*\(ctrl\+o',
+        r'^● Searched for \d+ patterns?',
+        r'^● Explore\(',
+        r'^● Skill\(',
+        r'^● Searched for \d+ patterns?, read \d+ files?',
+    ]
+    return any(re.match(p, line.strip()) for p in patterns)
+
+
+def is_tool_block_start(line: str, next_line: str = '') -> bool:
+    """Check if line starts a multi-line tool block (Update/Write with diff).
+    Handles long paths that wrap to the next line."""
+    stripped = line.strip()
+    if re.match(r'^● (Update|Write|Edit)\(.+\)$', stripped):
+        return True
+    # Wrapped case: "● Write(long-path..." on this line, "       ...path)" on next
+    if re.match(r'^● (Update|Write|Edit)\(', stripped) and not stripped.endswith(')'):
+        combined = stripped + next_line.strip()
+        if re.match(r'^● (Update|Write|Edit)\(.+\)$', combined):
+            return True
+    return False
+
+
+def is_status_line(line: str) -> bool:
+    """Check if line is a status/timing line."""
+    stripped = line.strip()
+    return stripped.startswith('✻')
+
+
+def is_banner_line(line: str) -> bool:
+    """Check if line is part of the Claude Code startup banner."""
+    patterns = [
+        r'▐▛███▜▌',
+        r'▝▜█████▛▘',
+        r'▘▘ ▝▝',
+        r'Claude Code v\d+',
+        r'Opus \d+\.\d+ · Claude',
+        r'Welcome back',
+        r'Recent activity',
+        r'No recent activity',
+        r"What's new",
+        r'Added [`/]',
+        r'Added cron',
+        r'Added `voice',
+        r'/release-notes for more',
+        r'Organization',
+        r'^╭─',
+        r'^╰─',
+        r'^│',
+        r'^├─',
+    ]
+    stripped = line.strip()
+    return any(re.search(p, stripped) for p in patterns)
+
+
+def extract_tool_name(line: str, next_line: str = '') -> str:
+    """Extract the operation and filename from a tool line (handles wrapped paths)."""
+    combined = line.strip()
+    if not combined.endswith(')') and next_line:
+        combined = combined + next_line.strip()
+    m = re.match(r'^● (Update|Write|Edit)\((.+)\)$', combined)
+    if m:
+        op = m.group(1)
+        filepath = m.group(2)
+        filename = Path(filepath.replace('\\', '/')).name
+        return f"{op}: {filename}"
+    return ""
+
+
+def clean_file(input_path: Path) -> Path:
+    """Clean a single file and return the output path."""
+    lines = input_path.read_text(encoding='utf-8').splitlines()
+    output_lines = []
+    i = 0
+    in_banner = False
+    banner_replaced = False
+
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Banner box detection
+        if is_banner_line(line):
+            if not banner_replaced:
+                in_banner = True
+            if in_banner:
+                i += 1
+                continue
+
+        if in_banner and stripped == '':
+            in_banner = False
+            banner_replaced = True
+            output_lines.append('')
+            i += 1
+            continue
+
+        in_banner = False
+
+        # Status/timing lines — remove
+        if is_status_line(line):
+            i += 1
+            continue
+
+        # Single-line tool outputs (Read, Searched, Explore) — remove
+        if is_tool_single_line(line):
+            # Also skip the ⎿ continuation lines that follow
+            i += 1
+            while i < len(lines) and is_continuation_line(lines[i]):
+                i += 1
+            continue
+
+        # Multi-line tool blocks (Update/Write/Edit with diffs)
+        next_line = lines[i + 1] if i + 1 < len(lines) else ''
+        if is_tool_block_start(line, next_line):
+            tool_info = extract_tool_name(line, next_line)
+            i += 1
+            # Skip the wrapped continuation of the tool line itself
+            if not line.strip().endswith(')') and i < len(lines):
+                i += 1
+
+            # Consume ALL lines until next block start or empty line followed by non-indented text
+            # The diff block consists of: ⎿ summary, then numbered/indented diff lines
+            while i < len(lines):
+                next_line = lines[i]
+                next_stripped = next_line.strip()
+
+                # Stop at next tool call, user prompt, or AI paragraph
+                if is_new_block_start(next_line):
+                    break
+
+                # Stop at an empty line ONLY if next non-empty line is a new block
+                if next_stripped == '':
+                    # Look ahead to see what comes next
+                    j = i + 1
+                    while j < len(lines) and lines[j].strip() == '':
+                        j += 1
+                    if j < len(lines) and is_new_block_start(lines[j]):
+                        break
+                    # If next non-empty line is still diff-like (indented with numbers), keep consuming
+                    if j < len(lines) and re.match(r'^\s{4,}\d+\s', lines[j]):
+                        i += 1
+                        continue
+                    # Otherwise this empty line ends the diff block
+                    break
+
+                # This is a diff content line — skip it
+                i += 1
+
+            output_lines.append(f'  [--- {tool_info} — diff removed for readability ---]')
+            output_lines.append('')
+            continue
+
+        # ⎿ continuation lines following tool single-liners we already removed
+        if is_continuation_line(line):
+            # Check context: if this follows a removed tool line, skip it
+            # Look at what's in output_lines
+            last_output = ''
+            for ol in reversed(output_lines):
+                if ol.strip():
+                    last_output = ol.strip()
+                    break
+            # If the last output line is a [--- removed ---] comment or empty, skip
+            if last_output.startswith('[---'):
+                i += 1
+                continue
+            # Keep other continuation lines (user prompt continuations, error messages)
+            output_lines.append(line)
+            i += 1
+            continue
+
+        # Regular line — keep
+        output_lines.append(line)
+        i += 1
+
+    # Collapse consecutive identical [--- ... ---] comments into one with count
+    collapsed_lines = []
+    i2 = 0
+    while i2 < len(output_lines):
+        line = output_lines[i2]
+        m = re.match(r'^\s*\[--- (.+?) — diff removed for readability ---\]$', line)
+        if m:
+            tool_info = m.group(1)
+            count = 1
+            j = i2 + 1
+            # Look ahead for same comment (possibly separated by blank lines)
+            while j < len(output_lines):
+                if output_lines[j].strip() == '':
+                    j += 1
+                    continue
+                m2 = re.match(r'^\s*\[--- (.+?) — diff removed for readability ---\]$', output_lines[j])
+                if m2 and m2.group(1) == tool_info:
+                    count += 1
+                    j += 1
+                else:
+                    break
+            if count > 1:
+                collapsed_lines.append(f'  [--- {tool_info} — {count} edits, diffs removed for readability ---]')
+            else:
+                collapsed_lines.append(line)
+            collapsed_lines.append('')
+            i2 = j
+        else:
+            collapsed_lines.append(line)
+            i2 += 1
+
+    # Clean up excessive blank lines (max 2 consecutive)
+    final_lines = []
+    blank_count = 0
+    for line in collapsed_lines:
+        if line.strip() == '':
+            blank_count += 1
+            if blank_count <= 2:
+                final_lines.append(line)
+        else:
+            blank_count = 0
+            final_lines.append(line)
+
+    output_path = input_path.with_stem(input_path.stem + '_clean')
+    output_path.write_text('\n'.join(final_lines) + '\n', encoding='utf-8')
+    return output_path
+
+
+def main():
+    script_dir = Path(__file__).parent
+
+    if len(sys.argv) > 1:
+        files = [Path(f) for f in sys.argv[1:]]
+    else:
+        files = sorted(script_dir.glob('*.txt'))
+        # Exclude already cleaned files
+        files = [f for f in files if not f.stem.endswith('_clean')]
+
+    if not files:
+        print("No .txt files found to process.")
+        return
+
+    for f in files:
+        if not f.exists():
+            print(f"  SKIP: {f} not found")
+            continue
+        output = clean_file(f)
+        original_lines = len(f.read_text(encoding='utf-8').splitlines())
+        cleaned_lines = len(output.read_text(encoding='utf-8').splitlines())
+        reduction = round((1 - cleaned_lines / original_lines) * 100) if original_lines else 0
+        print(f"  {f.name} -> {output.name} ({original_lines} -> {cleaned_lines} lines, -{reduction}%)")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/bmad-examples/epics_to_stories_clean.txt
+++ b/docs/bmad-examples/epics_to_stories_clean.txt
@@ -1,0 +1,213 @@
+
+
+❯ /clear 
+  ⎿  (no content)
+
+❯ /usage 
+  ⎿  Status dialog dismissed
+
+❯ /usage 
+  ⎿  Status dialog dismissed
+
+❯ /bmad-bmm-dev-story 
+
+
+● Workflow załadowany. Teraz przechodzę do Step 1 — szukam następnej gotowej
+  story.
+
+  Zmienne rozwiązane:
+  - user_name = Ziutus
+  - communication_language = Polish
+  - document_output_language = English
+  - user_skill_level = intermediate
+  - implementation_artifacts = _bmad-output/implementation-artifacts
+  - sprint_status = _bmad-output/implementation-artifacts/sprint-status.yaml
+
+  Sprawdzam plik sprint-status.yaml...
+
+
+● Przeskanowałem cały plik sprint-status.yaml. Nie ma żadnej story ze statusem
+  ready-for-dev.
+
+  📋 Brak story gotowych do implementacji
+
+  Aktualny stan sprintu 8:
+  - Epic 22 (Slack Bot Stabilization & DM Commands): done
+  - Epic 23 (Channel App Mentions): done
+  - Epic 24 (Conversational LLM Intelligence): in-progress
+    - 24-1-llm-intent-parser: done
+    - 24-2-semantic-search-via-natural-language: review (czeka na code review)
+  - Epic 25 (Proactive Health Monitoring): backlog
+
+  Backlog zawiera wiele pozycji (B-65, B-85, B-86, B-87, itd.) ale żadna nie ma
+  statusu ready-for-dev.
+
+  Co chcesz zrobić?
+  1. Uruchom create-story aby stworzyć następną story z epics
+  2. Uruchom validate-create-story aby poprawić istniejące stories przed
+  implementacją
+  3. Podaj ścieżkę do konkretnego pliku story do implementacji
+  4. Sprawdź sprint-status.yaml żeby zobaczyć szczegółowy status
+
+
+❯ interesuja mnie taski dla @_bmad-output/planning-artifacts/epics.md jak   
+  je zaczac?                                                                
+  ⎿  Read _bmad-output\planning-artifacts\epics.md (608 lines)
+
+● Te epic-i (SQLAlchemy ORM Migration) nie są jeszcze w sprint-status.yaml — to
+  nowy sprint, który trzeba najpierw przygotować.
+
+  Żeby zacząć, potrzebujesz:
+
+  1. Stworzyć story files — uruchom workflow create-story
+  (/bmad-bmm-create-story), który:
+    - Weźmie epic z epics.md
+    - Wygeneruje pełny plik story (z taskami, subtaskami, dev notes, acceptance
+  criteria)
+    - Doda story do sprint-status.yaml ze statusem ready-for-dev
+  2. Potem wróć do dev-story (/bmad-bmm-dev-story) — workflow automatycznie
+  znajdzie pierwszą story ready-for-dev i zacznie implementację.
+
+  Zalecana kolejność:
+  - Zacznij od Story 1.1 (Dependencies, Engine & Session Factories) — to
+  fundament dla wszystkich pozostałych
+  - Epic-i mają zależności: Epic 2 wymaga Epic 1, Epic 3 wymaga 1+2, Epic 4
+  wymaga 1+2+3
+
+  Co chcesz zrobić?
+  1. Uruchomić /bmad-bmm-create-story żeby stworzyć pierwszą story (1.1)
+  2. Najpierw sprawdzić/zwalidować epics przed tworzeniem stories
+  (/bmad-bmm-validate-create-story)
+  3. Coś innego
+
+❯ 1 
+
+     disable-model-invocation
+
+● Skill nie może być wywołany bezpośrednio — załaduję workflow create-story
+  ręcznie, tak jak wcześniej dev-story.
+
+
+● Widzę problem — nowe epic-i w epics.md są ponumerowane 1-4, ale w
+  sprint-status.yaml już istnieją Epic 1-25. Konflikt numeracji!
+
+  Nowe epic-i (SQLAlchemy ORM Migration):
+  - Epic 1 → powinien być Epic 26: ORM Foundation & Schema Management
+  - Epic 2 → Epic 27: Document CRUD & API Serving
+  - Epic 3 → Epic 28: Vector Embeddings & Similarity Search
+  - Epic 4 → Epic 29: Data Pipeline Migration & Cleanup
+
+  Żeby poprawnie dodać je do sprint-status.yaml i stworzyć story, muszę najpierw
+   przenumerować.
+
+● User answered Claude's questions:
+  ⎿  · Jak chcesz potraktować nowe epic-i z epics.md (SQLAlchemy ORM 
+     Migration)? → Przenumeruj na 26-29 (Recommended)
+
+● Świetnie. Przenumerowuję epic-i na 26-29 w epics.md i dodaję nowy Sprint 9 do
+  sprint-status.yaml.
+
+  Zaczynam od aktualizacji epics.md — zamieniam numerację Epic 1-4 → 26-29.
+
+  [--- Update: epics.md — 4 edits, diffs removed for readability ---]
+
+● Teraz przenumerowuję story — 1.x → 26.x, 2.x → 27.x, itd.
+
+  [--- Update: epics.md — 11 edits, diffs removed for readability ---]
+
+● Przenumerowanie zakończone. Teraz aktualizuję referencję "Sprint 6" → "Sprint
+  9" w nagłówku epics.md i dodaję Sprint 9 do sprint-status.yaml.
+
+  [--- Update: epics.md — diff removed for readability ---]
+
+● Teraz dodaję Sprint 9 do sprint-status.yaml.
+
+
+  [--- Update: sprint-status.yaml — diff removed for readability ---]
+
+● Sprint 9 dodany do sprint-status.yaml. Teraz przechodzę do Step 2 workflow
+  create-story — ładuję i analizuję artefakty dla Story 26.1.
+
+  Zmienne ustawione:
+  - epic_num = 26
+  - story_num = 1
+  - story_key = 26-1-dependencies-engine-session-factories
+  - story_id = 26.1
+
+  Uruchamiam analizę artefaktów równolegle.
+
+● 3 agents finished (ctrl+o to expand)
+   ├─ Explore (Analyze architecture for Story 26.1) · 14 tool uses · 47.2k
+   tokens
+   │  ⎿  Done
+   ├─ Explore (Analyze existing DB code patterns) · 25 tool uses · 57.6k tokens
+   │  ⎿  Done
+   └─ Agent (Check recent git commits) · 3 tool uses · 19.5k tokens
+      ⎿  Done
+
+● Analiza zakończona. Teraz Step 4 — sprawdzam najnowsze wersje bibliotek i
+  ładuję schemat DDL.
+
+● context7 - resolve-library-id (MCP)(query: "SQLAlchemy 2.x engine creation,
+                                     session factory, scoped_session,
+                                     pool_pre_ping", libraryName: "sqlalchemy")
+  ⎿  Available Libraries:
+
+     - Title: SQLAlchemy
+     … +24 lines (ctrl+o to expand)
+
+
+● context7 - query-docs (MCP)(libraryId: "/websites/sqlalchemy_en_21", query:
+                             "create_engine pool_pre_ping Session sessionmaker
+                             scoped_session DeclarativeBase mapped_column for
+                             Flask integration")
+  ⎿  ### Enable Pessimistic Disconnect Handling with pool_pre_ping
+
+     Source: https://docs.sqlalchemy.org/en/21/core/pooling
+     … +44 lines (ctrl+o to expand)
+
+
+● Mam wszystkie dane. Teraz tworzę plik story.
+
+
+  [--- Write: 26-1-dependencies-engine-session-factories.md — diff removed for readability ---]
+
+● Teraz aktualizuję sprint-status.yaml — zmieniam status epic-26 na in-progress
+  i story 26-1 na ready-for-dev.
+
+  [--- Update: sprint-status.yaml — diff removed for readability ---]
+
+● Teraz walidacja — szybko sprawdzam checklist.
+
+
+● Story 26.1 została stworzona! Walidacja zakończona — story zawiera:
+
+  - Kompletne acceptance criteria (5 AC z BDD)
+  - 4 taski z 18 subtaskami
+  - Szczegółowe Dev Notes z architekturą, schematem DB, SQLAlchemy API reference
+  - Referencje do źródeł
+  - Komendy WSL sync
+
+  ---
+  🎯 ULTIMATE BMad Method STORY CONTEXT CREATED, Ziutus!
+
+  Story Details:
+  - Story ID: 26.1
+  - Story Key: 26-1-dependencies-engine-session-factories
+  - File: _bmad-output/implementation-artifacts/26-1-dependencies-engine-session
+  -factories.md
+  - Status: ready-for-dev
+
+  Sprint Status Updated:
+  - epic-26: backlog → in-progress
+  - 26-1-dependencies-engine-session-factories: backlog → ready-for-dev
+
+  Zmiany w epics.md: Epic 1-4 → Epic 26-29, Sprint 6 → Sprint 9
+
+  Co dalej?
+  1. Przejrzyj story w pliku powyżej
+  2. Uruchom /bmad-bmm-dev-story żeby rozpocząć implementację
+  3. Opcjonalnie: uruchom validate-create-story dla dodatkowej kontroli jakości
+  story
+  4. Po implementacji: uruchom code-review (najlepiej innym LLM)
+


### PR DESCRIPTION
## Summary
- Add `clean_examples.py` script that strips Claude Code tool noise (diffs, file reads, search output, timing lines) from BMad Method session transcripts
- Add cleaned `*_clean.txt` versions of all 8 example files (47-80% noise reduction)
- Makes examples readable for demoing the BMad Method to others

## Test plan
- [x] Script runs on all `.txt` files without errors
- [x] Cleaned files preserve conversation flow (user prompts, AI responses)
- [x] All tool noise removed (diffs, `● Read/Searched/Write/Update`, `✻` timing lines, banner)
- [x] Consecutive edits to same file collapsed into single comment with count

🤖 Generated with [Claude Code](https://claude.com/claude-code)