### PR TITLE
docs: ADR-013 LLM abstraction + LLM observability strategy

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -711,3 +711,82 @@ Project Lenie ingests content from untrusted external sources (RSS feeds, web pa
 - `backend/imports/feed_monitor.py` — `strip_html()`, `apply_skip_filters()` — input sanitization
 - `backend/library/ai.py` — LLM interaction layer
 - [ADR-005](#adr-005-remove-ai_ask-endpoint--delegate-ai-analysis-to-claude-desktop-via-mcp) — MCP architecture (Claude Desktop handles AI analysis, reducing in-app LLM attack surface)
+
+---
+
+## ADR-013: Custom LLM Provider Abstraction — Keep Own Interface, Evaluate LiteLLM for Future
+
+**Date:** 2026-03 (Sprint 6)
+**Status:** Accepted
+**Decision Makers:** Ziutus
+
+### Context
+
+The project uses a custom abstraction layer for LLM API calls:
+- `backend/library/ai.py` — `ai_ask()` routes requests to the correct provider based on model name
+- `backend/library/embedding.py` — `get_embedding()` routes to the correct embedding provider
+- Per-provider integrations: OpenAI SDK (`openai`), AWS Bedrock (`boto3`), Google Vertex AI (`vertexai`), CloudFerro Sherlock (OpenAI-compatible), ArkLabs (OpenAI-compatible)
+
+The question arose whether to replace this custom layer with a framework like **LangChain** or a lightweight proxy like **LiteLLM**.
+
+### Alternatives Considered
+
+**1. LangChain**
+- Zunifikowany interfejs dla wszystkich providerów (`langchain_openai`, `langchain_aws`, `langchain_google_vertexai`)
+- Bogaty ekosystem: agenty, chainy, RAG pipeline, integracja z pgvector
+- Natywna integracja z LangSmith i Langfuse (callback handler)
+- **Odrzucony, ponieważ:**
+  - Ciężka zależność — duża biblioteka z częstymi breaking changes między wersjami
+  - Projekt nie buduje agentów, chainów ani złożonych pipeline'ów — wzorzec użycia to proste zapytanie→odpowiedź
+  - Dodaje warstwę abstrakcji i "magii" utrudniającą debugowanie
+  - Overhead niewspółmierny do aktualnych potrzeb (5 providerów, prosty routing)
+
+**2. LiteLLM**
+- Lekka biblioteka — jeden interfejs (kompatybilny z OpenAI) dla 100+ providerów
+- `litellm.completion(model="bedrock/amazon.nova-pro", messages=[...])` — zero konfiguracji per-provider
+- Wbudowana integracja z Langfuse
+- Nie narzuca frameworka — zastępuje tylko warstwę transportową
+- **Rozważany jako przyszła opcja** — sensowny gdy liczba providerów wzrośnie lub gdy utrzymanie własnego kodu stanie się kosztowne
+
+**3. Pozostanie przy własnej implementacji (wybrane)**
+- Obecna warstwa jest prosta, działa i pokrywa wszystkie 5 providerów
+- Zero zewnętrznych zależności na warstwie routingu
+- Pełna kontrola nad zachowaniem — brak "magii"
+- Debugowanie proste — bezpośrednie wywołania SDK
+
+### Decision
+
+1. **Pozostać przy własnej warstwie abstrakcji** (`ai.py`, `embedding.py`) jako primary interface dla LLM calls.
+2. **Nie wprowadzać LangChain** — projekt nie wymaga agentów, chainów ani złożonych pipeline'ów.
+3. **Rozważyć migrację do LiteLLM** gdy:
+   - Liczba obsługiwanych providerów wzrośnie powyżej 7-8
+   - Pojawi się potrzeba obsługi nowych API (np. streaming, function calling) wymagającej znacznych zmian w każdym providerze
+   - Koszt utrzymania per-provider integrations stanie się istotny
+4. **Aktywować Langfuse** jako narzędzie observability dla LLM calls (osobna decyzja — patrz `docs/observability.md`, sekcja "LLM Observability").
+
+### Rationale
+
+- **YAGNI** — obecny wzorzec użycia (prompt→odpowiedź, 5 providerów) nie uzasadnia wprowadzenia frameworka
+- **Koszt utrzymania jest niski** — dodanie nowego providera to ~50 linii kodu w osobnym pliku + 5 linii routingu w `ai.py`
+- **LiteLLM jako ewolucja, nie rewolucja** — gdyby migracja była potrzebna, LiteLLM jest drop-in replacement dla `ai_ask()` z minimalnym ryzykiem. Interfejs jest kompatybilny z OpenAI SDK, więc integracja z Langfuse nie zmienia się.
+- **LangChain opłaca się dopiero przy złożonych workflow** — agenty z narzędziami, pamięcią, wielokrokowymi chainami, zaawansowany RAG. Żaden z tych wzorców nie jest aktualnie potrzebny.
+
+### Consequences
+
+- **Positive:** Brak dodatkowej zależności — mniej ryzyka breaking changes, mniejszy rozmiar deploymentu
+- **Positive:** Pełna kontrola nad retry logic, error handling, token counting per provider
+- **Positive:** Jasna ścieżka migracji do LiteLLM gdy zajdzie potrzeba
+- **Negative:** Każdy nowy provider wymaga ręcznej integracji (~50 LOC)
+- **Negative:** Brak gotowych abstrakcji na streaming, function calling — trzeba implementować samodzielnie per provider gdy będą potrzebne
+
+### Related Artifacts
+
+- `backend/library/ai.py` — LLM routing layer (`ai_ask()`)
+- `backend/library/embedding.py` — Embedding routing layer (`get_embedding()`)
+- `backend/library/api/openai/openai_my.py` — OpenAI integration
+- `backend/library/api/aws/bedrock_ask.py` — AWS Bedrock integration
+- `backend/library/api/google/google_vertexai.py` — Google Vertex AI integration
+- `backend/library/api/cloudferro/sherlock/sherlock.py` — CloudFerro Bielik integration
+- `backend/library/api/arklabs/arklabs_embedding.py` — ArkLabs embedding integration
+- `docs/observability.md` — LLM observability strategy (Langfuse)
+- `docs/technology-choices.md` — Multi-provider abstraction rationale

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -229,6 +229,113 @@ No GCloud deployment exists yet — this section will be updated when GCloud sup
 
 ---
 
+## LLM Observability
+
+### Why Monitor LLM Calls?
+
+LLM API calls are a significant cost driver and a critical point of failure. Unlike traditional API calls, they have variable cost (per-token billing), unpredictable latency, and quality that can degrade silently (model updates, prompt drift).
+
+Key monitoring goals:
+- **Costs** — token usage and billing per provider/model
+- **Debugging** — exact prompts and responses for troubleshooting
+- **Quality** — detecting regressions in model outputs
+- **Rate limits** — alerts when approaching provider limits
+- **Latency** — tracking response times across providers
+
+### Chosen Tool: Langfuse
+
+**Why Langfuse** (over alternatives like Helicone, LangSmith, OpenLLMetry):
+
+| Criterion | Langfuse | Helicone | LangSmith |
+|-----------|----------|----------|-----------|
+| Integration method | SDK / `@observe()` decorator | Proxy (URL redirect) | LangChain callback |
+| Multi-provider support | Any provider (SDK-based) | OpenAI-compatible only | Best with LangChain |
+| AWS Bedrock (`boto3`) | ✅ works (wraps any function) | ❌ not proxy-compatible | Requires LangChain wrapper |
+| Google Vertex AI (native SDK) | ✅ works (wraps any function) | ❌ not proxy-compatible | Requires LangChain wrapper |
+| Self-hosting | Docker Compose (5 min) | Possible but harder | No |
+| Free tier | 50k units/month, 30 days retention | 10k requests, 7 days | Limited |
+| Prompt management | ✅ versioning, A/B tests | ✅ | ✅ |
+| Evaluations (LLM-as-judge) | ✅ | ❌ | ✅ |
+| MCP server | ✅ native | ❌ | ❌ |
+
+**Key reason for choice:** The project uses 5 LLM providers with different SDKs (OpenAI, boto3, vertexai, OpenAI-compatible). Helicone's proxy approach only works for OpenAI-compatible APIs. Langfuse's SDK-based approach wraps any function regardless of the underlying transport, making it the only tool that covers all providers uniformly.
+
+See also: [ADR-013](./architecture-decisions.md#adr-013-custom-llm-provider-abstraction--keep-own-interface-evaluate-litellm-for-future)
+
+### Integration Plan
+
+Langfuse is already installed (`pyproject.toml:32`) and configured (`vars-classification.yaml`: `LANGFUSE_HOST`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_PUBLIC_KEY`). Activation requires:
+
+**Step 1 — Uncomment and enable in `openai_my.py`:**
+```python
+from langfuse.decorators import observe
+```
+
+**Step 2 — Add `@observe()` decorator to key functions:**
+
+```python
+# backend/library/ai.py
+from langfuse.decorators import observe
+
+@observe()
+def ai_ask(model, prompt, system_prompt=None, ...):
+    # Existing routing logic — Langfuse traces automatically
+    ...
+```
+
+```python
+# backend/library/embedding.py
+from langfuse.decorators import observe
+
+@observe()
+def get_embedding(text, model=None, ...):
+    ...
+```
+
+**Step 3 — Set environment variables:**
+```
+LANGFUSE_HOST=https://cloud.langfuse.com  # or self-hosted URL
+LANGFUSE_SECRET_KEY=sk-lf-...
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+```
+
+### What Gets Traced
+
+With `@observe()` on `ai_ask()` and `get_embedding()`:
+
+| Data | Captured | Notes |
+|------|----------|-------|
+| Model name | ✅ | Automatic from OpenAI SDK; manual `langfuse_context.update_current_observation()` for Bedrock/Vertex |
+| Input (prompt) | ✅ | Full prompt text |
+| Output (response) | ✅ | Full response text |
+| Token usage | ✅ (OpenAI, Sherlock, ArkLabs) | Automatic for OpenAI-compatible; requires manual reporting for Bedrock/Vertex |
+| Latency | ✅ | Automatic |
+| Cost | ✅ (estimated) | Langfuse calculates based on model pricing tables |
+| Errors | ✅ | Exceptions are captured automatically |
+
+**Note:** For AWS Bedrock and Google Vertex AI, token counts must be extracted from the provider response and passed to Langfuse manually via `langfuse_context.update_current_observation(usage={"input": N, "output": M})`. This is because these SDKs don't follow the OpenAI response format that Langfuse auto-parses.
+
+### Self-Hosting Option
+
+For full data control, Langfuse can be self-hosted via Docker Compose:
+
+```yaml
+# Add to existing docker-compose.yml or separate file
+services:
+  langfuse:
+    image: langfuse/langfuse:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=postgresql://...
+      - NEXTAUTH_SECRET=...
+      - SALT=...
+```
+
+Self-hosting eliminates the 50k units/month limit and keeps all prompt/response data on-premises.
+
+---
+
 ## Tools Inventory
 
 ### Installed but Unused Tools
@@ -236,7 +343,7 @@ No GCloud deployment exists yet — this section will be updated when GCloud sup
 | Tool | Location | Status | Decision |
 |------|----------|--------|----------|
 | **aws-xray-sdk** | `pyproject.toml:63` (docker extra), `pyproject.toml:82` (all extra) | Dependency installed in Docker and all extras. **NOT imported or used** in any application code. | **Keep for now** — needed when X-Ray instrumentation is implemented in Lambda application code. Remove if X-Ray approach is abandoned. |
-| **Langfuse** | `pyproject.toml:32` (base dependency), `library/api/openai/openai_my.py:5` (commented import: `# from langfuse.decorators import observe`) | Dependency installed. Import and `@observe()` decorator commented out (line 5, 14). | **Keep for now** — useful for LLM call tracing and cost tracking. Activate when LLM observability becomes a priority. |
+| **Langfuse** | `pyproject.toml:32` (base dependency), `library/api/openai/openai_my.py:5` (commented import: `# from langfuse.decorators import observe`) | Dependency installed. Import and `@observe()` decorator commented out (line 5, 14). | **Activate** — chosen as LLM observability tool. See [LLM Observability](#llm-observability) section for integration plan. |
 | **Prometheus `/metrics`** | `server.py:695-697` | Endpoint exists but implementation is `pass` (returns `None`, causing Flask 500 error). `prometheus_client` library is **NOT installed**. | **Keep stub** — implement with `prometheus_client` when Kubernetes monitoring is set up. The route registration ensures the path is reserved for future use. |
 
 ### Removed Tools


### PR DESCRIPTION
## Summary

- **ADR-013** — decyzja o pozostaniu przy własnej warstwie abstrakcji LLM (`ai.py`, `embedding.py`) zamiast LangChain, z jasną ścieżką migracji do LiteLLM gdy zajdzie potrzeba
- **LLM Observability** — nowa sekcja w `observability.md` z wyborem Langfuse jako narzędzia monitorowania, porównaniem z Helicone/LangSmith, planem integracji i opisem self-hostingu
- Aktualizacja statusu Langfuse w Tools Inventory z "Keep for now" na "Activate"

## Test plan

- [ ] Review ADR-013 content in `docs/architecture-decisions.md`
- [ ] Review LLM Observability section in `docs/observability.md`
- [ ] Verify internal markdown links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)