### PR TITLE
feat: email page, backend version, nginx fix

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -49,6 +49,10 @@
         "git+https://github.com/GitGuardian/ggmcp.git",
         "developer-mcp-server"
       ]
+    },
+    "wpcom-mcp": {
+      "type": "http",
+      "url": "https://public-api.wordpress.com/wpcom/v2/mcp/v1"
     }
   }
 }

--- a/docs/CICD/NAS_Deployment.md
+++ b/docs/CICD/NAS_Deployment.md
@@ -488,6 +488,32 @@ Clean unused Docker images on NAS:
 $DOCKER system prune -a
 ```
 
+### docker push fails with "file integrity checksum failed"
+
+Known issue with Docker Desktop on Windows — `docker push` (and `docker save`) may fail with `file integrity checksum failed for "etc/apk/..."` for images using Alpine-based base images (e.g. `nginx:alpine`). The Docker Desktop storage layer becomes corrupted.
+
+**Fix:** Prune builder cache and rebuild with fresh base images:
+
+```bash
+docker builder prune -f
+docker build --no-cache --pull -t 192.168.200.7:5005/lenie-ai-frontend:latest -f web_interface_react/Dockerfile .
+docker push 192.168.200.7:5005/lenie-ai-frontend:latest
+```
+
+If the problem persists, restart Docker Desktop (Settings → Resources → Restart).
+
+**Alternative (bypass registry):** Transfer image directly via SSH:
+
+```bash
+docker save 192.168.200.7:5005/lenie-ai-frontend:latest | \
+  ssh admin@192.168.200.7 \
+  "/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/.libs/docker load"
+```
+
+### WSL integration for make targets
+
+The `make nas-*` targets in the Makefile require WSL with Docker integration. Docker Desktop WSL integration must be enabled for the specific WSL distribution (Settings → Resources → WSL integration → enable Ubuntu-24.04/Fedora). Without this, `docker` commands inside WSL fail with "cannot connect to docker daemon".
+
 ### Registry troubleshooting
 
 ```bash

--- a/web_interface_react/Dockerfile
+++ b/web_interface_react/Dockerfile
@@ -10,7 +10,7 @@ COPY shared/ ../shared/
 COPY web_interface_react/ .
 RUN npm run build
 
-FROM nginx:alpine
+FROM nginx:stable-bookworm
 COPY --from=build-stage /app/build /usr/share/nginx/html
 COPY --from=build-stage /app/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -6,6 +6,7 @@ import Link from "./modules/shared/pages/link";
 import Webpage from "./modules/shared/pages/webpage";
 import Youtube from "./modules/shared/pages/youtube";
 import Movie from "./modules/shared/pages/movie";
+import Email from "./modules/shared/pages/email";
 import Search from "./modules/shared/pages/search";
 import List from "./modules/shared/pages/list";
 import UploadFile from "./modules/shared/pages/file";
@@ -37,6 +38,7 @@ function App() {
                   <Route path="/link/:id?" element={<Link />} />
                   <Route path="/movie/:id?" element={<Movie />} />
                   <Route path="/youtube/:id?" element={<Youtube />} />
+                  <Route path="/email/:id?" element={<Email />} />
                   <Route path="/list" element={<List />} />
                   <Route path="/search" element={<Search />} />
                   <Route path="/upload-file" element={<UploadFile />} />

--- a/web_interface_react/src/modules/shared/components/Authorization/authorization.tsx
+++ b/web_interface_react/src/modules/shared/components/Authorization/authorization.tsx
@@ -19,6 +19,21 @@ const Authorization = () => {
 
   const { fetchSqsSize } = useSqs();
   const navigate = useNavigate();
+  const [backendVersion, setBackendVersion] = React.useState<string | null>(null);
+
+  // Fetch backend version on mount
+  React.useEffect(() => {
+    if (apiUrl) {
+      fetch(`${apiUrl}/version`)
+        .then(res => res.json())
+        .then(data => {
+          if (data.status === "success" && data.app_version) {
+            setBackendVersion(data.app_version);
+          }
+        })
+        .catch(() => setBackendVersion(null));
+    }
+  }, [apiUrl]);
 
   // Auto-check infrastructure status on mount (AWS only — Docker/NAS has no infra endpoints)
   React.useEffect(() => {
@@ -67,6 +82,7 @@ const Authorization = () => {
       <div style={{ marginBottom: "10px", fontSize: "13px" }}>
         <span style={{ color: "#28a745", fontWeight: 500 }}>Connected</span>
         {" "}({apiType}) — {apiUrl}
+        {backendVersion && <span style={{ marginLeft: "10px", color: "#6c757d" }}>Backend v{backendVersion}</span>}
         <button
           type="button"
           className="button"

--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -62,6 +62,16 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
             >
               Youtube (Alfa)
             </NavLink>
+            <NavLink
+              to="/email"
+              className={({ isActive }) =>
+                isActive
+                  ? `${classes.subLink} ${classes.activeLink}`
+                  : `${classes.subLink} ${classes.link}`
+              }
+            >
+              Email (Alfa)
+            </NavLink>
           </div>
         ) : null}
         <NavLink

--- a/web_interface_react/src/modules/shared/pages/email.tsx
+++ b/web_interface_react/src/modules/shared/pages/email.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useFormik } from "formik";
+import { useManageLLM } from "../hooks/useManageLLM";
+import SharedInputs from "../components/SharedInputs/sharedInputs";
+import InputsForAllExceptLink from "../components/SharedInputs/InputsForAllExceptLink";
+import { useParams } from "react-router-dom";
+import FormButtons from "../components/FormButtons/formButtons";
+import { AuthorizationContext } from '../context/authorizationContext';
+
+const Email = () => {
+  const { id } = useParams();
+  const { selectedDocumentType, selectedDocumentState} = React.useContext(AuthorizationContext);
+
+  React.useEffect(() => {
+    if (id) {
+      handleGetLinkByID(id).then(() => null);
+    }
+  }, [id]);
+
+  const formik: any = useFormik({
+    initialValues: {
+      id: "",
+      author: "",
+      source: "",
+      language: "",
+      url: "",
+      tags: "",
+      title: "",
+      document_type: "email",
+      summary: "",
+      text: "",
+      text_md: "",
+      document_state: "",
+      document_state_error: "",
+      chapter_list: "",
+      note: "",
+      next_id: null,
+      previous_id: null,
+      next_type: "",
+      previous_type: "",
+    },
+    onSubmit: () => {},
+  });
+
+  const {
+    message,
+    isError,
+    isLoading,
+    handleGetPageByUrl,
+    handleSaveWebsiteNext,
+    handleSaveWebsiteToCorrect,
+    handleGetLinkByID,
+    handleGetEntryToReview,
+    handleSplitTextForEmbedding,
+    handleRemoveNotNeededText
+  } = useManageLLM({
+    formik, selectedDocumentType, selectedDocumentState
+  });
+
+  return (
+    <div>
+      <h2 style={{ marginBottom: "10px" }}>Email</h2>
+      <form onSubmit={formik.handleSubmit} style={{ maxWidth: "800px" }}>
+        <SharedInputs
+          formik={formik}
+          isLoading={isLoading}
+          handleGetLinkByID={(id: any) => handleGetLinkByID(id, true)}
+          handleGetEntryToReview={handleGetEntryToReview}
+          handleGetPageByUrl={handleGetPageByUrl}
+        />
+        <InputsForAllExceptLink
+          formik={formik}
+          handleSplitTextForEmbedding={handleSplitTextForEmbedding}
+          isLoading={isLoading}
+          handleRemoveNotNeededText={handleRemoveNotNeededText}
+        />
+
+        <FormButtons
+          message={message}
+          formik={formik}
+          isError={isError}
+          isLoading={isLoading}
+          handleSaveWebsiteNext={handleSaveWebsiteNext}
+          handleSaveWebsiteToCorrect={handleSaveWebsiteToCorrect}
+        />
+      </form>
+    </div>
+  );
+};
+
+export default Email;


### PR DESCRIPTION
## Summary

- **Email (Alfa)** — nowa strona `/email` z routingiem i linkiem w nawigacji
- **Backend version** — wyświetlanie wersji backendu w headerze autoryzacji (fetch z `/version`)
- **Nginx fix** — zmiana base image z `nginx:alpine` na `nginx:stable-bookworm` (fix na docker push checksum errors)
- **Docs** — opis fix-a w `docs/CICD/NAS_Deployment.md`
- **MCP** — dodany wpcom-mcp (WordPress) do `.mcp.json`

## Test plan

- [ ] Verify `/email` page loads in frontend
- [ ] Verify backend version displays in header
- [ ] Build and push Docker image with new nginx base
- [ ] Verify navigation link "Email (Alfa)" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)