### PR TITLE
refactor: Webshare proxy — API key IP auth instead of username/password

### DIFF
--- a/backend/library/webshare_ip_auth.py
+++ b/backend/library/webshare_ip_auth.py
@@ -1,0 +1,117 @@
+"""Webshare proxy IP authorization and bandwidth check helper.
+
+Ensures the current public IP is authorized in Webshare so that
+rotating residential proxies work without manual dashboard changes.
+Also checks remaining bandwidth to avoid wasting requests when the
+monthly limit is exhausted.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+WEBSHARE_IP_CHECK_URL = "https://ipv4.webshare.io/"
+WEBSHARE_API_BASE = "https://proxy.webshare.io/api/v2/"
+MIN_BANDWIDTH_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _headers(api_key: str) -> dict:
+    return {"Authorization": f"Token {api_key}"}
+
+
+def get_current_ip() -> str:
+    """Get current public IPv4 address via Webshare's IP check service."""
+    resp = requests.get(WEBSHARE_IP_CHECK_URL, timeout=10)
+    resp.raise_for_status()
+    return resp.text.strip()
+
+
+def ensure_ip_authorized(api_key: str, expected_ip: str = None) -> str:
+    """Ensure current IP is authorized in Webshare. Returns the authorized IP.
+
+    Args:
+        api_key: Webshare API key (Token).
+        expected_ip: If set, verify that current IP matches this value.
+
+    Returns:
+        The current public IP address.
+
+    Raises:
+        SystemExit: If IP mismatch with expected_ip.
+    """
+    headers = _headers(api_key)
+    current_ip = get_current_ip()
+    logger.info(f"Current public IP: {current_ip}")
+
+    if expected_ip and current_ip != expected_ip:
+        logger.error(f"IP mismatch! Current: {current_ip}, expected: {expected_ip}")
+        raise SystemExit(1)
+
+    resp = requests.get(f"{WEBSHARE_API_BASE}proxy/ipauthorization/", headers=headers, timeout=10)
+    resp.raise_for_status()
+
+    authorized_ips = [entry["ip_address"] for entry in resp.json()["results"]]
+
+    if current_ip in authorized_ips:
+        logger.info(f"IP {current_ip} is already authorized in Webshare")
+        return current_ip
+
+    resp = requests.post(
+        f"{WEBSHARE_API_BASE}proxy/ipauthorization/",
+        json={"ip_address": current_ip},
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    logger.info(f"IP {current_ip} authorized in Webshare")
+    return current_ip
+
+
+def check_bandwidth(api_key: str) -> dict:
+    """Check Webshare bandwidth usage for current month.
+
+    Returns:
+        Dict with keys: available (bool), used_mb, limit_mb, remaining_mb.
+    """
+    headers = _headers(api_key)
+
+    resp = requests.get(f"{WEBSHARE_API_BASE}subscription/plan/", headers=headers, timeout=10)
+    resp.raise_for_status()
+    plans = resp.json()["results"]
+
+    active_plan = next((p for p in plans if p["status"] == "active"), None)
+    if active_plan is None:
+        logger.warning("No active Webshare plan found")
+        return {"available": False, "used_mb": 0, "limit_mb": 0, "remaining_mb": 0}
+
+    bandwidth_limit_bytes = active_plan["bandwidth_limit"] * 1024
+
+    now = datetime.now(timezone.utc)
+    start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    resp = requests.get(
+        f"{WEBSHARE_API_BASE}stats/aggregate/",
+        params={"timestamp__gte": start_of_month.isoformat(), "timestamp__lte": now.isoformat()},
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    stats = resp.json()
+
+    bandwidth_used = stats.get("bandwidth_total", 0)
+    bandwidth_remaining = bandwidth_limit_bytes - bandwidth_used
+
+    used_mb = round(bandwidth_used / 1048576)
+    limit_mb = round(bandwidth_limit_bytes / 1048576)
+    remaining_mb = round(bandwidth_remaining / 1048576)
+    available = bandwidth_remaining > MIN_BANDWIDTH_BYTES
+
+    logger.info(f"Webshare bandwidth: {used_mb:.1f} MB used / {limit_mb:.0f} MB limit ({remaining_mb} MB remaining)")
+
+    if not available:
+        logger.warning(f"Webshare bandwidth nearly exhausted ({remaining_mb} MB remaining) — proxy disabled")
+
+    return {"available": available, "used_mb": used_mb, "limit_mb": limit_mb, "remaining_mb": remaining_mb}

--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 import assemblyai as aai
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled
-from youtube_transcript_api.proxies import WebshareProxyConfig
 
 from sqlalchemy.orm import Session
 
@@ -45,6 +44,7 @@ def process_youtube_url(
     ai_summary_needed: bool = False,
     llm_model: str | None = None,
     skip_captions: bool = False,
+    webshare_api_key: str | None = None,
 ) -> "WebDocument":
     """Process a YouTube URL: fetch metadata, download captions/transcription, store in DB.
 
@@ -146,15 +146,14 @@ def process_youtube_url(
             if yt_language == 'pl-PL':
                 yt_language = 'pl'
 
-            proxy_user = os.environ.get("WEBSHARE_PROXY_USERNAME")
-            proxy_pass = os.environ.get("WEBSHARE_PROXY_PASSWORD")
-            if proxy_user and proxy_pass:
-                proxy_config = WebshareProxyConfig(
-                    proxy_username=proxy_user,
-                    proxy_password=proxy_pass,
+            if webshare_api_key:
+                from youtube_transcript_api.proxies import GenericProxyConfig
+                proxy_config = GenericProxyConfig(
+                    http_url="http://p.webshare.io:80/",
+                    https_url="http://p.webshare.io:80/",
                 )
                 ytt_api = YouTubeTranscriptApi(proxy_config=proxy_config)
-                logger.info("Using Webshare proxy for YouTube captions")
+                logger.info("Using Webshare proxy for YouTube captions (IP auth)")
             else:
                 ytt_api = YouTubeTranscriptApi()
             transcript_list = ytt_api.list(youtube_file.video_id)

--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -75,9 +75,6 @@ if __name__ == '__main__':
                 print("WARNING: Webshare bandwidth exhausted — YouTube captions will use direct connection")
         except Exception as e:
             print(f"WARNING: Webshare setup failed: {e}")
-    elif cfg.get("WEBSHARE_PROXY_USERNAME"):
-        print("WARNING: WEBSHARE_PROXY_USERNAME is set but WEBSHARE_API_KEY is missing — IP auto-authorization disabled")
-        webshare_proxy_available = True  # credentials set, assume usable without API check
     else:
         print("skipped (no API key)", end="")
     print(f" ({time.monotonic() - t0:.1f}s)")
@@ -249,6 +246,7 @@ if __name__ == '__main__':
                         cache_dir=cfg.get('CACHE_DIR'),
                         llm_model=cfg.get("AI_MODEL_SUMMARY"),
                         skip_captions=youtube_captions_blocked,
+                        webshare_api_key=cfg.get("WEBSHARE_API_KEY"),
                     )
                     if result.document_state_error == StalkerDocumentStatusError.CAPTIONS_FETCH_ERROR.name \
                             and not youtube_captions_blocked:

--- a/backend/youtube_add.py
+++ b/backend/youtube_add.py
@@ -60,6 +60,7 @@ def main():
             source=args.source,
             ai_summary_needed=args.summary,
             force_reprocess=args.force,
+            webshare_api_key=cfg.get("WEBSHARE_API_KEY"),
         )
     except Exception as e:
         logging.error(f"Error processing YouTube URL: {e}")

--- a/docs/CICD/Vault_Setup.md
+++ b/docs/CICD/Vault_Setup.md
@@ -30,7 +30,7 @@ From the developer machine:
 scp docs/CICD/vault.hcl admin@192.168.200.7:/share/vault/config/vault.hcl
 ```
 
-Configuration (`vault.hcl`):
+Configuration (`vault.hcl`) — includes KMS auto-unseal (see [Auto-Unseal with AWS KMS](#auto-unseal-with-aws-kms)):
 
 ```hcl
 storage "file" {
@@ -42,7 +42,13 @@ listener "tcp" {
   tls_disable = 1
 }
 
+seal "awskms" {
+  region     = "eu-central-1"
+  kms_key_id = "0c6a400d-096b-4b9c-9098-7a0ec7a74f15"
+}
+
 ui = true
+disable_mlock = true
 api_addr = "http://0.0.0.0:8200"
 ```
 

--- a/docs/CICD/vault.hcl
+++ b/docs/CICD/vault.hcl
@@ -7,5 +7,11 @@ listener "tcp" {
   tls_disable = 1
 }
 
+seal "awskms" {
+  region     = "eu-central-1"
+  kms_key_id = "0c6a400d-096b-4b9c-9098-7a0ec7a74f15"
+}
+
 ui = true
+disable_mlock = true
 api_addr = "http://0.0.0.0:8200"

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -359,13 +359,8 @@ groups:
         type: secret
         required: false
         used_by: [docker, local]
-      WEBSHARE_PROXY_USERNAME:
-        description: "Webshare rotating residential proxy username for YouTube captions"
-        type: secret
-        required: false
-        used_by: [docker, local]
-      WEBSHARE_PROXY_PASSWORD:
-        description: "Webshare rotating residential proxy password for YouTube captions"
+      WEBSHARE_API_KEY:
+        description: "Webshare API key for IP-based proxy authorization and bandwidth monitoring"
         type: secret
         required: false
         used_by: [docker, local]


### PR DESCRIPTION
## Summary

- Migracja proxy YouTube z `WEBSHARE_PROXY_USERNAME/PASSWORD` na `WEBSHARE_API_KEY` (IP-based auth)
- Odtworzenie `webshare_ip_auth.py` (źródło było usunięte, został tylko `.pyc`) — autoryzacja IP + monitoring bandwidth
- Aktualizacja `vault.hcl` i `Vault_Setup.md` z aktualną konfiguracją KMS auto-unseal
- Aktualizacja `vars-classification.yaml` — nowa zmienna `WEBSHARE_API_KEY` zamiast starych

## Test plan

- [x] Unit testy `test_youtube_processing_orm.py` — 9/9 passed
- [ ] E2E: uruchomić `youtube_add.py` z `WEBSHARE_API_KEY` w Vault i zweryfikować proxy
- [ ] Zweryfikować bandwidth check w `web_documents_do_the_needful_new.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)