### PR TITLE
feat: LLM fallback for article extraction + Obsidian browser

### DIFF
--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Browse articles from Lenie DB and create/update Obsidian notes via Claude Code.
+
+Usage:
+    cd backend
+    python imports/article_browser.py --list                              # List recent articles
+    python imports/article_browser.py --list --state MD_SIMPLIFIED        # Filter by state
+    python imports/article_browser.py --review --since 2026-03-20         # Interactive review
+    python imports/article_browser.py --review --portal onet.pl           # Filter by portal
+    python imports/article_browser.py --review --id 8786                  # Start from specific article
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import textwrap
+from datetime import datetime
+from typing import Optional
+
+from library.config_loader import load_config
+from library.db.engine import get_session
+from library.db.models import WebDocument
+from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
+from library.article_extractor import process_article_with_llm_fallback, _detect_portal
+from library.lenie_markdown import (
+    links_correct, md_square_brackets_in_one_line,
+    md_get_images_as_links, get_images_with_links_md, process_markdown_and_extract_links,
+)
+
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OBSIDIAN_VAULT = r"C:\Users\ziutus\Obsydian\personal"
+OBSIDIAN_KNOWLEDGE_DIR = os.path.join(OBSIDIAN_VAULT, "02-wiedza")
+NOTES_DIR = os.path.join(_BACKEND_DIR, "tmp", "article_notes")
+
+
+def clean_article_text(text: str, url: str = "") -> str:
+    """Wyczyść wyekstrahowany markdown: napraw rozłamane tagi, usuń obrazki, reklamy, sekcje premium."""
+    import re
+    from library.article_extractor import _detect_portal, _find_footer_line
+
+    # 1. Napraw wieloliniowe linki i tagi markdown
+    text = links_correct(text)
+    text = md_square_brackets_in_one_line(text)
+
+    # 2. Usuń linki-obrazki [![](img)](url) i same obrazki ![](url)
+    text, _, _ = md_get_images_as_links(text)
+    text, _ = get_images_with_links_md(text)
+
+    # 3. Odetnij od footer markera portalu (linki, waluty, kalkulatory itp.)
+    portal = _detect_portal(url)
+    footer_line = _find_footer_line(text, portal)
+    if footer_line is not None:
+        lines_all = text.splitlines()
+        text = "\n".join(lines_all[:footer_line])
+
+    # 4. Usuń picture[N]:"..." i link[N]:... inline referencje
+    text = re.sub(r'picture\[\d+\]:"[^"]*"', '', text)
+    text = re.sub(r'link\[\d+\]:[^\n]*', '', text)
+
+    # 5. Usuń NBSP, wielokrotne spacje
+    text = text.replace('\xa0', ' ')
+    text = re.sub(' +', ' ', text)
+
+    # 5. Usuń szum linia po linii
+    lines = text.splitlines()
+    cleaned = []
+    skip_section = False
+    skip_markers = {
+        "### Więcej pogłębionych treści", "### Więcej treści premium dla Ciebie",
+        "## Top 5 treści Premium", "## Najlepsze w premium",
+        "## Czeka nas skok cen",  # money.pl wstawki reklamowe
+    }
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped in skip_markers:
+            skip_section = True
+            continue
+
+        # Koniec sekcji: następne pytanie dziennikarza (**...**) lub długi akapit
+        if skip_section and stripped and (stripped.startswith("**") or
+                                          (len(stripped) > 50 and not stripped.startswith("[")
+                                           and not stripped.startswith("picture[")
+                                           and not stripped.startswith("!"))):
+            skip_section = False
+
+        if skip_section:
+            continue
+
+        # Pomiń picture[N]:"..." referencje (mogą być na początku lub same w linii)
+        if re.match(r'^picture\[\d+\]:', stripped):
+            continue
+        # Pomiń linie które są TYLKO picture refs (np. w środku tekstu)
+        stripped_no_pictures = re.sub(r'picture\[\d+\]:"[^"]*"', '', stripped).strip()
+        if not stripped_no_pictures and 'picture[' in stripped:
+            continue
+
+        # Pomiń link[N]: referencje
+        if re.match(r'^link\[\d+\]:', stripped):
+            continue
+
+        # Pomiń frazy portalowe
+        if stripped in ("Dalszy ciąg materiału pod wideo", "Posłuchaj artykułu",
+                        "Skróć artykuł", "REKLAMAKONIEC REKLAMY", "REKLAMA",
+                        "Lubię to", "Obserwuj", "Udostępnij", "Skomentuj",
+                        "- x1 +", "x1", "Notowania", "Źródło artykułu:",
+                        "[ ]"):
+            continue
+        if stripped.startswith("Audio generowane") or stripped.startswith("Dźwięk został wygenerowany"):
+            continue
+        if stripped.startswith("Udostępnij na X"):
+            continue
+
+        # Pomiń linie z samą liczbą
+        if stripped.isdigit():
+            continue
+
+        # Pomiń linie z samymi tagami portalu: [tag](/tag/...) [tag](/tag/...)
+        if re.match(r'^(\[[\w\s]+\]\(/tag/[\w-]+/[^)]*\)\s*)+\+?\d*$', stripped):
+            continue
+
+        cleaned.append(line)
+
+    text = "\n".join(cleaned)
+
+    # 6. Zwiń wielokrotne puste linie
+    text = re.sub(r'\n{3,}', '\n\n', text)
+
+    return text.strip()
+
+
+def get_article_text(doc, session) -> Optional[str]:
+    """Pobierz wyekstrahowany tekst artykułu z cache lub przez LLM."""
+    cfg = load_config()
+    cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
+    cache_dir = os.path.join(cache_dir_base, str(doc.id))
+
+    # Szukaj w cache (kolejność: step_2 > llm_extracted > step_1)
+    for suffix in ["_step_2_1_article.md", "_llm_extracted_article.md", "_step_1_all.md"]:
+        cache_file = os.path.join(cache_dir, f"{doc.id}{suffix}")
+        if os.path.isfile(cache_file):
+            with open(cache_file, "r", encoding="utf-8") as f:
+                text = f.read()
+            if len(text) > 100:
+                return clean_article_text(text, doc.url)
+
+    # Szukaj markdown (step_1 lub .md)
+    md_file = os.path.join(cache_dir, f"{doc.id}.md")
+    step1_file = os.path.join(cache_dir, f"{doc.id}_step_1_all.md")
+    markdown_text = None
+
+    for path in [step1_file, md_file]:
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as f:
+                markdown_text = f.read()
+            break
+
+    if not markdown_text:
+        # Automatyczne pobranie z S3 i konwersja do markdown
+        print(f"  Pobieram HTML z S3 i konwertuję do markdown...")
+        from library.document_prepare import prepare_markdown, save_document_info
+        os.makedirs(cache_dir, exist_ok=True)
+        save_document_info(doc.id, doc, cache_dir)
+        markdown_text = prepare_markdown(doc.id, doc, cache_dir)
+        if not markdown_text:
+            print(f"  Nie udało się pobrać artykułu z S3.")
+            return None
+
+    # Próba ekstrakcji przez LLM
+    print(f"  Ekstrakcja artykułu przez LLM...")
+    os.makedirs(cache_dir, exist_ok=True)
+    result = process_article_with_llm_fallback(
+        markdown_text=markdown_text,
+        document_id=doc.id,
+        cache_dir=cache_dir,
+        url=doc.url,
+    )
+    if result:
+        return clean_article_text(result, doc.url)
+    return None
+
+
+def call_claude(prompt: str):
+    """Wywołaj Claude Code z promptem."""
+    try:
+        subprocess.run(["claude", "-p", prompt], check=False)
+    except FileNotFoundError:
+        print("  BŁĄD: komenda 'claude' nie znaleziona. Czy Claude Code jest zainstalowany?")
+
+
+def action_save_note(doc, article_text: str) -> Optional[str]:
+    """Zapisz notatkę użytkownika + treść artykułu do pliku.
+
+    Returns: ścieżka do pliku lub None
+    """
+    print("  Napisz co Cię zainteresowało (kilka linii, pusta linia kończy):")
+    note_lines = []
+    while True:
+        try:
+            line = input("  > ")
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return None
+        if line.strip() == "":
+            break
+        note_lines.append(line)
+
+    if not note_lines:
+        print("  Pusta notatka — nie zapisano.")
+        return None
+
+    note_text = "\n".join(note_lines)
+
+    os.makedirs(NOTES_DIR, exist_ok=True)
+    note_file = os.path.join(NOTES_DIR, f"{doc.id}_note.md")
+
+    with open(note_file, "w", encoding="utf-8") as f:
+        f.write(f"# Notatka do artykułu: {doc.title}\n\n")
+        f.write(f"- **Lenie ID**: {doc.id}\n")
+        f.write(f"- **URL**: {doc.url}\n")
+        f.write(f"- **Data**: {doc.created_at}\n")
+        f.write(f"- **Obsidian vault**: {OBSIDIAN_KNOWLEDGE_DIR}\n\n")
+        f.write(f"## Moja notatka\n\n")
+        f.write(f"{note_text}\n\n")
+        f.write(f"## Treść artykułu\n\n")
+        f.write(f"{article_text}\n")
+
+    print(f"  Zapisano: {note_file}")
+    print(f"  Aby pracować nad notatką w Claude Code:")
+    print(f"    claude \"przeczytaj @{note_file} i dodaj do mojego Obsidian vault\"")
+    return note_file
+
+
+def action_obsidian(doc, article_text: str):
+    """Wywołaj Claude Code aby stworzył/zaktualizował notatkę Obsidian."""
+    prompt = textwrap.dedent(f"""\
+        Przeczytaj poniższy artykuł i wykonaj następujące kroki:
+
+        1. Przeszukaj folder "{OBSIDIAN_KNOWLEDGE_DIR}" — szukaj istniejących notatek .md powiązanych tematycznie (użyj Grep/Glob po słowach kluczowych z artykułu)
+        2. Jeśli znajdziesz powiązaną notatkę — zaproponuj dodanie nowych informacji z artykułu do odpowiedniej sekcji. Pokaż mi propozycję zmian i poczekaj na akceptację.
+        3. Jeśli nie ma powiązanej notatki — zaproponuj stworzenie nowej w odpowiednim podfolderze z formatem:
+           - Frontmatter z tagami (tags: wiedza/...)
+           - Nagłówek H1
+           - Treść ze strukturą (## sekcje, **pogrubienia** dla kluczowych myśli)
+           - Na końcu: źródło z linkiem i ID z Lenie
+        4. Zawsze dodaj na końcu sekcji/notatki linię źródła:
+           Źródło: [{doc.title}]({doc.url}) (Lenie AI id={doc.id})
+
+        Odpowiadaj po polsku.
+
+        ---
+        TYTUŁ: {doc.title}
+        URL: {doc.url}
+        DATA: {doc.created_at}
+        LENIE ID: {doc.id}
+
+        TREŚĆ ARTYKUŁU:
+        {article_text}
+    """)
+    call_claude(prompt)
+
+
+def action_compare(doc, article_text: str):
+    """Wywołaj Claude Code aby porównał artykuł z istniejącymi notatkami."""
+    prompt = textwrap.dedent(f"""\
+        Przeczytaj poniższy artykuł, a następnie:
+
+        1. Przeszukaj folder "{OBSIDIAN_KNOWLEDGE_DIR}" — znajdź notatki powiązane tematycznie (Grep/Glob)
+        2. Porównaj informacje z artykułu z tym co jest w notatkach:
+           - Co NOWEGO wnosi ten artykuł?
+           - Czy coś jest SPRZECZNE z istniejącymi notatkami?
+           - Czy artykuł POTWIERDZA wcześniejsze ustalenia?
+        3. Podsumuj w 3-5 punktach po polsku
+
+        NIE modyfikuj żadnych plików — tylko analiza.
+
+        ---
+        TYTUŁ: {doc.title}
+        URL: {doc.url}
+        LENIE ID: {doc.id}
+
+        TREŚĆ ARTYKUŁU:
+        {article_text}
+    """)
+    call_claude(prompt)
+
+
+def action_view(article_text: str):
+    """Wyświetl pełną treść artykułu w terminalu."""
+    print("\n" + "=" * 60)
+    print(article_text)
+    print("=" * 60)
+    print(f"  [{len(article_text)} znaków]")
+
+
+def _get_documents(session, limit: int = 50, since: Optional[str] = None,
+                   portal: Optional[str] = None, state: Optional[str] = None) -> list:
+    """Pobierz dokumenty z bazy z filtrami. Zwraca listę obiektów WebDocument."""
+    wb_db = WebsitesDBPostgreSQL(session=session)
+    doc_dicts = wb_db.get_list(document_type="webpage", limit=limit)
+
+    results = []
+    for d in doc_dicts:
+        doc = WebDocument.get_by_id(session, d["id"])
+        if doc is None:
+            continue
+        if portal and portal not in (doc.url or ""):
+            continue
+        if state and doc.document_state != state:
+            continue
+        if since:
+            since_date = datetime.strptime(since, "%Y-%m-%d").date()
+            if doc.created_at and doc.created_at.date() < since_date:
+                continue
+        results.append(doc)
+    return results
+
+
+def cmd_list(session, since: Optional[str] = None, portal: Optional[str] = None,
+             state: Optional[str] = None, limit: int = 30):
+    """Wyświetl listę artykułów z bazy."""
+    documents = _get_documents(session, limit=limit, since=since, portal=portal, state=state)
+
+    print(f"\nArtykuły w bazie ({len(documents)}):\n")
+
+    for doc in documents:
+        date_str = doc.created_at.strftime("%Y-%m-%d") if doc.created_at else "????"
+        state_short = (doc.document_state or "?")[:15]
+        title = (doc.title or "brak tytułu")[:80]
+        print(f"  {doc.id:5d}  [{date_str}] [{state_short:15s}] {title}")
+
+
+def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = None,
+               start_id: Optional[int] = None, limit: int = 50):
+    """Interaktywny przegląd artykułów."""
+    filtered = _get_documents(session, limit=limit, since=since, portal=portal)
+
+    if start_id:
+        # Znajdź pozycję startową
+        start_idx = next((i for i, d in enumerate(filtered) if d.id == start_id), 0)
+        filtered = filtered[start_idx:]
+
+    if not filtered:
+        print("Brak artykułów do przeglądu.")
+        return
+
+    print(f"\n{len(filtered)} artykułów do przeglądu. Komendy:")
+    print("  [n]ext / Enter  - następny artykuł")
+    print("  [v]iew          - pokaż treść artykułu")
+    print("  [s]ave          - zapisz notatkę (co mnie zainteresowało) + artykuł do pliku")
+    print("  [o]bsidian      - stwórz/zaktualizuj notatkę Obsidian teraz (Claude Code)")
+    print("  [c]ompare       - porównaj z istniejącymi notatkami (Claude Code)")
+    print("  [q]uit          - zakończ")
+    print()
+
+    for idx, doc in enumerate(filtered, 1):
+        date_str = doc.created_at.strftime("%Y-%m-%d %H:%M") if doc.created_at else "????"
+        detected_portal = _detect_portal(doc.url) or "?"
+
+        print(f"\n--- [{idx}/{len(filtered)}] ID: {doc.id} ---")
+        print(f"  Tytuł:   {doc.title}")
+        print(f"  Data:    {date_str}")
+        print(f"  Portal:  {detected_portal}")
+        print(f"  URL:     {doc.url}")
+        print(f"  Stan:    {doc.document_state}")
+        print()
+
+        article_text = None  # lazy load
+
+        while True:
+            try:
+                action = input(f"  [{idx}] [n/v/s/o/c/q]: ").strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                print("\nPrzegląd zakończony.")
+                return
+
+            if action in ("n", "next", ""):
+                break
+
+            elif action in ("v", "view"):
+                if article_text is None:
+                    article_text = get_article_text(doc, session)
+                if article_text:
+                    action_view(article_text)
+                else:
+                    print("  Nie udało się pobrać treści artykułu.")
+                continue
+
+            elif action in ("s", "save"):
+                if article_text is None:
+                    article_text = get_article_text(doc, session)
+                if article_text:
+                    action_save_note(doc, article_text)
+                else:
+                    print("  Nie udało się pobrać treści artykułu.")
+                break
+
+            elif action in ("o", "obsidian"):
+                if article_text is None:
+                    article_text = get_article_text(doc, session)
+                if article_text:
+                    action_obsidian(doc, article_text)
+                else:
+                    print("  Nie udało się pobrać treści artykułu.")
+                break
+
+            elif action in ("c", "compare"):
+                if article_text is None:
+                    article_text = get_article_text(doc, session)
+                if article_text:
+                    action_compare(doc, article_text)
+                else:
+                    print("  Nie udało się pobrać treści artykułu.")
+                continue
+
+            elif action in ("q", "quit"):
+                print("Przegląd zakończony.")
+                return
+
+            else:
+                print("  Nieznana komenda. Użyj: n, o, c, v, q")
+
+
+def cmd_notes():
+    """Wyświetl zapisane notatki do artykułów."""
+    if not os.path.exists(NOTES_DIR):
+        print("Brak zapisanych notatek.")
+        return
+
+    notes = sorted([f for f in os.listdir(NOTES_DIR) if f.endswith("_note.md")])
+    if not notes:
+        print("Brak zapisanych notatek.")
+        return
+
+    print(f"\nZapisane notatki ({len(notes)}):\n")
+    for note_file in notes:
+        path = os.path.join(NOTES_DIR, note_file)
+        with open(path, "r", encoding="utf-8") as f:
+            first_lines = [l.strip() for l in f.readlines()[:8] if l.strip()]
+
+        title = first_lines[0].removeprefix("# Notatka do artykułu: ") if first_lines else "?"
+        print(f"  {note_file}")
+        print(f"    Tytuł: {title[:80]}")
+        print(f"    Plik:  {path}")
+        print(f"    Claude: claude \"przeczytaj @{path} i dodaj do mojego Obsidian vault\"")
+        print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Przeglądaj artykuły z Lenie DB i twórz notatki Obsidian")
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--list", action="store_true", help="Lista artykułów")
+    group.add_argument("--review", action="store_true", help="Interaktywny przegląd")
+    group.add_argument("--notes", action="store_true", help="Pokaż zapisane notatki do przetworzenia")
+
+    parser.add_argument("--since", default=None, help="Data od (YYYY-MM-DD)")
+    parser.add_argument("--portal", default=None, help="Filtruj po portalu (np. onet.pl)")
+    parser.add_argument("--state", default=None, help="Filtruj po stanie (np. MD_SIMPLIFIED)")
+    parser.add_argument("--id", type=int, default=None, help="Zacznij od konkretnego ID")
+    parser.add_argument("--limit", type=int, default=50, help="Maks. artykułów (domyślnie 50)")
+    args = parser.parse_args()
+
+    if args.notes:
+        cmd_notes()
+        return
+
+    load_config()
+    session = get_session()
+
+    try:
+        if args.list:
+            cmd_list(session, since=args.since, portal=args.portal,
+                     state=args.state, limit=args.limit)
+        elif args.review:
+            cmd_review(session, since=args.since, portal=args.portal,
+                       start_id=args.id, limit=args.limit)
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/ai.py
+++ b/backend/library/ai.py
@@ -8,6 +8,7 @@ def get_all_models_info():
         "gpt-3.5-turbo": {"need_translation": True},
         "Bielik-11B-v2.3-Instruct": {"need_translation": False},
         "Bielik-11B-v3.0-Instruct": {"need_translation": False},
+        "arklabs/Bielik-11B-v3.0-Instruct": {"need_translation": False},
         "gemini-2.0-flash-lite-001": {"need_translation": False},
     }
 
@@ -72,6 +73,11 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
     elif model in ["Bielik-11B-v2.3-Instruct", "Bielik-11B-v3.0-Instruct"]:
         from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
         return sherlock_get_completion(query, model=model)
+    elif model.startswith("arklabs/"):
+        from library.api.arklabs.arklabs_completion import arklabs_get_completion
+        actual_model = model.removeprefix("arklabs/")
+        return arklabs_get_completion(query, model=actual_model, temperature=temperature,
+                                      max_tokens=max_token_count)
     elif model in ['gemini-2.0-flash-lite-001']:
         import library.api.google.google_vertexai as google_vertexai
         return google_vertexai.connect_to_google_llm_with_role(query, model)

--- a/backend/library/api/arklabs/arklabs_completion.py
+++ b/backend/library/api/arklabs/arklabs_completion.py
@@ -1,0 +1,33 @@
+from openai import OpenAI
+
+from library.models.ai_response import AiResponse
+from library.api.arklabs.config import get_arklabs_config
+
+
+def arklabs_get_completion(prompt: str, model: str = "speakleash/Bielik-11B-v3.0-Instruct",
+                           max_tokens: int = 1000, temperature: float = 0.1,
+                           system_prompt: str = None) -> AiResponse:
+    ai_response = AiResponse(query=prompt, model=model)
+
+    api_key, base_url = get_arklabs_config()
+    client = OpenAI(api_key=api_key, base_url=base_url)
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+
+    chat_response = client.chat.completions.create(
+        model=model,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+
+    ai_response.id = chat_response.id
+    ai_response.response_text = chat_response.choices[0].message.content
+    ai_response.prompt_tokens = chat_response.usage.prompt_tokens
+    ai_response.completion_tokens = chat_response.usage.completion_tokens
+    ai_response.total_tokens = chat_response.usage.total_tokens
+
+    return ai_response

--- a/backend/library/api/arklabs/arklabs_embedding.py
+++ b/backend/library/api/arklabs/arklabs_embedding.py
@@ -1,22 +1,12 @@
 from openai import OpenAI
 
 from library.models.embedding_result import EmbeddingResult
-
-
-API_BASE = "https://api.ark-labs.cloud/api/v1"
-
-
-def _get_api_key():
-    from library.config_loader import load_config
-    cfg = load_config()
-    key = cfg.get("ARKLABS_API_KEY")
-    if not key:
-        raise RuntimeError("ARKLABS_API_KEY is not set")
-    return key
+from library.api.arklabs.config import get_arklabs_config
 
 
 def get_embedding(text: str, model: str = "BAAI/bge-m3") -> EmbeddingResult:
-    client = OpenAI(api_key=_get_api_key(), base_url=API_BASE)
+    api_key, base_url = get_arklabs_config()
+    client = OpenAI(api_key=api_key, base_url=base_url)
 
     result = EmbeddingResult(text=text, model_id=model)
 

--- a/backend/library/api/arklabs/config.py
+++ b/backend/library/api/arklabs/config.py
@@ -1,0 +1,16 @@
+API_BASE_DEFAULT = "https://api.ark-labs.cloud/api/v1"
+
+
+def get_arklabs_config():
+    """Pobierz klucz API i bazowy URL ARK Labs z konfiguracji."""
+    from library.config_loader import load_config
+    cfg = load_config()
+    key = cfg.get("ARK_LABS_KEY")
+    if not key:
+        raise RuntimeError("ARK_LABS_KEY is not set in configuration")
+    base_url = cfg.get("ARK_LABS_URL") or API_BASE_DEFAULT
+    if not base_url.startswith("http"):
+        base_url = f"https://{base_url}"
+    if not base_url.endswith("/api/v1"):
+        base_url = base_url.rstrip("/") + "/api/v1"
+    return key, base_url

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -1,0 +1,562 @@
+"""
+Moduł do ekstrakcji treści artykułu z markdown za pomocą LLM (Bielik)
+oraz generowania plików .regex.draft na podstawie wyników.
+
+Flow:
+1. Przytnij markdown (usuń oczywistą nawigację z początku)
+2. Wyślij do Bielika z promptem ekstrakcji markerów granic
+3. Na podstawie markerów znajdź granice artykułu w oryginalnym markdown
+4. Wygeneruj plik .regex.draft do ręcznej weryfikacji
+"""
+
+import json
+import logging
+import re
+import os
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_SYSTEM_PROMPT = """Jesteś ekspertem od analizy polskich portali informacyjnych. Twoim zadaniem jest zidentyfikowanie DOKŁADNYCH granic artykułu prasowego w tekście markdown.
+
+Odpowiadaj WYŁĄCZNIE poprawnym JSON, bez żadnego dodatkowego tekstu, komentarzy ani formatowania."""
+
+EXTRACTION_USER_PROMPT_TEMPLATE = """Przeanalizuj poniższy tekst markdown ze strony internetowej polskiego portalu informacyjnego. Tekst zawiera artykuł prasowy otoczony elementami portalu (nawigacja, reklamy, linki do innych artykułów, komentarze, emotki, stopka).
+
+Twoim zadaniem jest znalezienie DOKŁADNYCH granic artykułu. Zwróć JSON z polami:
+
+- "title": tytuł artykułu (nagłówek H1)
+- "author": autor artykułu (imię i nazwisko, jeśli dostępne, w przeciwnym razie null)
+- "date": data publikacji (jeśli dostępna, w przeciwnym razie null)
+- "article_first_sentence": DOKŁADNY CYTAT pierwszego zdania treści artykułu. To jest pierwsze zdanie tekstu właściwego — NIE tytuł, NIE imię autora, NIE data. Zazwyczaj zaczyna się od opisu tematu lub osoby.
+- "article_last_sentence": DOKŁADNY CYTAT ostatniego zdania lub akapitu artykułu. Artykuły prasowe często kończą się: notką biograficzną o rozmówcy/autorze, ostatnią wypowiedzią w wywiadzie, lub podsumowaniem. Szukaj OSTATNIEGO zdania PRZED elementami portalu takimi jak: "Dziękujemy, że przeczytałaś/eś", emotki/reakcje, tagi, sekcja "Zobacz również", linki do innych artykułów. Jeśli artykuł kończy się notką biograficzną (np. "jest ekspertem...", "pełnił funkcję...") — to jest część artykułu, uwzględnij ją.
+- "tags": lista tagów/słów kluczowych artykułu (jeśli widoczne na stronie, np. jako linki na dole)
+
+ZASADY:
+1. article_first_sentence i article_last_sentence muszą być DOKŁADNYMI cytatami z tekstu — skopiuj je znak po znaku
+2. Cytaty muszą mieć minimum 40 znaków
+3. Treść artykułu NIE obejmuje: nawigacji portalu, sekcji "Top 5 treści Premium", "Więcej pogłębionych treści", "Więcej treści premium dla Ciebie", "Zobacz także", reklam, komentarzy, emotek/reakcji, "Dalszy ciąg materiału pod wideo"
+4. Treść artykułu OBEJMUJE: tekst właściwy, cytaty (blockquote >), pytania dziennikarza (pogrubione **), odpowiedzi rozmówcy, śródtytuły, notki biograficzne na końcu
+
+Tekst markdown:
+---
+{markdown_text}
+---
+
+JSON:"""
+
+
+def _trim_markdown_navigation(markdown_text: str) -> str:
+    """Przytnij oczywistą nawigację z początku markdown.
+
+    Szuka ostatniego nagłówka H1 (#) — portale często mają kilka H1,
+    a właściwy artykuł jest pod ostatnim. Zwraca tekst od 3 linii przed nim.
+    Jeśli nie znajdzie H1, zwraca ostatnie 60% tekstu.
+    """
+    lines = markdown_text.splitlines()
+
+    # Znajdź OSTATNI H1 (właściwy artykuł jest zwykle pod ostatnim)
+    last_h1 = None
+    for i, line in enumerate(lines):
+        if line.startswith("# ") and len(line) > 10:
+            last_h1 = i
+
+    if last_h1 is not None:
+        start = max(0, last_h1 - 3)
+        return "\n".join(lines[start:])
+
+    # Fallback: weź ostatnie 60%
+    start = len(lines) * 4 // 10
+    return "\n".join(lines[start:])
+
+
+def _detect_portal(url: str) -> str | None:
+    """Rozpoznaj portal na podstawie URL."""
+    if not url:
+        return None
+    url_lower = url.lower()
+    if "onet.pl" in url_lower or "fakt.pl" in url_lower:
+        return "onet"
+    if "money.pl" in url_lower:
+        return "money"
+    if "wp.pl" in url_lower or "o2.pl" in url_lower:
+        return "wp"
+    if "interia.pl" in url_lower:
+        return "interia"
+    if "businessinsider.com.pl" in url_lower:
+        return "businessinsider"
+    return None
+
+
+# Wzorce oznaczające KONIEC artykułu per portal.
+# Tekst od pierwszego dopasowanego wzorca w dół jest odcinany.
+PORTAL_FOOTER_MARKERS = {
+    "onet": [
+        "Dziękujemy, że przeczytałaś/eś",
+        "*Dziękujemy, że przeczytałaś/eś",
+        "*Masz ochotę na więcej?",
+        "## Zobacz również",
+        "## Zobacz także",
+    ],
+    "money": [
+        "**Masz newsa, zdjęcie lub filmik?",
+        "Oceń jakość naszego artykułu",
+        "Wybrane dla Ciebie",
+        "WALUTY",
+        "KALKULATORY",
+        "MONEY NA SKR",
+    ],
+    "wp": [
+        "### Wybrane dla Ciebie",
+        "**Masz newsa, zdjęcie lub filmik?",
+        "**Czytaj także:**",
+        "Oceń jakość naszego artykułu",
+    ],
+    "interia": [
+        "Masz sugestie, uwagi albo widzisz na stronie błąd",
+        "INTERIA.PL",
+        "Polecjemy",
+    ],
+    "businessinsider": [
+        "Dziękujemy, że przeczytałaś/eś",
+        "## Autor",
+    ],
+}
+
+# Wzorce wewnątrz artykułu do pominięcia per portal (sekcje reklamowe/premium)
+PORTAL_SKIP_SECTIONS = {
+    "onet": [
+        "## Top 5 treści Premium",
+        "### Więcej pogłębionych treści",
+        "### Więcej treści premium dla Ciebie",
+        "## Najlepsze w premium",
+    ],
+    "money": [],
+    "wp": [],
+    "interia": [],
+    "businessinsider": [],
+}
+
+# Jednolinijkowe frazy do pominięcia per portal
+PORTAL_SKIP_LINES = {
+    "onet": [
+        "Posłuchaj artykułu", "Skróć artykuł", "x1", "- x1 +",
+        "Dalszy ciąg materiału pod wideo",
+        "Więcej w Strefie Premium", "Obserwuj",
+    ],
+    "money": [
+        "Dalszy ciąg materiału pod wideo",
+    ],
+    "wp": [
+        "Dalszy ciąg materiału pod wideo",
+        "ZAPISZUDOSTĘPNIJ",
+    ],
+    "interia": [
+        "Dalszy ciąg materiału pod wideo",
+        "Udostępnij",
+    ],
+    "businessinsider": [
+        "Udostępnij artykuł",
+        "Dalszy ciąg materiału pod wideo",
+    ],
+}
+
+
+def _find_footer_line(text: str, portal: str | None) -> int | None:
+    """Znajdź numer linii pierwszego markera stopki portalu w oryginalnym markdown."""
+    universal_markers = [
+        "## Zobacz również",
+        "## Zobacz także",
+        "Dziękujemy, że przeczytałaś/eś",
+        "*Dziękujemy, że przeczytałaś/eś",
+    ]
+
+    markers = []
+    if portal and portal in PORTAL_FOOTER_MARKERS:
+        markers = PORTAL_FOOTER_MARKERS[portal][:]
+    markers.extend(universal_markers)
+
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        for marker in markers:
+            if stripped.startswith(marker):
+                return i
+
+    return None
+
+
+def _cut_at_footer(text: str, portal: str | None) -> str:
+    """Odetnij tekst od pierwszego markera stopki portalu."""
+    # Markery uniwersalne (działają dla każdego portalu)
+    universal_markers = [
+        "## Zobacz również",
+        "## Zobacz także",
+    ]
+
+    markers = universal_markers[:]
+    if portal and portal in PORTAL_FOOTER_MARKERS:
+        markers = PORTAL_FOOTER_MARKERS[portal] + markers
+
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        for marker in markers:
+            if stripped.startswith(marker):
+                logger.debug(f"Footer marker found at line {i}: {marker}")
+                return "\n".join(lines[:i])
+
+    return text
+
+
+def _clean_markdown_for_llm(text: str, portal: str | None = None) -> str:
+    """Usuń szum z markdown przed wysłaniem do LLM.
+
+    Krok 1: Odetnij stopkę portalu (komentarze, "Zobacz również", tracking)
+    Krok 2: Usuń sekcje reklamowe/premium wewnątrz artykułu
+    Krok 3: Usuń obrazki, emotki, linie z samymi liczbami
+    """
+    # Krok 1: Odetnij od stopki
+    text = _cut_at_footer(text, portal)
+
+    skip_sections = PORTAL_SKIP_SECTIONS.get(portal, []) if portal else []
+    skip_lines_set = set(PORTAL_SKIP_LINES.get(portal, [])) if portal else set()
+
+    lines = text.splitlines()
+    cleaned = []
+    skip_section = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Krok 2: Pomiń sekcje portalowe (od nagłówka do następnej treści)
+        if stripped in skip_sections:
+            skip_section = True
+            continue
+
+        # Koniec sekcji portalowej: następne pytanie dziennikarza lub zwykły akapit
+        if skip_section and stripped and (stripped.startswith("**") or
+                                          (len(stripped) > 50 and not stripped.startswith("[") and
+                                           not stripped.startswith("!") and not stripped.startswith("#"))):
+            skip_section = False
+
+        if skip_section:
+            continue
+
+        # Krok 3: Ogólne czyszczenie
+
+        # Pomiń linie z samymi obrazkami markdown
+        if stripped.startswith("![") and stripped.endswith(")"):
+            continue
+
+        # Pomiń linki-obrazki: [![](url)](url)
+        if stripped.startswith("[![") and stripped.endswith(")"):
+            continue
+
+        # Pomiń linie z samą liczbą (np. "385" - liczba reakcji)
+        if stripped.isdigit():
+            continue
+
+        # Pomiń frazy per portal
+        if stripped in skip_lines_set:
+            continue
+
+        # Pomiń linie zaczynające się od "Audio generowane"
+        if stripped.startswith("Audio generowane"):
+            continue
+
+        cleaned.append(line)
+
+    return "\n".join(cleaned)
+
+
+def _truncate_for_llm(text: str, max_chars: int = 15000) -> str:
+    """Ogranicz tekst do max_chars znaków, przycinając od końca."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n\n[...tekst przycięty...]"
+
+
+def extract_article_markers_with_llm(markdown_text: str, url: str = "",
+                                     model: str = "speakleash/Bielik-11B-v3.0-Instruct") -> dict | None:
+    """Wyślij markdown do LLM i pobierz markery granic artykułu.
+
+    Returns:
+        dict z polami: title, author, date, article_first_sentence, article_last_sentence, tags
+        lub None w przypadku błędu
+    """
+    from library.api.arklabs.arklabs_completion import arklabs_get_completion
+
+    portal = _detect_portal(url)
+    logger.info(f"Detected portal: {portal or 'unknown'} (url: {url[:60]})")
+
+    trimmed = _trim_markdown_navigation(markdown_text)
+    cleaned = _clean_markdown_for_llm(trimmed, portal=portal)
+    cleaned = _truncate_for_llm(cleaned)
+
+    logger.info(f"LLM input: {len(markdown_text)} -> trimmed {len(trimmed)} -> cleaned {len(cleaned)} chars")
+
+    prompt = EXTRACTION_USER_PROMPT_TEMPLATE.format(markdown_text=cleaned)
+
+    try:
+        response = arklabs_get_completion(
+            prompt=prompt,
+            model=model,
+            max_tokens=800,
+            temperature=0.1,
+            system_prompt=EXTRACTION_SYSTEM_PROMPT,
+        )
+
+        logger.info(f"LLM extraction tokens: prompt={response.prompt_tokens}, "
+                     f"completion={response.completion_tokens}, total={response.total_tokens}")
+
+        response_text = response.response_text.strip()
+
+        # Wyczyść odpowiedź - usuń ewentualne ```json``` wrappery
+        if response_text.startswith("```"):
+            response_text = re.sub(r'^```(?:json)?\s*', '', response_text)
+            response_text = re.sub(r'\s*```$', '', response_text)
+
+        markers = json.loads(response_text)
+
+        # Walidacja: wymagane pola
+        required_fields = ["article_first_sentence", "article_last_sentence"]
+        missing = [f for f in required_fields if not markers.get(f)]
+        if missing:
+            logger.warning(f"LLM response missing fields: {missing}. Response: {response_text[:200]}")
+            return None
+
+        return markers
+
+    except json.JSONDecodeError as e:
+        logger.error(f"LLM response is not valid JSON: {e}\nResponse: {response.response_text}")
+        return None
+    except Exception as e:
+        logger.error(f"LLM extraction failed: {e}")
+        return None
+
+
+def find_text_in_markdown(markdown_text: str, search_text: str) -> int | None:
+    """Znajdź pozycję (numer linii) tekstu w markdown.
+
+    Próbuje: exact match → match bez białych znaków → match po słowach.
+    Returns: numer linii (0-based) lub None
+    """
+    if not search_text:
+        return None
+
+    lines = markdown_text.splitlines()
+
+    # 1. Exact match
+    for i, line in enumerate(lines):
+        if search_text in line:
+            return i
+
+    # 2. Normalizacja białych znaków
+    normalized_search = " ".join(search_text.split())
+    for i, line in enumerate(lines):
+        if normalized_search in " ".join(line.split()):
+            return i
+
+    # 3. Szukaj po pierwszych kilku słowach (min 5)
+    words = normalized_search.split()
+    if len(words) >= 5:
+        partial = " ".join(words[:8])
+        for i, line in enumerate(lines):
+            if partial in " ".join(line.split()):
+                return i
+
+    return None
+
+
+def extract_article_by_markers(markdown_text: str, markers: dict, url: str = "") -> str | None:
+    """Wyodrębnij treść artykułu na podstawie markerów z LLM.
+
+    Strategia hybrydowa:
+    - Początek artykułu: z LLM (article_first_sentence)
+    - Koniec artykułu: z LLM (article_last_sentence) LUB z footer markera portalu (co dalej)
+
+    Returns: tekst artykułu lub None
+    """
+    first_sentence = markers.get("article_first_sentence", "")
+    last_sentence = markers.get("article_last_sentence", "")
+
+    start_line = find_text_in_markdown(markdown_text, first_sentence)
+    end_line = find_text_in_markdown(markdown_text, last_sentence)
+
+    if start_line is None:
+        logger.warning(f"Cannot find article_first_sentence in markdown: {first_sentence[:80]}...")
+        return None
+
+    # Znajdź koniec na podstawie footer markera portalu
+    portal = _detect_portal(url)
+    footer_line = _find_footer_line(markdown_text, portal)
+
+    if footer_line is not None:
+        # Footer marker jest pewny (deterministyczny) — użyj go jako koniec
+        # LLM marker traktuj jako fallback gdy brak footera
+        end_line = footer_line - 1
+        logger.info(f"Article end: footer line {footer_line}"
+                     + (f", LLM line {find_text_in_markdown(markdown_text, last_sentence)}" if last_sentence else ""))
+    elif end_line is not None:
+        # Brak footera — użyj LLM markera
+        logger.info(f"Article end: LLM line {end_line} (no footer marker found)")
+    else:
+        logger.warning(f"Cannot find article end: no footer marker, no LLM marker")
+        return None
+
+    # Cofnij się przez puste linie na końcu
+    lines_list = markdown_text.splitlines()
+    while end_line > start_line and not lines_list[end_line].strip():
+        end_line -= 1
+
+    if end_line <= start_line:
+        logger.warning(f"article_last_sentence (line {end_line}) is before article_first_sentence (line {start_line})")
+        return None
+
+    lines = markdown_text.splitlines()
+    # Dołącz linię z last_sentence
+    article_lines = lines[start_line:end_line + 1]
+
+    return "\n".join(article_lines)
+
+
+def generate_regex_draft(markdown_text: str, markers: dict, output_path: str) -> bool:
+    """Generuje plik .regex.draft na podstawie markerów granic artykułu.
+
+    Analizuje kontekst przed article_first_sentence i po article_last_sentence,
+    aby stworzyć wzorzec regex.
+
+    Returns: True jeśli plik został zapisany
+    """
+    first_sentence = markers.get("article_first_sentence", "")
+    last_sentence = markers.get("article_last_sentence", "")
+
+    start_line = find_text_in_markdown(markdown_text, first_sentence)
+    end_line = find_text_in_markdown(markdown_text, last_sentence)
+
+    if start_line is None or end_line is None:
+        logger.error("Cannot generate regex draft: markers not found in markdown")
+        return False
+
+    lines = markdown_text.splitlines()
+
+    # Pobierz kontekst PRZED artykułem (5 linii) — to będzie "pre" pattern
+    pre_start = max(0, start_line - 5)
+    pre_lines = [l for l in lines[pre_start:start_line] if l.strip()]
+
+    # Pobierz kontekst PO artykule (5 linii) — to będzie "post" pattern
+    post_end = min(len(lines), end_line + 6)
+    post_lines = [l for l in lines[end_line + 1:post_end] if l.strip()]
+
+    # Buduj regex
+    draft_lines = []
+    draft_lines.append(f"# Auto-generated regex draft from LLM extraction")
+    draft_lines.append(f"# Markers: title={markers.get('title', 'N/A')}")
+    draft_lines.append(f"# Pre-article context (lines {pre_start+1}-{start_line}):")
+
+    for line in pre_lines:
+        escaped = _escape_for_regex(line)
+        draft_lines.append(escaped)
+
+    draft_lines.append("(?P<article_text>.*)")
+
+    draft_lines.append(f"# Post-article context (lines {end_line+2}-{post_end}):")
+    for line in post_lines:
+        escaped = _escape_for_regex(line)
+        draft_lines.append(escaped)
+
+    # Zapisz wersję czytelną (draft)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(draft_lines))
+
+    logger.info(f"Regex draft saved to {output_path}")
+
+    # Zapisz też metadane z LLM obok
+    meta_path = output_path.replace(".regex.draft", "_llm_markers.json")
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "markers": markers,
+            "start_line": start_line,
+            "end_line": end_line,
+            "pre_context_lines": pre_lines,
+            "post_context_lines": post_lines,
+        }, f, ensure_ascii=False, indent=2)
+
+    logger.info(f"LLM markers saved to {meta_path}")
+    return True
+
+
+def _escape_for_regex(line: str) -> str:
+    """Zamień linię tekstu na wzorzec regex z escape specjalnych znaków.
+
+    Zachowuje czytelność: zamiast pełnego re.escape, escapuje tylko znaki specjalne regex
+    i zamienia zmienne elementy (np. daty, liczby) na wzorce.
+    """
+    # Escapuj znaki specjalne regex
+    escaped = re.escape(line.strip())
+
+    # Zamień escaped spacje na \s+
+    escaped = escaped.replace(r"\ ", r"\s+")
+
+    # Zamień daty typu "24 marca 2026, 12:15" na pattern
+    escaped = re.sub(
+        r"\d{1,2}\\s\+(?:stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|"
+        r"września|października|listopada|grudnia)\\s\+\d{4},\\s\+\d{2}:\d{2}",
+        r"\\d{1,2}\\s+(?:stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|"
+        r"września|października|listopada|grudnia)\\s+\\d{4},\\s+\\d{2}:\\d{2}",
+        escaped
+    )
+
+    # Zamień "X min czytania" na pattern
+    escaped = re.sub(r"\d+\\s\+min\\s\+czytania", r"\\d+\\s+min\\s+czytania", escaped)
+
+    # Zamień liczby (np. reakcje "385") na \d+
+    escaped = re.sub(r'^\d+$', r'\\d+', escaped)
+
+    return escaped
+
+
+def process_article_with_llm_fallback(markdown_text: str, document_id: int,
+                                       cache_dir: str, url: str,
+                                       model: str = "speakleash/Bielik-11B-v3.0-Instruct") -> str | None:
+    """Główna funkcja fallback: ekstrakcja artykułu przez LLM + generowanie regex draft.
+
+    Returns: wyodrębniony tekst artykułu lub None
+    """
+    logger.info(f"document_id: {document_id} Starting LLM fallback extraction")
+
+    # 1. Wyślij do LLM po markery (max 2 próby)
+    markers = None
+    for attempt in range(2):
+        markers = extract_article_markers_with_llm(markdown_text, url=url, model=model)
+        if markers is not None:
+            break
+        logger.warning(f"document_id: {document_id} LLM attempt {attempt + 1} failed, "
+                       f"{'retrying' if attempt == 0 else 'giving up'}")
+
+    if markers is None:
+        logger.error(f"document_id: {document_id} LLM extraction returned no markers after 2 attempts")
+        return None
+
+    logger.info(f"document_id: {document_id} LLM markers: title={markers.get('title', 'N/A')}, "
+                f"author={markers.get('author', 'N/A')}")
+
+    # 2. Wyodrębnij artykuł na podstawie markerów
+    article_text = extract_article_by_markers(markdown_text, markers, url=url)
+    if article_text is None:
+        logger.error(f"document_id: {document_id} Cannot extract article by LLM markers")
+        return None
+
+    # 3. Zapisz wyekstrahowany artykuł
+    article_path = os.path.join(cache_dir, f"{document_id}_llm_extracted_article.md")
+    with open(article_path, "w", encoding="utf-8") as f:
+        f.write(article_text)
+    logger.info(f"document_id: {document_id} LLM extracted article saved to {article_path}")
+
+    # 4. Wygeneruj regex draft (w cache_dir, do ręcznej weryfikacji)
+    from urllib.parse import urlparse
+    domain = urlparse(url).netloc.replace(".", "_").replace("www_", "")
+    draft_path = os.path.join(cache_dir, f"{domain}_{document_id}.regex.draft")
+    generate_regex_draft(markdown_text, markers, draft_path)
+
+    return article_text

--- a/backend/library/document_prepare.py
+++ b/backend/library/document_prepare.py
@@ -1,0 +1,96 @@
+"""Wspólne funkcje do pobierania HTML z S3 i konwersji do markdown.
+
+Używane przez:
+- webdocument_prepare_regexp_by_ai.py
+- imports/article_browser.py
+- webdocument_md_decode.py
+"""
+
+import json
+import logging
+import os
+
+from markitdown import MarkItDown
+from html2markdown import convert
+import html2text
+
+from library.api.aws.s3_aws import s3_file_exist, s3_take_file
+from library.config_loader import load_config
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_reduction(html_size, markdown_size):
+    return ((html_size - markdown_size) / html_size) * 100
+
+
+def prepare_markdown(document_id, doc, cache_dir) -> str | None:
+    """Pobierz HTML z S3 i skonwertuj do markdown. Zwraca tekst markdown lub None."""
+    cfg = load_config()
+    s3_bucket = cfg.get("AWS_S3_WEBSITE_CONTENT")
+
+    cache_file_html = os.path.join(cache_dir, f"{document_id}.html")
+    cache_file_md = os.path.join(cache_dir, f"{document_id}.md")
+
+    if os.path.isfile(cache_file_md):
+        logger.info(f"document_id: {document_id} Using cached markdown: {cache_file_md}")
+        with open(cache_file_md, "r", encoding="utf-8") as f:
+            return f.read()
+
+    if not os.path.isfile(cache_file_html):
+        if not doc.s3_uuid:
+            logger.warning(f"document_id: {document_id} Missing s3_uuid, skipping")
+            return None
+
+        s3_key = f"{doc.s3_uuid}.html"
+        if not s3_file_exist(s3_bucket, s3_key):
+            logger.error(f"document_id: {document_id} HTML not found in S3: {s3_key}")
+            return None
+
+        if not s3_take_file(s3_bucket, s3_key, cache_file_html):
+            logger.error(f"document_id: {document_id} Failed to download from S3: {s3_key}")
+            return None
+
+    logger.info(f"document_id: {document_id} Converting HTML to markdown")
+    html_size = os.path.getsize(cache_file_html)
+
+    mdit = MarkItDown()
+    markdown_text = mdit.convert(cache_file_html).text_content
+    reduction = calculate_reduction(html_size, len(markdown_text))
+
+    if reduction < 30:
+        logger.debug(f"document_id: {document_id} MarkItDown reduction {reduction:.0f}%, trying html2markdown")
+        with open(cache_file_html, "r", encoding="utf-8") as f:
+            html = f.read()
+        markdown_text = convert(html)
+        reduction = calculate_reduction(html_size, len(markdown_text))
+
+        if reduction < 30:
+            logger.debug(f"document_id: {document_id} html2markdown reduction {reduction:.0f}%, trying html2text")
+            h = html2text.HTML2Text()
+            h.ignore_links = False
+            h.ignore_images = False
+            markdown_text = h.handle(html)
+
+    with open(cache_file_md, "w", encoding="utf-8") as f:
+        f.write(markdown_text)
+    logger.info(f"document_id: {document_id} Markdown saved ({len(markdown_text)} chars)")
+
+    return markdown_text
+
+
+def save_document_info(document_id, doc, cache_dir):
+    """Zapisz metadane dokumentu do JSON."""
+    cache_file_info = os.path.join(cache_dir, f"{document_id}_info.json")
+    doc_info = {
+        "id": doc.id,
+        "url": doc.url,
+        "title": doc.title,
+        "language": doc.language,
+        "s3_uuid": doc.s3_uuid,
+        "created_at": doc.created_at.strftime("%Y-%m-%d %H:%M:%S") if doc.created_at else None,
+        "document_type": doc.document_type if doc.document_type else None,
+        "document_state": doc.document_state if doc.document_state else None,
+    }
+    with open(cache_file_info, "w", encoding="utf-8") as f:
+        json.dump(doc_info, f, ensure_ascii=False, indent=2)

--- a/backend/webdocument_md_decode.py
+++ b/backend/webdocument_md_decode.py
@@ -92,6 +92,8 @@ text_to_md_check_only = False
 online = True
 embedding_update = False
 ignore_regexp_issue = True
+llm_fallback_enabled = True
+llm_fallback_model = "speakleash/Bielik-11B-v3.0-Instruct"
 cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
 split_limit = 200
 
@@ -364,19 +366,37 @@ if __name__ == '__main__':
                             continue
 
             if not found_rules:
-                logger.error(f"Can't find rules to analyze page {doc.url}, time to check next one...")
+                logger.error(f"Can't find rules to analyze page {doc.url}, trying LLM fallback...")
 
-                if find_problems:
-                    exit(1)
+                if llm_fallback_enabled:
+                    from library.article_extractor import process_article_with_llm_fallback
+                    llm_result = process_article_with_llm_fallback(
+                        markdown_text=markdown_text,
+                        document_id=document_id,
+                        cache_dir=cache_dir,
+                        url=doc.url,
+                        model=llm_fallback_model,
+                    )
+                    if llm_result:
+                        extracted_text = llm_result
+                        found_rules = True
+                        regexp_rules_file = "LLM_FALLBACK"
+                        logger.info(f"LLM fallback succeeded for document {document_id}")
+                    else:
+                        logger.error(f"LLM fallback also failed for document {document_id}")
 
-                if interactive:
-                    print("Naciśnij Enter, aby zakończyć program...")
-                    input()
+                if not found_rules:
+                    if find_problems:
+                        exit(1)
 
-                doc.document_state = StalkerDocumentStatus.ERROR.name
-                doc.document_state_error = StalkerDocumentStatusError.REGEX_ERROR.name
-                session.commit()
-                continue
+                    if interactive:
+                        print("Naciśnij Enter, aby zakończyć program...")
+                        input()
+
+                    doc.document_state = StalkerDocumentStatus.ERROR.name
+                    doc.document_state_error = StalkerDocumentStatusError.REGEX_ERROR.name
+                    session.commit()
+                    continue
 
             logger.debug(f"DEBUG: will use regex rule file: {regexp_rules_file}")
             metadata["regexp_rules_file"] = regexp_rules_file

--- a/backend/webdocument_prepare_regexp_by_ai.py
+++ b/backend/webdocument_prepare_regexp_by_ai.py
@@ -1,273 +1,91 @@
-import os.path
-import re
-import json
-import logging
-from pprint import pprint
+"""
+Skrypt do przygotowania reguł regex dla artykułów za pomocą LLM.
 
-from markitdown import MarkItDown
-from html2markdown import convert
-import html2text
+Pobiera HTML z S3, konwertuje do markdown, a następnie:
+1. Próbuje wyekstrahować artykuł za pomocą LLM (Bielik)
+2. Generuje plik .regex.draft do ręcznej weryfikacji
+3. Zapisuje wyekstrahowany artykuł i metadane do cache
+
+Użycie:
+    uv run python webdocument_prepare_regexp_by_ai.py 8779 8786
+"""
+
+import sys
+import os.path
+import logging
 
 from library.db.engine import get_session
 from library.db.models import WebDocument
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
-from library.api.aws.s3_aws import s3_file_exist, s3_take_file
 from library.config_loader import load_config
+from library.article_extractor import process_article_with_llm_fallback
+from library.document_prepare import prepare_markdown, save_document_info
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-cfg = load_config()
 
-S3_BUCKET_NAME = cfg.get("AWS_S3_WEBSITE_CONTENT")
-EMBEDDING_MODEL = cfg.get("EMBEDDING_MODEL")
+def parse_document_ids():
+    """Parsuj ID dokumentów z argumentów CLI."""
+    if len(sys.argv) < 2:
+        print(f"Użycie: {sys.argv[0]} <document_id> [document_id ...]")
+        print(f"Przykład: {sys.argv[0]} 8779 8786")
+        sys.exit(1)
 
-# cache dir for S3 downloads and markdown output
-cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
+    ids = []
+    for arg in sys.argv[1:]:
+        try:
+            ids.append(int(arg))
+        except ValueError:
+            print(f"Błąd: '{arg}' nie jest prawidłowym ID dokumentu")
+            sys.exit(1)
+    return ids
 
-def calculate_reduction(html_size, markdown_size):
-    return ((html_size - markdown_size) / html_size) * 100
-
-# regex for money.pl article extraction with author capture
-# Use the first H1 as the article start and detect the footer blocks as the end.
-MONEY_ARTICLE_REGEX_PRE = r'(?ms)^#\s+.+\n'
-MONEY_ARTICLE_REGEX_POST = (
-    r'(?ms)\n(?:\* \* \*\s*)?(?:\s*\n)*'
-    r'(?:WALUTY __|KALKULATORY __|KREDYTY __|GIE'
-    r'|MONEY NA SKR|MNIEJ TEMAT|Odkryj|Najnowsze)'
-)
 
 if __name__ == '__main__':
+    documents = parse_document_ids()
+
+    cfg = load_config()
+    cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
+
     session = get_session()
-    wb_db = WebsitesDBPostgreSQL(session=session)
 
-    documents = [11618]
+    logger.info(f"Documents to process: {documents}")
 
-    # documents = wb_db.get_documents_by_url("https://www.money.pl/")
-
-    pprint(documents)
     try:
         for document_id in documents:
             doc = WebDocument.get_by_id(session, document_id)
             if doc is None:
-                logger.warning(f"document_id: {document_id} Document not found, skipping")
+                logger.warning(f"document_id: {document_id} Not found, skipping")
                 continue
 
-            if not doc.s3_uuid:
-                logger.warning(f"document_id: {document_id} Missing s3_uuid, skipping")
-                continue
-
-            if not os.path.exists(cache_dir_base):
-                os.makedirs(cache_dir_base)
+            logger.info(f"document_id: {document_id} URL: {doc.url}")
+            logger.info(f"document_id: {document_id} Title: {doc.title}")
+            logger.info(f"document_id: {document_id} State: {doc.document_state}")
 
             cache_dir = os.path.join(cache_dir_base, str(document_id))
-            if not os.path.exists(cache_dir):
-                os.makedirs(cache_dir)
+            os.makedirs(cache_dir, exist_ok=True)
 
-            cache_file_html = os.path.join(cache_dir, f"{document_id}.html")
-            cache_file_md = os.path.join(cache_dir, f"{document_id}.md")
-            cache_file_text = os.path.join(cache_dir, f"{document_id}.txt")
+            save_document_info(document_id, doc, cache_dir)
 
-            if not os.path.isfile(cache_file_text):
-                logger.info(f"document_id: {document_id} Text file does not exist: {cache_file_text}, skipping")
+            markdown_text = prepare_markdown(document_id, doc, cache_dir)
+            if markdown_text is None:
                 continue
 
-            # save information to json file in chache dir
-            cache_file_info = os.path.join(cache_dir, f"{document_id}_info.json")
-            doc_info = {
-                "id": doc.id,
-                "url": doc.url,
-                "title": doc.title,
-                "language": doc.language,
-                "s3_uuid": doc.s3_uuid,
-                "created_at": doc.created_at.strftime("%Y-%m-%d %H:%M:%S") if doc.created_at else None,
-                "document_type": doc.document_type if doc.document_type else None,
-                "document_state": doc.document_state if doc.document_state else None,
-            }
-            with open(cache_file_info, "w", encoding="utf-8") as f:
-                json.dump(doc_info, f, ensure_ascii=False, indent=2)
-            logger.info(f"document_id: {document_id} Document info saved to {cache_file_info}")
-
-            if os.path.isfile(cache_file_md):
-                logger.info(f"document_id: {document_id} Using cached markdown file: {cache_file_md}")
-                with open(cache_file_md, "r", encoding="utf-8") as f:
-                    markdown_text = f.read()
-            else:
-                if not os.path.isfile(cache_file_html):
-                    logger.debug(f"document_id: {document_id} Downloading HTML file from S3")
-                    s3_key = f"{doc.s3_uuid}.html"
-                    if not s3_file_exist(S3_BUCKET_NAME, s3_key):
-                        logger.error(f"document_id: {document_id} HTML file not found in S3: {s3_key}")
-                        continue
-
-                    if not s3_take_file(S3_BUCKET_NAME, s3_key, cache_file_html):
-                        logger.error(f"document_id: {document_id} Failed to download HTML from S3: {s3_key}")
-                        continue
-
-                logger.info(f"document_id: {document_id} Converting HTML to markdown")
-                mdit = MarkItDown()
-                result = mdit.convert(cache_file_html).text_content
-
-                html_size = os.path.getsize(cache_file_html)
-                md_size = len(result)
-                reduction_percentage = calculate_reduction(html_size, md_size)
-                markdown_text = result
-
-                if reduction_percentage < 30:
-                    logger.debug(f"document_id: {document_id} MarkItDown reduction too small, trying html2markdown")
-                    with open(cache_file_html, "r", encoding="utf-8") as f:
-                        html = f.read()
-
-                    markdown = convert(html)
-                    md_size_2 = len(markdown)
-                    reduction_percentage = calculate_reduction(html_size, md_size_2)
-                    markdown_text = markdown
-
-                    if reduction_percentage < 30:
-                        logger.debug(f"document_id: {document_id} html2markdown reduction too small, trying html2text")
-                        h = html2text.HTML2Text()
-                        h.ignore_links = False
-                        h.ignore_images = False
-                        markdown_text = h.handle(html)
-
-                with open(cache_file_md, "w", encoding="utf-8") as f:
-                    f.write(markdown_text)
-                    logger.info(f"document_id: {document_id} Markdown saved to {cache_file_md}")
-
-                doc.text_md = markdown_text
-                session.commit()
-
-            pre_match = re.search(MONEY_ARTICLE_REGEX_PRE, markdown_text)
-
-            if not pre_match:
-                logger.warning(f"document_id: {document_id} Money.pl regex PRE did not match the markdown content")
-                post_match = None
-            else:
-                post_match = re.search(MONEY_ARTICLE_REGEX_POST, markdown_text[pre_match.end():])
-                if not post_match:
-                    logger.warning(f"document_id: {document_id} Money.pl regex POST did not match the markdown content")
-
-            if not pre_match or not post_match:
-                try:
-                    with open(cache_file_text, "r", encoding="utf-8") as f:
-                        cache_text = f.read().strip()
-                except OSError as exc:
-                    logger.warning(f"document_id: {document_id} Failed to read cache_file_text: {exc}")
-                    continue
-
-                if not cache_text:
-                    logger.warning(f"document_id: {document_id} cache_file_text is empty")
-                    continue
-
-                # Find first line
-                first_line = next((line.strip() for line in cache_text.splitlines() if line.strip()), "")
-                if not first_line:
-                    logger.warning(f"document_id: {document_id} cache_file_text has no non-empty lines")
-                    continue
-
-                match_source = "first_line"
-                match_text = first_line
-                match_index = markdown_text.find(match_text)
-
-                # Find last line
-                last_line = next((line.strip() for line in reversed(cache_text.splitlines()) if line.strip()), "")
-                if not last_line:
-                    logger.warning(f"document_id: {document_id} cache_file_text has no last line")
-                    continue
-
-                match_end_text = last_line
-                match_end_index = markdown_text.find(match_end_text)
-                match_end = match_end_index + len(match_end_text) if match_end_index != -1 else -1
-
-                if match_index == -1 and match_text:
-                    underscored = f"_{match_text}_"
-                    match_index = markdown_text.find(underscored)
-                    if match_index != -1:
-                        match_source = "underscored"
-                        match_text = underscored
-                        match_end = match_index + len(match_text)
-
-                if match_index == -1 and cache_text:
-                    words = [w for w in cache_text.split() if w]
-                    if words:
-                        whitespace_pattern = r"\s+".join(re.escape(w) for w in words)
-                        soft_pattern = rf"_?{whitespace_pattern}_?"
-                        soft_match = re.search(soft_pattern, markdown_text, flags=re.MULTILINE)
-                        if soft_match:
-                            match_source = "soft_regex"
-                            match_text = soft_match.group(0)
-                            match_index = soft_match.start()
-                            match_end = soft_match.end()
-
-                if match_index == -1:
-                    logger.warning(f"document_id: {document_id} cache_file_text not found in markdown")
-                    continue
-
-                logger.info(
-                    "document_id: %s cache_file_text match source=%s length=%s start=%s end=%s",
-                    document_id,
-                    match_source,
-                    len(match_text),
-                    match_index,
-                    match_end,
-                )
-
-                markdown_lines = markdown_text.splitlines()
-                line_start = markdown_text.count("\n", 0, match_index)
-                line_end = markdown_text.count("\n", 0, match_end if match_end != -1 else match_index)
-
-                start = max(0, line_start - 10)
-                end = min(len(markdown_lines), line_start + 10 + 1)
-                start_context = "\n".join(f"{i + 1:04d}: {markdown_lines[i]}" for i in range(start, end))
-                logger.info(
-                    "document_id: %s Markdown context around start of cache_file_text (lines %s..%s):\n%s",
-                    document_id,
-                    start + 1,
-                    end,
-                    start_context,
-                )
-
-                end_start = max(0, line_end - 10)
-                end_end = min(len(markdown_lines), line_end + 10 + 1)
-                end_context = "\n".join(f"{i + 1:04d}: {markdown_lines[i]}" for i in range(end_start, end_end))
-                logger.info(
-                    "document_id: %s Markdown context around end of cache_file_text (lines %s..%s):\n%s",
-                    document_id,
-                    end_start + 1,
-                    end_end,
-                    end_context,
-                )
-
-                continue
-
-            article_chunk = markdown_text[pre_match.end():pre_match.end() + post_match.start()]
-
-            author_regex_link = (
-                r'(?ms)\[(?P<author>[^\]]+)\]\(https?://www\.money\.pl/archiwum/autor/[^)]+\)\s*\n'
-                r'(?:[^\n]*\n){0,6}?\s*\n(?P<article_text>\S[\s\S]*)'
+            result = process_article_with_llm_fallback(
+                markdown_text=markdown_text,
+                document_id=document_id,
+                cache_dir=cache_dir,
+                url=doc.url,
             )
-            author_regex_underscore = (
-                r'(?ms)(?P<article_text>.*?\n_(?P<author>[^,_\n]+?)(?:,\s*(?P<author_desc>[^_\n]+))?_\s*)'
-            )
-            match = re.search(author_regex_link, article_chunk) or re.search(author_regex_underscore, article_chunk)
-            if match:
-                logger.info(f"document_id: {document_id} Money.pl author regex matched the markdown content")
-                article_text = match.group("article_text").strip()
-                author = match.group("author").strip()
-                author = re.sub(r'^Rozmaw\\S+\\s+', '', author, flags=re.IGNORECASE)
-                author_desc = match.groupdict().get("author_desc")
-                author_desc = author_desc.strip() if author_desc else ""
 
-                cache_file_article = os.path.join(cache_dir, f"{document_id}_article.md")
-                with open(cache_file_article, "w", encoding="utf-8") as f:
-                    f.write(article_text)
-
-                cache_file_author = os.path.join(cache_dir, f"{document_id}_author.json")
-                with open(cache_file_author, "w", encoding="utf-8") as f:
-                    f.write(json.dumps({"author": author, "author_desc": author_desc}, ensure_ascii=False, indent=2))
-
-                logger.info(f"document_id: {document_id} Article and author extracted to {cache_file_article}")
+            if result:
+                lines = [l for l in result.splitlines() if l.strip()]
+                logger.info(f"document_id: {document_id} Extracted: {len(result)} chars, {len(lines)} non-empty lines")
+                logger.info(f"document_id: {document_id} FIRST: {lines[0][:100]}")
+                logger.info(f"document_id: {document_id} LAST:  {lines[-1][:100]}")
             else:
-                logger.warning(f"document_id: {document_id} Money.pl author regex did not match the markdown content")
+                logger.error(f"document_id: {document_id} Extraction FAILED")
+
     finally:
         session.close()


### PR DESCRIPTION
## Summary

- **LLM fallback** for article extraction when regex rules fail — uses Bielik-11B via ARK Labs API
- **Hybrid end detection**: LLM finds article start, portal-specific footer markers find article end (deterministic)
- **Article browser** (`imports/article_browser.py`) — interactive CLI to browse DB articles, view clean text, save notes, create Obsidian notes via Claude Code
- **Shared libraries**: `document_prepare.py` (HTML→markdown), `arklabs/config.py` (API config)
- **Portal-specific cleaning** for onet.pl, money.pl, wp.pl/o2.pl, interia.pl, businessinsider.com.pl + generic fallback for unknown portals

## Tested on

| ID | Portal | Tokens | Result |
|----|--------|--------|--------|
| 8786 | onet.pl | 6498 | OK |
| 8779 | onet.pl | 4110 | OK |
| 8775 | o2.pl | 11072 | OK |
| 8768 | money.pl | 8638 | OK |
| 8749 | wyborcza.pl | 8542 | OK |
| 8763 | businessinsider.com.pl | 7541 | OK |

## Usage

```bash
# Extract article with LLM + generate regex draft
uv run python webdocument_prepare_regexp_by_ai.py 8786

# Browse articles interactively
uv run python imports/article_browser.py --list --limit 20
uv run python imports/article_browser.py --review --since 2026-03-20

# In review: [v]iew [s]ave note [o]bsidian [c]ompare [n]ext [q]uit
```

## Test plan

- [ ] Verify LLM extraction works on new articles from each supported portal
- [ ] Verify `article_browser.py --review` flow: view → save note → open in Claude Code
- [ ] Verify regex fallback still works in `webdocument_md_decode.py` (primary path unchanged)
- [ ] Check ARK_LABS_KEY is accessible from Vault config

🤖 Generated with [Claude Code](https://claude.com/claude-code)