### PR TITLE
fix: article browser — portal-specific cleaning, --view, --check-urls

### DIFF
--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -637,6 +637,20 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
             else:
                 print("  Nie udało się pobrać treści artykułu.")
 
+        # Pokaż istniejącą notatkę jeśli jest
+        note_file = os.path.join(NOTES_DIR, f"{doc.id}_note.md")
+        if os.path.isfile(note_file):
+            with open(note_file, "r", encoding="utf-8") as f:
+                content = f.read()
+            # Wyciągnij sekcję "Moja notatka"
+            if "## Moja notatka" in content:
+                note_part = content.split("## Moja notatka")[1].split("## Treść artykułu")[0].strip()
+                print(f"\n  NOTATKA:")
+                for line in note_part.splitlines():
+                    print(f"     {line}")
+            else:
+                print(f"\n  NOTATKA: {note_file}")
+
         print()
         print("  [n]ext  [p]rev  [v]iew  [d]b save  [s]ave note  [o]bsidian  [c]ompare  [q]uit")
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -511,11 +511,11 @@ def action_view(article: dict, check_urls: bool = False):
                 alt = img.get("alt", "")
                 desc = f" — {alt}" if alt else ""
                 print(f"    [img{i}]{desc}")
-                print(f"           {img['url'][:100]}")
+                print(f"           {img['url']}")
         if dead_images:
             print(f"\n  Obrazki niedostępne ({len(dead_images)}):")
             for i, img in dead_images:
-                print(f"    [img{i}] {img['_status']} — {img['url'][:80]}")
+                print(f"    [img{i}] {img['_status']} — {img['url']}")
 
     if links:
         if check_urls:
@@ -535,12 +535,12 @@ def action_view(article: dict, check_urls: bool = False):
         if active_links:
             print(f"\n  Linki ({len(active_links)}):")
             for i, link in active_links:
-                print(f"    [link{i}] {link['text'][:60]}")
-                print(f"            {link['url'][:100]}")
+                print(f"    [link{i}] {link['text']}")
+                print(f"            {link['url']}")
         if dead_links:
             print(f"\n  Linki niedostępne ({len(dead_links)}):")
             for i, link in dead_links:
-                print(f"    [link{i}] {link['_status']} — {link['text'][:40]} — {link['url'][:60]}")
+                print(f"    [link{i}] {link['_status']} — {link['text']} — {link['url']}")
 
     total_imgs = len(images)
     total_links = len(links)

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -352,6 +352,8 @@ def action_save_note(doc, article_text: str) -> Optional[str]:
         return None
 
     note_text = "\n".join(note_lines)
+    # Napraw surrogaty z WSL/Windows terminal
+    note_text = note_text.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
 
     os.makedirs(NOTES_DIR, exist_ok=True)
     note_file = os.path.join(NOTES_DIR, f"{doc.id}_note.md")

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -76,6 +76,7 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
     skip_section_markers = {
         "### Więcej pogłębionych treści", "### Więcej treści premium dla Ciebie",
         "## Top 5 treści Premium", "## Najlepsze w premium",
+        "## Czytaj także w BUSINESS INSIDER",
     }
 
     for line in lines:
@@ -103,6 +104,13 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         # Frazy portalowe wspólne
         if stripped in ("Dalszy ciąg materiału pod wideo", "REKLAMAKONIEC REKLAMY",
                         "REKLAMA", "Lubię to", "[ ]"):
+            continue
+        # Warianty "Dalsza część artykułu pod wideo" (z kursywą, dwukropkiem)
+        if "dalsza część artykułu pod wideo" in stripped.lower() or \
+           "dalszy ciąg materiału pod wideo" in stripped.lower():
+            continue
+        # "Czytaj także:" + link na tej samej lub następnej linii
+        if stripped.startswith("**Czytaj także:**") or stripped.startswith("**Czytaj również:**"):
             continue
 
         # Linia z samymi [imgN] markerami (osierocone po usunięciu kontekstu)

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -589,7 +589,8 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 
     text_only = article["text"]
-    embedding_model = "BAAI/bge-m3"
+    cfg = load_config()
+    embedding_model = cfg.get("EMBEDDING_MODEL") or "BAAI/bge-m3"
 
     print(f"  Zapisuję do bazy danych (ID: {doc.id})...")
     print(f"    Tekst: {len(text_only)} znaków")

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -591,12 +591,20 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                start_id: Optional[int] = None, limit: int = 50, auto_view: bool = False,
                check_urls: bool = False):
     """Interaktywny przegląd artykułów."""
-    filtered = _get_documents(session, limit=limit, since=since, portal=portal)
-
     if start_id:
-        # Znajdź pozycję startową
-        start_idx = next((i for i, d in enumerate(filtered) if d.id == start_id), 0)
-        filtered = filtered[start_idx:]
+        # Gdy podano --id, zacznij od tego dokumentu (nawet jeśli nie jest na liście)
+        doc = WebDocument.get_by_id(session, start_id)
+        if doc is None:
+            print(f"Dokument {start_id} nie znaleziony.")
+            return
+        filtered = [doc]
+        # Dodaj kolejne dokumenty z listy (po start_id)
+        all_docs = _get_documents(session, limit=limit, since=since, portal=portal)
+        for d in all_docs:
+            if d.id != start_id:
+                filtered.append(d)
+    else:
+        filtered = _get_documents(session, limit=limit, since=since, portal=portal)
 
     if not filtered:
         print("Brak artykułów do przeglądu.")

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -567,18 +567,38 @@ def action_view(article: dict, check_urls: bool = False):
     print(summary + "]")
 
 
-def action_save_to_db(doc, article: dict, session) -> bool:
-    """Zapisz oczyszczony tekst artykułu do bazy danych i ustaw status MD_SIMPLIFIED."""
-    from library.models.stalker_document_status import StalkerDocumentStatus
+def _refresh_db_connection(session):
+    """Odśwież połączenie z bazą (mogło wygasnąć przy długim przeglądaniu)."""
+    try:
+        session.execute(text_sql("SELECT 1"))
+        return True
+    except Exception:
+        session.rollback()
+        try:
+            session.execute(text_sql("SELECT 1"))
+            return True
+        except Exception as e:
+            print(f"  BŁĄD: nie mogę połączyć się z bazą: {e}")
+            return False
 
-    full_text = _article_full_text(article)
+
+def action_save_to_db(doc, article: dict, session) -> bool:
+    """Zapisz oczyszczony tekst do bazy, stwórz embedding, ustaw status."""
+    from library.models.stalker_document_status import StalkerDocumentStatus
+    from library.embedding import get_embedding
+    from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
+    from library.config_loader import load_config
+
     text_only = article["text"]
+    cfg = load_config()
+    embedding_model = cfg.get("EMBEDDING_MODEL") or "BAAI/bge-m3"
 
     print(f"  Zapisuję do bazy danych (ID: {doc.id})...")
     print(f"    Tekst: {len(text_only)} znaków")
     print(f"    Linki: {len(article['links'])}")
     print(f"    Obrazki: {len(article['images'])}")
-    print(f"    Status: {doc.document_state} → MD_SIMPLIFIED")
+    print(f"    Embedding model: {embedding_model}")
+    print(f"    Status: {doc.document_state} → MD_SIMPLIFIED → EMBEDDING_EXIST")
 
     try:
         confirm = input("  Potwierdzasz? [y/N]: ").strip().lower()
@@ -590,22 +610,11 @@ def action_save_to_db(doc, article: dict, session) -> bool:
         print("  Anulowano.")
         return False
 
-    # Odśwież połączenie z bazą (mogło wygasnąć przy długim przeglądaniu)
-    try:
-        session.execute(text_sql("SELECT 1"))
-    except Exception:
-        session.rollback()
-        print("  Odświeżam połączenie z bazą...")
-        try:
-            session.execute(text_sql("SELECT 1"))
-        except Exception as e:
-            print(f"  BŁĄD: nie mogę połączyć się z bazą: {e}")
-            return False
-
-    # Odśwież obiekt dokumentu po reconnect
+    if not _refresh_db_connection(session):
+        return False
     session.refresh(doc)
 
-    # Backup oryginalnego tekstu jeśli istnieje
+    # 1. Zapisz tekst
     if doc.text and not doc.text_raw:
         doc.text_raw = doc.text
 
@@ -614,11 +623,43 @@ def action_save_to_db(doc, article: dict, session) -> bool:
 
     try:
         session.commit()
-        print(f"  Zapisano. Status: MD_SIMPLIFIED")
-        return True
+        print(f"  Tekst zapisany. Status: MD_SIMPLIFIED")
     except Exception as e:
         session.rollback()
-        print(f"  BŁĄD zapisu: {e}")
+        print(f"  BŁĄD zapisu tekstu: {e}")
+        return False
+
+    # 2. Twórz embedding
+    print(f"  Tworzę embedding...")
+    try:
+        wb_db = WebsitesDBPostgreSQL(session=session)
+        # Usuń stare embeddingi dla tego dokumentu
+        wb_db.embedding_delete(doc.id, embedding_model)
+        session.commit()
+
+        emb_result = get_embedding(embedding_model, text_only)
+
+        if not doc.language:
+            doc.language = 'pl'
+
+        wb_db.embedding_add(
+            website_id=doc.id,
+            embedding=emb_result.embedding,
+            language=doc.language,
+            text=text_only,
+            text_original=text_only,
+            model=embedding_model,
+        )
+
+        doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
+        session.commit()
+        print(f"  Embedding zapisany. Status: EMBEDDING_EXIST")
+        return True
+
+    except Exception as e:
+        session.rollback()
+        print(f"  BŁĄD embeddingu: {e}")
+        print(f"  Tekst został zapisany (MD_SIMPLIFIED), ale embedding nie. Spróbuj ponownie.")
         return False
 
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -24,8 +25,7 @@ from library.db.models import WebDocument
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.article_extractor import process_article_with_llm_fallback, _detect_portal
 from library.lenie_markdown import (
-    links_correct, md_square_brackets_in_one_line,
-    md_get_images_as_links, get_images_with_links_md, process_markdown_and_extract_links,
+    links_correct, md_square_brackets_in_one_line, md_get_images_as_links,
 )
 
 _BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -34,105 +34,221 @@ OBSIDIAN_KNOWLEDGE_DIR = os.path.join(OBSIDIAN_VAULT, "02-wiedza")
 NOTES_DIR = os.path.join(_BACKEND_DIR, "tmp", "article_notes")
 
 
-def clean_article_text(text: str, url: str = "") -> str:
-    """Wyczyść wyekstrahowany markdown: napraw rozłamane tagi, usuń obrazki, reklamy, sekcje premium."""
-    import re
-    from library.article_extractor import _detect_portal, _find_footer_line
-
-    # 1. Napraw wieloliniowe linki i tagi markdown
-    text = links_correct(text)
-    text = md_square_brackets_in_one_line(text)
-
-    # 2. Usuń linki-obrazki [![](img)](url) i same obrazki ![](url)
-    text, _, _ = md_get_images_as_links(text)
-    text, _ = get_images_with_links_md(text)
-
-    # 3. Odetnij od footer markera portalu (linki, waluty, kalkulatory itp.)
-    portal = _detect_portal(url)
-    footer_line = _find_footer_line(text, portal)
-    if footer_line is not None:
-        lines_all = text.splitlines()
-        text = "\n".join(lines_all[:footer_line])
-
-    # 4. Usuń picture[N]:"..." i link[N]:... inline referencje
-    text = re.sub(r'picture\[\d+\]:"[^"]*"', '', text)
-    text = re.sub(r'link\[\d+\]:[^\n]*', '', text)
-
-    # 5. Usuń NBSP, wielokrotne spacje
-    text = text.replace('\xa0', ' ')
-    text = re.sub(' +', ' ', text)
-
-    # 5. Usuń szum linia po linii
+def _detect_h2_ads(text: str) -> set:
+    """Wykryj nagłówki H2 z obrazkiem/video zaraz po nich (wstawki reklamowe).
+    Musi być wywołane PRZED usuwaniem obrazków."""
     lines = text.splitlines()
+    h2_ad_titles = set()
+    for i, line in enumerate(lines):
+        stripped = line.strip().replace('\xa0', ' ')
+        if stripped.startswith("## "):
+            next_nonempty = [lines[j].strip() for j in range(i + 1, min(i + 4, len(lines)))
+                             if lines[j].strip()]
+            if next_nonempty and (next_nonempty[0].startswith("![")
+                                  or next_nonempty[0].startswith("[![")
+                                  or "wpimg.pl" in next_nonempty[0]
+                                  or "v.wp.pl" in next_nonempty[0]):
+                h2_ad_titles.add(stripped)
+    return h2_ad_titles
+
+
+# Wzorce linków wewnętrznych portali (tagi, kategorie — nie artykuły)
+_PORTAL_INTERNAL_LINK_PATTERNS = [
+    r'/wiadomosci/[\w-]+\.html$',     # money.pl tagi
+    r'/tag/',                          # wp.pl/o2.pl tagi
+    r'0%2C128956\.html\?tag=',        # wyborcza.pl tagi
+    r'wiadomosci\.onet\.pl/[\w-]+$',  # onet tagi
+]
+
+
+def _is_portal_internal_link(url: str) -> bool:
+    """Czy link jest wewnętrznym linkiem portalu (tag, kategoria)?
+    Linki do autorów (/archiwum/autor/, /autorzy/) NIE są wewnętrzne."""
+    if "/archiwum/autor/" in url or "/autorzy/" in url:
+        return False
+    return any(re.search(p, url) for p in _PORTAL_INTERNAL_LINK_PATTERNS)
+
+
+def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
+    """Generyczne czyszczenie linia po linii — wspólne dla wszystkich portali."""
     cleaned = []
     skip_section = False
-    skip_markers = {
+    skip_section_markers = {
         "### Więcej pogłębionych treści", "### Więcej treści premium dla Ciebie",
         "## Top 5 treści Premium", "## Najlepsze w premium",
-        "## Czeka nas skok cen",  # money.pl wstawki reklamowe
     }
 
     for line in lines:
         stripped = line.strip()
 
-        if stripped in skip_markers:
+        # Sekcje do pominięcia (premium, wstawki H2+img)
+        if stripped in skip_section_markers or stripped in h2_ad_titles:
             skip_section = True
             continue
-
-        # Koniec sekcji: następne pytanie dziennikarza (**...**) lub długi akapit
         if skip_section and stripped and (stripped.startswith("**") or
                                           (len(stripped) > 50 and not stripped.startswith("[")
-                                           and not stripped.startswith("picture[")
                                            and not stripped.startswith("!"))):
             skip_section = False
-
         if skip_section:
             continue
 
-        # Pomiń picture[N]:"..." referencje (mogą być na początku lub same w linii)
-        if re.match(r'^picture\[\d+\]:', stripped):
-            continue
-        # Pomiń linie które są TYLKO picture refs (np. w środku tekstu)
-        stripped_no_pictures = re.sub(r'picture\[\d+\]:"[^"]*"', '', stripped).strip()
-        if not stripped_no_pictures and 'picture[' in stripped:
+        # picture[N]:, link[N]:
+        if re.match(r'^(picture|link)\[\d+\]:', stripped):
             continue
 
-        # Pomiń link[N]: referencje
-        if re.match(r'^link\[\d+\]:', stripped):
-            continue
-
-        # Pomiń frazy portalowe
-        if stripped in ("Dalszy ciąg materiału pod wideo", "Posłuchaj artykułu",
-                        "Skróć artykuł", "REKLAMAKONIEC REKLAMY", "REKLAMA",
-                        "Lubię to", "Obserwuj", "Udostępnij", "Skomentuj",
-                        "- x1 +", "x1", "Notowania", "Źródło artykułu:",
-                        "[ ]"):
-            continue
-        if stripped.startswith("Audio generowane") or stripped.startswith("Dźwięk został wygenerowany"):
-            continue
-        if stripped.startswith("Udostępnij na X"):
-            continue
-
-        # Pomiń linie z samą liczbą
+        # Puste linie z samą liczbą (reakcje)
         if stripped.isdigit():
             continue
 
-        # Pomiń linie z samymi tagami portalu: [tag](/tag/...) [tag](/tag/...)
-        if re.match(r'^(\[[\w\s]+\]\(/tag/[\w-]+/[^)]*\)\s*)+\+?\d*$', stripped):
+        # Frazy portalowe wspólne
+        if stripped in ("Dalszy ciąg materiału pod wideo", "REKLAMAKONIEC REKLAMY",
+                        "REKLAMA", "Lubię to", "[ ]"):
+            continue
+
+        # Linia z samymi [imgN] markerami (osierocone po usunięciu kontekstu)
+        if re.match(r'^(\[img\d+[^\]]*\]\s*)+$', stripped):
             continue
 
         cleaned.append(line)
 
-    text = "\n".join(cleaned)
+    return cleaned
 
-    # 6. Zwiń wielokrotne puste linie
+
+def _clean_lines_onet(lines: list[str]) -> list[str]:
+    """Czyszczenie specyficzne dla onet.pl/fakt.pl."""
+    skip = {"Posłuchaj artykułu", "Skróć artykuł", "- x1 +", "x1", "Obserwuj"}
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in skip:
+            continue
+        if stripped.startswith("Audio generowane"):
+            continue
+        cleaned.append(line)
+    return cleaned
+
+
+def _clean_lines_money(lines: list[str]) -> list[str]:
+    """Czyszczenie specyficzne dla money.pl."""
+    skip_exact = {"Skomentuj", "Notowania", "Udostępnij"}
+    skip_startswith = ("Udostępnij na X", "Źródło zdjęć:", "Źródło artykułu:",
+                       "oprac.", "Dźwięk został wygenerowany")
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in skip_exact:
+            continue
+        if any(stripped.startswith(s) for s in skip_startswith):
+            continue
+        # Samodzielna data: "24 marca 2026, 12:26"
+        if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
+            continue
+        # Linia z samymi tagami (tekst bez linków): "gospodarka elektrownia atomowa rosja +1"
+        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', stripped):
+            continue
+        # "Zobacz też" — linia z [imgN: tytuł] i link do innego artykułu money.pl
+        if re.match(r'^\[?\[img\d+:.*\].*money\.pl/', stripped):
+            continue
+        cleaned.append(line)
+    return cleaned
+
+
+def _clean_lines_wp(lines: list[str]) -> list[str]:
+    """Czyszczenie specyficzne dla wp.pl/o2.pl."""
+    skip = {"Skomentuj", "Udostępnij"}
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in skip:
+            continue
+        if stripped.startswith("Udostępnij na X"):
+            continue
+        if stripped.startswith("Dźwięk został wygenerowany"):
+            continue
+        if re.match(r'^\d+\s+komentarz', stripped):
+            continue
+        cleaned.append(line)
+    return cleaned
+
+
+def clean_article_text(text: str, url: str = "") -> dict:
+    """Wyczyść wyekstrahowany markdown. Zwraca dict: {text, links, images}."""
+    from library.article_extractor import _detect_portal, _find_footer_line
+
+    extracted_links = []
+    extracted_images = []
+    portal = _detect_portal(url)
+
+    # 1. Napraw wieloliniowe linki i tagi markdown
+    text = links_correct(text)
+    text = md_square_brackets_in_one_line(text)
+
+    # 2. Wykryj H2+obrazek wstawki PRZED usuwaniem obrazków
+    h2_ad_titles = _detect_h2_ads(text)
+
+    # 3. Wyodrębnij obrazki → markery [imgN]
+    def replace_image(m):
+        alt = m.group(1).strip()
+        img_url = m.group(2).strip()
+        idx = len(extracted_images)
+        extracted_images.append({"alt": alt, "url": img_url})
+        return f"[img{idx}: {alt}]" if alt else f"[img{idx}]"
+
+    text = re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', replace_image, text)
+    # Linki owijające markery img: [[imgN]](url) → [imgN]
+    text = re.sub(r'\[(\[img\d+[^\]]*\])\]\([^)]+\)', lambda m: m.group(1), text)
+
+    # 4. Odetnij od footer markera portalu
+    footer_line = _find_footer_line(text, portal)
+    if footer_line is not None:
+        text = "\n".join(text.splitlines()[:footer_line])
+
+    # 5. Wyodrębnij linki → markery [linkN] (portalowe → sam tekst)
+    def replace_link(m):
+        link_text = m.group(1).strip()
+        link_url = m.group(2).strip().split('"')[0].strip()
+        if not link_text:
+            return ""
+        if _is_portal_internal_link(link_url):
+            return link_text
+        idx = len(extracted_links)
+        extracted_links.append({"text": link_text, "url": link_url})
+        return f"{link_text} [link{idx}]"
+
+    text = re.sub(r'\[([^\]]*)\]\(([^)]+)\)', replace_link, text)
+
+    # 6. Usuń stare referencje z webdocument_md_decode
+    text = re.sub(r'picture\[\d+\]:"[^"]*"', '', text)
+    text = re.sub(r'link\[\d+\]:[^\n]*', '', text)
+
+    # 7. Normalizacja
+    text = text.replace('\xa0', ' ')
+    text = re.sub(' +', ' ', text)
+
+    # 8. Czyszczenie linia po linii: generyczne + per-portal
+    lines = text.splitlines()
+    lines = _clean_lines_generic(lines, h2_ad_titles)
+
+    if portal == "onet":
+        lines = _clean_lines_onet(lines)
+    elif portal == "money":
+        lines = _clean_lines_money(lines)
+    elif portal == "wp":
+        lines = _clean_lines_wp(lines)
+
+    text = "\n".join(lines)
     text = re.sub(r'\n{3,}', '\n\n', text)
 
-    return text.strip()
+    return {
+        "text": text.strip(),
+        "links": extracted_links,
+        "images": extracted_images,
+    }
 
 
-def get_article_text(doc, session) -> Optional[str]:
-    """Pobierz wyekstrahowany tekst artykułu z cache lub przez LLM."""
+def get_article_text(doc, session) -> Optional[dict]:
+    """Pobierz wyekstrahowany tekst artykułu z cache lub przez LLM.
+    Zwraca dict: {text, links, images} lub None."""
     cfg = load_config()
     cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
     cache_dir = os.path.join(cache_dir_base, str(doc.id))
@@ -188,6 +304,22 @@ def call_claude(prompt: str):
         subprocess.run(["claude", "-p", prompt], check=False)
     except FileNotFoundError:
         print("  BŁĄD: komenda 'claude' nie znaleziona. Czy Claude Code jest zainstalowany?")
+
+
+def _article_full_text(article: dict) -> str:
+    """Złóż pełny tekst artykułu z linkami i obrazkami na dole (do zapisu/Claude)."""
+    parts = [article["text"]]
+    if article["links"]:
+        parts.append("\n\n## Linki w artykule")
+        for i, link in enumerate(article["links"]):
+            parts.append(f"  [link{i}] {link['text']} — {link['url']}")
+    if article["images"]:
+        parts.append("\n\n## Obrazki w artykule")
+        for i, img in enumerate(article["images"]):
+            alt = img.get("alt", "")
+            desc = f" — {alt}" if alt else ""
+            parts.append(f"  [img{i}]{desc} — {img['url']}")
+    return "\n".join(parts)
 
 
 def action_save_note(doc, article_text: str) -> Optional[str]:
@@ -287,12 +419,87 @@ def action_compare(doc, article_text: str):
     call_claude(prompt)
 
 
-def action_view(article_text: str):
-    """Wyświetl pełną treść artykułu w terminalu."""
+def _check_url_status(url: str) -> str:
+    """Sprawdź HTTP status URL (HEAD request). Zwraca status string."""
+    import requests
+    try:
+        r = requests.head(url, timeout=5, allow_redirects=True)
+        if r.status_code == 200:
+            return "OK"
+        return f"{r.status_code}"
+    except requests.RequestException:
+        return "ERR"
+
+
+def action_view(article: dict, check_urls: bool = False):
+    """Wyświetl treść artykułu z listą linków i obrazków na dole."""
+    text = article["text"]
+    links = article["links"]
+    images = article["images"]
+
     print("\n" + "=" * 60)
-    print(article_text)
+    print(text)
     print("=" * 60)
-    print(f"  [{len(article_text)} znaków]")
+
+    if images:
+        active_images = []
+        dead_images = []
+        for i, img in enumerate(images):
+            if check_urls:
+                status = _check_url_status(img["url"])
+                img["_status"] = status
+                if status == "OK":
+                    active_images.append((i, img))
+                else:
+                    dead_images.append((i, img))
+            else:
+                active_images.append((i, img))
+
+        if active_images:
+            print(f"\n  Obrazki ({len(active_images)}):")
+            for i, img in active_images:
+                alt = img.get("alt", "")
+                desc = f" — {alt}" if alt else ""
+                print(f"    [img{i}]{desc}")
+                print(f"           {img['url'][:100]}")
+        if dead_images:
+            print(f"\n  Obrazki niedostępne ({len(dead_images)}):")
+            for i, img in dead_images:
+                print(f"    [img{i}] {img['_status']} — {img['url'][:80]}")
+
+    if links:
+        if check_urls:
+            active_links = []
+            dead_links = []
+            for i, link in enumerate(links):
+                status = _check_url_status(link["url"])
+                link["_status"] = status
+                if status == "OK":
+                    active_links.append((i, link))
+                else:
+                    dead_links.append((i, link))
+        else:
+            active_links = list(enumerate(links))
+            dead_links = []
+
+        if active_links:
+            print(f"\n  Linki ({len(active_links)}):")
+            for i, link in active_links:
+                print(f"    [link{i}] {link['text'][:60]}")
+                print(f"            {link['url'][:100]}")
+        if dead_links:
+            print(f"\n  Linki niedostępne ({len(dead_links)}):")
+            for i, link in dead_links:
+                print(f"    [link{i}] {link['_status']} — {link['text'][:40]} — {link['url'][:60]}")
+
+    total_imgs = len(images)
+    total_links = len(links)
+    summary = f"  [{len(text)} znaków, {total_links} linków, {total_imgs} obrazków"
+    if check_urls and images:
+        dead_count = len([1 for img in images if img.get("_status", "OK") != "OK"])
+        if dead_count:
+            summary += f", {dead_count} niedostępnych"
+    print(summary + "]")
 
 
 def _get_documents(session, limit: int = 50, since: Optional[str] = None,
@@ -333,7 +540,8 @@ def cmd_list(session, since: Optional[str] = None, portal: Optional[str] = None,
 
 
 def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = None,
-               start_id: Optional[int] = None, limit: int = 50):
+               start_id: Optional[int] = None, limit: int = 50, auto_view: bool = False,
+               check_urls: bool = False):
     """Interaktywny przegląd artykułów."""
     filtered = _get_documents(session, limit=limit, since=since, portal=portal)
 
@@ -367,7 +575,14 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
         print(f"  Stan:    {doc.document_state}")
         print()
 
-        article_text = None  # lazy load
+        article = None  # lazy load (dict: text, links, images)
+
+        if auto_view:
+            article = get_article_text(doc, session)
+            if article:
+                action_view(article, check_urls=check_urls)
+            else:
+                print("  Nie udało się pobrać treści artykułu.")
 
         while True:
             try:
@@ -380,37 +595,37 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                 break
 
             elif action in ("v", "view"):
-                if article_text is None:
-                    article_text = get_article_text(doc, session)
-                if article_text:
-                    action_view(article_text)
+                if article is None:
+                    article = get_article_text(doc, session)
+                if article:
+                    action_view(article, check_urls=check_urls)
                 else:
                     print("  Nie udało się pobrać treści artykułu.")
                 continue
 
             elif action in ("s", "save"):
-                if article_text is None:
-                    article_text = get_article_text(doc, session)
-                if article_text:
-                    action_save_note(doc, article_text)
+                if article is None:
+                    article = get_article_text(doc, session)
+                if article:
+                    action_save_note(doc, _article_full_text(article))
                 else:
                     print("  Nie udało się pobrać treści artykułu.")
                 break
 
             elif action in ("o", "obsidian"):
-                if article_text is None:
-                    article_text = get_article_text(doc, session)
-                if article_text:
-                    action_obsidian(doc, article_text)
+                if article is None:
+                    article = get_article_text(doc, session)
+                if article:
+                    action_obsidian(doc, _article_full_text(article))
                 else:
                     print("  Nie udało się pobrać treści artykułu.")
                 break
 
             elif action in ("c", "compare"):
-                if article_text is None:
-                    article_text = get_article_text(doc, session)
-                if article_text:
-                    action_compare(doc, article_text)
+                if article is None:
+                    article = get_article_text(doc, session)
+                if article:
+                    action_compare(doc, _article_full_text(article))
                 else:
                     print("  Nie udało się pobrać treści artykułu.")
                 continue
@@ -461,6 +676,8 @@ def main():
     parser.add_argument("--portal", default=None, help="Filtruj po portalu (np. onet.pl)")
     parser.add_argument("--state", default=None, help="Filtruj po stanie (np. MD_SIMPLIFIED)")
     parser.add_argument("--id", type=int, default=None, help="Zacznij od konkretnego ID")
+    parser.add_argument("--view", action="store_true", help="Automatycznie pokaż treść przy --review")
+    parser.add_argument("--check-urls", action="store_true", help="Sprawdź dostępność obrazków i linków")
     parser.add_argument("--limit", type=int, default=50, help="Maks. artykułów (domyślnie 50)")
     args = parser.parse_args()
 
@@ -477,7 +694,8 @@ def main():
                      state=args.state, limit=args.limit)
         elif args.review:
             cmd_review(session, since=args.since, portal=args.portal,
-                       start_id=args.id, limit=args.limit)
+                       start_id=args.id, limit=args.limit, auto_view=args.view,
+                       check_urls=args.check_urls)
     finally:
         session.close()
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -502,6 +502,46 @@ def action_view(article: dict, check_urls: bool = False):
     print(summary + "]")
 
 
+def action_save_to_db(doc, article: dict, session) -> bool:
+    """Zapisz oczyszczony tekst artykułu do bazy danych i ustaw status MD_SIMPLIFIED."""
+    from library.models.stalker_document_status import StalkerDocumentStatus
+
+    full_text = _article_full_text(article)
+    text_only = article["text"]
+
+    print(f"  Zapisuję do bazy danych (ID: {doc.id})...")
+    print(f"    Tekst: {len(text_only)} znaków")
+    print(f"    Linki: {len(article['links'])}")
+    print(f"    Obrazki: {len(article['images'])}")
+    print(f"    Status: {doc.document_state} → MD_SIMPLIFIED")
+
+    try:
+        confirm = input("  Potwierdzasz? [y/N]: ").strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return False
+
+    if confirm != "y":
+        print("  Anulowano.")
+        return False
+
+    # Backup oryginalnego tekstu jeśli istnieje
+    if doc.text and not doc.text_raw:
+        doc.text_raw = doc.text
+
+    doc.text = text_only
+    doc.document_state = StalkerDocumentStatus.MD_SIMPLIFIED.name
+
+    try:
+        session.commit()
+        print(f"  Zapisano. Status: MD_SIMPLIFIED")
+        return True
+    except Exception as e:
+        session.rollback()
+        print(f"  BŁĄD zapisu: {e}")
+        return False
+
+
 def _get_documents(session, limit: int = 50, since: Optional[str] = None,
                    portal: Optional[str] = None, state: Optional[str] = None) -> list:
     """Pobierz dokumenty z bazy z filtrami. Zwraca listę obiektów WebDocument."""
@@ -557,6 +597,7 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
     print(f"\n{len(filtered)} artykułów do przeglądu. Komendy:")
     print("  [n]ext / Enter  - następny artykuł")
     print("  [v]iew          - pokaż treść artykułu")
+    print("  [d]b            - zapisz oczyszczony tekst do bazy danych")
     print("  [s]ave          - zapisz notatkę (co mnie zainteresowało) + artykuł do pliku")
     print("  [o]bsidian      - stwórz/zaktualizuj notatkę Obsidian teraz (Claude Code)")
     print("  [c]ompare       - porównaj z istniejącymi notatkami (Claude Code)")
@@ -586,7 +627,7 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
 
         while True:
             try:
-                action = input(f"  [{idx}] [n/v/s/o/c/q]: ").strip().lower()
+                action = input(f"  [{idx}] [n/v/d/s/o/c/q]: ").strip().lower()
             except (KeyboardInterrupt, EOFError):
                 print("\nPrzegląd zakończony.")
                 return
@@ -599,6 +640,15 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                     article = get_article_text(doc, session)
                 if article:
                     action_view(article, check_urls=check_urls)
+                else:
+                    print("  Nie udało się pobrać treści artykułu.")
+                continue
+
+            elif action in ("d", "db"):
+                if article is None:
+                    article = get_article_text(doc, session)
+                if article:
+                    action_save_to_db(doc, article, session)
                 else:
                     print("  Nie udało się pobrać treści artykułu.")
                 continue

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -587,11 +587,9 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     from library.models.stalker_document_status import StalkerDocumentStatus
     from library.embedding import get_embedding
     from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
-    from library.config_loader import load_config
 
     text_only = article["text"]
-    cfg = load_config()
-    embedding_model = cfg.get("EMBEDDING_MODEL") or "BAAI/bge-m3"
+    embedding_model = "BAAI/bge-m3"
 
     print(f"  Zapisuję do bazy danych (ID: {doc.id})...")
     print(f"    Tekst: {len(text_only)} znaków")

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -140,7 +140,7 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
             continue
 
         # Linia z samymi [imgN] markerami (osierocone po usunięciu kontekstu)
-        if re.match(r'^(\[img\d+[^\]]*\]\s*)+$', stripped):
+        if stripped.startswith("[img") and not any(c.isalpha() for c in re.sub(r'\[img\d+[^\]]*\]', '', stripped)):
             continue
 
         cleaned.append(line)

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -37,19 +37,27 @@ NOTES_DIR = os.path.join(_BACKEND_DIR, "tmp", "article_notes")
 
 
 def _detect_h2_ads(text: str) -> set:
-    """Wykryj nagłówki H2 z obrazkiem/video zaraz po nich (wstawki reklamowe).
+    """Wykryj nagłówki H2 z obrazkiem/video/playerem zaraz po nich (wstawki).
     Musi być wywołane PRZED usuwaniem obrazków."""
     lines = text.splitlines()
     h2_ad_titles = set()
+    video_player_markers = {"Przewiń wstecz", "Odtwórz/Pauza", "Przewiń naprzód", "Wycisz"}
     for i, line in enumerate(lines):
         stripped = line.strip().replace('\xa0', ' ')
         if stripped.startswith("## "):
-            next_nonempty = [lines[j].strip() for j in range(i + 1, min(i + 4, len(lines)))
+            next_nonempty = [lines[j].strip() for j in range(i + 1, min(i + 10, len(lines)))
                              if lines[j].strip()]
-            if next_nonempty and (next_nonempty[0].startswith("![")
-                                  or next_nonempty[0].startswith("[![")
-                                  or "wpimg.pl" in next_nonempty[0]
-                                  or "v.wp.pl" in next_nonempty[0]):
+            if not next_nonempty:
+                continue
+            # H2 + obrazek/video embed
+            if (next_nonempty[0].startswith("![")
+                    or next_nonempty[0].startswith("[![")
+                    or "wpimg.pl" in next_nonempty[0]
+                    or "v.wp.pl" in next_nonempty[0]
+                    or next_nonempty[0].startswith("[](blob:")):
+                h2_ad_titles.add(stripped)
+            # H2 + kontrolki video playera w kolejnych liniach
+            elif any(m in set(next_nonempty) for m in video_player_markers):
                 h2_ad_titles.add(stripped)
     return h2_ad_titles
 
@@ -113,6 +121,15 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         # Frazy portalowe wspólne
         if stripped in ("Dalszy ciąg materiału pod wideo", "REKLAMAKONIEC REKLAMY",
                         "REKLAMA", "Lubię to", "[ ]"):
+            continue
+
+        # Kontrolki video playera
+        if stripped in ("Przewiń wstecz", "Odtwórz/Pauza", "Przewiń naprzód", "Wycisz",
+                        "Ustawienia", "NA ŻYWO", "Oglądaj z dźwiękiem", "Zamknij",
+                        "Włącz / wyłącz pełny ekran"):
+            continue
+        # Timestamp video: "00:09 / 00:16"
+        if re.match(r'^\d{2}:\d{2}\s*/\s*\d{2}:\d{2}$', stripped):
             continue
         # Warianty "Dalsza część artykułu pod wideo" (z kursywą, dwukropkiem)
         if "dalsza część artykułu pod wideo" in stripped.lower() or \

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -610,27 +610,21 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
         print("Brak artykułów do przeglądu.")
         return
 
-    print(f"\n{len(filtered)} artykułów do przeglądu. Komendy:")
-    print("  [n]ext / Enter  - następny artykuł")
-    print("  [v]iew          - pokaż treść artykułu")
-    print("  [d]b            - zapisz oczyszczony tekst do bazy danych")
-    print("  [s]ave          - zapisz notatkę (co mnie zainteresowało) + artykuł do pliku")
-    print("  [o]bsidian      - stwórz/zaktualizuj notatkę Obsidian teraz (Claude Code)")
-    print("  [c]ompare       - porównaj z istniejącymi notatkami (Claude Code)")
-    print("  [q]uit          - zakończ")
-    print()
+    print(f"{len(filtered)} artykułów do przeglądu.\n")
 
-    for idx, doc in enumerate(filtered, 1):
+    idx = 0
+    while 0 <= idx < len(filtered):
+        doc = filtered[idx]
         date_str = doc.created_at.strftime("%Y-%m-%d %H:%M") if doc.created_at else "????"
         detected_portal = _detect_portal(doc.url) or "?"
 
-        print(f"\n--- [{idx}/{len(filtered)}] ID: {doc.id} ---")
+        os.system("cls" if os.name == "nt" else "clear")
+        print(f"--- [{idx + 1}/{len(filtered)}] ID: {doc.id} ---")
         print(f"  Tytuł:   {doc.title}")
         print(f"  Data:    {date_str}")
         print(f"  Portal:  {detected_portal}")
         print(f"  URL:     {doc.url}")
         print(f"  Stan:    {doc.document_state}")
-        print()
 
         article = None  # lazy load (dict: text, links, images)
 
@@ -641,14 +635,26 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
             else:
                 print("  Nie udało się pobrać treści artykułu.")
 
+        print()
+        print("  [n]ext  [p]rev  [v]iew  [d]b save  [s]ave note  [o]bsidian  [c]ompare  [q]uit")
+
         while True:
             try:
-                action = input(f"  [{idx}] [n/v/d/s/o/c/q]: ").strip().lower()
+                action = input(f"  [{idx + 1}] > ").strip().lower()
             except (KeyboardInterrupt, EOFError):
                 print("\nPrzegląd zakończony.")
                 return
 
             if action in ("n", "next", ""):
+                idx += 1
+                break
+
+            elif action in ("p", "prev", "previous"):
+                if idx > 0:
+                    idx -= 1
+                else:
+                    print("  Jesteś na pierwszym artykule.")
+                    continue
                 break
 
             elif action in ("v", "view"):
@@ -701,7 +707,7 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                 return
 
             else:
-                print("  Nieznana komenda. Użyj: n, o, c, v, q")
+                print("  Nieznana komenda. Użyj: n, p, v, d, s, o, c, q")
 
 
 def cmd_notes():

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -86,12 +86,19 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         if stripped in skip_section_markers or stripped in h2_ad_titles:
             skip_section = True
             continue
-        if skip_section and stripped and (stripped.startswith("**") or
-                                          (len(stripped) > 50 and not stripped.startswith("[")
-                                           and not stripped.startswith("!"))):
-            skip_section = False
         if skip_section:
-            continue
+            # "Więcej w Strefie Premium" — koniec sekcji, ale też pomiń tę linię
+            if "Więcej w Strefie Premium" in stripped:
+                skip_section = False
+                continue
+            # Koniec sekcji: pytanie dziennikarza (**Tekst**) lub długi akapit
+            # Ale nie **1**, **2** itp. (numeracja w sekcji premium)
+            if stripped and stripped.startswith("**") and not re.match(r'^\*\*\d+\*\*', stripped):
+                skip_section = False
+            elif stripped and len(stripped) > 80 and not stripped.startswith("[") and not stripped.startswith("!"):
+                skip_section = False
+            else:
+                continue
 
         # picture[N]:, link[N]:
         if re.match(r'^(picture|link)\[\d+\]:', stripped):
@@ -129,6 +136,12 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
     for line in lines:
         stripped = line.strip()
         if stripped in skip:
+            continue
+        # Wstawki premium: "**1** ### Tytuł [linkN]**2** ### ..."
+        if re.match(r'^\*\*\d+\*\*\s+###\s+', stripped):
+            continue
+        # "Więcej w Strefie Premium [linkN]"
+        if "Więcej w Strefie Premium" in stripped:
             continue
         if stripped.startswith("Audio generowane"):
             continue

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -19,6 +19,8 @@ import textwrap
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy import text as text_sql
+
 from library.config_loader import load_config
 from library.db.engine import get_session
 from library.db.models import WebDocument
@@ -587,6 +589,21 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     if confirm != "y":
         print("  Anulowano.")
         return False
+
+    # Odśwież połączenie z bazą (mogło wygasnąć przy długim przeglądaniu)
+    try:
+        session.execute(text_sql("SELECT 1"))
+    except Exception:
+        session.rollback()
+        print("  Odświeżam połączenie z bazą...")
+        try:
+            session.execute(text_sql("SELECT 1"))
+        except Exception as e:
+            print(f"  BŁĄD: nie mogę połączyć się z bazą: {e}")
+            return False
+
+    # Odśwież obiekt dokumentu po reconnect
+    session.refresh(doc)
 
     # Backup oryginalnego tekstu jeśli istnieje
     if doc.text and not doc.text_raw:

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -330,11 +330,46 @@ def _article_full_text(article: dict) -> str:
     return "\n".join(parts)
 
 
+def _read_existing_note(doc_id: int) -> str | None:
+    """Odczytaj istniejącą notatkę użytkownika (sekcja 'Moja notatka')."""
+    note_file = os.path.join(NOTES_DIR, f"{doc_id}_note.md")
+    if not os.path.isfile(note_file):
+        return None
+    with open(note_file, "r", encoding="utf-8") as f:
+        content = f.read()
+    if "## Moja notatka" in content:
+        return content.split("## Moja notatka")[1].split("## Treść artykułu")[0].strip()
+    return None
+
+
 def action_save_note(doc, article_text: str) -> Optional[str]:
-    """Zapisz notatkę użytkownika + treść artykułu do pliku.
+    """Zapisz/edytuj notatkę użytkownika + treść artykułu do pliku.
 
     Returns: ścieżka do pliku lub None
     """
+    existing_note = _read_existing_note(doc.id)
+
+    if existing_note:
+        print(f"\n  Istniejąca notatka:")
+        for line in existing_note.splitlines():
+            print(f"     {line}")
+        print()
+        print("  [e]dytuj — napisz nową treść (zastąpi obecną)")
+        print("  [d]opisz — dopisz nowy tekst pod istniejącym")
+        print("  [Enter]  — anuluj")
+        try:
+            choice = input("  > ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return None
+
+        if choice not in ("e", "edytuj", "d", "dopisz"):
+            print("  Anulowano.")
+            return None
+        append_mode = choice in ("d", "dopisz")
+    else:
+        append_mode = False
+
     print("  Napisz co Cię zainteresowało (kilka linii, pusta linia kończy):")
     note_lines = []
     while True:
@@ -351,9 +386,14 @@ def action_save_note(doc, article_text: str) -> Optional[str]:
         print("  Pusta notatka — nie zapisano.")
         return None
 
-    note_text = "\n".join(note_lines)
+    new_text = "\n".join(note_lines)
     # Napraw surrogaty z WSL/Windows terminal
-    note_text = note_text.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
+    new_text = new_text.encode("utf-8", errors="surrogateescape").decode("utf-8", errors="replace")
+
+    if append_mode and existing_note:
+        note_text = existing_note + "\n\n" + new_text
+    else:
+        note_text = new_text
 
     os.makedirs(NOTES_DIR, exist_ok=True)
     note_file = os.path.join(NOTES_DIR, f"{doc.id}_note.md")

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -118,7 +118,6 @@ PORTAL_FOOTER_MARKERS = {
     ],
     "businessinsider": [
         "Dziękujemy, że przeczytałaś/eś",
-        "## Czytaj także w BUSINESS INSIDER",
         "## Autor",
     ],
 }

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -106,6 +106,7 @@ PORTAL_FOOTER_MARKERS = {
         "MONEY NA SKR",
     ],
     "wp": [
+        "Wybrane dla Ciebie",
         "### Wybrane dla Ciebie",
         "**Masz newsa, zdjęcie lub filmik?",
         "**Czytaj także:**",

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -118,6 +118,7 @@ PORTAL_FOOTER_MARKERS = {
     ],
     "businessinsider": [
         "Dziękujemy, że przeczytałaś/eś",
+        "## Czytaj także w BUSINESS INSIDER",
         "## Autor",
     ],
 }


### PR DESCRIPTION
## Summary

Follow-up to #101. Improves `article_browser.py`:

- **Refactored** `clean_article_text` into generic + per-portal functions (`_clean_lines_onet`, `_clean_lines_money`, `_clean_lines_wp`)
- **Links/images as references**: `[linkN]`/`[imgN]` markers in text, full list with URLs below
- **Portal-internal links filtered**: tag/category links → plain text, author links preserved
- **H2+image ad detection**: money.pl inline ads (H2 followed by video embed) auto-removed
- **`--view` flag**: auto-show article content on `--review`
- **`--check-urls` flag**: HEAD request to verify image/link availability (shows 404s)
- **`--notes` command**: list saved notes for later Claude Code processing
- Fix: `re` import at module level, NBSP normalization for H2 detection
- Fix: use simple regex for image removal instead of `get_images_with_links_md` (which had a bug collapsing text to 1 line)

## Usage

```bash
# Auto-show article + check URLs
uv run python imports/article_browser.py --review --id 8785 --view --check-urls
```

## Test plan

- [ ] Verify money.pl articles display cleanly (no tags, no "Źródło artykułu", no ad inserts)
- [ ] Verify onet.pl articles still display correctly
- [ ] Verify `--check-urls` correctly identifies 404 links/images

🤖 Generated with [Claude Code](https://claude.com/claude-code)