### PR TITLE
docs: fix bmad-examples README list formatting

### DIFF
--- a/docs/bmad-examples/README.md
+++ b/docs/bmad-examples/README.md
@@ -4,7 +4,7 @@
 - [PRD_example_2_clean.txt](clean/PRD_example_2_clean.txt) - 50 metod na pogłębienie zrozumienia zagadnienia, 
 - [PRD_example_epics_clean.txt](clean/PRD_example_epics_clean.txt) - epic review
 - [PRD_validation_clean.txt](clean/PRD_validation_clean.txt) - da się przetestować? czy wymagania funkcjonalne spełniają wymagania kryteriów SMART?
-[PRD_arch_clean.txt](clean/PRD_arch_clean.txt) - tworzenie architektury na podstawie PRD, zwróć uwagę na linie 437: PRD mówi o eliminacji StalkerWebDocumentDB, ale plan migracji proponuje thin 
+- [PRD_arch_clean.txt](clean/PRD_arch_clean.txt) - tworzenie architektury na podstawie PRD, zwróć uwagę na linie 437: PRD mówi o eliminacji StalkerWebDocumentDB, ale plan migracji proponuje thin 
   wrapper delegujący do ORM modelu (z __getattr__/__setattr__).) zwróć też uwagę na linie 524: pytanie o Pydantic.
 - [PRD_to_EPICS_clean.txt](clean/PRD_to_EPICS_clean.txt)
 - [epics_to_stories_clean.txt](clean/epics_to_stories_clean.txt) - tworzymy stories 


### PR DESCRIPTION
## Summary

- Fix missing `- ` prefix on PRD_arch_clean.txt line in bmad-examples README, which broke markdown bullet list rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)