### PR TITLE
feat: stateful ARK Labs mode + onet cleanup + B-101 backlog

### DIFF
--- a/_bmad-output/planning-artifacts/epics/backlog.md
+++ b/_bmad-output/planning-artifacts/epics/backlog.md
@@ -1433,3 +1433,34 @@ so that on-premises workloads (NAS, local dev) use short-lived temporary credent
 
 **Priority:** LOW
 **Status:** backlog
+
+---
+
+### B-101: Track Obsidian Note Status for Articles
+
+As a **knowledge worker**,
+I want to know which articles from the database have already been processed into Obsidian notes,
+so that I can focus on unprocessed articles during review and avoid duplicating work.
+
+**Origin:** During article_browser.py review sessions, there's no way to tell if an article was already used to create/update an Obsidian note. After reviewing 50+ articles, it's easy to lose track.
+
+**Context / decisions to make:**
+- **New DB field vs. new status vs. separate tracking table?** A new column `obsidian_note_path` (TEXT, nullable) on `web_documents` is simplest but couples Obsidian to the DB schema. A separate `article_notes` table might be cleaner. A new status value (e.g., `OBSIDIAN_NOTE_CREATED`) requires Alembic migration for the lookup table.
+- **One article → many notes?** An article about Russia+Vietnam might update both `Rosja.md` and `Wietnam.md`. Need to support multiple paths per article.
+- **Bidirectional linking?** Should Obsidian notes also reference back to other articles that contributed? (Currently done manually via `Lenie AI id=XXXX`)
+- **Integration with article_browser.py:** `--list` and `--review` should be filterable by obsidian status (e.g., `--no-obsidian` to show only unprocessed articles)
+
+**Possible approaches:**
+1. New column `obsidian_note_paths` (TEXT/JSON) on `web_documents` — simple, requires Alembic migration
+2. New join table `article_obsidian_notes` (article_id, note_path, created_at) — normalized, supports many-to-many
+3. Track via local files only (e.g., `tmp/article_notes/{id}_note.md` existence) — no DB change, but fragile
+
+**Acceptance Criteria:**
+- After creating/updating an Obsidian note from an article, the system records which note(s) were created
+- `article_browser.py --list` shows obsidian status per article
+- `article_browser.py --review --no-obsidian` filters to articles not yet processed
+- Multiple Obsidian notes per article are supported
+- Alembic migration is created if DB schema changes are needed
+
+**Priority:** MEDIUM
+**Status:** backlog

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -72,7 +72,7 @@ _PORTAL_INTERNAL_LINK_PATTERNS = [
     r'onet\.pl/autorzy/',             # onet autorzy
     r'/archiwum/autor/',              # money.pl autorzy
     r'/autor/',                        # wp.pl autorzy
-    r',temat,',                        # wp.pl tagi: /iran,temat,598...
+    r'[,%]temat[,%]',                   # wp.pl tagi: /iran,temat,598... lub %2Ctemat%2C
 ]
 
 
@@ -315,9 +315,11 @@ def clean_article_text(text: str, url: str = "") -> dict:
             return link_text
         if "Więcej w Strefie Premium" in link_text:
             return link_text
-        # "Zobacz też" z obrazkiem: "[imgN...] ## Tytuł" lub "[imgN] Tytuł"
+        # "Zobacz też" z obrazkiem lub nagłówkiem H2/H3
         if re.match(r'^\[img\d+', link_text):
             return link_text
+        if link_text.startswith("## ") or link_text.startswith("### "):
+            return ""
         # Reklamy natywne z gigantycznym tracking URL (>200 znaków, encoded)
         if len(link_url) > 200:
             return ""

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -274,8 +274,10 @@ def clean_article_text(text: str, url: str = "") -> dict:
     def replace_image(m):
         alt = m.group(1).strip()
         img_url = m.group(2).strip()
-        # Pomijaj emotki i ikony portalu
+        # Pomijaj emotki, ikony portalu i bannery reklamowe
         if any(p in img_url for p in _skip_image_patterns):
+            return ""
+        if alt and alt.lower().startswith("misja ai"):
             return ""
         # Pomijaj duplikaty (ten sam URL)
         if img_url in _seen_image_urls:

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -359,7 +359,7 @@ def get_article_text(doc, session) -> Optional[dict]:
         from library.document_prepare import prepare_markdown, save_document_info
         os.makedirs(cache_dir, exist_ok=True)
         save_document_info(doc.id, doc, cache_dir)
-        markdown_text = prepare_markdown(doc.id, doc, cache_dir)
+        markdown_text = prepare_markdown(doc.id, doc, cache_dir, verbose=True)
         if not markdown_text:
             print(f"  Nie udało się pobrać artykułu z S3.")
             return None

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -237,9 +237,18 @@ def clean_article_text(text: str, url: str = "") -> dict:
     h2_ad_titles = _detect_h2_ads(text)
 
     # 3. Wyodrębnij obrazki → markery [imgN]
+    # Pomijaj emotki portali (onet emotion svg, onet service logos)
+    _skip_image_patterns = [
+        "onetmobilemainpage/emotion/",
+        "onetmobilemainpage/onet30/subServiceLogos/",
+    ]
+
     def replace_image(m):
         alt = m.group(1).strip()
         img_url = m.group(2).strip()
+        # Pomijaj emotki i ikony portalu — usuń bez śladu
+        if any(p in img_url for p in _skip_image_patterns):
+            return ""
         idx = len(extracted_images)
         extracted_images.append({"alt": alt, "url": img_url})
         return f"[img{idx}: {alt}]" if alt else f"[img{idx}]"

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -164,6 +164,15 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
             continue
         if stripped.startswith("Audio generowane"):
             continue
+        # Data publikacji: "17 marca 2026, 12:31"
+        if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
+            continue
+        # Czas czytania: "1 min czytania", "5 min czytania"
+        if re.match(r'^\d+\s+min\s+czytania$', stripped):
+            continue
+        # Reakcje: "[img1][img2]1,6 tys." lub "[img0][img1]385"
+        if re.match(r'^(\[img\d+\])+[\d,]+(\s*tys\.)?$', stripped):
+            continue
         cleaned.append(line)
     return cleaned
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -95,7 +95,10 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         stripped = line.strip()
 
         # Sekcje do pominięcia (premium, wstawki H2+img)
-        if stripped in skip_section_markers or stripped in h2_ad_titles:
+        # Po replace_link linia może mieć [linkN] na końcu — usuń przed porównaniem
+        stripped_no_links = re.sub(r'\s*\[link\d+\]', '', stripped).strip()
+        if stripped in skip_section_markers or stripped_no_links in skip_section_markers \
+                or stripped in h2_ad_titles or stripped_no_links in h2_ad_titles:
             skip_section = True
             continue
         if skip_section:

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -261,6 +261,11 @@ def clean_article_text(text: str, url: str = "") -> dict:
             return ""
         if _is_portal_internal_link(link_url):
             return link_text
+        # Onet premium numerowane linki: "**1** ### Tytuł", "Więcej w Strefie Premium"
+        if re.match(r'^\*\*\d+\*\*\s+###', link_text):
+            return link_text
+        if "Więcej w Strefie Premium" in link_text:
+            return link_text
         idx = len(extracted_links)
         extracted_links.append({"text": link_text, "url": link_url})
         return f"{link_text} [link{idx}]"

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -146,6 +146,10 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         if stripped.startswith("[img") and not any(c.isalpha() for c in re.sub(r'\[img\d+[^\]]*\]', '', stripped)):
             continue
 
+        # "Zobacz też" z obrazkiem: [[imgN...] tytuł](url) lub [[imgN...] tytuł [linkN]
+        if stripped.startswith("[[img"):
+            continue
+
         cleaned.append(line)
 
     return cleaned
@@ -291,6 +295,9 @@ def clean_article_text(text: str, url: str = "") -> dict:
         if re.match(r'^\*\*\d+\*\*\s+###', link_text):
             return link_text
         if "Więcej w Strefie Premium" in link_text:
+            return link_text
+        # "Zobacz też" z obrazkiem: "[imgN...] ## Tytuł" lub "[imgN] Tytuł"
+        if re.match(r'^\[img\d+', link_text):
             return link_text
         idx = len(extracted_links)
         extracted_links.append({"text": link_text, "url": link_url})

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -72,6 +72,7 @@ _PORTAL_INTERNAL_LINK_PATTERNS = [
     r'onet\.pl/autorzy/',             # onet autorzy
     r'/archiwum/autor/',              # money.pl autorzy
     r'/autor/',                        # wp.pl autorzy
+    r',temat,',                        # wp.pl tagi: /iran,temat,598...
 ]
 
 
@@ -260,17 +261,25 @@ def clean_article_text(text: str, url: str = "") -> dict:
     h2_ad_titles = _detect_h2_ads(text)
 
     # 3. Wyodrębnij obrazki → markery [imgN]
-    # Pomijaj emotki portali (onet emotion svg, onet service logos)
+    # Pomijaj emotki, ikony, tracking pixele, duplikaty
     _skip_image_patterns = [
         "onetmobilemainpage/emotion/",
         "onetmobilemainpage/onet30/subServiceLogos/",
     ]
+    _seen_image_urls = set()
 
     def replace_image(m):
         alt = m.group(1).strip()
         img_url = m.group(2).strip()
-        # Pomijaj emotki i ikony portalu — usuń bez śladu
+        # Pomijaj emotki i ikony portalu
         if any(p in img_url for p in _skip_image_patterns):
+            return ""
+        # Pomijaj duplikaty (ten sam URL)
+        if img_url in _seen_image_urls:
+            return ""
+        _seen_image_urls.add(img_url)
+        # Pomijaj obrazki bez alt i bez rozszerzenia (prawdopodobnie tracking pixel)
+        if not alt and not any(img_url.lower().endswith(ext) for ext in ('.jpg', '.jpeg', '.png', '.gif', '.svg', '.webp')):
             return ""
         idx = len(extracted_images)
         extracted_images.append({"alt": alt, "url": img_url})
@@ -859,7 +868,7 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                 print(f"\n  NOTATKA: {note_file}")
 
         print()
-        print("  [n]ext  [p]rev  [v]iew  [d]b save  [s]ave note  [o]bsidian  [c]ompare  [q]uit")
+        print("  [n]ext  [p]rev  [v]iew  [r]efresh  [d]b save  [s]ave note  [o]bsidian  [c]ompare  [q]uit")
 
         while True:
             try:
@@ -879,6 +888,18 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
                     print("  Jesteś na pierwszym artykule.")
                     continue
                 break
+
+            elif action in ("r", "refresh"):
+                # Usuń cache LLM extracted i ponów analizę
+                cache_dir_base_r = (load_config().get("CACHE_DIR") or "tmp/markdown")
+                cache_dir_r = os.path.join(cache_dir_base_r, str(doc.id))
+                import glob as glob_mod
+                for f in glob_mod.glob(os.path.join(cache_dir_r, "*_llm_extracted_article.md")):
+                    os.remove(f)
+                    print(f"  Usunięto cache: {os.path.basename(f)}")
+                article = None  # wymuś ponowną analizę
+                print("  Cache wyczyszczony. Użyj [v] żeby zobaczyć ponownie wyekstrahowany tekst.")
+                continue
 
             elif action in ("v", "view"):
                 if article is None:

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -677,6 +677,20 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     doc.text = text_only
     doc.document_state = StalkerDocumentStatus.MD_SIMPLIFIED.name
 
+    # Zapisz autora z LLM markers jeśli dostępny
+    cfg = load_config()
+    cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
+    import glob as glob_mod
+    markers_files = glob_mod.glob(os.path.join(cache_dir_base, str(doc.id), "*_llm_markers.json"))
+    if markers_files and not doc.author:
+        import json
+        with open(markers_files[0], "r", encoding="utf-8") as f:
+            markers_data = json.load(f)
+        author = markers_data.get("markers", {}).get("author")
+        if author:
+            doc.author = author
+            print(f"    Autor: {author}")
+
     try:
         session.commit()
         print(f"  Tekst zapisany. Status: MD_SIMPLIFIED")

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -281,9 +281,20 @@ def clean_article_text(text: str, url: str = "") -> dict:
 
     text = re.sub(r'\[([^\]]*)\]\(([^)]+)\)', replace_link, text)
 
-    # 6. Usuń stare referencje z webdocument_md_decode
+    # 6. Usuń stare referencje z webdocument_md_decode i osierocone markery
     text = re.sub(r'picture\[\d+\]:"[^"]*"', '', text)
     text = re.sub(r'link\[\d+\]:[^\n]*', '', text)
+    # Osierocone [imgN] / [imgN: opis] — markery bez odpowiadającego obrazka
+    # (np. z tekstu zapisanego do DB lub po odfiltrowaniu emotek)
+    def _clean_orphan_img(m):
+        try:
+            idx = int(re.search(r'\d+', m.group(0)).group())
+            if idx < len(extracted_images):
+                return m.group(0)  # zachowaj — ma odpowiadający obrazek
+        except (ValueError, AttributeError):
+            pass
+        return ""  # usuń osierocony
+    text = re.sub(r'\[img\d+(?::[^\]]*)?\]', _clean_orphan_img, text)
 
     # 7. Normalizacja
     text = text.replace('\xa0', ' ')

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -68,6 +68,7 @@ _PORTAL_INTERNAL_LINK_PATTERNS = [
     r'/tag/',                          # wp.pl/o2.pl tagi
     r'0%2C128956\.html\?tag=',        # wyborcza.pl tagi
     r'wiadomosci\.onet\.pl/[\w-]+$',  # onet tagi
+    r'onet\.pl/premium$',             # onet "Więcej w Strefie Premium"
 ]
 
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -129,8 +129,10 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
                         "Ustawienia", "NA ŻYWO", "Oglądaj z dźwiękiem", "Zamknij",
                         "Włącz / wyłącz pełny ekran"):
             continue
-        # Timestamp video: "00:09 / 00:16"
+        # Timestamp video: "00:09 / 00:16" lub samodzielne "Oglądaj" + czas
         if re.match(r'^\d{2}:\d{2}\s*/\s*\d{2}:\d{2}$', stripped):
+            continue
+        if re.match(r'^Ogl[aą]daj\s*$', stripped) or re.match(r'^\d{2}:\d{2}$', stripped):
             continue
         # Warianty "Dalsza część artykułu pod wideo" (z kursywą, dwukropkiem)
         if "dalsza część artykułu pod wideo" in stripped.lower() or \
@@ -204,18 +206,33 @@ def _clean_lines_money(lines: list[str]) -> list[str]:
 
 
 def _clean_lines_wp(lines: list[str]) -> list[str]:
-    """Czyszczenie specyficzne dla wp.pl/o2.pl."""
-    skip = {"Skomentuj", "Udostępnij"}
+    """Czyszczenie specyficzne dla wp.pl/o2.pl/tech.wp.pl."""
+    skip_exact = {"Skomentuj", "Udostępnij"}
+    skip_startswith = ("Udostępnij na X", "Dźwięk został wygenerowany",
+                       "Źródło zdjęć:", "Źródło artykułu:", "oprac.")
     cleaned = []
     for line in lines:
         stripped = line.strip()
-        if stripped in skip:
+        if stripped in skip_exact:
             continue
-        if stripped.startswith("Udostępnij na X"):
-            continue
-        if stripped.startswith("Dźwięk został wygenerowany"):
+        if any(stripped.startswith(s) for s in skip_startswith):
             continue
         if re.match(r'^\d+\s+komentarz', stripped):
+            continue
+        # Samodzielna data: "23 marca 2026, 06:15"
+        if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
+            continue
+        # Tagi jako tekst: "iran rakiety balistyczne europa +3"
+        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', stripped):
+            continue
+        # Autor wp.pl: "Imię Nazwisko, dziennikarz/ka Wirtualnej Polski"
+        if "dziennikarz" in stripped.lower() and "wirtualnej polski" in stripped.lower():
+            continue
+        # Banner "Misja AI" itp.
+        if stripped.startswith("Misja AI"):
+            continue
+        # Reklamy z gigantycznym tracking URL (>300 znaków)
+        if stripped.startswith("[") and stripped.endswith(")") and len(stripped) > 300:
             continue
         cleaned.append(line)
     return cleaned

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -199,8 +199,9 @@ def _clean_lines_money(lines: list[str]) -> list[str]:
         # Samodzielna data: "24 marca 2026, 12:26"
         if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
             continue
-        # Linia z samymi tagami (tekst bez linków): "gospodarka elektrownia atomowa rosja +1"
-        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', stripped):
+        # Tagi: "gospodarka elektrownia atomowa rosja +1" lub z markerami [linkN]
+        tag_line = re.sub(r'\[link\d+\]', '', stripped).strip()
+        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', tag_line):
             continue
         # "Zobacz też" — linia z [imgN: tytuł] i link do innego artykułu money.pl
         if re.match(r'^\[?\[img\d+:.*\].*money\.pl/', stripped):
@@ -226,8 +227,9 @@ def _clean_lines_wp(lines: list[str]) -> list[str]:
         # Samodzielna data: "23 marca 2026, 06:15"
         if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
             continue
-        # Tagi jako tekst: "iran rakiety balistyczne europa +3"
-        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', stripped):
+        # Tagi: "iran rakiety balistyczne europa +3" lub z markerami "iran [link3] rakiety +3"
+        tag_line = re.sub(r'\[link\d+\]', '', stripped).strip()
+        if re.match(r'^[\w\sąćęłńóśźżĄĆĘŁŃÓŚŹŻ]+\+\d+$', tag_line):
             continue
         # Autor wp.pl: "Imię Nazwisko, dziennikarz/ka Wirtualnej Polski"
         if "dziennikarz" in stripped.lower() and "wirtualnej polski" in stripped.lower():

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -72,7 +72,7 @@ _PORTAL_INTERNAL_LINK_PATTERNS = [
     r'onet\.pl/autorzy/',             # onet autorzy
     r'/archiwum/autor/',              # money.pl autorzy
     r'/autor/',                        # wp.pl autorzy
-    r'[,%]temat[,%]',                   # wp.pl tagi: /iran,temat,598... lub %2Ctemat%2C
+    r'(%2C|,)temat(%2C|,)',             # wp.pl tagi: /iran,temat,598... lub %2Ctemat%2C
 ]
 
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -313,6 +313,9 @@ def clean_article_text(text: str, url: str = "") -> dict:
         # "Zobacz też" z obrazkiem: "[imgN...] ## Tytuł" lub "[imgN] Tytuł"
         if re.match(r'^\[img\d+', link_text):
             return link_text
+        # Reklamy natywne z gigantycznym tracking URL (>200 znaków, encoded)
+        if len(link_url) > 200:
+            return ""
         idx = len(extracted_links)
         extracted_links.append({"text": link_text, "url": link_url})
         return f"{link_text} [link{idx}]"

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -101,6 +101,9 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
                 or stripped in h2_ad_titles or stripped_no_links in h2_ad_titles:
             skip_section = True
             continue
+        # H2 z [linkN] = "Zobacz też" link, nie treść artykułu
+        if stripped.startswith("## ") and re.search(r'\[link\d+\]$', stripped):
+            continue
         if skip_section:
             # "Więcej w Strefie Premium" — koniec sekcji, ale też pomiń tę linię
             if "Więcej w Strefie Premium" in stripped:

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -69,14 +69,14 @@ _PORTAL_INTERNAL_LINK_PATTERNS = [
     r'0%2C128956\.html\?tag=',        # wyborcza.pl tagi
     r'wiadomosci\.onet\.pl/[\w-]+$',  # onet tagi
     r'onet\.pl/premium$',             # onet "Więcej w Strefie Premium"
+    r'onet\.pl/autorzy/',             # onet autorzy
+    r'/archiwum/autor/',              # money.pl autorzy
+    r'/autor/',                        # wp.pl autorzy
 ]
 
 
 def _is_portal_internal_link(url: str) -> bool:
-    """Czy link jest wewnętrznym linkiem portalu (tag, kategoria)?
-    Linki do autorów (/archiwum/autor/, /autorzy/) NIE są wewnętrzne."""
-    if "/archiwum/autor/" in url or "/autorzy/" in url:
-        return False
+    """Czy link jest wewnętrznym linkiem portalu (tag, kategoria, autor)?"""
     return any(re.search(p, url) for p in _PORTAL_INTERNAL_LINK_PATTERNS)
 
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -302,13 +302,18 @@ def clean_article_text(text: str, url: str = "") -> dict:
 
 
 def get_article_text(doc, session) -> Optional[dict]:
-    """Pobierz wyekstrahowany tekst artykułu z cache lub przez LLM.
+    """Pobierz wyekstrahowany tekst artykułu z DB, cache lub przez LLM.
     Zwraca dict: {text, links, images} lub None."""
+
+    # 1. Jeśli tekst jest w bazie (MD_SIMPLIFIED, EMBEDDING_EXIST) — użyj go
+    if doc.text and len(doc.text) > 100 and doc.document_state in ("MD_SIMPLIFIED", "EMBEDDING_EXIST"):
+        return clean_article_text(doc.text, doc.url)
+
     cfg = load_config()
     cache_dir_base = cfg.get("CACHE_DIR") or "tmp/markdown"
     cache_dir = os.path.join(cache_dir_base, str(doc.id))
 
-    # Szukaj w cache (kolejność: step_2 > llm_extracted > step_1)
+    # 2. Szukaj w cache (kolejność: step_2 > llm_extracted > step_1)
     for suffix in ["_step_2_1_article.md", "_llm_extracted_article.md", "_step_1_all.md"]:
         cache_file = os.path.join(cache_dir, f"{doc.id}{suffix}")
         if os.path.isfile(cache_file):

--- a/backend/library/api/arklabs/arklabs_completion.py
+++ b/backend/library/api/arklabs/arklabs_completion.py
@@ -1,15 +1,43 @@
+import logging
+
+import requests as http_requests
 from openai import OpenAI
 
 from library.models.ai_response import AiResponse
 from library.api.arklabs.config import get_arklabs_config
 
+logger = logging.getLogger(__name__)
+
+# Stateful session — reuses GPU session via ark_session_id cookie
+_stateful_session: http_requests.Session | None = None
+
+
+def _get_stateful_session() -> http_requests.Session:
+    """Get or create a persistent requests.Session for stateful ARK Labs calls."""
+    global _stateful_session
+    if _stateful_session is None:
+        _stateful_session = http_requests.Session()
+    return _stateful_session
+
 
 def arklabs_get_completion(prompt: str, model: str = "speakleash/Bielik-11B-v3.0-Instruct",
                            max_tokens: int = 1000, temperature: float = 0.1,
-                           system_prompt: str = None) -> AiResponse:
+                           system_prompt: str = None,
+                           stateful: bool = False) -> AiResponse:
     ai_response = AiResponse(query=prompt, model=model)
-
     api_key, base_url = get_arklabs_config()
+
+    if stateful:
+        return _completion_stateful(ai_response, prompt, model, max_tokens,
+                                    temperature, system_prompt, api_key, base_url)
+    else:
+        return _completion_stateless(ai_response, prompt, model, max_tokens,
+                                     temperature, system_prompt, api_key, base_url)
+
+
+def _completion_stateless(ai_response, prompt, model, max_tokens,
+                          temperature, system_prompt, api_key, base_url):
+    """Stateless mode — each request is independent (OpenAI SDK)."""
     client = OpenAI(api_key=api_key, base_url=base_url)
 
     messages = []
@@ -29,5 +57,48 @@ def arklabs_get_completion(prompt: str, model: str = "speakleash/Bielik-11B-v3.0
     ai_response.prompt_tokens = chat_response.usage.prompt_tokens
     ai_response.completion_tokens = chat_response.usage.completion_tokens
     ai_response.total_tokens = chat_response.usage.total_tokens
+
+    return ai_response
+
+
+def _completion_stateful(ai_response, prompt, model, max_tokens,
+                         temperature, system_prompt, api_key, base_url):
+    """Stateful mode — reuses GPU session via cookies (cheaper input tokens)."""
+    session = _get_stateful_session()
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+
+    url = f"{base_url}/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+
+    response = session.post(url, json=payload, headers=headers, timeout=120)
+    response.raise_for_status()
+    data = response.json()
+
+    ai_response.id = data.get("id")
+    ai_response.response_text = data["choices"][0]["message"]["content"]
+
+    usage = data.get("usage", {})
+    ai_response.prompt_tokens = usage.get("prompt_tokens")
+    ai_response.completion_tokens = usage.get("completion_tokens")
+    ai_response.total_tokens = usage.get("total_tokens")
+
+    # Log credit usage for cost comparison
+    credits_used = usage.get("credits_used")
+    credit_balance = usage.get("credit_balance")
+    if credits_used is not None:
+        logger.info(f"ARK Labs stateful: credits_used={credits_used}, balance={credit_balance}")
 
     return ai_response

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -305,6 +305,7 @@ def extract_article_markers_with_llm(markdown_text: str, url: str = "",
             max_tokens=800,
             temperature=0.1,
             system_prompt=EXTRACTION_SYSTEM_PROMPT,
+            stateful=True,
         )
 
         logger.info(f"LLM extraction tokens: prompt={response.prompt_tokens}, "

--- a/backend/library/document_prepare.py
+++ b/backend/library/document_prepare.py
@@ -24,7 +24,7 @@ def calculate_reduction(html_size, markdown_size):
     return ((html_size - markdown_size) / html_size) * 100
 
 
-def prepare_markdown(document_id, doc, cache_dir) -> str | None:
+def prepare_markdown(document_id, doc, cache_dir, verbose: bool = False) -> str | None:
     """Pobierz HTML z S3 i skonwertuj do markdown. Zwraca tekst markdown lub None."""
     cfg = load_config()
     s3_bucket = cfg.get("AWS_S3_WEBSITE_CONTENT")
@@ -32,41 +32,50 @@ def prepare_markdown(document_id, doc, cache_dir) -> str | None:
     cache_file_html = os.path.join(cache_dir, f"{document_id}.html")
     cache_file_md = os.path.join(cache_dir, f"{document_id}.md")
 
+    def _log(msg):
+        logger.info(msg)
+        if verbose:
+            print(f"    {msg}")
+
     if os.path.isfile(cache_file_md):
-        logger.info(f"document_id: {document_id} Using cached markdown: {cache_file_md}")
+        _log(f"[1/3] Markdown w cache: {cache_file_md}")
         with open(cache_file_md, "r", encoding="utf-8") as f:
             return f.read()
 
     if not os.path.isfile(cache_file_html):
         if not doc.s3_uuid:
-            logger.warning(f"document_id: {document_id} Missing s3_uuid, skipping")
+            _log("Brak s3_uuid — nie mogę pobrać HTML")
             return None
 
         s3_key = f"{doc.s3_uuid}.html"
+        _log(f"[1/3] Sprawdzam HTML w S3...")
         if not s3_file_exist(s3_bucket, s3_key):
-            logger.error(f"document_id: {document_id} HTML not found in S3: {s3_key}")
+            _log("HTML nie znaleziony w S3")
             return None
 
+        _log(f"[2/3] Pobieram HTML z S3 ({s3_key[:40]}...)")
         if not s3_take_file(s3_bucket, s3_key, cache_file_html):
-            logger.error(f"document_id: {document_id} Failed to download from S3: {s3_key}")
+            _log("Nie udało się pobrać HTML z S3")
             return None
+    else:
+        _log(f"[1/3] HTML w cache: {cache_file_html}")
 
-    logger.info(f"document_id: {document_id} Converting HTML to markdown")
     html_size = os.path.getsize(cache_file_html)
+    _log(f"[3/3] Konwertuję HTML ({html_size // 1024} KB) do markdown (MarkItDown)...")
 
     mdit = MarkItDown()
     markdown_text = mdit.convert(cache_file_html).text_content
     reduction = calculate_reduction(html_size, len(markdown_text))
 
     if reduction < 30:
-        logger.debug(f"document_id: {document_id} MarkItDown reduction {reduction:.0f}%, trying html2markdown")
+        _log(f"  MarkItDown: redukcja {reduction:.0f}% — za mało, próbuję html2markdown...")
         with open(cache_file_html, "r", encoding="utf-8") as f:
             html = f.read()
         markdown_text = convert(html)
         reduction = calculate_reduction(html_size, len(markdown_text))
 
         if reduction < 30:
-            logger.debug(f"document_id: {document_id} html2markdown reduction {reduction:.0f}%, trying html2text")
+            _log(f"  html2markdown: redukcja {reduction:.0f}% — za mało, próbuję html2text...")
             h = html2text.HTML2Text()
             h.ignore_links = False
             h.ignore_images = False
@@ -74,7 +83,7 @@ def prepare_markdown(document_id, doc, cache_dir) -> str | None:
 
     with open(cache_file_md, "w", encoding="utf-8") as f:
         f.write(markdown_text)
-    logger.info(f"document_id: {document_id} Markdown saved ({len(markdown_text)} chars)")
+    _log(f"  Markdown zapisany ({len(markdown_text)} znaków, redukcja {reduction:.0f}%)")
 
     return markdown_text
 


### PR DESCRIPTION
## Summary

- **Stateful ARK Labs API** — reuses GPU session via cookies, ~2x cheaper for article extraction ($0.01/M input vs $0.49/M stateless)
- **Onet cleanup** — remove publication date, reading time, reaction counts from article view
- **B-101 backlog** — Track Obsidian Note Status for Articles (design decisions to make)

## Test results (stateful vs stateless)

| Mode | Tokens | Credits |
|------|--------|---------|
| Stateless | 5032 | ~2500 |
| **Stateful** | **2680** | **1314** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)