### PR TITLE
feat: unify S3 cache directory with document_prepare convention

### DIFF
--- a/backend/imports/CLAUDE.md
+++ b/backend/imports/CLAUDE.md
@@ -24,9 +24,10 @@ Incremental sync of documents from AWS DynamoDB and S3 webpage content to the lo
 1. Resolves DynamoDB table name and S3 bucket from SSM Parameter Store (or CLI overrides)
 2. Queries DynamoDB `DateIndex` GSI day-by-day from `--since` date to today (handles pagination)
 3. For each item, checks if URL already exists in local PostgreSQL (duplicate detection via `WebDocument.get_by_url()`)
-4. For `webpage` type items with `s3_uuid`: downloads `{uuid}.txt` and `{uuid}.html` from S3, saves locally to `data/`
+4. For `webpage` type items with `s3_uuid`: fetches `{uuid}.txt` and `{uuid}.html` from S3 into memory
 5. Inserts new documents via ORM: `WebDocument(url=url)` → set attributes → `session.add(doc)` + `session.commit()`
-6. Sets `document_state` to `DOCUMENT_INTO_DATABASE` (with S3 content) or `URL_ADDED` (without)
+6. After insert, saves S3 content to cache as `{CACHE_DIR}/{doc.id}/{doc.id}.html` (same convention as `document_prepare.py`, so downstream tools can reuse cached files without re-downloading from S3)
+7. Sets `document_state` to `DOCUMENT_INTO_DATABASE` (with S3 content) or `URL_ADDED` (without)
 
 **DynamoDB → PostgreSQL field mapping:**
 - `url` → `url`, `type` → `document_type`, `title` → `title`, `language` → `language`
@@ -53,7 +54,7 @@ cd backend
 - `--env ENV` — environment for SSM path (default: `dev`)
 - `--table TABLE` — DynamoDB table name override (skips SSM lookup)
 - `--bucket BUCKET` — S3 bucket name override (skips SSM lookup)
-- `--data-dir PATH` — local dir for S3 files (default: `data/`)
+- `--data-dir PATH` — cache dir for S3 files (default: `CACHE_DIR` config or `tmp/markdown`)
 - `-y`, `--yes` — skip confirmation prompt (for automation)
 
 Before executing any operations, the script displays source (AWS profile, region) and target (PostgreSQL host/db/port/user) information, then asks for confirmation (`Continue? [y/N]`). Use `-y` to skip the prompt.

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -14,6 +14,7 @@ Usage:
     ./imports/dynamodb_sync.py --since 2026-02-20 --limit 10
     ./imports/dynamodb_sync.py --since 2026-02-20 --skip-s3
     ./imports/dynamodb_sync.py --since 2026-02-20 --env dev --project lenie
+    ./imports/dynamodb_sync.py --since 2026-02-20 --data-dir /custom/cache
 """
 
 import argparse
@@ -111,61 +112,74 @@ def get_dynamodb_items(table_name: str, since_date: str) -> list[dict]:
     return all_items
 
 
-def download_s3_content(s3_client, bucket: str, s3_uuid: str, data_dir: str) -> tuple[str | None, str | None]:
-    """Download .txt and .html from S3, save locally, return (text_content, html_content)."""
+def fetch_s3_content(s3_client, bucket: str, s3_uuid: str) -> tuple[str | None, str | None]:
+    """Fetch .txt and .html from S3 into memory (no disk write)."""
     text_content = None
     html_content = None
 
     for ext, label in [(".txt", "text"), (".html", "html")]:
         key = f"{s3_uuid}{ext}"
-        local_path = os.path.join(data_dir, key)
 
         try:
             response = s3_client.get_object(Bucket=bucket, Key=key)
             content = response["Body"].read().decode("utf-8")
-
-            os.makedirs(data_dir, exist_ok=True)
-            with open(local_path, "w", encoding="utf-8") as f:
-                f.write(content)
 
             if ext == ".txt":
                 text_content = content
             else:
                 html_content = content
 
-            print(f"  S3: downloaded {key} ({len(content)} chars)")
+            print(f"  S3: fetched {key} ({len(content)} chars)")
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 print(f"  S3: {key} not found (skipping)")
             else:
-                print(f"  S3: error downloading {key}: {e}")
+                print(f"  S3: error fetching {key}: {e}")
 
     return text_content, html_content
 
 
+def save_cache_files(doc_id: int, text_content: str | None, html_content: str | None, cache_dir: str):
+    """Save S3 content to cache in document_prepare convention: {cache_dir}/{doc_id}/{doc_id}.ext"""
+    doc_dir = os.path.join(cache_dir, str(doc_id))
+    os.makedirs(doc_dir, exist_ok=True)
+
+    if html_content:
+        path = os.path.join(doc_dir, f"{doc_id}.html")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(html_content)
+        print(f"  Cache: saved {path} ({len(html_content)} chars)")
+
+    if text_content:
+        path = os.path.join(doc_dir, f"{doc_id}.txt")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text_content)
+        print(f"  Cache: saved {path} ({len(text_content)} chars)")
+
+
 def sync_item_to_postgres(item: dict, text_content: str | None, html_content: str | None,
-                          dry_run: bool, session=None) -> str:
-    """Insert a DynamoDB item into PostgreSQL via ORM. Returns 'added', 'skipped', or 'error'."""
+                          dry_run: bool, session=None) -> tuple[str, int | None]:
+    """Insert a DynamoDB item into PostgreSQL via ORM. Returns ('added'/'skipped'/'error', doc_id or None)."""
     url = item.get("url")
     if not url:
         print("  SKIP: no url in item")
-        return "error"
+        return "error", None
 
     if dry_run:
         doc_type = item.get("type", "link")
         title = item.get("title", "(no title)")
         print(f"  DRY-RUN: would add [{doc_type}] {title[:80]}")
-        return "added"
+        return "added", None
 
     try:
         existing = WebDocument.get_by_url(session, url)
     except Exception as e:
         print(f"  ERROR checking URL {url}: {e}")
-        return "error"
+        return "error", None
 
     if existing is not None:
         print(f"  SKIP: already exists (id={existing.id}): {url}")
-        return "skipped"
+        return "skipped", None
 
     try:
         doc = WebDocument(url=url)
@@ -197,12 +211,12 @@ def sync_item_to_postgres(item: dict, text_content: str | None, html_content: st
         session.commit()
 
         print(f"  ADDED (id={doc.id}): [{doc_type}] {doc.title or url}")
-        return "added"
+        return "added", doc.id
 
     except SQLAlchemyError as e:
         session.rollback()
         print(f"  ERROR adding {url}: {e}")
-        return "error"
+        return "error", None
 
 
 def main():
@@ -216,9 +230,13 @@ def main():
     parser.add_argument("--env", default="dev", help="Environment for SSM path (default: dev)")
     parser.add_argument("--table", default=None, help="DynamoDB table name override (skips SSM lookup)")
     parser.add_argument("--bucket", default=None, help="S3 bucket name override (skips SSM lookup)")
-    parser.add_argument("--data-dir", default="data", help="Local dir for S3 files (default: data/)")
+    parser.add_argument("--data-dir", default=None, help="Cache dir for S3 files (default: CACHE_DIR config or tmp/markdown)")
     parser.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
     args = parser.parse_args()
+
+    # Resolve cache dir default from config
+    if args.data_dir is None:
+        args.data_dir = cfg.get("CACHE_DIR") or "tmp/markdown"
 
     # Validate date format
     try:
@@ -306,14 +324,19 @@ def main():
                     skipped += 1
                     continue
 
-            # Download S3 content for webpage items with s3_uuid
+            # Fetch S3 content into memory (no disk write yet)
             s3_uuid = item.get("s3_uuid")
             doc_type = item.get("type", "link")
 
             if s3_uuid and doc_type == "webpage" and not args.skip_s3 and not args.dry_run:
-                text_content, html_content = download_s3_content(s3_client, bucket, s3_uuid, args.data_dir)
+                text_content, html_content = fetch_s3_content(s3_client, bucket, s3_uuid)
 
-            result = sync_item_to_postgres(item, text_content, html_content, args.dry_run, session=session)
+            result, doc_id = sync_item_to_postgres(item, text_content, html_content, args.dry_run, session=session)
+
+            # Save cache files after successful insert (doc_id now available)
+            if result == "added" and doc_id and (text_content or html_content):
+                save_cache_files(doc_id, text_content, html_content, args.data_dir)
+
             if result == "added":
                 added += 1
             elif result == "skipped":

--- a/backend/imports/feeds.yaml
+++ b/backend/imports/feeds.yaml
@@ -136,3 +136,12 @@ feeds:
   - to \d+ Regions
   - in the .* AWS Region
   - Amazon WorkSpace
+- name: Niebezpiecznik.pl
+  type: rss
+  url: https://niebezpiecznik.pl/feed/
+  language: pl
+  project: technologia
+  tags:
+  - security
+  - cyberbezpieczeństwo
+  - polska

--- a/backend/imports/migrate_data_to_cache.py
+++ b/backend/imports/migrate_data_to_cache.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""One-time migration: move S3 files from data/ to CACHE_DIR/{doc_id}/{doc_id}.ext
+
+Reads UUID-named files from data/, queries PostgreSQL for doc.id by s3_uuid,
+and moves files to the cache directory convention used by document_prepare.py.
+
+Usage:
+    cd backend
+    python imports/migrate_data_to_cache.py
+    python imports/migrate_data_to_cache.py --dry-run
+    python imports/migrate_data_to_cache.py --source-dir data --target-dir tmp/markdown
+"""
+
+import argparse
+import os
+import shutil
+import sys
+from glob import glob
+
+from sqlalchemy import select
+
+from library.config_loader import load_config
+from library.db.models import WebDocument
+from library.db.engine import get_session
+
+cfg = load_config()
+
+
+def get_s3_uuid_to_doc_id_map(session, s3_uuids: list[str]) -> dict[str, int]:
+    """Query DB for doc.id by s3_uuid. Returns {s3_uuid: doc_id} mapping."""
+    stmt = select(WebDocument.id, WebDocument.s3_uuid).where(WebDocument.s3_uuid.in_(s3_uuids))
+    rows = session.execute(stmt).all()
+    return {row.s3_uuid: row.id for row in rows}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate S3 files from data/ to cache dir")
+    parser.add_argument("--source-dir", default="data", help="Source directory with UUID-named files (default: data)")
+    parser.add_argument("--target-dir", default=None, help="Target cache dir (default: CACHE_DIR config or tmp/markdown)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only, no file moves")
+    parser.add_argument("--delete-source", action="store_true", help="Delete source files after successful move")
+    args = parser.parse_args()
+
+    if args.target_dir is None:
+        args.target_dir = cfg.get("CACHE_DIR") or "tmp/markdown"
+
+    if not os.path.isdir(args.source_dir):
+        print(f"ERROR: source directory '{args.source_dir}' does not exist")
+        sys.exit(1)
+
+    # Find all UUID-named files (html and txt)
+    files = glob(os.path.join(args.source_dir, "*.html")) + glob(os.path.join(args.source_dir, "*.txt"))
+    if not files:
+        print(f"No .html/.txt files found in {args.source_dir}")
+        return
+
+    # Extract unique s3_uuids from filenames
+    s3_uuids = set()
+    for f in files:
+        basename = os.path.basename(f)
+        s3_uuid = os.path.splitext(basename)[0]
+        s3_uuids.add(s3_uuid)
+
+    print(f"Found {len(files)} files ({len(s3_uuids)} unique UUIDs) in {args.source_dir}")
+    print(f"Target: {args.target_dir}")
+    if args.dry_run:
+        print("Mode: DRY-RUN")
+    print()
+
+    # Query DB for mapping
+    session = get_session()
+    try:
+        uuid_to_id = get_s3_uuid_to_doc_id_map(session, list(s3_uuids))
+    finally:
+        session.close()
+
+    print(f"DB mapping: {len(uuid_to_id)}/{len(s3_uuids)} UUIDs found in database\n")
+
+    moved = 0
+    skipped = 0
+    not_found = 0
+
+    for s3_uuid in sorted(s3_uuids):
+        doc_id = uuid_to_id.get(s3_uuid)
+        if doc_id is None:
+            print(f"  SKIP: {s3_uuid} — not found in database")
+            not_found += 1
+            continue
+
+        doc_dir = os.path.join(args.target_dir, str(doc_id))
+
+        for ext in [".html", ".txt"]:
+            src = os.path.join(args.source_dir, f"{s3_uuid}{ext}")
+            if not os.path.isfile(src):
+                continue
+
+            dst = os.path.join(doc_dir, f"{doc_id}{ext}")
+
+            if os.path.isfile(dst):
+                print(f"  SKIP: {dst} already exists")
+                skipped += 1
+                continue
+
+            if args.dry_run:
+                print(f"  DRY-RUN: {src} -> {dst}")
+                moved += 1
+            else:
+                os.makedirs(doc_dir, exist_ok=True)
+                shutil.copy2(src, dst)
+                print(f"  MOVED: {src} -> {dst}")
+                moved += 1
+
+                if args.delete_source:
+                    os.remove(src)
+                    print(f"  DELETED: {src}")
+
+    print("\n=== Summary ===")
+    print(f"Moved: {moved}")
+    print(f"Skipped (already exist): {skipped}")
+    print(f"Not found in DB: {not_found}")
+
+    if not args.dry_run and not args.delete_source and moved > 0:
+        print(f"\nSource files kept in {args.source_dir}. Use --delete-source to remove them after migration.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **dynamodb_sync.py**: S3 files now saved to `CACHE_DIR/{doc_id}/{doc_id}.html` (same convention as `document_prepare.py`) instead of `data/{s3_uuid}.html` — downstream tools can reuse cached files without re-downloading from S3
- **`--data-dir` default** changed from hardcoded `data/` to `CACHE_DIR` from config (Vault/env), fallback `tmp/markdown`
- **migrate_data_to_cache.py**: one-time migration script to move existing UUID-named files from `data/` to the new cache structure
- **feeds.yaml**: added niebezpiecznik.pl RSS feed

## Test plan
- [ ] Run `cd backend && PYTHONPATH=. uvx pytest tests/unit/ -v` — all 70 tests pass
- [ ] Run `uvx ruff check backend/imports/dynamodb_sync.py` — no lint issues
- [ ] Verify `python imports/dynamodb_sync.py --help` shows new `--data-dir` default
- [ ] Run migration: `python imports/migrate_data_to_cache.py --dry-run` then `--delete-source`
- [ ] After full sync, verify files appear in `CACHE_DIR/{doc_id}/` and are reused by `document_prepare.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)