### PR TITLE
fix: resolve remaining 6 CodeQL code scanning alerts

### DIFF
--- a/backend/library/website/website_download_context.py
+++ b/backend/library/website/website_download_context.py
@@ -78,9 +78,8 @@ def webpage_text_clean(url: str, content: str):
             for regex in site_rules[url_path]["remove_string_regexp"]:
                 content = remove_text_regex(content, regex)
 
-    content = re.sub(r'\n\s+\n', '\n\n', content)
-    content = re.sub(r'\n\n+', '\n\n', content)
-    content = re.sub(r'\n+$', '', content)
-    content = re.sub(r'^\n+', '', content)
+    content = re.sub(r'\n[^\S\n]+\n', '\n\n', content)
+    content = re.sub(r'\n{2,}', '\n\n', content)
+    content = content.strip('\n')
 
     return content

--- a/backend/scripts/notion_changelog.py
+++ b/backend/scripts/notion_changelog.py
@@ -139,7 +139,6 @@ def main():
     args = parser.parse_args()
 
     config = load_config()
-    logging.debug("Config backend: %s", config.get('SECRETS_BACKEND', 'env'))
 
     db_host = config.get("POSTGRESQL_HOST", "localhost")
     db_port = config.get("POSTGRESQL_PORT", "5432")

--- a/shared_python/unified-config-loader/unified_config_loader/backends/aws.py
+++ b/shared_python/unified-config-loader/unified_config_loader/backends/aws.py
@@ -27,7 +27,7 @@ class AWSSSMBackend:
             sys.exit(1)
 
         prefix = f"/{project_code}/{secrets_env}/"
-        logger.info("AWS SSM: reading parameters under %s (region: %s)", prefix, aws_region)
+        logger.debug("AWS SSM: reading parameters (region: %s)", aws_region)
 
         try:
             session = boto3.Session(region_name=aws_region)
@@ -45,7 +45,7 @@ class AWSSSMBackend:
                     params[key] = param["Value"]
 
         except Exception as exc:
-            logger.error("Failed to load config from AWS SSM (%s): %s", prefix, exc)
+            logger.error("Failed to load config from AWS SSM: %s", exc)
             sys.exit(1)
 
         if not params:

--- a/shared_python/unified-config-loader/unified_config_loader/config.py
+++ b/shared_python/unified-config-loader/unified_config_loader/config.py
@@ -58,8 +58,7 @@ def _create_backend(name: str):
     if name == "aws":
         return AWSSSMBackend()
     logger.error(
-        "Unknown SECRETS_BACKEND value: '%s'. Valid options: %s",
-        name,
+        "Unknown SECRETS_BACKEND value. Valid options: %s",
         ", ".join(sorted(_KNOWN_BACKENDS)),
     )
     sys.exit(1)
@@ -98,7 +97,7 @@ def load_config() -> Config:
         logger.info("Config: loaded .env from %s", dotenv_path)
 
     backend_name = os.environ.get("SECRETS_BACKEND", "env")
-    logger.debug("Config: using '%s' backend", backend_name)
+    logger.debug("Config: backend selected")
     backend = _create_backend(backend_name)
     _config = Config(backend.load())
 


### PR DESCRIPTION
## Summary
- **Clear-text logging** (#3, #4, #6, #38, #39) — fully redact secret paths, backend names, and config values from all log messages in config_loader and AWS SSM backend
- **Polynomial regex ReDoS** (#1) — replace `\s+` with `[^\S\n]+` in `webpage_text_clean()` to prevent catastrophic backtracking on inputs with many newlines

## Test plan
- [x] Backend unit tests pass (70 passed, 25 skipped)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)