### PR TITLE
fix: prevent IndexError in links_correct

### DIFF
--- a/backend/library/lenie_markdown.py
+++ b/backend/library/lenie_markdown.py
@@ -61,18 +61,17 @@ def links_correct(text):
     inside_link = False
     i=0
     while i < len(text):
-        if text[i] == "h" and text[i+1] == "t" and text[i+2] == "t" and text[i+3] == "p" and text[i+4] == "s" and \
-            text[i+5] == ":" and text[i+6] == "/" and text[i+7] == "/":
+        if i + 7 < len(text) and text[i:i+8] == "https://":
             inside_link = True
-            i+=8
+            i += 8
             text_new = text_new + "https://"
             continue
 
-        if inside_link and text[i] == " " or text[i] == ")" or text[i] == "]":
+        if inside_link and (text[i] == " " or text[i] == ")" or text[i] == "]"):
             inside_link = False
 
-        if inside_link and text[i] == '\r' and text[i+1] == '\n':
-            i+=2
+        if inside_link and text[i] == '\r' and i + 1 < len(text) and text[i+1] == '\n':
+            i += 2
             continue
 
         if inside_link and text[i] == '\n':


### PR DESCRIPTION
## Summary
- Fix `IndexError: string index out of range` in `links_correct()` when URL appears near end of text
- Add bounds checking before accessing `text[i+N]` offsets
- Fix operator precedence bug in link-end detection (`or` without parentheses)

## Test plan
- [x] Crash reproduced via `article_browser.py` on document ID 8805
- [ ] Re-run `article_browser.py` review on same document to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)