### PR TITLE
feat: article_browser --dump mode, AWS roadmap, ADR-016

### DIFF
--- a/.claude/commands/obsidian-note.md
+++ b/.claude/commands/obsidian-note.md
@@ -12,16 +12,22 @@ Execute ALL steps below in order. Do NOT skip step 4 (database update).
 
 ### Step 1: Fetch article from database
 
-Run Python via `uv run` in the `backend/` directory to get article content:
-- Title, URL, date, state, language, source
-- Full text (`text_md` or `text` or `text_raw`)
-- Current `reviewed_at` and `obsidian_note_paths` values
+Use article_browser.py `--dump` mode — it outputs UTF-8 JSON with all metadata and full text:
+
+```bash
+cd backend && .venv/Scripts/python imports/article_browser.py --dump --id <ARTICLE_ID>
+```
+
+The JSON contains: `id`, `title`, `url`, `created_at`, `document_state`, `document_type`, `language`, `source`, `author`, `reviewed_at`, `obsidian_note_paths`, `text_length`, `text`.
 
 Display article metadata to the user.
 
 ### Step 2: Search Obsidian vault for related notes
 
-Search `C:\Users\ziutus\Obsydian\personal\02-wiedza` using Grep and Glob for notes related to the article's topic. Check keywords from the article title and content. Report what was found.
+Search `C:\Users\ziutus\Obsydian\personal\02-wiedza` using Grep and Glob for notes related to the article's topic:
+1. First search country files in `Kraje/**/*.md` (Glob + Grep)
+2. Then search by keywords from the article title and content
+3. Report what was found
 
 ### Step 3: Discuss with user and create/update notes
 
@@ -39,31 +45,39 @@ Wait for user input on what to create/update. Then create/update the Obsidian .m
 
 ### Step 4: Update database (MANDATORY — never skip)
 
-After creating/updating Obsidian notes, ALWAYS run Python to update the article in the database:
+After creating/updating Obsidian notes, ALWAYS update the article in the database.
+Use article_browser.py's ORM session pattern:
 
-```python
-# Append new note paths to obsidian_note_paths
+```bash
+cd backend && .venv/Scripts/python -c "
+from datetime import datetime
+from library.db.engine import get_session
+from library.db.models import WebDocument
+session = get_session()
+doc = WebDocument.get_by_id(session, <ARTICLE_ID>)
 paths = list(doc.obsidian_note_paths or [])
-paths.append("relative/path/to/note.md")  # relative to vault root
+paths.append('relative/path/to/note.md')
 doc.obsidian_note_paths = paths
-
-# Set reviewed_at if not already set
 if not doc.reviewed_at:
     doc.reviewed_at = datetime.now()
-
 session.commit()
+print(f'obsidian_note_paths: {doc.obsidian_note_paths}')
+print(f'reviewed_at: {doc.reviewed_at}')
+session.close()
+"
 ```
 
 Report the updated `obsidian_note_paths` and `reviewed_at` to confirm success.
 
 ### Step 5: Update cross-references (if applicable)
 
-If the article topic relates to existing notes (e.g., `Wojny dronowe.md`, country files), add a brief entry with a link to the new note using `[[Note Name]]` syntax.
+If the article topic relates to existing notes (e.g., country files, topic notes), add a brief entry with a link to the new note using `[[Note Name]]` syntax. Also update notes about countries/organizations mentioned in the article (e.g., if the article mentions Russia or China cooperation, update Rosja.md and Chiny.md too).
 
 ## Important
 
 - All notes and communication in **Polish**
 - Obsidian vault root: `C:\Users\ziutus\Obsydian\personal`
 - Knowledge directory: `C:\Users\ziutus\Obsydian\personal\02-wiedza`
-- Database runs in `backend/` directory, use `uv run` to execute Python
+- **NEVER use `uv run`** — it does not work in this project (hatchling build error)
+- Run commands from `backend/` dir: `cd backend && .venv/Scripts/python ...`
 - Always include source with Lenie AI id

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -10,6 +10,7 @@ Usage:
     python imports/article_browser.py --review --id 8786                  # Start from specific article
     python imports/article_browser.py --show --id 8799                    # Display article and exit (non-interactive)
     python imports/article_browser.py --show --id 8799 --check-urls       # Display with link validation
+    python imports/article_browser.py --dump --id 8805                    # JSON output for Claude Code
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW   # Articles needing manual review
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW --format ids    # Just IDs (for scripting)
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW --format short  # IDs + titles
@@ -714,12 +715,12 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     print(f"    Status: {doc.document_state} → MD_SIMPLIFIED → EMBEDDING_EXIST")
 
     try:
-        confirm = input("  Potwierdzasz? [y/N]: ").strip().lower()
+        confirm = input("  Potwierdzasz? [Y/n]: ").strip().lower()
     except (KeyboardInterrupt, EOFError):
         print()
         return False
 
-    if confirm != "y":
+    if confirm == "n":
         print("  Anulowano.")
         return False
 
@@ -925,6 +926,45 @@ def action_mark_review(doc, session):
         print(f"  BŁĄD zmiany statusu: {e}")
 
 
+def cmd_dump(session, article_id: Optional[int] = None):
+    """Wypisz artykuł jako JSON na stdout — do użycia przez Claude Code slash commands.
+
+    Zawiera metadane + pełny tekst (preferuje text_md > text > text_raw).
+    Wyjście jest UTF-8 JSON, bez interakcji, bez efektów ubocznych.
+    """
+    import json
+
+    if article_id is None:
+        print(json.dumps({"error": "--dump wymaga --id <ARTICLE_ID>"}), file=sys.stderr)
+        sys.exit(1)
+
+    doc = WebDocument.get_by_id(session, article_id)
+    if doc is None:
+        print(json.dumps({"error": f"Dokument {article_id} nie znaleziony."}), file=sys.stderr)
+        sys.exit(1)
+
+    text = doc.text_md or doc.text or doc.text_raw or ""
+
+    result = {
+        "id": doc.id,
+        "title": doc.title,
+        "url": doc.url,
+        "created_at": doc.created_at.isoformat() if doc.created_at else None,
+        "document_state": doc.document_state,
+        "document_type": doc.document_type,
+        "language": doc.language,
+        "source": doc.source,
+        "author": doc.author,
+        "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
+        "obsidian_note_paths": doc.obsidian_note_paths or [],
+        "text_length": len(text),
+        "text": text,
+    }
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
 def cmd_show(session, article_id: Optional[int] = None, check_urls: bool = False):
     """Wyświetl artykuł (metadane + treść) i zakończ — tryb nieinteraktywny."""
     if article_id is None:
@@ -948,6 +988,13 @@ def cmd_show(session, article_id: Optional[int] = None, check_urls: bool = False
     print(f"  Typ:     {doc.document_type}")
     print(f"  Język:   {doc.language}")
     print(f"  Źródło:  {doc.source}")
+    obsidian_paths = doc.obsidian_note_paths or []
+    if obsidian_paths:
+        print(f"  Obsidian: {len(obsidian_paths)} notatek")
+        for op in obsidian_paths:
+            print(f"    - {op}")
+    reviewed_str = doc.reviewed_at.strftime("%Y-%m-%d %H:%M") if doc.reviewed_at else "nie"
+    print(f"  Reviewed: {reviewed_str}")
 
     article = get_article_text(doc, session)
     if article:
@@ -996,6 +1043,13 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
         print(f"  Portal:  {detected_portal}")
         print(f"  URL:     {doc.url}")
         print(f"  Stan:    {doc.document_state}")
+        obsidian_paths = doc.obsidian_note_paths or []
+        if obsidian_paths:
+            print(f"  Obsidian: {len(obsidian_paths)} notatek")
+            for op in obsidian_paths:
+                print(f"    - {op}")
+        reviewed_str = doc.reviewed_at.strftime("%Y-%m-%d %H:%M") if doc.reviewed_at else "nie"
+        print(f"  Reviewed: {reviewed_str}")
 
         article = None  # lazy load (dict: text, links, images)
 
@@ -1149,6 +1203,7 @@ def main():
     group.add_argument("--list", action="store_true", help="Lista artykułów")
     group.add_argument("--review", action="store_true", help="Interaktywny przegląd")
     group.add_argument("--show", action="store_true", help="Wyświetl artykuł i zakończ (wymaga --id)")
+    group.add_argument("--dump", action="store_true", help="Wypisz artykuł jako JSON (do użycia przez Claude Code)")
     group.add_argument("--notes", action="store_true", help="Pokaż zapisane notatki do przetworzenia")
 
     parser.add_argument("--since", default=None, help="Data od (YYYY-MM-DD)")
@@ -1172,7 +1227,9 @@ def main():
     session = get_session()
 
     try:
-        if args.show:
+        if args.dump:
+            cmd_dump(session, article_id=args.id)
+        elif args.show:
             cmd_show(session, article_id=args.id, check_urls=args.check_urls)
         elif args.list:
             cmd_list(session, since=args.since, portal=args.portal,

--- a/docs/adr-016-cloudformation-vs-cdk.md
+++ b/docs/adr-016-cloudformation-vs-cdk.md
@@ -1,0 +1,76 @@
+# ADR-016: CloudFormation as Primary IaC — Evaluate CDK for Future Comparison
+
+**Date:** 2026-03-31
+**Status:** Accepted (CloudFormation); Proposed (CDK evaluation)
+**Decision Makers:** Ziutus
+
+## Context
+
+Project Lenie's AWS infrastructure is managed by **29 CloudFormation templates** deployed via a universal `deploy.sh` script. This setup was built incrementally across 3 infrastructure sprints (Feb–Mar 2026) and now covers the entire AWS stack: VPC, RDS, DynamoDB, SQS, S3, 11 Lambda functions, 2 API Gateways, Step Functions, CloudFront, ACM, and budget controls.
+
+The project owner wants to evaluate **AWS CDK** as an alternative/complementary IaC tool for learning purposes and to make an informed long-term decision. The project also uses Terraform (VPC + bastion) and Kubernetes (Kustomize) as secondary IaC tools for comparison.
+
+## Decision
+
+1. **CloudFormation remains the primary IaC tool** for all production infrastructure.
+2. **A CDK evaluation will be conducted** by reimplementing a self-contained subset of infrastructure (e.g., SQS → Lambda → DynamoDB pipeline) in CDK.
+3. The evaluation is **non-urgent** — it will happen when the owner has bandwidth, after AWS restoration (see [aws-roadmap.md](aws-roadmap.md), Phase 5).
+4. Both implementations (CF and CDK) will coexist in the repository for comparison.
+
+## Rationale — Why CloudFormation Now
+
+| Advantage | Detail |
+|-----------|--------|
+| **Battle-tested** | 29 templates, 3 sprints of refinement, universal deploy script |
+| **No build step** | YAML is directly deployable — no compilation, no CDK bootstrap |
+| **Full AWS coverage** | Every AWS feature available on day 1, no waiting for CDK construct updates |
+| **Simple mental model** | Declarative — describe desired state, AWS figures out the rest |
+| **No runtime dependency** | No Node.js/Python CDK library to manage, no `cdk synth` step |
+| **Drift detection** | Native CloudFormation drift detection |
+
+## Rationale — Why Evaluate CDK
+
+| Advantage | Detail |
+|-----------|--------|
+| **Type safety** | TypeScript/Python constructs catch errors at compile time vs runtime |
+| **L2/L3 constructs** | Higher-level abstractions encode AWS best practices (e.g., `Function` auto-creates IAM role, log group) |
+| **Less boilerplate** | Equivalent infrastructure in ~60% fewer lines |
+| **Testing** | Infrastructure testable with jest/pytest — assert on synthesized CloudFormation |
+| **Reusable patterns** | Custom constructs shareable across projects |
+| **AWS investment** | CDK is where AWS is investing most IaC development effort |
+
+## Evaluation Plan
+
+1. **Scope:** Reimplement the SQS + Lambda (`sqs-weblink-put-into`) + DynamoDB pipeline
+2. **Language:** Python CDK (to stay in the project's primary language) or TypeScript (for stronger typing)
+3. **Location:** `infra/aws/cdk/` alongside existing `infra/aws/cloudformation/`
+4. **Comparison criteria:**
+   - Lines of code for equivalent functionality
+   - Developer experience (IDE support, error messages, documentation)
+   - Deployment speed and reliability
+   - Testing capabilities
+   - Drift handling
+   - Learning curve
+5. **Tool support:** [AWS Serverless plugin](https://claude.com/plugins/aws-serverless) for Claude Code
+6. **Output:** Findings documented in this ADR (update status to "Evaluated" with conclusions)
+
+## Risks
+
+- **CDK bootstrap** adds a CloudFormation stack (`CDKToolkit`) per account/region — minor but permanent overhead.
+- **Version drift** — CDK library updates may introduce breaking changes; CF YAML is stable.
+- **Two systems to maintain** during evaluation period — mitigated by limiting CDK scope to one pipeline.
+- **CDK-generated CloudFormation** is verbose and hard to debug when things go wrong — you're debugging generated code, not code you wrote.
+
+## Consequences
+
+- CloudFormation templates in `infra/aws/cloudformation/` remain the source of truth.
+- No CDK work until Phase 5 of the [AWS Roadmap](aws-roadmap.md) — after AWS restoration and CI/CD.
+- When CDK evaluation starts, install the AWS Serverless plugin for Claude Code.
+- Decision will be updated with evaluation findings — possible outcomes: (a) stay with CF, (b) migrate to CDK, (c) use CDK for new infra / CF for existing.
+
+## References
+
+- [AWS Roadmap](aws-roadmap.md) — full infrastructure development plan
+- [Technology Choices](technology-choices.md) — current tool rationale
+- [System Evolution](system-evolution.md) — infrastructure history
+- [CloudFormation deploy docs](../infra/aws/cloudformation/CLAUDE.md) — operational guide

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -801,3 +801,14 @@ The question arose whether to replace this custom layer with a framework like **
 ### Summary
 
 Track article review status and Obsidian note creation using two new columns on `web_documents` (`reviewed_at`, `obsidian_note_path`) for the current single-user system. Migrate to a `user_document_reviews` join table when multi-user authentication (B-33) is implemented in Phase 9. This avoids polluting the `document_state` processing pipeline with user-action states, which are orthogonal to technical document processing.
+
+## ADR-016: CloudFormation as Primary IaC — Evaluate CDK for Future Comparison
+
+**Date:** 2026-03-31
+**Status:** Accepted (CloudFormation); Proposed (CDK evaluation)
+**Decision Makers:** Ziutus
+**Full document:** [adr-016-cloudformation-vs-cdk.md](adr-016-cloudformation-vs-cdk.md)
+
+### Summary
+
+CloudFormation remains the primary IaC tool (29 battle-tested templates). A future CDK evaluation is planned — reimplement a self-contained pipeline (SQS + Lambda + DynamoDB) in CDK to compare developer experience, boilerplate, type safety, and testing. Not started — scheduled for Phase 5 of the [AWS Roadmap](aws-roadmap.md), after AWS restoration and CI/CD. See full document for evaluation plan and comparison criteria.

--- a/docs/aws-roadmap.md
+++ b/docs/aws-roadmap.md
@@ -1,0 +1,112 @@
+# AWS Infrastructure Roadmap
+
+> Plan rozwoju infrastruktury AWS w Project Lenie. Dokument zbiorczy — łączy informacje z [backlog-reference.md](backlog-reference.md), [aws-sync-backlog.md](aws-sync-backlog.md), [technology-choices.md](technology-choices.md) i [architecture-decisions.md](architecture-decisions.md).
+>
+> **Last updated:** 2026-03-31
+
+## Current State
+
+### What works (production — application account)
+
+- **29 CloudFormation templates** managing: VPC, RDS PostgreSQL, DynamoDB, SQS, S3, 11 Lambda functions, 2 API Gateways, Step Functions, CloudFront, ACM, budgets
+- **API Gateway** as secure entry point (API keys, no NAT Gateway)
+- **DynamoDB + SQS** as always-available buffer for incoming documents (mobile → cloud → local sync)
+- **$8/month budget target** with SCPs and budget alerts
+- **Deploy script**: `infra/aws/cloudformation/deploy.sh` (universal create/update/delete)
+
+### What's on hold
+
+- **Lambda/API Gateway deployment** — not actively deployed. Changes are developed locally (NAS/Docker) and tracked in [aws-sync-backlog.md](aws-sync-backlog.md)
+- **CI/CD** — all pipelines inactive, configuration files remain in repo
+
+### What's active (local)
+
+- **NAS (QNAP)**: PostgreSQL (port 5434), Flask backend (port 5055), Vault (port 8210)
+- **Docker Compose**: local development stack (PostgreSQL + Flask + React)
+
+## Phase 1: Prerequisites (before AWS can be restored)
+
+| ID | Task | Status | Notes |
+|----|------|--------|-------|
+| [B-68](backlog-reference.md) | Upgrade Python Lambda runtime to 3.12+ | backlog | Python 3.11 EOL: Oct 2027. SSM parameter makes this straightforward |
+| [B-75](backlog-reference.md) | Standardize Node.js to 24 LTS | backlog | Docker already on 24, update docs/CI |
+| — | Apply [aws-sync-backlog.md](aws-sync-backlog.md) changes | pending | DB schema (uuid rename), Lambda code, DynamoDB compatibility |
+| [B-64](backlog-reference.md) | Verify pre-commit secret detection | backlog | Before any CI/CD restoration |
+
+## Phase 2: CI/CD Restoration
+
+| ID | Task | Status | Depends on |
+|----|------|--------|------------|
+| [B-70](backlog-reference.md) | Common prerequisites (test harness, lint, Docker build) | backlog | Phase 1 |
+| [B-71](backlog-reference.md) | GitHub Actions pipeline | backlog | B-70 |
+| [B-72](backlog-reference.md) | CircleCI pipeline | backlog | B-70 |
+| [B-73](backlog-reference.md) | GitLab CI pipeline | backlog | B-70 |
+| [B-74](backlog-reference.md) | Jenkins pipeline | backlog | B-70 |
+| [B-76](backlog-reference.md) | Restore pytest-html for CI reports | backlog | B-70 |
+
+**Goal:** At least one working CI/CD pipeline (likely GitHub Actions) before restoring Lambda deployments.
+
+## Phase 3: Security Hardening
+
+| ID | Task | Status | Notes |
+|----|------|--------|-------|
+| [B-86](backlog-reference.md) | Triage clear-text logging (12 HIGH) | backlog | CodeQL findings |
+| [B-87](backlog-reference.md) | Fix stack trace exposure (7 MEDIUM) | backlog | |
+| [B-88](backlog-reference.md) | Review reflected XSS (8 MEDIUM) | backlog | |
+| [B-89](backlog-reference.md) | Fix ReDoS vulnerability | backlog | |
+| [B-90](backlog-reference.md) | Add timeout to all requests calls | backlog | |
+| [B-91](backlog-reference.md) | Migrate SQL f-strings to parameterized queries | backlog | Consider combining with psycopg3 migration |
+
+## Phase 4: AWS Restoration & Sync
+
+1. Apply all pending changes from [aws-sync-backlog.md](aws-sync-backlog.md)
+2. Rebuild Lambda layers with Python 3.12+
+3. Re-deploy CloudFormation stacks to application account
+4. Verify API Gateway endpoints match local Flask routes
+5. Test DynamoDB → SQS → RDS pipeline end-to-end
+
+## Phase 5: IaC Comparison — CloudFormation vs CDK
+
+**Status:** Not started. See [ADR-016](adr-016-cloudformation-vs-cdk.md) for decision context.
+
+**Plan:**
+1. Pick a self-contained subset of infrastructure (e.g., SQS + Lambda + DynamoDB pipeline)
+2. Reimplement in CDK (TypeScript or Python)
+3. Compare: developer experience, template size, type safety, testing, drift detection
+4. Document findings — decide whether to migrate, keep CF, or use both
+5. **Tool:** Install [AWS Serverless plugin](https://claude.com/plugins/aws-serverless) for Claude Code when starting CDK work
+
+**Why CDK is interesting:**
+- Type-safe constructs (vs YAML/JSON strings)
+- Built-in best practices (L2/L3 constructs)
+- Testing with standard frameworks (jest, pytest)
+- Smaller codebase for equivalent infrastructure
+- Growing community and AWS investment
+
+**Why CF may still be preferred:**
+- No build step — YAML is directly deployable
+- Full AWS feature coverage on day 1
+- Existing 29 templates + deploy.sh are battle-tested
+- Simpler mental model (declarative, no code execution)
+- No CDK bootstrap required
+
+## Phase 6: Account Migration
+
+**Target:** Migrate from application account → target account when everything is ready (including RDS data).
+
+Prerequisites:
+- All phases above completed
+- Data migration strategy for RDS (pg_dump/restore or DMS)
+- DNS/CloudFront reconfiguration
+- Vault secrets re-provisioned on new account
+- All SSM parameters recreated
+
+## Future Directions
+
+| Direction | Notes |
+|-----------|-------|
+| **Graph database (Neo4j)** | [B-102](backlog-reference.md) — evaluate Neo4j AuraDB Free for document relationships |
+| **MCP server for Lenie** | Expose search/retrieval to Claude Desktop via MCP (see [system-evolution.md](system-evolution.md)) |
+| **Serverless YouTube processing** | [B-67](backlog-reference.md) — choose compute model (Lambda vs Fargate vs Step Functions) |
+| **psycopg3 migration** | Would solve SQL injection concerns (B-91) via server-side parameter binding |
+| **Kubernetes (GKE)** | Alternative deployment target, already has Kustomize configs in `infra/kubernetes/` |


### PR DESCRIPTION
## Summary
- **article_browser.py**: new `--dump` mode (JSON for Claude Code), default `[Y/n]`, show obsidian paths in review
- **obsidian-note slash command**: uses `--dump` instead of inline Python (no more quote escaping issues)
- **docs/aws-roadmap.md**: consolidated 6-phase AWS infrastructure plan
- **docs/adr-016-cloudformation-vs-cdk.md**: CF stays primary, CDK evaluation planned for Phase 5

## Test plan
- [ ] `cd backend && .venv/Scripts/python imports/article_browser.py --dump --id 8805` outputs valid JSON
- [ ] `/obsidian-note 8805` uses --dump and works without quote confirmation prompts
- [ ] No AWS account numbers in committed docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)