### PR TITLE
fix: use shared CACHE_DIR for freedom_house_import.py

### DIFF
--- a/backend/imports/freedom_house_import.py
+++ b/backend/imports/freedom_house_import.py
@@ -22,7 +22,8 @@ from typing import Optional
 from urllib.request import urlopen, Request
 from urllib.error import URLError
 
-CACHE_DIR = os.path.join(os.path.dirname(__file__), "tmp")
+_BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CACHE_DIR = os.environ.get("CACHE_DIR") or os.path.join(_BACKEND_DIR, "tmp")
 CACHE_FILE = os.path.join(CACHE_DIR, "freedom_house.csv")
 
 # OWID indicator IDs for Freedom House data


### PR DESCRIPTION
## Summary

- Use `backend/tmp/` (via `CACHE_DIR` env var) instead of `imports/tmp/`, consistent with other backend scripts (`webdocument_md_decode.py`, `article_browser.py`, etc.)

## Test plan

- [ ] Verify `--download` saves CSV to `backend/tmp/freedom_house.csv` (not `backend/imports/tmp/`)
- [ ] Verify `CACHE_DIR` env var override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)