### PR TITLE
feat: add social_media_post document type

### DIFF
--- a/backend/database/init/09-create-lookup-tables.sql
+++ b/backend/database/init/09-create-lookup-tables.sql
@@ -56,7 +56,7 @@ INSERT INTO public.document_status_error_types (name) VALUES
     ('CAPTIONS_FETCH_ERROR')
 ON CONFLICT (name) DO NOTHING;
 
--- document_types (6 rows)
+-- document_types (8 rows)
 -- Source: backend/library/models/stalker_document_type.py
 CREATE TABLE IF NOT EXISTS public.document_types (
     id SERIAL PRIMARY KEY,
@@ -70,7 +70,8 @@ INSERT INTO public.document_types (name) VALUES
     ('webpage'),
     ('text_message'),
     ('text'),
-    ('email')
+    ('email'),
+    ('social_media_post')
 ON CONFLICT (name) DO NOTHING;
 
 -- embedding_models (7 rows)

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -238,9 +238,11 @@ class WebDocument(Base):
             self.document_type = StalkerDocumentType.text_message.name
         elif document_type in ["text"]:
             self.document_type = StalkerDocumentType.text.name
+        elif document_type in ["social_media_post", "social"]:
+            self.document_type = StalkerDocumentType.social_media_post.name
         else:
             raise ValueError(
-                f"document_type must be either 'movie', 'webpage', 'text_message', 'text' or 'link' not >{document_type}<"
+                f"document_type must be one of 'movie', 'webpage', 'text_message', 'text', 'link', 'social_media_post' not >{document_type}<"
             )
 
     def set_document_state(self, document_state: str) -> None:
@@ -419,6 +421,10 @@ class TextMessageDocument(WebDocument):
 
 class TextDocument(WebDocument):
     __mapper_args__ = {"polymorphic_identity": "text"}
+
+
+class SocialMediaPostDocument(WebDocument):
+    __mapper_args__ = {"polymorphic_identity": "social_media_post"}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/models/stalker_document_type.py
+++ b/backend/library/models/stalker_document_type.py
@@ -13,4 +13,5 @@ class StalkerDocumentType(Enum):
     text_message = 5
     text = 6
     email = 7
+    social_media_post = 8
 


### PR DESCRIPTION
## Summary

- New document type `social_media_post` for Facebook, X/Twitter, LinkedIn posts etc.
- Added to: Python enum, SQL seed, ORM STI subclass, `set_document_type()` (alias: `"social"`)

## Changed files

- `backend/library/models/stalker_document_type.py` — new enum value `social_media_post = 8`
- `backend/database/init/09-create-lookup-tables.sql` — seed row
- `backend/library/db/models.py` — STI subclass + setter alias

## Test plan

- [ ] Verify `StalkerDocumentType.social_media_post.name` returns `"social_media_post"`
- [ ] Verify `set_document_type("social_media_post")` and `set_document_type("social")` work
- [ ] Verify SQL seed inserts correctly on fresh DB init

🤖 Generated with [Claude Code](https://claude.com/claude-code)