### PR TITLE
feat(youtube): add video_description field and auto-parse chapters

### DIFF
--- a/backend/database/init/03-create-table.sql
+++ b/backend/database/init/03-create-table.sql
@@ -22,6 +22,7 @@ create table web_documents
     original_id          text,
     document_length      integer,
     chapter_list         text,
+    video_description    text,
     document_state       varchar(50) default 'URL_ADDED'::character varying not null,
     document_state_error text,
     text_raw             text,

--- a/backend/database/init/12-add-video-description.sql
+++ b/backend/database/init/12-add-video-description.sql
@@ -1,0 +1,5 @@
+-- Migration: add video_description column to web_documents
+-- Stores the full YouTube video description (used for auto-parsing chapter timestamps)
+ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS video_description TEXT;
+
+SELECT 'Column video_description added to web_documents' AS status;

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -117,6 +117,7 @@ class WebDocument(Base):
     original_id: Mapped[str | None] = mapped_column(Text)
     document_length: Mapped[int | None] = mapped_column(Integer)
     chapter_list: Mapped[str | None] = mapped_column(Text)
+    video_description: Mapped[str | None] = mapped_column(Text)
 
     document_state: Mapped[str] = mapped_column(
         String(50), ForeignKey("document_status_types.name"),
@@ -378,6 +379,7 @@ class WebDocument(Base):
             "original_id": self.original_id,
             "document_length": self.document_length,
             "chapter_list": self.chapter_list,
+            "video_description": self.video_description,
             "document_state": self.document_state,
             "document_state_error": self.document_state_error or "NONE",
             "text_raw": self.text_raw,

--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
@@ -22,6 +23,20 @@ from library.text_transcript import youtube_titles_split_with_chapters, youtube_
 from library.transcript import transcript_price, get_assemblyai_price_per_minute
 
 logger = logging.getLogger(__name__)
+
+_CHAPTER_LINE_RE = re.compile(r'^(\d+:)?\d{1,2}:\d{2}\s+\S')
+
+
+def parse_chapters_from_description(description: str) -> str | None:
+    """Extract chapter timestamps from YouTube video description.
+
+    Matches lines like '0:00 Intro', '1:49 Topic', '1:01:36 Title'.
+    Returns newline-joined chapter lines, or None if fewer than 2 found.
+    """
+    if not description:
+        return None
+    lines = [line.strip() for line in description.splitlines() if _CHAPTER_LINE_RE.match(line.strip())]
+    return '\n'.join(lines) if len(lines) >= 2 else None
 
 
 def clean_youtube_url(url: str) -> str:
@@ -119,6 +134,13 @@ def process_youtube_url(
         web_document.text_raw = youtube_file.text
         web_document.document_type = StalkerDocumentType.youtube.name
         web_document.document_length = youtube_file.length_seconds
+        if youtube_file.description:
+            web_document.video_description = youtube_file.description
+            if not web_document.chapter_list:
+                parsed_chapters = parse_chapters_from_description(youtube_file.description)
+                if parsed_chapters:
+                    web_document.chapter_list = parsed_chapters
+                    logger.info(f"Auto-parsed {len(parsed_chapters.splitlines())} chapters from description")
         session.commit()
 
     logger.info(f"Video ID: {youtube_file.video_id}")

--- a/backend/youtube_add.py
+++ b/backend/youtube_add.py
@@ -49,6 +49,19 @@ def main():
     t_start = time.time()
     logging.info("Script started")
 
+    webshare_api_key = cfg.get("WEBSHARE_API_KEY")
+    if webshare_api_key:
+        try:
+            from library.webshare_ip_auth import ensure_ip_authorized, check_bandwidth
+            ensure_ip_authorized(webshare_api_key)
+            bw = check_bandwidth(webshare_api_key)
+            if not bw["available"]:
+                logging.warning("Webshare bandwidth exhausted — proxy disabled")
+                webshare_api_key = None
+        except Exception as e:
+            logging.warning(f"Webshare IP auth failed: {e} — proceeding without proxy")
+            webshare_api_key = None
+
     session = get_session()
     try:
         web_document = process_youtube_url(
@@ -60,8 +73,18 @@ def main():
             source=args.source,
             ai_summary_needed=args.summary,
             force_reprocess=args.force,
-            webshare_api_key=cfg.get("WEBSHARE_API_KEY"),
+            webshare_api_key=webshare_api_key,
         )
+
+        # Collect attributes while session is still open
+        elapsed = time.time() - t_start
+        doc_id = web_document.id
+        doc_title = web_document.title
+        doc_url = web_document.url
+        doc_language = web_document.language
+        doc_state = web_document.document_state
+        doc_text_len = len(web_document.text) if web_document.text else 0
+        doc_summary = web_document.summary
     except Exception as e:
         logging.error(f"Error processing YouTube URL: {e}")
         sys.exit(1)
@@ -70,16 +93,14 @@ def main():
 
     # Print summary
     print("\n--- Document Summary ---")
-    print(f"  ID:       {web_document.id}")
-    print(f"  Title:    {web_document.title}")
-    print(f"  URL:      {web_document.url}")
-    print(f"  Language: {web_document.language}")
-    print(f"  Status:   {web_document.document_state}")
-    text_len = len(web_document.text) if web_document.text else 0
-    print(f"  Text length: {text_len} characters")
-    if web_document.summary:
-        print(f"  Summary:  {web_document.summary[:200]}...")
-    elapsed = time.time() - t_start
+    print(f"  ID:       {doc_id}")
+    print(f"  Title:    {doc_title}")
+    print(f"  URL:      {doc_url}")
+    print(f"  Language: {doc_language}")
+    print(f"  Status:   {doc_state}")
+    print(f"  Text length: {doc_text_len} characters")
+    if doc_summary:
+        print(f"  Summary:  {doc_summary[:200]}...")
     print(f"  Elapsed:  {elapsed:.2f}s")
     print("------------------------")
 


### PR DESCRIPTION
## Summary
- Add `video_description` column to `web_documents` table (schema + migration `12-add-video-description.sql`)
- Store raw YouTube description text in `WebDocument.video_description`
- Auto-extract chapter timestamps from description when `chapter_list` is empty (`parse_chapters_from_description()`)
- Fix `youtube_add.py`: read document attributes before session closes (detached instance error)
- Add Webshare bandwidth check before enabling proxy

## Test plan
- [ ] Run migration `12-add-video-description.sql` on dev DB
- [ ] Process a YouTube video with chapters in description — verify `chapter_list` is auto-populated
- [ ] Process a YouTube video without chapters — verify no crash, `chapter_list` stays empty
- [ ] Verify `video_description` is saved and returned in document JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)