### PR TITLE
feat: article_browser --meta flag + /obsidian-note token savings

### DIFF
--- a/.claude/commands/obsidian-note.md
+++ b/.claude/commands/obsidian-note.md
@@ -16,50 +16,132 @@ If a comment is provided, treat it as **the user's key takeaway** — this is wh
 2. Decide where to place the note (which existing note to update)
 3. Skip the "discuss with user" step if the comment is clear enough — go straight to creating/updating notes
 
+**`note` field from database (Chrome extension):** After fetching the article (Step 1), check if the `note` field is non-empty. If present, treat it exactly like a comment argument above — it is the user's thought recorded at save time. If both a CLI comment and a `note` field are present, combine both as the user's intent.
+
 ## Workflow
 
-Execute ALL steps below in order. Do NOT skip step 4 (database update).
+Execute ALL steps below in order. Do NOT skip step 5 (database update).
 
 ### Step 1: Fetch article from database
 
-Use article_browser.py `--dump` mode — it outputs UTF-8 JSON with all metadata and full text:
+**Step 1a — metadata only (no text field, cheap):**
 
 ```bash
-cd backend && .venv/Scripts/python imports/article_browser.py --dump --id <ARTICLE_ID>
+.venv/Scripts/python imports/article_browser.py --meta --id <ARTICLE_ID>
 ```
 
-The JSON contains: `id`, `title`, `url`, `created_at`, `document_state`, `document_type`, `language`, `source`, `author`, `reviewed_at`, `obsidian_note_paths`, `text_length`, `text`.
+Display the metadata to the user.
 
-Display article metadata to the user.
+**Step 1b — check `document_state` before fetching text:**
 
-### Step 2: Search Obsidian vault for related notes
+- If `document_state` is `URL_ADDED` or `DOCUMENT_INTO_DATABASE` → **STOP and warn the user**:
+  > "Artykuł ma status `{state}` — tekst jest surowy (zawiera szum nawigacyjny strony, reklamy itp.) i zużyje znacznie więcej tokenów niż czysty artykuł. Pobierać mimo to?"
+  Proceed only if user confirms.
 
-Search `C:\Users\ziutus\Obsydian\personal\02-wiedza` using Grep and Glob for notes related to the article's topic:
-1. First search country files in `Kraje/**/*.md` (Glob + Grep)
-2. Then search by keywords from the article title and content
-3. Report what was found
+- If `document_state` is `DOCUMENT_CLEANED` or any later state → fetch full text:
 
-### Step 3: Discuss with user and create/update notes
+```bash
+.venv/Scripts/python imports/article_browser.py --dump --id <ARTICLE_ID>
+```
+
+The `--dump` JSON adds one extra field to `--meta`: `text` (full article content).
+
+### Step 2: Detect content type and plan approach
+
+**Before anything else**, check `document_type` and `text_length`:
+
+#### Long YouTube video (document_type == "youtube" AND text_length > 10 000)
+
+This is a long video transcript — treat it as a multi-topic document, NOT a single article.
+
+1. Read the full text and identify **thematic sections** (typically 4-8 topics)
+2. Present the user with a numbered list of sections
+3. Ask: "Od której części zaczynamy?" or "Omawiamy po kolei?"
+4. Process **one section at a time** — for each section:
+   - Summarize key points (3-5 bullets)
+   - Ask about financial angle: kto finansuje / skąd pieniądze / skala rynku
+   - Propose: new note or update existing?
+   - Show full note proposal, wait for approval
+   - Save note, update index, update DB (append path)
+5. Repeat for each section the user wants to cover
+6. Each section may produce **one or more notes** — track all paths for DB update
+
+**Do NOT** try to process the whole video at once into a single note.
+
+#### Short article or webpage (text_length ≤ 10 000 OR document_type != "youtube")
+
+Follow the standard single-note flow (Steps 3–6 below).
+
+### Step 3: Find related notes via index
+
+**Always start by reading the index:**
+
+```
+C:\Users\ziutus\Obsydian\personal\02-wiedza\_index.md
+```
+
+The index maps topics/keywords → file paths. Steps:
+1. Read `_index.md`
+2. Match keywords from the article title and main theme against the index entries
+3. For country-specific articles: derive the path from the pattern `Geopolityka i polityka/Kraje/<Region>/<Kraj>.md` (regions: Afryka, Ameryka Południowa, Ameryka Północna, Azja, Bliski Wschód, Europa, Półwysep Arabski i Arabowie)
+4. Open only the 1-2 most relevant files found in the index — read them to check existing content
+5. **Use Grep/Glob only as fallback** if the topic is clearly not covered by the index
+
+Report which notes were found and what they already contain.
+
+### Step 4: Check geopolitical control questions (if applicable)
+
+If the article is about **geopolitics** (countries, wars, alliances, military, diplomacy, regions), read the control questions file:
+
+`C:\Users\ziutus\Obsydian\personal\02-wiedza\Geopolityka i polityka\_pytania_kontrolne\_Pytania do każdego kraju czy obszaru.md`
+
+Then check which of the questions below are answered by the article. Report only the ones that **are** answered — skip those with no data:
+
+- **Czyja to strefa wpływu / do jakiego bloku należy?** — USA, Russia, China orbit? Non-aligned?
+- **Czyjej technologii używa?** — whose weapons, internet infrastructure, nuclear reactors?
+- **Z kim prowadzi konflikty i na jakim poziomie?** — political / proxy / traditional war
+- **Jaka ma armię w porównaniu do innych?** — arms imports, capabilities, suppliers
+- **Jakie ma aspiracje i cele strategiczne?** — what does the country want to achieve?
+- **Jaki jest stan finansów?** — rich, bankrupt, dependent on commodities?
+- **Czy jest regionalnym hegemonem?** — does it dominate the region militarily/politically?
+- **Jaka panuje ideologia?** — imperialism, nationalism, theocracy, democracy?
+- **Jakie są strefy buforowe?** — which countries/territories act as buffers?
+- **Czy kraj jest bliski rewolucji?** — internal stability?
+- **Jaka rolę pełni w systemie międzynarodowym?** — mediator, supplier, client state?
+
+If any questions are answered, include those answers explicitly in the notes when creating/updating them (as dedicated `##` sections matching the question topic, e.g. `## Aspiracje i cele strategiczne`, `## Konflikty`, `## Stan finansów`).
+
+If the article is **not** about geopolitics, skip this step entirely.
+
+### Step 5: Discuss with user and create/update notes
 
 Present the user with:
 - Summary of the article (3-5 key points in Polish)
 - Found related Obsidian notes
+- Which control questions are answered (if geopolitics article)
 - Proposal: create new note, update existing, or both
+
+**Financial angle (always check):** For every note about technology, geopolitics, projects or companies — explicitly ask or include: kto finansuje, ile to kosztuje, skąd pochodzi zwrot z inwestycji, jaka jest skala rynku. If data is missing — mark as `TODO: wątek finansowy`. Bez pieniędzy nie ma efektów.
 
 Wait for user input on what to create/update. Then create/update the Obsidian .md files following vault conventions:
 - Frontmatter with tags (`tags: wiedza/...`)
 - H1 heading
 - Content with `##` sections, `**bold**` for key points
 - Obsidian wiki-links `[[Country]]` for cross-references
-- Source line at the end: `Źródło: [Title](URL) (Lenie AI id=ID)`
+- Source line at the end: `Źródło: [Title](URL) (Lenie AI uuid=UUID)` — use the `uuid` field from `--dump` output (NOT the numeric `id`)
 
-### Step 4: Update database (MANDATORY — never skip)
+**After creating/updating the note — update `_index.md` if needed:**
+- If the note is a **new file** OR its topic has **no matching entry** in `_index.md` → add a line to the appropriate section in `_index.md` (keywords → path)
+- If the note already exists in the index → skip
+- `_index.md` is already in context from Step 3, so no extra read needed
+
+### Step 6: Update database (MANDATORY — never skip)
 
 After creating/updating Obsidian notes, ALWAYS update the article in the database.
 Use article_browser.py's ORM session pattern:
 
 ```bash
-cd backend && .venv/Scripts/python -c "
+.venv/Scripts/python -c "
 from datetime import datetime
 from library.db.engine import get_session
 from library.db.models import WebDocument
@@ -77,9 +159,11 @@ session.close()
 "
 ```
 
+**For multi-note sessions (YouTube):** append paths one by one after each note is saved, OR append all at once at the end of the session.
+
 Report the updated `obsidian_note_paths` and `reviewed_at` to confirm success.
 
-### Step 5: Update cross-references (if applicable)
+### Step 7: Update cross-references (if applicable)
 
 If the article topic relates to existing notes (e.g., country files, topic notes), add a brief entry with a link to the new note using `[[Note Name]]` syntax. Also update notes about countries/organizations mentioned in the article (e.g., if the article mentions Russia or China cooperation, update Rosja.md and Chiny.md too).
 
@@ -89,5 +173,7 @@ If the article topic relates to existing notes (e.g., country files, topic notes
 - Obsidian vault root: `C:\Users\ziutus\Obsydian\personal`
 - Knowledge directory: `C:\Users\ziutus\Obsydian\personal\02-wiedza`
 - **NEVER use `uv run`** — it does not work in this project (hatchling build error)
-- Run commands from `backend/` dir: `cd backend && .venv/Scripts/python ...`
-- Always include source with Lenie AI id
+- Run Python commands directly: `.venv/Scripts/python ...` (bash working dir is already `backend/` — do NOT prefix with `cd backend &&`)
+- Always include source with Lenie AI **uuid** (not numeric id) — `doc.uuid` from database
+- **Always propose note content before saving** — wait for user approval
+- **Financial angle is mandatory** for tech/geopolitics/project notes — include or mark as TODO

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -10,7 +10,8 @@ Usage:
     python imports/article_browser.py --review --id 8786                  # Start from specific article
     python imports/article_browser.py --show --id 8799                    # Display article and exit (non-interactive)
     python imports/article_browser.py --show --id 8799 --check-urls       # Display with link validation
-    python imports/article_browser.py --dump --id 8805                    # JSON output for Claude Code
+    python imports/article_browser.py --meta --id 8805                    # JSON metadata only (no text) — cheap token usage
+    python imports/article_browser.py --dump --id 8805                    # JSON output for Claude Code (includes full text)
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW   # Articles needing manual review
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW --format ids    # Just IDs (for scripting)
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW --format short  # IDs + titles
@@ -29,8 +30,9 @@ from typing import Optional
 
 from library.models.stalker_document_status import StalkerDocumentStatus
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 # Changelog:
+#   0.3.3 — dodano --meta: JSON z metadanymi bez pola text (oszczędność tokenów dla Claude Code)
 #   0.3.2 — menu akcji drukowane przed każdym promptem (widoczne też po [v]/[b]/[r])
 #   0.3.1 — [b] rozszerza kontekst HEAD/TAIL o +400 znaków (kolejne ~2 zdania) na każde naciśnięcie
 #   0.3.0 — boundaries inline: HEAD przed tekstem, TAIL po tekście (wizualna ciągłość)
@@ -1158,6 +1160,47 @@ def action_mark_review(doc, session):
         print(f"  BŁĄD zmiany statusu: {e}")
 
 
+def cmd_meta(session, article_id: Optional[int] = None):
+    """Wypisz metadane artykułu jako JSON bez pola text — tanie wywołanie dla Claude Code.
+
+    Używane jako Step 1a w slash command /obsidian-note: sprawdź document_state
+    przed podjęciem decyzji czy pobierać pełny tekst (--dump).
+    """
+    import json
+
+    if article_id is None:
+        print(json.dumps({"error": "--meta wymaga --id <ARTICLE_ID>"}), file=sys.stderr)
+        sys.exit(1)
+
+    doc = WebDocument.get_by_id(session, article_id)
+    if doc is None:
+        print(json.dumps({"error": f"Dokument {article_id} nie znaleziony."}), file=sys.stderr)
+        sys.exit(1)
+
+    result = {
+        "id": doc.id,
+        "uuid": str(doc.uuid) if doc.uuid else None,
+        "title": doc.title,
+        "url": doc.url,
+        "created_at": doc.created_at.isoformat() if doc.created_at else None,
+        "document_state": doc.document_state,
+        "document_type": doc.document_type,
+        "language": doc.language,
+        "source": doc.source,
+        "author": doc.author,
+        "note": doc.note,
+        "summary": doc.summary,
+        "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
+        "obsidian_note_paths": doc.obsidian_note_paths or [],
+        "chapter_list": doc.chapter_list,
+        "video_description": doc.video_description,
+        "text_length": len(doc.text or doc.text_raw or ""),
+    }
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
 def cmd_dump(session, article_id: Optional[int] = None, use_md: bool = False):
     """Wypisz artykuł jako JSON na stdout — do użycia przez Claude Code slash commands.
 
@@ -1192,6 +1235,8 @@ def cmd_dump(session, article_id: Optional[int] = None, use_md: bool = False):
         "language": doc.language,
         "source": doc.source,
         "author": doc.author,
+        "note": doc.note,
+        "summary": doc.summary,
         "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
         "obsidian_note_paths": doc.obsidian_note_paths or [],
         "chapter_list": doc.chapter_list,
@@ -1479,6 +1524,7 @@ def main():
     group.add_argument("--list", action="store_true", help="Lista artykułów")
     group.add_argument("--review", action="store_true", help="Interaktywny przegląd")
     group.add_argument("--show", action="store_true", help="Wyświetl artykuł i zakończ (wymaga --id)")
+    group.add_argument("--meta", action="store_true", help="Wypisz metadane artykułu jako JSON bez tekstu — tanie wywołanie (wymaga --id)")
     group.add_argument("--dump", action="store_true", help="Wypisz artykuł jako JSON — pole text (czysta treść)")
     group.add_argument("--dump-md", action="store_true", help="Wypisz artykuł jako JSON — pole text_md (markdown z formatowaniem)")
     group.add_argument("--notes", action="store_true", help="Pokaż zapisane notatki do przetworzenia")
@@ -1512,7 +1558,9 @@ def main():
     session = get_session()
 
     try:
-        if args.dump:
+        if args.meta:
+            cmd_meta(session, article_id=args.id)
+        elif args.dump:
             cmd_dump(session, article_id=args.id, use_md=False)
         elif args.dump_md:
             cmd_dump(session, article_id=args.id, use_md=True)

--- a/backend/library/website/website_download_context.py
+++ b/backend/library/website/website_download_context.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse
 
 import requests
 from bs4 import BeautifulSoup
@@ -15,6 +16,10 @@ def load_site_rules(file_path: str) -> dict:
 
 
 def download_raw_html(url: str) -> bytes | None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme!r}. Only http and https are allowed.")
+
     response = requests.get(url)
 
     if response.status_code == 200:

--- a/web_interface_app2/package-lock.json
+++ b/web_interface_app2/package-lock.json
@@ -2433,9 +2433,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- **New `--meta` flag** in `article_browser.py` (v0.3.3): returns JSON metadata without the `text` field — saves ~2000 tokens when checking article status before deciding whether to fetch full content
- **Missing fields fixed**: `note` and `summary` were absent from both `--dump` and `--meta` output, so Chrome extension user notes were silently ignored by Claude Code
- **Two-stage fetch** in `/obsidian-note` slash command: `--meta` first (cheap), `--dump` only when `document_state` is `DOCUMENT_CLEANED` or higher — warns user before loading raw noisy content
- **`note` field awareness**: slash command now treats the `note` DB field (set via Chrome extension at save time) as the user's key takeaway, equivalent to a CLI comment argument

## Test plan

- [ ] `article_browser.py --meta --id <ID>` returns JSON with `note`, `summary` but no `text`
- [ ] `article_browser.py --dump --id <ID>` still includes `note` and `summary`
- [ ] `article_browser.py --meta --id <ID>` with missing `--id` prints error and exits 1
- [ ] `/obsidian-note` on article with `DOCUMENT_INTO_DATABASE` status shows warning before fetching text
- [ ] `/obsidian-note` on article with user note set in Chrome extension picks it up as key takeaway

🤖 Generated with [Claude Code](https://claude.com/claude-code)