### PR TITLE
fix: handle DB block corruption in article_browser

### DIFF
--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -83,6 +83,7 @@ def _getch_action(prompt: str) -> str:
         return input().strip().lower()
 
 from sqlalchemy import text as text_sql
+from sqlalchemy.exc import InternalError as SqlInternalError
 
 from library.config_loader import load_config
 from library.db.engine import get_session
@@ -1025,7 +1026,12 @@ def _get_documents(session, limit: int = 50, since: Optional[str] = None,
 
     results = []
     for d in doc_dicts:
-        doc = WebDocument.get_by_id(session, d["id"])
+        try:
+            doc = WebDocument.get_by_id(session, d["id"])
+        except SqlInternalError as e:
+            session.rollback()
+            print(f"  OSTRZEŻENIE: pominięto dokument id={d['id']} — korupcja bloku DB: {e.orig}")
+            continue
         if doc is None:
             continue
         if portal and portal not in (doc.url or ""):


### PR DESCRIPTION
## Summary

- Dodano obsługę `SqlInternalError` (psycopg2 `DataCorrupted`) w pętli `_get_documents` w `article_browser.py`
- Przy korupcji bloku PostgreSQL skrypt robi `session.rollback()`, wypisuje ostrzeżenie z ID dokumentu i kontynuuje — zamiast się wysypywać
- Poprawka odkryta przy realnej korupcji bloku 10064/10065 w tabeli `web_documents` na NAS (baza naprawiona osobno przez VACUUM FULL)

## Test plan

- [x] Uruchomić `article_browser.py --review --not-cleaned` na bazie z poprawką — powinno działać bez wyjątku `InternalError`
- [ ] Przy uszkodzonym bloku: w output pojawia się `OSTRZEŻENIE: pominięto dokument id=X — korupcja bloku DB: ...` i przeglądanie kontynuuje

🤖 Generated with [Claude Code](https://claude.com/claude-code)