### PR TITLE
feat: article browser meta flag, obsidian-note fixes, wp.pl cleanup rules

### DIFF
--- a/backend/library/website/website_text_clean_regexp.py
+++ b/backend/library/website/website_text_clean_regexp.py
@@ -4,7 +4,8 @@ site_rules = {
         "remove_before": ["PomorskieWrocławKoronawirus", "PomorskieWrocławKoronawirus"],
         "remove_after": [r"Elementem\swspółczesnej\swojny\sjest\swojna\sinformacyjna",
                              r"Masz newsa,\s+zdjęcie\s+lub\s+filmik\?\s+Prześlij\s+nam\s+przez\s+dziejesie\.wp\.pl\s+Oceń\s+jakość\s+naszego\s+artykułu",# noqa
-                         r"### Wybrane dla Ciebie"# noqa
+                         r"### Wybrane dla Ciebie",# noqa
+                         r"PREMIUM\s+Zapisz\s+się\s+na\s+newsletter!"# noqa
         ], # noqa
         "remove_string": ["Wyłączono komentarze", "Dalsza część artykułu pod materiałem wideo"],# noqa
         "remove_string_regexp": [r"\n\s*Trwa\sładowanie\swpisu:\sfacebook\s*\n", r"\n\s*Rozwin\s*\n"] # noqa


### PR DESCRIPTION
## Summary

- Add `--meta` flag to `article_browser` and improve `/obsidian-note` slash command
- Fix DB block corruption handling in `article_browser._get_documents`
- Move `youtube_add.py` to `imports/` and update documentation
- Fix `youtube`/`movie` type handling in `get_article_text` and obsidian-note flow
- Fix PowerShell absolute path in obsidian-note skill
- Add `PREMIUM Zapisz się na newsletter!` as stop rule for wiadomosci.wp.pl content extraction
- Fix: validate URL scheme in `download_raw_html` to prevent SSRF
- Fix: update postcss to fix XSS vulnerability (Dependabot #339, #340)

## Test plan

- [ ] Verify `article_browser --meta` displays metadata correctly
- [ ] Verify `/obsidian-note` works for `youtube` and `movie` types
- [ ] Verify wp.pl articles no longer include newsletter signup block in extracted text
- [ ] Verify SSRF protection on `download_raw_html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)