### PR TITLE
feat: automatic thematic tagging + control questions filter

### DIFF
--- a/.claude/commands/obsidian-note.md
+++ b/.claude/commands/obsidian-note.md
@@ -98,27 +98,26 @@ Report which notes were found and what they already contain.
 
 ### Step 4: Check geopolitical control questions (if applicable)
 
-If the article is about **geopolitics** (countries, wars, alliances, military, diplomacy, regions), read the control questions file:
+Check the `tags` field from the `--dump` output (Step 1b).
 
-`C:\Users\ziutus\Obsydian\personal\02-wiedza\Geopolityka i polityka\_pytania_kontrolne\_Pytania do każdego kraju czy obszaru.md`
+If `tags` is non-empty, fetch only the relevant control questions by running:
 
-Then check which of the questions below are answered by the article. Report only the ones that **are** answered — skip those with no data:
+```powershell
+cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python imports/control_questions.py --tags <tags_from_dump>
+```
 
-- **Czyja to strefa wpływu / do jakiego bloku należy?** — USA, Russia, China orbit? Non-aligned?
-- **Czyjej technologii używa?** — whose weapons, internet infrastructure, nuclear reactors?
-- **Z kim prowadzi konflikty i na jakim poziomie?** — political / proxy / traditional war
-- **Jaka ma armię w porównaniu do innych?** — arms imports, capabilities, suppliers
-- **Jakie ma aspiracje i cele strategiczne?** — what does the country want to achieve?
-- **Jaki jest stan finansów?** — rich, bankrupt, dependent on commodities?
-- **Czy jest regionalnym hegemonem?** — does it dominate the region militarily/politically?
-- **Jaka panuje ideologia?** — imperialism, nationalism, theocracy, democracy?
-- **Jakie są strefy buforowe?** — which countries/territories act as buffers?
-- **Czy kraj jest bliski rewolucji?** — internal stability?
-- **Jaka rolę pełni w systemie międzynarodowym?** — mediator, supplier, client state?
+For example, if `tags` is `wojsko,gospodarka,sojusze`:
+```powershell
+cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python imports/control_questions.py --tags wojsko,gospodarka,sojusze
+```
 
-If any questions are answered, include those answers explicitly in the notes when creating/updating them (as dedicated `##` sections matching the question topic, e.g. `## Aspiracje i cele strategiczne`, `## Konflikty`, `## Stan finansów`).
+The script returns only the `##` sections from the control questions file that are relevant to those tags — a small, focused subset instead of the full list.
 
-If the article is **not** about geopolitics, skip this step entirely.
+Then check which of the returned questions are **answered** by the article. Report only the ones that are answered — skip those with no data.
+
+If any questions are answered, include those answers explicitly in the notes (as dedicated `##` sections matching the question topic, e.g. `## Aspiracje i cele strategiczne`, `## Konflikty`, `## Stan finansów`).
+
+If `tags` is empty, skip this step entirely.
 
 ### Step 5: Discuss with user and create/update notes
 

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -100,6 +100,13 @@ OBSIDIAN_VAULT = r"C:\Users\ziutus\Obsydian\personal"
 OBSIDIAN_KNOWLEDGE_DIR = os.path.join(OBSIDIAN_VAULT, "02-wiedza")
 NOTES_DIR = os.path.join(_BACKEND_DIR, "tmp", "article_notes")
 
+THEMATIC_TAGS = [
+    "wojsko", "gospodarka", "geopolityka", "ideologia",
+    "religia", "demografia", "etniczne", "soft-power-religijny",
+    "ustroj", "sluzby-specjalne", "technologia", "internet",
+    "finanse-publiczne", "sojusze",
+]
+
 
 def _get_cache_status(doc_id: int) -> str:
     """Zwraca jednoliniowy status plików cache dla artykułu: [md ✓/—] [llm ✓/—] [regexp ✓/—]"""
@@ -207,6 +214,10 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
         if re.match(r'^[-*_]{3,}\s*$', stripped):
             continue
 
+        # Puste nagłówki markdown (np. "####" po usunięciu obrazka z pustym URL)
+        if re.match(r'^#{1,6}\s*$', stripped):
+            continue
+
         # Puste linie z samą liczbą (reakcje)
         if stripped.isdigit():
             continue
@@ -251,9 +262,27 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla onet.pl/fakt.pl."""
     skip = {"Posłuchaj artykułu", "Skróć artykuł", "- x1 +", "x1", "Obserwuj"}
     cleaned = []
+    in_top_premium = False
     for line in lines:
         stripped = line.strip()
-        if stripped in skip:
+
+        # Sekcja "Top treści w Premium": nagłówek + ponumerowane linki (1 Tytuł [linkN])
+        if stripped == "Top treści w Premium":
+            in_top_premium = True
+            continue
+        if in_top_premium:
+            if not stripped:
+                continue
+            if re.match(r'^\d+\s+\S', stripped) and re.search(r'\[link\d+\]\s*$', stripped):
+                continue
+            in_top_premium = False  # koniec sekcji — przetwórz tę linię normalnie
+
+        # Porównuj treść linii bez prefiksów nagłówkowych (#### Posłuchaj artykułu → Posłuchaj artykułu)
+        stripped_content = re.sub(r'^#{1,6}\s+', '', stripped)
+        if stripped_content in skip:
+            continue
+        # Przyciski prędkości audio playera: x2, x1.75, x1.5, x1.25, x0.75
+        if re.match(r'^x[\d.]+$', stripped):
             continue
         # Wstawki premium: "**1** ### Tytuł [linkN]**2** ### ..."
         if re.match(r'^\*\*\d+\*\*\s+###\s+', stripped):
@@ -362,6 +391,9 @@ def clean_article_text(text: str, url: str = "") -> dict:
     def replace_image(m):
         alt = m.group(1).strip()
         img_url = m.group(2).strip()
+        # Artefakty z konwersji HTML: obrazki z pustym URL → usuń
+        if not img_url:
+            return ""
         # Pomijaj emotki, ikony portalu i bannery reklamowe
         if any(p in img_url for p in _skip_image_patterns):
             return ""
@@ -378,7 +410,7 @@ def clean_article_text(text: str, url: str = "") -> dict:
         extracted_images.append({"alt": alt, "url": img_url})
         return f"[img{idx}: {alt}]" if alt else f"[img{idx}]"
 
-    text = re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', replace_image, text)
+    text = re.sub(r'!\[([^\]]*)\]\(([^)]*)\)', replace_image, text)
     # Linki owijające markery img: [[imgN]](url) → [imgN]
     text = re.sub(r'\[(\[img\d+[^\]]*\])\]\([^)]+\)', lambda m: m.group(1), text)
 
@@ -937,6 +969,28 @@ def _refresh_db_connection(session):
             return False
 
 
+def _tag_article_with_llm(text: str, title: str) -> list[str]:
+    """Klasyfikuj artykuł według kategorii tematycznych. Zwraca listę tagów."""
+    from library.ai import ai_ask
+
+    tags_list = ", ".join(THEMATIC_TAGS)
+    prompt = (
+        f"Przeczytaj poniższy artykuł i wybierz kategorie tematyczne, które są w nim WYRAŹNIE omawiane.\n\n"
+        f"Dostępne kategorie: {tags_list}\n\n"
+        f"Zwróć TYLKO listę wybranych kategorii oddzielonych przecinkami, bez żadnych wyjaśnień.\n"
+        f"Jeśli żadna kategoria nie pasuje, zwróć pustą odpowiedź.\n\n"
+        f"TYTUŁ: {title}\n\nTREŚĆ:\n{text[:3000]}"
+    )
+    try:
+        response = ai_ask(prompt, model="Bielik-11B-v3.0-Instruct", temperature=0.0, max_token_count=100)
+        raw = response.response_text.strip().lower()
+        found = [t.strip() for t in raw.split(",") if t.strip() in THEMATIC_TAGS]
+        return found
+    except Exception as e:
+        print(f"  OSTRZEŻENIE: klasyfikacja tematyczna nie powiodła się: {e}")
+        return []
+
+
 def action_save_to_db(doc, article: dict, session) -> bool:
     """Zapisz oczyszczony tekst do bazy, stwórz embedding, ustaw status."""
     from library.models.stalker_document_status import StalkerDocumentStatus
@@ -987,7 +1041,21 @@ def action_save_to_db(doc, article: dict, session) -> bool:
         print(f"  BŁĄD zapisu tekstu: {e}")
         return False
 
-    # 2. Twórz embedding
+    # 2. Klasyfikacja tematyczna
+    print(f"  Klasyfikuję artykuł tematycznie...")
+    article_tags = _tag_article_with_llm(text_only, doc.title or "")
+    if article_tags:
+        doc.tags = ",".join(article_tags)
+        try:
+            session.commit()
+            print(f"  Tagi: {', '.join(article_tags)}")
+        except Exception as e:
+            session.rollback()
+            print(f"  OSTRZEŻENIE: nie udało się zapisać tagów: {e}")
+    else:
+        print(f"  Brak tagów tematycznych.")
+
+    # 3. Twórz embedding
     print(f"  Tworzę embedding...")
     try:
         wb_db = WebsitesDBPostgreSQL(session=session)
@@ -1205,6 +1273,7 @@ def cmd_meta(session, article_id: Optional[int] = None):
         "note": doc.note,
         "summary": doc.summary,
         "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
+        "tags": doc.tags or "",
         "obsidian_note_paths": doc.obsidian_note_paths or [],
         "chapter_list": doc.chapter_list,
         "video_description": doc.video_description,
@@ -1252,6 +1321,7 @@ def cmd_dump(session, article_id: Optional[int] = None, use_md: bool = False):
         "note": doc.note,
         "summary": doc.summary,
         "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
+        "tags": doc.tags or "",
         "obsidian_note_paths": doc.obsidian_note_paths or [],
         "chapter_list": doc.chapter_list,
         "video_description": doc.video_description,
@@ -1292,6 +1362,8 @@ def cmd_show(session, article_id: Optional[int] = None, check_urls: bool = False
         print(f"  Obsidian: {len(obsidian_paths)} notatek")
         for op in obsidian_paths:
             print(f"    - {op}")
+    if doc.tags:
+        print(f"  Tagi:    {doc.tags}")
     reviewed_str = doc.reviewed_at.strftime("%Y-%m-%d %H:%M") if doc.reviewed_at else "nie"
     print(f"  Reviewed: {reviewed_str}")
 
@@ -1360,6 +1432,8 @@ def cmd_review(session, since: Optional[str] = None, portal: Optional[str] = Non
             print(f"  Obsidian: {len(obsidian_paths)} notatek")
             for op in obsidian_paths:
                 print(f"    - {op}")
+        if doc.tags:
+            print(f"  Tagi:    {doc.tags}")
         reviewed_str = doc.reviewed_at.strftime("%Y-%m-%d %H:%M") if doc.reviewed_at else "nie"
         print(f"  Reviewed: {reviewed_str}")
 

--- a/backend/imports/control_questions.py
+++ b/backend/imports/control_questions.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Return control questions filtered by thematic tags.
+
+Usage:
+    python imports/control_questions.py --tags wojsko,gospodarka,sojusze
+    python imports/control_questions.py --tags geopolityka --file path/to/questions.md
+    python imports/control_questions.py --list-tags
+"""
+
+import argparse
+import os
+import re
+import sys
+
+DEFAULT_QUESTIONS_FILE = (
+    r"C:\Users\ziutus\Obsydian\personal\02-wiedza"
+    r"\Geopolityka i polityka\_pytania_kontrolne"
+    r"\_Pytania do każdego kraju czy obszaru.md"
+)
+
+# Mapping: tag → substrings to match in ## / # section headers (case-insensitive)
+TAG_TO_HEADERS: dict[str, list[str]] = {
+    "wojsko": [
+        "jaką ma armię",
+        "w razie ataku może oddać",
+        "agresywne czy pasywne",
+        "prowadzi konflikty",
+    ],
+    "gospodarka": [
+        "stan finansów",
+        "model ekonomiczny",
+        "gospodarka internetowa",
+    ],
+    "geopolityka": [
+        "poziom ważności",
+        "rolę pełni w systemie",
+        "strefy buforowe",
+        "dystrybucja prestiżu",
+        "powiązane jest państwo",
+        "aspiracje",
+        "cele strategiczne",
+        "jakie nianie dominują",
+    ],
+    "ideologia": [
+        "jaka panuje ideologia",
+        "aspiracje",
+        "cele strategiczne",
+    ],
+    "religia": [
+        "rola religii",
+    ],
+    "demografia": [
+        "demografia",
+    ],
+    "etniczne": [
+        "podziały etniczne",
+    ],
+    "soft-power-religijny": [
+        "podmiotem lub obiektem religijnego",
+    ],
+    "ustroj": [
+        "faktyczny ustrój polityczny",
+        "bliski rewolucji",
+        "politykę da się ukryć",
+        "status państwa",
+        "rząd centralny kontroluje",
+        "bloku politycznego",
+        "bloku mentalnych",
+        "regionalnym hegemonem",
+    ],
+    "sluzby-specjalne": [
+        "służby specjalne kontrolują",
+    ],
+    "technologia": [
+        "czyjej technologii używa",
+    ],
+    "internet": [
+        "internet i gospodarka internetowa",
+    ],
+    "finanse-publiczne": [
+        "stan finansów",
+    ],
+    "sojusze": [
+        "bloku politycznego",
+        "bloku mentalnych",
+        "rolę pełni w systemie",
+        "jakie ma sojusze",
+    ],
+}
+
+ALL_TAGS = sorted(TAG_TO_HEADERS.keys())
+
+
+def parse_sections(text: str) -> list[tuple[str, str]]:
+    """Split markdown into (header, body) pairs for ## and # sections."""
+    sections = []
+    current_header = ""
+    current_lines: list[str] = []
+
+    for line in text.splitlines():
+        if re.match(r"^#{1,2} ", line):
+            if current_header or current_lines:
+                sections.append((current_header, "\n".join(current_lines).strip()))
+            current_header = line
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_header or current_lines:
+        sections.append((current_header, "\n".join(current_lines).strip()))
+
+    return sections
+
+
+def sections_for_tags(sections: list[tuple[str, str]], tags: list[str]) -> list[tuple[str, str]]:
+    """Return deduplicated sections matching any of the requested tags."""
+    needles: list[str] = []
+    for tag in tags:
+        needles.extend(TAG_TO_HEADERS.get(tag, []))
+
+    seen: set[str] = set()
+    result: list[tuple[str, str]] = []
+    for header, body in sections:
+        header_lower = header.lower()
+        if any(n in header_lower for n in needles):
+            if header not in seen:
+                seen.add(header)
+                result.append((header, body))
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Return control questions filtered by tags")
+    parser.add_argument("--tags", help="Comma-separated tags, e.g. wojsko,gospodarka")
+    parser.add_argument("--file", default=DEFAULT_QUESTIONS_FILE,
+                        help="Path to the markdown questions file")
+    parser.add_argument("--list-tags", action="store_true",
+                        help="List all available tags and exit")
+    args = parser.parse_args()
+
+    if args.list_tags:
+        print("Available tags:")
+        for tag in ALL_TAGS:
+            print(f"  {tag}")
+        return
+
+    if not args.tags:
+        parser.error("--tags is required (or use --list-tags)")
+
+    if not os.path.isfile(args.file):
+        print(f"ERROR: questions file not found: {args.file}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.file, encoding="utf-8") as f:
+        text = f.read()
+
+    tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+    unknown = [t for t in tags if t not in TAG_TO_HEADERS]
+    if unknown:
+        print(f"WARNING: unknown tags (ignored): {', '.join(unknown)}", file=sys.stderr)
+
+    sections = parse_sections(text)
+    matched = sections_for_tags(sections, tags)
+
+    if not matched:
+        print(f"# Brak pytań dla tagów: {', '.join(tags)}", file=sys.stderr)
+        sys.exit(0)
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(f"# Pytania kontrolne dla: {', '.join(tags)}\n")
+    for header, body in matched:
+        print(header)
+        if body:
+            print(body)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -150,6 +150,7 @@ PORTAL_SKIP_SECTIONS = {
         "### Więcej pogłębionych treści",
         "### Więcej treści premium dla Ciebie",
         "## Najlepsze w premium",
+        "Top treści w Premium",
     ],
     "money": [],
     "wp": [],
@@ -308,8 +309,12 @@ def _clean_markdown_for_llm(text: str, portal: str | None = None) -> str:
         if stripped.isdigit():
             continue
 
-        # Pomiń frazy per portal
-        if stripped in skip_lines_set:
+        # Pomiń frazy per portal (normalizuj prefix nagłówkowy: #### Posłuchaj → Posłuchaj)
+        stripped_content = re.sub(r'^#{1,6}\s+', '', stripped)
+        if stripped_content in skip_lines_set:
+            continue
+        # Pomiń przyciski prędkości audio playera: x2, x1.75, x1.5, x1.25, x0.75
+        if re.match(r'^x[\d.]+$', stripped):
             continue
 
         # Pomiń linie zaczynające się od "Audio generowane"


### PR DESCRIPTION
## Summary

- Auto-tag articles with thematic categories (wojsko, gospodarka, geopolityka, etc.) via Bielik-11B-v3.0-Instruct when saving to DB — tags stored in `web_documents.tags` field
- New `control_questions.py` script filters geopolitical control questions by tag, so `/obsidian-note` Step 4 gets only relevant questions instead of the full list
- `obsidian-note.md` Step 4 updated to call the script dynamically using article tags from `--dump`
- `--meta` and `--dump` now expose the `tags` field in JSON output
- Tags displayed in `--review` and `--show` article headers
- Fix onet.pl article cleaning: Top treści w Premium section, audio player speed buttons, heading-prefixed skip phrases

## Test plan

- [ ] Save an article via `[w]rite` in `article_browser --review` and verify tags appear in header
- [ ] Run `python imports/control_questions.py --tags wojsko,gospodarka,geopolityka,sojusze` and verify filtered output
- [ ] Run `article_browser --meta --id <ID>` and verify `tags` field present in JSON
- [ ] Run `/obsidian-note <ID>` for a geopolitics article and verify Step 4 uses filtered questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)