### PR TITLE
refactor: simplify web_documents*/webdocument* batch scripts (steps 1+2)

### DIFF
--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import time
-import uuid
 
 script_start = time.monotonic()
 print("=== web_documents_do_the_needful_new.py ===")
@@ -19,8 +18,6 @@ print(f"done ({time.monotonic() - t0:.1f}s)")
 logging.basicConfig(level=logging.INFO)  # Change level as per your need
 
 print(f"aws_xray_enabled: {cfg.get('AWS_XRAY_ENABLED')}")
-
-missing_markdown_correct = False
 
 """
 TODO: add limits for asemblay.ai upload files (check), see: https://www.assemblyai.com/docs/concepts/faq
@@ -100,9 +97,8 @@ if __name__ == '__main__':
     )
     print(f"done ({time.monotonic() - t0:.1f}s)")
 
-    aws_session = boto3.Session(region_name=cfg.get("AWS_REGION"))
     try:
-        sts = aws_session.client("sts")
+        sts = boto_session.client("sts")
         identity = sts.get_caller_identity()
         actual_account = identity['Account']
         print(f"AWS account: {actual_account}, identity: {identity['Arn']}")
@@ -113,7 +109,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(f"WARNING: Could not determine AWS identity: {e}")
 
-    s3_check = aws_session.client("s3")
+    s3_check = boto_session.client("s3")
     try:
         s3_check.head_bucket(Bucket=cfg.get("AWS_S3_WEBSITE_CONTENT"))
     except Exception as e:
@@ -138,6 +134,14 @@ if __name__ == '__main__':
     t0 = time.monotonic()
     session = get_session()
     print(f"done ({time.monotonic() - t0:.1f}s)")
+
+    def get_or_create_document(url: str) -> "WebDocument":
+        """Return existing document for URL or a new one added to the session."""
+        doc = WebDocument.get_by_url(session, url)
+        if doc is None:
+            doc = WebDocument(url=url)
+            session.add(doc)
+        return doc
 
     print(f"\nTotal startup time: {time.monotonic() - script_start:.1f}s")
     print("=" * 50)
@@ -176,25 +180,23 @@ if __name__ == '__main__':
                             print(link_data["chapterList"])
 
                         # Map camelCase SQS fields to snake_case metadata
-                        metadata = {}
-                        metadata["source"] = link_data.get("source", "own")
-                        if 'chapterList' in link_data:
-                            metadata["chapter_list"] = link_data["chapterList"]
-                        if 'chapter_list' in link_data:
-                            metadata["chapter_list"] = link_data["chapter_list"]
-                        if 'language' in link_data:
-                            metadata["language"] = link_data["language"]
-                        if 'makeAISummary' in link_data:
-                            metadata["ai_summary_needed"] = link_data["makeAISummary"]
-                        if 'note' in link_data:
-                            metadata["note"] = link_data["note"]
+                        # (snake_case key wins when both variants are present)
+                        sqs_field_map = {
+                            "chapterList": "chapter_list",
+                            "chapter_list": "chapter_list",
+                            "language": "language",
+                            "makeAISummary": "ai_summary_needed",
+                            "note": "note",
+                            "title": "title",
+                            "paywall": "paywall",
+                        }
+                        metadata = {"source": link_data.get("source", "own")}
+                        for sqs_key, meta_key in sqs_field_map.items():
+                            if sqs_key in link_data:
+                                metadata[meta_key] = link_data[sqs_key]
                         uuid_val = link_data.get("uuid") or link_data.get("s3_uuid")
                         if uuid_val:
                             metadata["uuid"] = uuid_val
-                        if 'title' in link_data:
-                            metadata["title"] = link_data["title"]
-                        if 'paywall' in link_data:
-                            metadata["paywall"] = link_data["paywall"]
 
                         doc, status = doc_service.import_document(
                             url=link_data["url"],
@@ -276,8 +278,7 @@ if __name__ == '__main__':
 
             s3 = boto_session.client('s3')
 
-            website_nb = 1
-            for page_info in website_data:
+            for website_nb, page_info in enumerate(website_data, 1):
                 website_id = int(page_info[0])
                 url = page_info[1]
                 website_document_type = page_info[2]
@@ -297,10 +298,7 @@ if __name__ == '__main__':
                             print(f"* Reading text of article from S3 bucket >{cfg.get('AWS_S3_WEBSITE_CONTENT')}< and file: >{doc_uuid}.txt<", end=" ")
                             obj = s3.get_object(Bucket=cfg.get("AWS_S3_WEBSITE_CONTENT"), Key=f"{doc_uuid}.txt")
                             content = obj['Body'].read().decode('utf-8')
-                            web_doc = WebDocument.get_by_url(session, url)
-                            if web_doc is None:
-                                web_doc = WebDocument(url=url)
-                                session.add(web_doc)
+                            web_doc = get_or_create_document(url)
                             web_doc.text = content
                             print('[DONE]')
 
@@ -354,10 +352,7 @@ if __name__ == '__main__':
                             raw_html = download_raw_html(url)
                             if not raw_html:
                                 print("empty response! [ERROR]")
-                                web_doc = WebDocument.get_by_url(session, url)
-                                if web_doc is None:
-                                    web_doc = WebDocument(url=url)
-                                    session.add(web_doc)
+                                web_doc = get_or_create_document(url)
                                 web_doc.document_state = StalkerDocumentStatus.ERROR.name
                                 web_doc.document_state_error = StalkerDocumentStatusError.ERROR_DOWNLOAD.name
                                 session.commit()
@@ -368,10 +363,7 @@ if __name__ == '__main__':
 
                             parse_result = webpage_raw_parse(url, raw_html)
 
-                            web_doc = WebDocument.get_by_url(session, url)
-                            if web_doc is None:
-                                web_doc = WebDocument(url=url)
-                                session.add(web_doc)
+                            web_doc = get_or_create_document(url)
 
                             # Apply parse result fields
                             web_doc.text_raw = parse_result.text_raw
@@ -405,8 +397,6 @@ if __name__ == '__main__':
                             session.commit()
                 finally:
                     print(".")
-
-                website_nb += 1
 
         print(f"Step 2b completed in {time.monotonic() - step_start:.1f}s")
 
@@ -498,97 +488,9 @@ if __name__ == '__main__':
 
         print(f"Step 5 completed in {time.monotonic() - step_start:.1f}s")
 
-        print("\nStep 6: adding missing markdown entries")
-        step_start = time.monotonic()
-        if missing_markdown_correct:
-            from library.website.website_download_context import download_raw_html
-            # TODO: sprawdzić, dlaczego jest problem z pobraniem poniższych stron
-            problems = [38, 89, 150, 157, 191, 208, 220, 311, 371, 376, 396,
-                        443, 456, 465, 470, 486, 497, 499, 503, 531, 553, 581, 592, 600, 601, 602, 611, 662,
-                        664, 668, 686, 694, 1013, 6735, 6863, 6878, 6883, 6904, 6913, 6918, 6923, 6926, 6930, 7025]
-
-            # 611 certificate expired
-            # problems = []
-
-            document_id_start = max(problems) if len(problems) > 0 else 0
-            md_needed = websites.get_documents_md_needed(min_id=document_id_start)
-            print(md_needed)
-
-            s3_client = boto3.client('s3')
-
-            for document_id in md_needed:
-                web_doc = WebDocument.get_by_id(session, document_id)
-                if web_doc is None:
-                    logging.error(f"Document {document_id} not found")
-                    continue
-
-                if web_doc.paywall:
-                    print("Need manual download")
-                    continue
-
-                if web_doc.id in problems:
-                    print(f"Skipping problem on {document_id}")
-                    continue
-
-                print(f"Downloading {web_doc.id} {web_doc.url}, md len({len(web_doc.text_md or '')})")
-
-                html = download_raw_html(url=web_doc.url)
-                if not html:
-                    print("empty response! [ERROR]")
-                    web_doc.document_state = StalkerDocumentStatus.ERROR.name
-                    web_doc.document_state_error = StalkerDocumentStatusError.ERROR_DOWNLOAD.name
-                    session.commit()
-                    continue
-
-                # Detect encoding and handle invalid bytes
-                try:
-                    html = html.decode("utf-8")
-                except UnicodeDecodeError:
-                    import chardet
-
-                    detected_encoding = chardet.detect(html)['encoding']
-                    print(f"Detected encoding: {detected_encoding}")
-                    if detected_encoding:
-                        html = html.decode(detected_encoding, errors="replace")
-                    else:
-                        print("Encoding detection failed, using replacement characters.")
-                        html = html.decode("latin-1", errors="replace")
-
-                doc_uuid = str(uuid.uuid4())
-                file_name = f"{doc_uuid}.html"
-
-                try:
-                    s3_client.put_object(Bucket=cfg.get("AWS_S3_WEBSITE_CONTENT"), Key=file_name, Body=html)
-                    print(f"Successfully uploaded {file_name} to {cfg.get('AWS_S3_WEBSITE_CONTENT')}")
-                except Exception as e:
-                    error_message = f"Failed to upload {file_name} to {cfg.get('AWS_S3_WEBSITE_CONTENT')}: {str(e)}"
-                    print(error_message)
-                    continue
-
-                doc_cache_dir = os.path.join(cache_dir, str(doc_uuid))
-                os.makedirs(doc_cache_dir, exist_ok=True)
-                page_file = os.path.join(doc_cache_dir, f"{doc_uuid}.html")
-                with open(page_file, 'w', encoding="utf-8") as file:
-                    file.write(html)
-
-                from markitdown import MarkItDown
-                md = MarkItDown()
-                result = md.convert(page_file)
-
-                md_file = os.path.join(doc_cache_dir, f"{doc_uuid}.md")
-                with open(md_file, 'w', encoding="utf-8") as file:
-                    file.write(result.text_content)
-
-                md_clean_file = os.path.join(doc_cache_dir, f"{doc_uuid}_clean.md")
-                md_cleaned = result.text_content
-
-                # md_cleaned = webpage_text_clean(web_doc.url, md_cleaned)
-                web_doc.text_md = md_cleaned
-                web_doc.uuid = doc_uuid
-
-                session.commit()
-
-        print(f"Step 6 completed in {time.monotonic() - step_start:.1f}s")
+        # Step 6 (adding missing markdown entries) was removed — it was dead code
+        # behind a hardcoded False flag and duplicated the standalone script
+        # web_documents_fix_missing_markdown.py. Use that script instead.
 
         print(f"\nAll done in {time.monotonic() - script_start:.1f}s, exiting with status 0")
     finally:

--- a/backend/webdocument_md_decode.py
+++ b/backend/webdocument_md_decode.py
@@ -1,3 +1,4 @@
+import argparse
 import os.path
 import re
 import json
@@ -80,22 +81,7 @@ def load_regex_from_file(file_path):
         return f.read().strip()
 
 
-def generate_links_regex(links):
-    patterns = [re.escape(f'[{link["description"]}]({link["url"]})') for link in links]
-    return '|'.join(patterns)
-
-
-interactive = False
-find_problems = False
-
-text_to_md_check_only = False
-online = True
-embedding_update = False
-ignore_regexp_issue = True
-llm_fallback_enabled = True
-llm_fallback_model = "speakleash/Bielik-11B-v3.0-Instruct"
 cache_dir_base = os.path.join(cfg.get("CACHE_DIR") or "tmp", "markdown")
-split_limit = 200
 
 
 page_regexp_map = {
@@ -191,18 +177,49 @@ page_rules_map = {
 }
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Extract article text from webpage markdown (regexp rules + LLM fallback), "
+                    "clean it and optionally create embeddings.")
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--url-prefix",
+                           help='Process documents whose URL starts with prefix, e.g. "https://biznes.interia.pl/"')
+    selection.add_argument("--ids", type=int, nargs="+", metavar="ID",
+                           help="Explicit document IDs to process")
+    parser.add_argument("--interactive", action="store_true",
+                        help="Pause for Enter after each document")
+    parser.add_argument("--find-problems", action="store_true",
+                        help="Exit immediately when neither regex rules nor LLM fallback match")
+    parser.add_argument("--md-check-only", action="store_true",
+                        help="Stop after article extraction (skip link/image processing and embeddings)")
+    parser.add_argument("--embedding-update", action="store_true",
+                        help="Create and store embeddings for the cleaned parts")
+    parser.add_argument("--skip-regex-errors", action="store_true",
+                        help="Skip documents already marked with REGEX_ERROR")
+    parser.add_argument("--no-llm-fallback", action="store_true",
+                        help="Disable LLM fallback when regex rules do not match")
+    parser.add_argument("--llm-model", default="speakleash/Bielik-11B-v3.0-Instruct",
+                        help="LLM model for fallback extraction")
+    args = parser.parse_args()
+
+    interactive = args.interactive
+    find_problems = args.find_problems
+    text_to_md_check_only = args.md_check_only
+    embedding_update = args.embedding_update
+    ignore_regexp_issue = not args.skip_regex_errors
+    llm_fallback_enabled = not args.no_llm_fallback
+    llm_fallback_model = args.llm_model
+
     session = get_session()
     wb_db = WebsitesDBPostgreSQL(session=session)
 
-    # interactive = True
-    documents = wb_db.get_documents_by_url("https://biznes.interia.pl/")
-    # documents = [7456]
     # TODO: 7683 - need to correct related liks
     # TODO: 7741 - udostępnij artykuł - linki do ustąpienia do regexp: businessinsider_com_pl_2025_1.regex
     # TODO: 7732 - lepszy podział na części do embeddingu
     # TODO: 7687 - poprawić regexp geekweek_interia_pl_7687.regex
-    # documents = wb_db.get_list(document_type="webpage", document_state="DOCUMENT_INTO_DATABASE")
-    # documents = wb_db.get_list(document_type="webpage", limit=700)
+    if args.ids:
+        documents = args.ids
+    else:
+        documents = wb_db.get_documents_by_url(args.url_prefix)
 
     try:
         if not os.path.exists(cache_dir_base):
@@ -505,8 +522,7 @@ if __name__ == '__main__':
 
                 markdown = re.sub(r"^\s*reklama\s*\n", "", markdown, flags=re.MULTILINE | re.DOTALL)
 
-
-                markdown = re.sub(r"s*reklama$", "", markdown)
+                markdown = re.sub(r"\s*reklama\s*$", "", markdown)
 
 
                 markdown = re.sub(r"^\s+\* link\[\d+\]:.*$", "", markdown, flags=re.MULTILINE)
@@ -539,16 +555,9 @@ if __name__ == '__main__':
 
             markdown = re.sub(r'^\s+$', '\n', markdown)
 
-            # from unknown reason below code doesnt' work
-            markdown = re.sub(r'^>\s', '', markdown, re.MULTILINE)
-            # TODO: repalce with better code:
-            lines = markdown.splitlines()
-            lines2 = []
-            for line in lines:
-                if line.startswith("> "):
-                    line = line.replace("> ", "")
-                lines2.append(line)
-            markdown = "\n".join(lines2)
+            # Note: 4th positional arg of re.sub is `count`, not `flags` — that was
+            # why the old `re.sub(r'^>\s', '', markdown, re.MULTILINE)` "didn't work".
+            markdown = re.sub(r'^>\s', '', markdown, flags=re.MULTILINE)
 
             markdown = re.sub(r'\*\*\n+\s*', '**\n', markdown)
 

--- a/backend/webdocument_md_decode.py
+++ b/backend/webdocument_md_decode.py
@@ -5,11 +5,9 @@ import json
 import logging
 from pprint import pprint
 
-from markitdown import MarkItDown
-from html2markdown import convert
-import html2text
-
 from library.api.cloudferro.sherlock.sherlock_embedding import sherlock_create_embeddings
+from library.article_pipeline import ensure_raw_markdown
+from library.document_prepare import calculate_reduction
 from library.lenie_markdown import get_images_with_links_md, links_correct, process_markdown_and_extract_links, \
     md_square_brackets_in_one_line, md_split_for_emb, md_get_images_as_links, md_remove_markdown
 from library.models.stalker_document_status import StalkerDocumentStatus
@@ -17,20 +15,12 @@ from library.models.stalker_document_status_error import StalkerDocumentStatusEr
 from library.db.engine import get_session
 from library.db.models import WebDocument
 from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
-from library.api.aws.s3_aws import s3_file_exist, s3_take_file
 from library.config_loader import load_config
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 cfg = load_config()
-
-S3_BUCKET_NAME = cfg.get("AWS_S3_WEBSITE_CONTENT")
-EMBEDDING_MODEL = cfg.get("EMBEDDING_MODEL")
-
-
-def calculate_reduction(html_size, markdown_size):
-    return ((html_size - markdown_size) / html_size) * 100
 
 
 def onet_see_also_process_markdown_and_extract_links_with_images(markdown_text):
@@ -255,84 +245,30 @@ if __name__ == '__main__':
 
             metadata = {"document_id": document_id}
             cache_file_html = os.path.join(cache_dir, f"{document_id}.html")
-            cache_file_step_1_md = os.path.join(cache_dir, f"{document_id}_step_1_all.md")
             cache_file_step_2_md = os.path.join(cache_dir, f"{document_id}_step_2_1_article.md")
 
             logger.info("Step 1: preparing markdown from HTML file")
-            logger.debug("Taking markdown content from local cache or from remote cache (S3)")
-
-            if not os.path.isfile(cache_file_step_1_md) and not os.path.isfile(cache_file_html):
-                logger.debug("Taking raw html file from cache in Amazon S3")
-
-                if not doc.uuid:
-                    logger.debug("Doesn't exist uuid, exiting...")
-                    continue
-
-                if not s3_file_exist(S3_BUCKET_NAME, doc.uuid + ".html"):
-                    logger.debug("I can't find file in S3 cache")
-                    continue
-
-                logger.debug("the HTML file exist in S3 cache")
-                if s3_take_file(S3_BUCKET_NAME, doc.uuid + ".html", cache_file_html):
-                    logger.debug("The HTML file has been copy to local cache")
-                else:
-                    logger.debug("Can't download file from S3 cache, exiting...")
-                    continue
-
-            if os.path.isfile(cache_file_step_1_md):
-                logger.debug("DEBUG: 1a. Taking raw markdown file from cache")
-                with open(cache_file_step_1_md, "r", encoding="utf-8") as f:
-                    result = f.read()
-            else:
-                logger.debug("DEBUG: 1b. Taking raw html file from cache")
-                mdit = MarkItDown()
-                result = mdit.convert(cache_file_html).text_content
-
-            md_size = len(result)
-            html_size = os.path.getsize(cache_file_html)
-
-            logger.debug(f"Rozmiar HTML: {html_size} bajtów")
-
-            reduction_percentage = calculate_reduction(html_size, md_size)
-            logger.debug(f"MarkItDown reduction: {reduction_percentage:.2f}%")
-            markdown_text = result
-
-            if reduction_percentage < 30:
-                logger.debug("Looks like MarkItDown didn't converted to markdown, choosing next metod: html2text")
-                with open(cache_file_html, "r", encoding="utf-8") as f:
-                    html = f.read()
-
-                    markdown = convert(html)
-                    md_size_2 = len(markdown)
-
-                    reduction_percentage = calculate_reduction(html_size, md_size_2)
-                    logger.debug(f"Markdown reduction: {reduction_percentage:.2f}%")
-                    markdown_text = markdown
-
-                    if reduction_percentage < 30:
-
-                        h = html2text.HTML2Text()
-                        h.ignore_links = False
-                        h.ignore_images = False
-                        markdown_content = h.handle(html)
-
-                        markdown_size = len(markdown_content)
-                        reduction_html2text_percentage = calculate_reduction(html_size, markdown_size)
-
-                        logger.debug(f"html2Text reduction: {reduction_html2text_percentage:.2f}%")
-
-                        markdown_text = markdown_content
-
-            with open(cache_file_step_1_md, 'w', encoding="utf-8") as file:
-                file.write(markdown_text)
-                logger.info("Transformation from text to markdown completed")
-
-            if reduction_percentage < 30 or reduction_percentage >= 98:
-                logger.error("ERROR: Something wrong with transformation to markdown, taking next document...")
-                doc.document_state = StalkerDocumentStatus.ERROR.name
-                doc.document_state_error = StalkerDocumentStatusError.TEXT_TO_MD_ERROR.name
-                session.commit()
+            # Reads step_1 from cache; otherwise downloads HTML (cache/S3),
+            # converts via the MarkItDown -> html2markdown -> html2text cascade
+            # and persists {id}_step_1_all.md (library/article_pipeline).
+            markdown_text = ensure_raw_markdown(doc, cache_dir, verbose=False)
+            if not markdown_text:
+                logger.debug("Can't get markdown (no uuid or HTML not in cache/S3), skipping...")
                 continue
+
+            # Quality gate: a sane conversion shrinks HTML by 30-98%.
+            # Only checkable when the HTML file is present in cache (it is not
+            # when markdown came straight from a cached step_1/md file).
+            if os.path.isfile(cache_file_html):
+                html_size = os.path.getsize(cache_file_html)
+                reduction_percentage = calculate_reduction(html_size, len(markdown_text))
+                logger.debug(f"HTML size: {html_size} B, markdown reduction: {reduction_percentage:.2f}%")
+                if reduction_percentage < 30 or reduction_percentage >= 98:
+                    logger.error("ERROR: Something wrong with transformation to markdown, taking next document...")
+                    doc.document_state = StalkerDocumentStatus.ERROR.name
+                    doc.document_state_error = StalkerDocumentStatusError.TEXT_TO_MD_ERROR.name
+                    session.commit()
+                    continue
 
             doc.document_state = StalkerDocumentStatus.NEED_CLEAN_MD.name
             session.commit()

--- a/backend/webdocument_prepare_regexp_by_ai.py
+++ b/backend/webdocument_prepare_regexp_by_ai.py
@@ -16,7 +16,6 @@ import logging
 
 from library.db.engine import get_session
 from library.db.models import WebDocument
-from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
 from library.config_loader import load_config
 from library.article_extractor import process_article_with_llm_fallback
 from library.document_prepare import prepare_markdown, save_document_info
@@ -80,7 +79,7 @@ if __name__ == '__main__':
             )
 
             if result:
-                lines = [l for l in result.splitlines() if l.strip()]
+                lines = [line for line in result.splitlines() if line.strip()]
                 logger.info(f"document_id: {document_id} Extracted: {len(result)} chars, {len(lines)} non-empty lines")
                 logger.info(f"document_id: {document_id} FIRST: {lines[0][:100]}")
                 logger.info(f"document_id: {document_id} LAST:  {lines[-1][:100]}")


### PR DESCRIPTION
## Summary

Step 1 of the batch-scripts cleanup (code review of `backend/web_documents*` / `backend/webdocument*`):

**`web_documents_do_the_needful_new.py`** (−122 lines)
- Removed dead Step 6 (~90 lines): it sat behind a hardcoded `missing_markdown_correct = False` flag and duplicated the standalone `web_documents_fix_missing_markdown.py` script
- Single boto3 session for STS/S3 checks (was: two sessions, one with explicit creds, one implicit)
- `get_or_create_document()` helper replaces 3 copies of the get-by-url-or-create block
- SQS camelCase→snake_case mapping as a dict-driven loop (8 ifs → 1 loop)
- Step 2b progress counter via `enumerate()` — `continue` no longer skips the increment

**`webdocument_md_decode.py`**
- **Bug fix**: `re.sub(r'^>\s', '', markdown, re.MULTILINE)` passed MULTILINE as the positional `count` argument — the documented *"unknown reason"* it never worked; now `flags=re.MULTILINE` and the manual workaround loop is gone
- **Bug fix**: `r"s*reklama$"` missing backslash → `r"\s*reklama\s*$"`
- Removed dead code: `online`, `split_limit`, `generate_links_regex()`
- Edit-the-source configuration (hardcoded URL + commented variants, module-level flags) replaced with argparse: `--url-prefix`/`--ids`, `--interactive`, `--find-problems`, `--md-check-only`, `--embedding-update`, `--skip-regex-errors`, `--no-llm-fallback`, `--llm-model`

**`webdocument_prepare_regexp_by_ai.py`** — unused import (F401), ambiguous variable name (E741)

## Test plan
- `PYTHONPATH=. uvx pytest tests/unit/` → 161 passed, 29 skipped
- `.venv pytest tests/unit/` → 682 passed (incl. `test_batch_pipeline_orm` source checks)
- `uvx ruff check` clean on all four files
- Smoke: `web_documents_do_the_needful_new.py --help`, `webdocument_md_decode.py --help`

**Step 2 (included here)**: `webdocument_md_decode.py` Step 1 (~80 lines of S3 fetch + MarkItDown→html2markdown→html2text cascade) replaced with a single `article_pipeline.ensure_raw_markdown()` call. The 30–98% reduction quality gate is preserved (and no longer crashes when step_1 exists without the HTML file); `calculate_reduction` imported from `library/document_prepare`; unused S3/markdown imports and constants removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
