### PR TITLE
docs: rewrite tests/CLAUDE.md to match the actual suite

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -171,5 +171,5 @@ Each subdirectory has its own `CLAUDE.md` with detailed documentation:
 | `database/` | [database/CLAUDE.md](database/CLAUDE.md) | PostgreSQL schema, pgvector setup, `web_documents` and `websites_embeddings` tables, 15 processing states |
 | `imports/` | [imports/CLAUDE.md](imports/CLAUDE.md) | CLI tools & import scripts: `youtube_add.py`, `dynamodb_sync.py`, `feed_monitor.py`, `article_browser.py`, `freedom_house_import.py`, `control_questions.py` |
 | `data/` | [data/CLAUDE.md](data/CLAUDE.md) | Site-specific cleanup rules (`site_rules.json`), regex patterns for Polish news portals |
-| `tests/` | [tests/CLAUDE.md](tests/CLAUDE.md) | Unit tests (9 files: markdown, text, paywall) and integration tests (5 files: REST API endpoints) |
+| `tests/` | [tests/CLAUDE.md](tests/CLAUDE.md) | Unit tests (41 files: ORM, services, Flask endpoints, batch/import scripts, article & markdown processing) and integration tests (6 files: REST API endpoints, FK constraints) |
 | `test_code/` | [test_code/CLAUDE.md](test_code/CLAUDE.md) | Experimental scripts: RAG pipeline, LLM provider testing, Bielik text processing, cloud migrations |

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -1,105 +1,110 @@
 # Tests — CLAUDE.md
 
-Pytest test suite for the backend. Split into **unit tests** (pure function testing, no external dependencies) and **integration tests** (REST API endpoints via Flask test client, requires running PostgreSQL database).
+Pytest test suite for the backend. Split into **unit tests** (41 files, ~690 tests — pure functions, ORM models with no DB connection, Flask endpoints with mocked sessions) and **integration tests** (6 files — REST API endpoints via Flask test client, require a running PostgreSQL database).
 
-## Directory Structure
+## Two Test Environments
 
-```
-backend/tests/
-├── unit/
-│   ├── test_md_extract_links.py              # Markdown link extraction
-│   ├── test_md_image_as_link.py              # Image-as-link extraction
-│   ├── test_md_images_with_links.py          # Image metadata extraction
-│   ├── test_md_link_inside.py                # Fix links split across lines
-│   ├── test_md_remove_new_line.py            # Newline removal in strings
-│   ├── test_md_squre_brackets_in_one_line.py # Join bracket text across lines
-│   ├── test_split_for_embedding.py           # Text chunking for embeddings
-│   ├── test_text_transcript.py               # Transcript timestamp parsing
-│   └── test_website_paid.py                  # Paywall detection
-│
-└── integration/
-    ├── test_page_exist.py                    # POST /website_exist
-    ├── test_website_crud.py                  # Full CRUD cycle (save/get/update/delete)
-    ├── test_website_get.py                   # GET /website_get with error cases
-    ├── test_website_get_list.py              # GET /website_list
-    └── test_website_is_paid.py               # POST /website_is_paid
-```
-
-## Running Tests
+Unit tests are designed to run in two environments:
 
 ```bash
-# All tests
-pytest
+# Lightweight (uvx) — no project dependencies installed.
+# Modules that need sqlalchemy/flask/boto3 skip themselves; pure-function tests run.
+cd backend && PYTHONPATH=. uvx pytest tests/unit/ -q
+# → ~169 passed, ~29 skipped
 
-# Unit tests only (no external dependencies)
-pytest backend/tests/unit/
-
-# Integration tests (requires PostgreSQL + .env)
-pytest backend/tests/integration/
-
-# Single test file
-pytest backend/tests/unit/test_split_for_embedding.py
+# Full venv — everything runs (~690 tests).
+cd backend && .venv/Scripts/python -m pytest tests/unit/ -q
 ```
 
-Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`.
+Integration tests additionally require PostgreSQL and a `.env` file:
 
-## Unit Tests
+```bash
+cd backend && .venv/Scripts/python -m pytest tests/integration/ -q
+```
 
-All unit tests inherit from `unittest.TestCase` and test pure library functions with no mocking or database access.
+Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. There is **no conftest.py** — run from `backend/` with `PYTHONPATH=.` (some tests open script sources via paths relative to the test file or to cwd).
 
-### Markdown Processing (6 files)
+## Unit Test Areas
 
-Tests for `library.lenie_markdown` module — the largest tested area:
+### ORM & Database Layer
+| File | Covers |
+|------|--------|
+| `test_db_engine.py` | Engine singleton, session factories, `Base` |
+| `test_db_models.py` | `WebDocument` columns (29), STI subclasses (7), `dict()` output (33 keys), lookup models |
+| `test_orm_crud.py` | `WebDocument` CRUD, `dict()` compatibility |
+| `test_repository_queries.py` | `WebsitesDBPostgreSQL` repository queries |
+| `test_get_list_query.py` | `get_list()` ORM query construction |
+| `test_embedding_crud_orm.py` | Embedding add/delete via ORM |
+| `test_similarity_search_orm.py` | `get_similar()` pgvector ORM path |
+| `test_sql_parameterization.py` | SQL parameterization (no string interpolation) |
+| `test_import_log_tracker.py` | `ImportLog` model + `ImportLogTracker` context manager |
+| `test_alembic_setup.py` | Alembic configuration, Flask session teardown |
 
-| File | Function Tested | Description |
-|------|----------------|-------------|
-| `test_md_extract_links.py` | `process_markdown_and_extract_links()` | Extract URLs from markdown content |
-| `test_md_image_as_link.py` | `md_get_images_as_links()` | Extract images encoded as `[![](...)](#)` |
-| `test_md_images_with_links.py` | `get_images_with_links_md()` | Extract image alt text, description, owner, URL |
-| `test_md_link_inside.py` | `links_correct()` | Join URLs split across lines (`google.\ncom` → `google.com`) |
-| `test_md_remove_new_line.py` | `remove_new_line_only_in_string()` | Remove line breaks only within matched strings |
-| `test_md_squre_brackets_in_one_line.py` | `md_square_brackets_in_one_line()` | Join `[text\nsplit]` → `[text split]` (6 test cases) |
+### Services & Flask Endpoints (mocked sessions)
+| File | Covers |
+|------|--------|
+| `test_document_service.py` | `DocumentService` (create/import document) |
+| `test_search_service.py` | `SearchService` (embeddings, similarity) |
+| `test_flask_endpoints_orm.py` | ORM-backed endpoints; error responses use generic messages (details logged, not leaked) |
+| `test_flask_endpoints_document_states.py` | `GET /document_states` |
+| `test_website_get_validation.py` | `/website_get` input validation |
+| `test_metrics_endpoint.py` | `/metrics` |
+| `test_ai_intent_parser.py` | AI intent parser |
+| `test_config_loader.py` | Config loader re-export (`unified_config_loader`) |
 
-### Text Processing (2 files)
+### Batch & Import Scripts
+| File | Covers |
+|------|--------|
+| `test_batch_pipeline_orm.py` | `web_documents_do_the_needful_new.py` — AST/source checks (ORM imports, no legacy calls); `youtube_add.py` source checks |
+| `test_dynamodb_sync_orm.py` / `test_dynamodb_sync_auto_since.py` | `dynamodb_sync.py` ORM usage; `--since` auto-detection (incl. `--dry-run` needs no DB) |
+| `test_unknown_news_import_orm.py` | Feed entry import logic (now in `feed_monitor.py`) |
+| `test_youtube_processing_orm.py` | `youtube_processing.py` ORM migration |
+| `test_feed_monitor_utils.py` | Pure helpers: `parse_date`, `strip_html`, `_parse_selection`, `apply_skip_filters`, `detect_document_type`, `build_feed_url` |
+| `test_article_browser_utils.py` | Pure helpers: `_trim_to_sentences`, `_article_full_text` |
+| `test_control_questions.py` | `parse_sections`, `sections_for_tags`, tag-needle invariants |
+| `test_md_decode_onet.py` | `clean_onet_artifacts()` from `webdocument_md_decode.py` |
 
-| File | Function Tested | Description |
-|------|----------------|-------------|
-| `test_split_for_embedding.py` | `library.text_functions.split_text_for_embedding()` | Split long text into chunks for AI embedding generation |
-| `test_text_transcript.py` | `library.text_transcript.split_text_and_time()` | Parse `HH:MM[:SS]` timestamps from transcripts (6 test cases, pytest-style assertions) |
+### Article Processing (`library/`)
+| File | Covers |
+|------|--------|
+| `test_article_cleaner.py` | `clean_article_text()` — portal artifact cleanup, `[imgN]`/`[linkN]` markers |
+| `test_article_pipeline.py` | `ensure_raw_markdown()` + `extract_article()` (cache/S3/LLM pipeline, no I/O) |
+| `test_article_tagging.py` | LLM thematic tagging & country extraction |
+| `test_article_review_tracking.py` | `reviewed_at` / `obsidian_note_paths` tracking |
 
-### Website Classification (1 file)
-
-| File | Function Tested | Description |
-|------|----------------|-------------|
-| `test_website_paid.py` | `library.website.website_paid.website_is_paid()` | Detect paywalled sites (wyborcza.pl → True, testfree.com → False) |
+### Markdown & Text Processing (legacy, `unittest.TestCase` style)
+| File | Function Tested |
+|------|----------------|
+| `test_md_extract_links.py` | `process_markdown_and_extract_links()` |
+| `test_md_image_as_link.py` | `md_get_images_as_links()` |
+| `test_md_images_with_links.py` | `get_images_with_links_md()` |
+| `test_md_link_inside.py` | `links_correct()` |
+| `test_md_remove_new_line.py` | `remove_new_line_only_in_string()` |
+| `test_md_squre_brackets_in_one_line.py` | `md_square_brackets_in_one_line()` |
+| `test_split_for_embedding.py` | `split_text_for_embedding()` |
+| `test_text_transcript.py` | `split_text_and_time()` |
+| `test_website_paid.py` | `website_is_paid()` |
+| `test_transcript_prices.py` / `test_transcription_usage.py` | AssemblyAI price mapping, usage aggregation |
 
 ## Integration Tests
 
-All integration tests use Flask `app.test_client()` from `server.py`. They test REST API endpoints end-to-end and **require a running PostgreSQL database**.
+All use Flask `app.test_client()` from `server.py` and **require PostgreSQL**.
 
-| File | Endpoints Tested | Description |
-|------|-----------------|-------------|
-| `test_page_exist.py` | `POST /website_exist` | Check if URL exists in DB (JSON body, form data, missing data error) |
-| `test_website_crud.py` | `POST /save_website`, `GET /website_get`, `GET /website_delete` | Full lifecycle: create → retrieve → update → verify → delete |
-| `test_website_get.py` | `GET /website_get` | Retrieve by ID with error handling (missing ID → 400, non-existent → 404) |
-| `test_website_get_list.py` | `GET /website_list` | List all websites, validates response structure |
-| `test_website_is_paid.py` | `POST /website_is_paid` | Paywall check via API (google.com → `is_paid: false`) |
+| File | Endpoints / Area |
+|------|-----------------|
+| `test_page_exist.py` | `POST /website_exist` |
+| `test_website_crud.py` | Full lifecycle: create → retrieve → update → delete |
+| `test_website_get.py` | `GET /website_get` with error cases |
+| `test_website_get_list.py` | `GET /website_list` |
+| `test_website_is_paid.py` | `POST /website_is_paid` |
+| `test_fk_constraints.py` | FK constraint validation on lookup tables |
 
 ## Test Conventions
 
-- **Framework**: `unittest.TestCase` base class, run via `pytest`
-- **Assertions**: Mostly `self.assertEqual`/`self.assertTrue` (unittest style); `test_text_transcript.py` uses bare `assert` (pytest style)
-- **Test data**: Real Polish URLs and content (interia.pl, onet.pl, wyborcza.pl)
-- **No mocking**: Tests use real library functions and Flask test client
-- **No conftest.py**: No shared fixtures or parametrization
-- **No teardown**: CRUD test creates unique URLs via UUID to avoid conflicts
-
-## Modules Under Test
-
-| Module | Source File | Test Coverage |
-|--------|-----------|---------------|
-| `library.lenie_markdown` | `backend/library/lenie_markdown.py` | 6 unit test files |
-| `library.text_functions` | `backend/library/text_functions.py` | 1 unit test file |
-| `library.text_transcript` | `backend/library/text_transcript.py` | 1 unit test file |
-| `library.website.website_paid` | `backend/library/website/website_paid.py` | 1 unit + 1 integration |
-| Flask REST API | `backend/server.py` | 5 integration test files |
+- **New tests**: pytest style — plain classes, bare `assert`, fixtures, `monkeypatch`, `parametrize`. **Legacy tests** (markdown/text group): `unittest.TestCase`.
+- **Heavy third-party deps** (`sqlalchemy`, `flask`): test modules guard with `pytest.importorskip("sqlalchemy")` at the top — in the lightweight uvx environment the whole module skips cleanly.
+- **Modules under test with heavy module-level imports** (`feed_monitor`, `article_browser`, `webdocument_md_decode`): tests install minimal stubs in `sys.modules` *only for the import of the module under test*, then remove them so the `importorskip` pattern in other modules keeps working. See the docstring in `test_feed_monitor_utils.py` for the `_ensure_importable` / `_remove_stubs` helpers.
+- **Lazy-imported dependencies** (e.g. `library.document_prepare` in `article_pipeline`): faked via `monkeypatch.setitem(sys.modules, ...)` per test — the real module (which pulls the optional `markitdown` extra) is never imported. See `test_article_pipeline.py`.
+- **Source-check tests**: `test_batch_pipeline_orm.py` parses script sources with `ast` to enforce ORM-only imports; script paths are resolved relative to the test file or assume cwd=`backend/`.
+- **No DB in unit tests**: ORM tests use model metadata and mocked sessions only.
+- Do not put stubs permanently into `sys.modules` at test-module level — it breaks `importorskip` detection in other files collected in the same session.


### PR DESCRIPTION
## Summary

`backend/tests/CLAUDE.md` described 9 unit test files in unittest style with "no mocking, no conftest" — the suite has 41 unit files (~690 tests) and 6 integration files. Rewritten to match reality:

- Inventory grouped by area (ORM/DB layer, services & Flask endpoints, batch & import scripts, article processing, legacy markdown/text, integration)
- Two test environments documented: lightweight `uvx pytest` (importorskip-based skipping, ~169 passed / 29 skipped) vs full venv (~690 tests)
- Current conventions: pytest style for new tests, `pytest.importorskip` guards, temporary `sys.modules` stubs for modules with heavy module-level imports (with the rule against permanent stubs), monkeypatch fakes for lazy imports, AST source-check tests
- `backend/CLAUDE.md` subdirectory table row updated

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)