### PR TITLE
feat: add lenie-registry to NAS compose, improve connect page UX

### DIFF
--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -90,6 +90,23 @@ services:
       timeout: 5s
       retries: 3
 
+  lenie-registry:
+    image: registry:2
+    container_name: lenie-registry
+    restart: unless-stopped
+    ports:
+      - "5005:5000"
+    environment:
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+      REGISTRY_HTTP_HEADERS_Access-Control-Allow-Origin: '["*"]'
+      REGISTRY_HTTP_HEADERS_Access-Control-Allow-Methods: '["HEAD","GET","OPTIONS","DELETE"]'
+      REGISTRY_HTTP_HEADERS_Access-Control-Allow-Headers: '["Authorization","Accept","Cache-Control"]'
+      REGISTRY_HTTP_HEADERS_Access-Control-Expose-Headers: '["Docker-Content-Digest"]'
+    volumes:
+      - lenie-registry-data:/var/lib/registry
+    networks:
+      - lenie-net
+
   lenie-registry-ui:
     image: joxit/docker-registry-ui:latest
     container_name: lenie-registry-ui
@@ -103,6 +120,8 @@ services:
       DELETE_IMAGES: "true"
     networks:
       - lenie-net
+    depends_on:
+      - lenie-registry
 
   lenie-vault:
     image: hashicorp/vault:1.21.3
@@ -151,7 +170,7 @@ services:
 networks:
   lenie-net:
     name: lenie-net
-    driver: bridge
+    external: true
 
 volumes:
   lenie-ai-db-data:
@@ -159,4 +178,6 @@ volumes:
   lenie-ai-data:
     external: true
   lenie-minio-data:
+    external: true
+  lenie-registry-data:
     external: true

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -5,6 +5,7 @@ import { AuthorizationContext } from "../context/authorizationContext";
 import { saveConnectionConfig } from "../services/storage";
 import type { ApiType } from "../../../types";
 import { DEFAULT_API_URLS } from "../../../types";
+import { lenie_version } from "../constants/variables";
 
 const Connect: React.FC = () => {
   const navigate = useNavigate();
@@ -14,6 +15,7 @@ const Connect: React.FC = () => {
   const [formApiType, setFormApiType] = useState<ApiType>("AWS Serverless");
   const [formApiUrl, setFormApiUrl] = useState(DEFAULT_API_URLS["AWS Serverless"]);
   const [formApiKey, setFormApiKey] = useState("");
+  const [showApiKey, setShowApiKey] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState("");
@@ -105,20 +107,32 @@ const Connect: React.FC = () => {
 
   return (
     <div style={{ maxWidth: "500px", margin: "80px auto", padding: "20px" }}>
-      <h2 style={{ marginBottom: "20px" }}>Connect to Lenie Backend</h2>
+      <h2 style={{ marginBottom: "4px" }}>Connect to Lenie Backend</h2>
+      <div style={{ fontSize: "12px", color: "#6c757d", marginBottom: "20px" }}>
+        Frontend v{lenie_version}
+      </div>
 
       <div style={{ marginBottom: "15px" }}>
         <label htmlFor="connect-api-key" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
           API Key
         </label>
-        <input
-          id="connect-api-key"
-          type="password"
-          value={formApiKey}
-          onChange={(e) => setFormApiKey(e.target.value)}
-          placeholder="Enter your API key"
-          style={{ width: "100%", padding: "8px", fontSize: "14px" }}
-        />
+        <div style={{ display: "flex", gap: "8px" }}>
+          <input
+            id="connect-api-key"
+            type={showApiKey ? "text" : "password"}
+            value={formApiKey}
+            onChange={(e) => setFormApiKey(e.target.value)}
+            placeholder="Enter your API key"
+            style={{ flex: 1, padding: "8px", fontSize: "14px" }}
+          />
+          <button
+            type="button"
+            onClick={() => setShowApiKey(!showApiKey)}
+            style={{ padding: "8px 12px", fontSize: "14px", cursor: "pointer" }}
+          >
+            {showApiKey ? "Hide" : "Show"}
+          </button>
+        </div>
       </div>
 
       <div style={{ marginBottom: "15px" }}>


### PR DESCRIPTION
## Summary

- **infra**: `lenie-registry` dodany do `compose.nas.yaml` jako pełnoprawny serwis — rejestr przeżywa teraz restarty NAS i awarie prądu (wcześniej był standalone kontenerem, który po crashu Dockera znikał); dodano wolumen `lenie-registry-data: external: true`; `lenie-net` oznaczona jako `external: true` (eliminuje warning compose); `lenie-registry-ui` ma `depends_on: lenie-registry`
- **frontend**: przycisk Show/Hide przy polu API Key na stronie `/connect`
- **frontend**: wyświetlanie wersji frontendu (`Frontend vX.Y.Z`) pod nagłówkiem connect — pozwala zweryfikować po deployu że nowa wersja jest aktywna

## Test plan

- [ ] Restart NAS — sprawdź `docker compose ps` czy `lenie-registry` startuje automatycznie
- [ ] `http://192.168.200.7:3000/connect` — widoczna wersja frontendu pod nagłówkiem
- [ ] Przycisk Show/Hide przy API Key działa (przełącza type=password/text)
- [ ] Połączenie z backendem (`Docker`, `http://192.168.200.7:5055`) działa

🤖 Generated with [Claude Code](https://claude.com/claude-code)