### PR TITLE
feat: YouTube chunk review web interface with LLM analysis

### DIFF
--- a/backend/database/init/13-create-analysis-tables.sql
+++ b/backend/database/init/13-create-analysis-tables.sql
@@ -1,0 +1,64 @@
+-- Migration: create document analysis tables for YouTube chunk analysis workflow
+-- Enables storing LLM analysis results per document, with chunk-level review workflow
+
+\c "lenie-ai";
+
+-- Jedno uruchomienie analizy LLM dla dokumentu
+CREATE TABLE IF NOT EXISTS public.document_analysis_runs (
+    id          SERIAL PRIMARY KEY,
+    document_id INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    model       VARCHAR(100) NOT NULL,
+    chunk_size  INTEGER NOT NULL DEFAULT 5000,
+    synthesis   TEXT,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_document_id ON public.document_analysis_runs(document_id);
+
+
+-- Poszczególne chunki z wynikami LLM
+-- status: pending | approved | needs_reanalysis | split_requested | split
+CREATE TABLE IF NOT EXISTS public.document_chunks (
+    id                SERIAL PRIMARY KEY,
+    run_id            INTEGER NOT NULL REFERENCES public.document_analysis_runs(id) ON DELETE CASCADE,
+    document_id       INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    position          SMALLINT NOT NULL,
+    type              VARCHAR(20) NOT NULL,        -- TEMAT | REKLAMA
+    topic             VARCHAR(500),
+    original_text     TEXT NOT NULL,
+    corrected_text    TEXT,
+    summary           TEXT,                        -- NULL dla REKLAMA
+    seg_start         INTEGER,                     -- indeks w text_raw JSON (włącznie)
+    seg_end           INTEGER,                     -- indeks w text_raw JSON (wyłączony)
+    rewrite_ratio     SMALLINT,                    -- % długości corrected vs original
+    status            VARCHAR(30) NOT NULL DEFAULT 'pending',
+    split_at_seg      INTEGER,                     -- segment podziału (przed zatwierdzeniem)
+    split_first_type  VARCHAR(20),                 -- typ pierwszej części po podziale
+    split_second_type VARCHAR(20),                 -- typ drugiej części po podziale
+    created_at        TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chunks_run_id       ON public.document_chunks(run_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id  ON public.document_chunks(document_id);
+CREATE INDEX IF NOT EXISTS idx_chunks_status       ON public.document_chunks(status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_run_position ON public.document_chunks(run_id, position);
+
+
+-- Sekcje tematyczne (pogrupowane chunki) — edytowalne przez usera
+CREATE TABLE IF NOT EXISTS public.document_topic_sections (
+    id              SERIAL PRIMARY KEY,
+    run_id          INTEGER NOT NULL REFERENCES public.document_analysis_runs(id) ON DELETE CASCADE,
+    document_id     INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    position        SMALLINT NOT NULL,
+    type            VARCHAR(20) NOT NULL,          -- TEMAT | REKLAMA
+    title           VARCHAR(500),
+    summary         TEXT,
+    chunk_positions INTEGER[] NOT NULL,            -- np. {1,2,3} — pozycje chunków z tego runu
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sections_run_id ON public.document_topic_sections(run_id);
+
+SELECT 'Tables document_analysis_runs, document_chunks, document_topic_sections created' AS status;

--- a/backend/database/init/14-add-speakers-to-analysis-runs.sql
+++ b/backend/database/init/14-add-speakers-to-analysis-runs.sql
@@ -1,0 +1,9 @@
+-- Migration: add speakers JSONB column to document_analysis_runs
+-- Stores extracted speaker info: [{"name": "...", "role": "...", "description": "..."}]
+
+\c "lenie-ai";
+
+ALTER TABLE public.document_analysis_runs
+    ADD COLUMN IF NOT EXISTS speakers JSONB NOT NULL DEFAULT '[]';
+
+SELECT 'Column speakers added to document_analysis_runs' AS status;

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -1,0 +1,233 @@
+"""LLM-based chunk analysis: rewrite (transcript correction) + summarize.
+
+Extracted from test_code/youtube_batch_analyze.py for use by Flask API endpoints.
+Supports Sherlock (Bielik) and ArkLabs models.
+"""
+
+import json
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+REWRITE_MAX_TOKENS = 2_500
+REWRITE_MIN_RATIO = 0.80
+SUMMARY_MAX_TOKENS = 400
+
+SECTION_HEADER_RE = re.compile(r"^### (REKLAMA|TEMAT): ?(.+)$", re.MULTILINE)
+
+_ARKLABS_PREFIX = "arklabs/"
+
+# Filler patterns: unambiguous hesitation sounds in Polish STT output
+_FILLER_SOUND_RE = re.compile(
+    r"\b(y{2,}|e{2,}|m{3,}|a{3,})\b",  # yyy, eee, mmm, aaaa
+    re.IGNORECASE,
+)
+_STANDALONE_Y_RE = re.compile(r"(?<!\w)y(?!\w)", re.IGNORECASE)
+_WORD_REPEAT_RE = re.compile(r"\b(\w+)\s+\1\b", re.IGNORECASE)
+
+
+def extract_speaker_info(intro_text: str, model: str) -> list[dict]:
+    """Ask LLM to identify speakers from the transcript introduction.
+
+    Returns list of dicts: [{"name": "...", "role": "...", "description": "..."}]
+    Returns [] if extraction fails or no speakers found.
+    Ported from test_code/youtube_batch_analyze.py.
+    """
+    prompt = f"""Z poniższego fragmentu transkrypcji podcastu wyekstrahuj informacje o rozmówcach.
+Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:
+[{{"name": "Imię Nazwisko", "role": "prowadzący", "description": "krótki opis stanowiska/roli"}}]
+
+Jeśli nie możesz zidentyfikować rozmówców, zwróć pustą tablicę: []
+
+Fragment transkrypcji:
+{intro_text}"""
+
+    logger.info("extract_speaker_info: len=%d", len(intro_text))
+    response_text, _ = call_model(prompt, model, max_tokens=300)
+    try:
+        match = re.search(r'\[.*\]', response_text, re.DOTALL)
+        if match:
+            return json.loads(match.group())
+    except Exception:
+        logger.warning("extract_speaker_info: failed to parse JSON response")
+    return []
+
+
+def remove_speech_fillers(text: str) -> str:
+    """Remove hesitation sounds and word repetitions from Polish STT transcript.
+
+    Handles: yyy/eee/mmm (unambiguous sounds), standalone 'y', doubled words.
+    Does NOT touch meaningful words — cheaper and more reliable than asking the LLM.
+    """
+    text = _FILLER_SOUND_RE.sub("", text)
+    text = _STANDALONE_Y_RE.sub("", text)
+    text = _WORD_REPEAT_RE.sub(r"\1", text)
+    # Collapse multiple spaces left after removal
+    text = re.sub(r" {2,}", " ", text)
+    text = re.sub(r" ([,.\?!])", r"\1", text)  # fix space before punctuation
+    return text.strip()
+
+
+def call_model(prompt: str, model: str, max_tokens: int) -> tuple[str, int]:
+    """Call the appropriate LLM backend and return (response_text, token_count)."""
+    if model.startswith(_ARKLABS_PREFIX):
+        from library.api.arklabs.arklabs_completion import arklabs_get_completion
+        actual = f"speakleash/{model.removeprefix(_ARKLABS_PREFIX)}"
+        result = arklabs_get_completion(prompt, model=actual, max_tokens=max_tokens, temperature=0.2)
+    else:
+        from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
+        result = sherlock_get_completion(prompt, model=model, max_tokens=max_tokens, temperature=0.2)
+    tokens = getattr(result, "prompt_tokens", 0) or 0
+    return result.response_text, tokens
+
+
+def rewrite_chunk_text(text: str, model: str, position: int = 1, total: int = 1) -> tuple[str, int]:
+    """Pass 1: label section + correct transcript verbatim.
+
+    Applies remove_speech_fillers() before sending to LLM — faster and cheaper than
+    asking the model to do it.
+    Returns (best_response_text, rewrite_ratio_pct).
+    Retries once if output < REWRITE_MIN_RATIO of input length, keeps the longer result.
+    """
+    text = remove_speech_fillers(text)
+    prompt = f"""Fragment {position}/{total} surowej transkrypcji podcastu YouTube.
+Wykonaj DWIE rzeczy — nic więcej:
+
+1. W PIERWSZEJ LINII wpisz etykietę sekcji (tylko jedną z dwóch opcji):
+   ### REKLAMA: nazwa_sponsora      (gdy to blok reklamowy lub sponsorski)
+   ### TEMAT: opis_3_4_słowa        (gdy to merytoryczna treść rozmowy)
+
+2. Przepisz poniższy tekst DOSŁOWNIE — każde słowo musi zostać zachowane. Popraw tylko:
+   - Interpunkcję i podział na zdania.
+   - Oczywiste błędy transkrypcji (zamienione lub zlepione wyrazy).
+   - Zachowaj etykiety [Mówca]: na początku każdej wypowiedzi — nie usuwaj ich.
+   NIE skracaj. NIE streszczaj. NIE pomijaj żadnej informacji.
+
+--- FRAGMENT DO PRZEPISANIA ---
+{text}
+--- KONIEC FRAGMENTU ---"""
+
+    best = ""
+    for attempt in range(1, 3):
+        logger.info("rewrite chunk %d/%d, attempt %d, len=%d", position, total, attempt, len(text))
+        response_text, tokens = call_model(prompt, model, REWRITE_MAX_TOKENS)
+        logger.info("rewrite done: %d chars, %d tokens", len(response_text), tokens)
+        if len(response_text) > len(best):
+            best = response_text
+        if len(response_text) >= len(text) * REWRITE_MIN_RATIO:
+            break
+        ratio_pct = round(len(response_text) / max(len(text), 1) * 100)
+        logger.warning("rewrite too short (%d%% < %d%%), retrying", ratio_pct, round(REWRITE_MIN_RATIO * 100))
+
+    ratio_pct = round(len(best) / max(len(text), 1) * 100)
+    return best, ratio_pct
+
+
+def summarize_chunk_text(corrected_text: str, model: str,
+                         speakers: list[dict] | None = None) -> str:
+    """Pass 2: summarize already-corrected text in 2-3 sentences.
+
+    If speakers list is provided, the prompt includes participant names so the
+    summary can use real names instead of generic 'Rozmówca'.
+    """
+    speakers_ctx = ""
+    if speakers:
+        names = ", ".join(
+            f"{sp['name']}" + (f" ({sp.get('role', '')})" if sp.get("role") else "")
+            for sp in speakers
+        )
+        speakers_ctx = f"Uczestnicy rozmowy: {names}.\n"
+
+    prompt = f"""{speakers_ctx}Napisz streszczenie poniższego fragmentu merytorycznej rozmowy w 2-3 zdaniach.
+Skup się na głównych tezach i wnioskach. Używaj imion rozmówców (nie pisz „Rozmówca"). Odpowiedz po polsku.
+
+--- TEKST ---
+{corrected_text}
+--- KONIEC ---"""
+
+    logger.info("summarize chunk, len=%d, speakers=%d", len(corrected_text), len(speakers or []))
+    response_text, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    logger.info("summarize done: %d tokens", tokens)
+    return response_text.strip()
+
+
+def parse_rewritten_chunk(raw: str) -> tuple[str, str, str]:
+    """Extract (section_type, topic, corrected_text) from rewrite LLM output."""
+    header_match = SECTION_HEADER_RE.search(raw)
+    section_type = header_match.group(1) if header_match else "TEMAT"
+    topic = header_match.group(2).strip() if header_match else ""
+    text = raw[header_match.end():].strip() if header_match else raw.strip()
+    return section_type, topic, text
+
+
+def analyze_chunk_semantic(corrected_text: str, model: str,
+                           speakers: list[dict] | None = None) -> dict:
+    """Semantic-only re-analysis: classify + summarize already-corrected text.
+
+    Skips the verbatim rewrite step. Use when corrected_text is already good
+    and only type/topic/summary need to be refreshed.
+    Returns dict with corrected_text unchanged.
+    """
+    speakers_ctx = ""
+    if speakers:
+        names = ", ".join(
+            f"{sp['name']}" + (f" ({sp.get('role', '')})" if sp.get("role") else "")
+            for sp in speakers
+        )
+        speakers_ctx = f"Uczestnicy rozmowy: {names}.\n"
+
+    prompt = f"""{speakers_ctx}Sklasyfikuj poniższy fragment i jeśli to TEMAT — napisz streszczenie.
+
+W PIERWSZEJ LINII wpisz etykietę (tylko jedną z dwóch opcji):
+   ### REKLAMA: nazwa_sponsora      (blok reklamowy lub sponsorski)
+   ### TEMAT: opis_3_4_słowa        (merytoryczna treść rozmowy)
+
+Jeśli TEMAT: w kolejnych liniach napisz streszczenie w 2-3 zdaniach po polsku.
+Używaj imion rozmówców (nie pisz „Rozmówca").
+Jeśli REKLAMA: nie dodawaj nic więcej.
+
+--- TEKST ---
+{corrected_text}
+--- KONIEC ---"""
+
+    logger.info("semantic analysis, len=%d, speakers=%d", len(corrected_text), len(speakers or []))
+    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    logger.info("semantic done: %d tokens", tokens)
+
+    section_type, topic, summary_text = parse_rewritten_chunk(raw)
+    return {
+        "type": section_type,
+        "topic": topic,
+        "corrected_text": corrected_text,
+        "summary": summary_text.strip() if section_type == "TEMAT" and summary_text.strip() else None,
+        "rewrite_ratio": None,
+    }
+
+
+def analyze_chunk(original_text: str, model: str,
+                  position: int = 1, total: int = 1,
+                  speakers: list[dict] | None = None) -> dict:
+    """Run full analysis pipeline on a single chunk.
+
+    Returns dict:
+        type          — "TEMAT" | "REKLAMA"
+        topic         — short topic label from LLM
+        corrected_text — rewritten transcript
+        summary        — 2-3 sentence summary (None for REKLAMA)
+        rewrite_ratio  — % of corrected vs original length
+    """
+    raw_rewrite, ratio = rewrite_chunk_text(original_text, model, position, total)
+    section_type, topic, corrected_text = parse_rewritten_chunk(raw_rewrite)
+
+    summary = None
+    if section_type == "TEMAT":
+        summary = summarize_chunk_text(corrected_text or original_text, model, speakers=speakers)
+
+    return {
+        "type": section_type,
+        "topic": topic,
+        "corrected_text": corrected_text,
+        "summary": summary,
+        "rewrite_ratio": ratio,
+    }

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1,0 +1,1051 @@
+"""Flask blueprint: chunk review API + interactive HTML page.
+
+Endpoints:
+  GET  /analysis_runs?doc_id=<id>         — list runs for a document
+  GET  /analysis_run/<run_id>/chunks      — full run data (chunks + segments)
+  PATCH /chunk/<chunk_id>                 — update status / type / topic / split_at_seg
+  GET  /chunk_review                      — interactive HTML review page
+"""
+
+import json
+import logging
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request, abort
+from sqlalchemy import select, update as sa_update
+
+from library.db.engine import get_scoped_session
+from library.db.models import (
+    DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument,
+)
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("chunk_review", __name__)
+
+ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split"}
+ALLOWED_TYPES = {"TEMAT", "REKLAMA"}
+
+
+def _parse_segments(text_raw: str | None) -> list[dict]:
+    if not text_raw or not text_raw.strip().startswith("["):
+        return []
+    try:
+        segs = json.loads(text_raw.strip())
+        if isinstance(segs, list) and segs and "start" in segs[0]:
+            return segs
+    except (ValueError, KeyError, IndexError):
+        pass
+    return []
+
+
+def _chunk_to_dict(c: DocumentChunk) -> dict:
+    return {
+        "id": c.id,
+        "position": c.position,
+        "type": c.type,
+        "topic": c.topic,
+        "corrected_text": c.corrected_text,
+        "summary": c.summary,
+        "seg_start": c.seg_start,
+        "seg_end": c.seg_end,
+        "rewrite_ratio": c.rewrite_ratio,
+        "status": c.status,
+        "split_at_seg": c.split_at_seg,
+        "split_first_type": c.split_first_type,
+        "split_second_type": c.split_second_type,
+    }
+
+
+# ---------------------------------------------------------------------------
+# API: GET /analysis_runs
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_runs", methods=["GET"])
+def list_runs():
+    doc_id = request.args.get("doc_id", type=int)
+    if not doc_id:
+        return jsonify({"status": "error", "message": "doc_id required"}), 400
+
+    session = get_scoped_session()
+    runs = session.scalars(
+        select(DocumentAnalysisRun)
+        .where(DocumentAnalysisRun.document_id == doc_id)
+        .order_by(DocumentAnalysisRun.created_at.desc())
+    ).all()
+
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "runs": [
+            {
+                "id": r.id,
+                "model": r.model,
+                "chunk_size": r.chunk_size,
+                "created_at": r.created_at.isoformat(),
+                "chunk_count": len(r.chunks),
+            }
+            for r in runs
+        ],
+    })
+
+
+# ---------------------------------------------------------------------------
+# API: GET /analysis_run/<run_id>/chunks
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/chunks", methods=["GET"])
+def get_run_chunks(run_id: int):
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    doc = session.get(WebDocument, run.document_id)
+    segments = _parse_segments(doc.text_raw if doc else None)
+
+    topic_sections = session.scalars(
+        select(DocumentTopicSection)
+        .where(DocumentTopicSection.run_id == run_id)
+        .order_by(DocumentTopicSection.position)
+    ).all()
+
+    return jsonify({
+        "status": "success",
+        "run": {
+            "id": run.id,
+            "model": run.model,
+            "chunk_size": run.chunk_size,
+            "synthesis": run.synthesis,
+            "speakers": run.speakers or [],
+            "created_at": run.created_at.isoformat(),
+        },
+        "document": {
+            "id": doc.id if doc else None,
+            "title": doc.title if doc else "",
+            "original_id": doc.original_id if doc else "",
+        },
+        "segments": segments,
+        "chunks": [_chunk_to_dict(c) for c in run.chunks],
+        "topic_sections": [
+            {
+                "id": ts.id,
+                "position": ts.position,
+                "type": ts.type,
+                "title": ts.title,
+                "summary": ts.summary,
+                "chunk_positions": ts.chunk_positions,
+            }
+            for ts in topic_sections
+        ],
+    })
+
+
+# ---------------------------------------------------------------------------
+# API: POST /analysis_run/<run_id>/extract_speakers
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/extract_speakers", methods=["POST"])
+def extract_speakers(run_id: int):
+    """Extract speaker names from the first few chunks using LLM.
+
+    Uses the intro text (first 3 chunks' original_text) where participants
+    typically introduce themselves. Saves result to run.speakers.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    intro_chunks = session.scalars(
+        select(DocumentChunk)
+        .where(DocumentChunk.run_id == run_id)
+        .order_by(DocumentChunk.position)
+        .limit(3)
+    ).all()
+
+    intro_text = "\n\n".join(
+        c.corrected_text or c.original_text or ""
+        for c in intro_chunks
+    ).strip()
+
+    if not intro_text:
+        return jsonify({"status": "error", "message": "No text in first chunks"}), 400
+
+    try:
+        from library.chunk_llm_analysis import extract_speaker_info
+        speakers = extract_speaker_info(intro_text, run.model)
+    except Exception:
+        logger.exception("extract_speaker_info failed for run %d", run_id)
+        return jsonify({"status": "error", "message": "LLM call failed"}), 500
+
+    run.speakers = speakers
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for run %d speakers", run_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "speakers": speakers})
+
+
+# ---------------------------------------------------------------------------
+# API: PATCH /chunk/<chunk_id>
+# ---------------------------------------------------------------------------
+
+@bp.route("/chunk/<int:chunk_id>", methods=["PATCH", "OPTIONS"])
+def update_chunk(chunk_id: int):
+    if request.method == "OPTIONS":
+        return jsonify({"status": "ok"}), 200
+
+    session = get_scoped_session()
+    chunk = session.get(DocumentChunk, chunk_id)
+    if chunk is None:
+        abort(404, f"Chunk {chunk_id} not found")
+
+    data = request.get_json() or {}
+    changed = False
+
+    if "status" in data:
+        if data["status"] not in ALLOWED_STATUSES:
+            return jsonify({"status": "error", "message": f"Invalid status: {data['status']}"}), 400
+        chunk.status = data["status"]
+        changed = True
+
+    if "type" in data:
+        if data["type"] not in ALLOWED_TYPES:
+            return jsonify({"status": "error", "message": f"Invalid type: {data['type']}"}), 400
+        chunk.type = data["type"]
+        changed = True
+
+    if "topic" in data:
+        chunk.topic = data["topic"] or None
+        changed = True
+
+    if "split_at_seg" in data:
+        chunk.split_at_seg = data["split_at_seg"]
+        changed = True
+
+    if "split_first_type" in data:
+        val = data["split_first_type"]
+        if val and val not in ALLOWED_TYPES:
+            return jsonify({"status": "error", "message": f"Invalid split_first_type: {val}"}), 400
+        chunk.split_first_type = val or None
+        changed = True
+
+    if "split_second_type" in data:
+        val = data["split_second_type"]
+        if val and val not in ALLOWED_TYPES:
+            return jsonify({"status": "error", "message": f"Invalid split_second_type: {val}"}), 400
+        chunk.split_second_type = val or None
+        changed = True
+
+    if changed:
+        chunk.updated_at = datetime.utcnow()
+        try:
+            session.commit()
+        except Exception:
+            session.rollback()
+            logger.exception("Failed to update chunk %d", chunk_id)
+            return jsonify({"status": "error", "message": "DB error"}), 500
+
+    return jsonify({"status": "success", "chunk": _chunk_to_dict(chunk)})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /chunk/<chunk_id>/execute_split
+# ---------------------------------------------------------------------------
+
+@bp.route("/chunk/<int:chunk_id>/execute_split", methods=["POST"])
+def execute_split(chunk_id: int):
+    """Split a chunk into two at the given segment index.
+
+    Body (JSON):
+        split_at_seg      — absolute segment index (required)
+        split_first_type  — type for part before split: TEMAT | REKLAMA
+        split_second_type — type for part after split:  TEMAT | REKLAMA
+
+    Effect:
+        - Deletes the original chunk
+        - Inserts chunk A (before split) at original position
+        - Inserts chunk B (after split) at original position + 1
+        - Shifts all following chunks' positions by +1
+    """
+    session = get_scoped_session()
+    chunk = session.get(DocumentChunk, chunk_id)
+    if chunk is None:
+        abort(404, f"Chunk {chunk_id} not found")
+
+    data = request.get_json() or {}
+
+    # Allow split data from body OR from what's already stored on the chunk
+    split_at = data.get("split_at_seg", chunk.split_at_seg)
+    first_type = data.get("split_first_type", chunk.split_first_type)
+    second_type = data.get("split_second_type", chunk.split_second_type)
+
+    if split_at is None:
+        return jsonify({"status": "error", "message": "split_at_seg required"}), 400
+    if first_type not in ALLOWED_TYPES:
+        return jsonify({"status": "error", "message": f"Invalid split_first_type: {first_type}"}), 400
+    if second_type not in ALLOWED_TYPES:
+        return jsonify({"status": "error", "message": f"Invalid split_second_type: {second_type}"}), 400
+
+    seg_start = chunk.seg_start or 0
+    seg_end = chunk.seg_end
+
+    if not (seg_start <= split_at < (seg_end or split_at + 1)):
+        return jsonify({"status": "error",
+                        "message": f"split_at_seg {split_at} out of range [{seg_start}, {seg_end})"}), 400
+
+    # Reconstruct text from raw transcript segments
+    doc = session.get(WebDocument, chunk.document_id)
+    segments = _parse_segments(doc.text_raw if doc else None)
+
+    def _text_from_segs(start: int, end: int | None) -> str:
+        parts = []
+        for seg in (segments[start:end] if segments else []):
+            t = (seg.get("text") or "").strip()
+            if t.startswith(">>"):
+                t = t[2:].strip()
+            if t:
+                parts.append(t)
+        return " ".join(parts)
+
+    orig_pos = chunk.position
+    run_id = chunk.run_id
+    doc_id = chunk.document_id
+
+    try:
+        # Shift positions after orig_pos to a temp range to avoid unique constraint violation,
+        # then back shifted by +1 (making room for chunk B).
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.position > orig_pos)
+            .values(position=DocumentChunk.position + 10000)
+        )
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.position > 10000)
+            .values(position=DocumentChunk.position - 9999)
+        )
+
+        # Remove original chunk (its position is now free)
+        session.delete(chunk)
+        session.flush()
+
+        # Chunk A — content before the split point
+        text_a = _text_from_segs(seg_start, split_at)
+        status_a = "approved" if first_type == "REKLAMA" else "pending"
+        chunk_a = DocumentChunk(
+            run_id=run_id, document_id=doc_id, position=orig_pos,
+            type=first_type, topic=None,
+            original_text=text_a or "(brak tekstu)",
+            corrected_text=None, summary=None,
+            seg_start=seg_start, seg_end=split_at,
+            rewrite_ratio=None, status=status_a,
+        )
+
+        # Chunk B — content after the split point
+        text_b = _text_from_segs(split_at, seg_end)
+        status_b = "needs_reanalysis" if second_type == "TEMAT" else "approved"
+        chunk_b = DocumentChunk(
+            run_id=run_id, document_id=doc_id, position=orig_pos + 1,
+            type=second_type, topic=None,
+            original_text=text_b or "(brak tekstu)",
+            corrected_text=None, summary=None,
+            seg_start=split_at, seg_end=seg_end,
+            rewrite_ratio=None, status=status_b,
+        )
+
+        session.add(chunk_a)
+        session.add(chunk_b)
+        session.commit()
+
+        logger.info("Split chunk %d at seg %d → chunks at pos %d and %d",
+                    chunk_id, split_at, orig_pos, orig_pos + 1)
+
+        return jsonify({
+            "status": "success",
+            "chunk_a": _chunk_to_dict(chunk_a),
+            "chunk_b": _chunk_to_dict(chunk_b),
+        })
+
+    except Exception:
+        session.rollback()
+        logger.exception("Failed to execute split on chunk %d", chunk_id)
+        return jsonify({"status": "error", "message": "DB error during split"}), 500
+
+
+# ---------------------------------------------------------------------------
+# API: POST /chunk/<chunk_id>/reanalyze
+# ---------------------------------------------------------------------------
+
+@bp.route("/chunk/<int:chunk_id>/reanalyze", methods=["POST"])
+def reanalyze_chunk(chunk_id: int):
+    """Re-run LLM analysis on a single chunk.
+
+    Body (JSON): {"mode": "full"|"semantic"}
+      full     — rewrite from original_text + summarize (default)
+      semantic — classify + summarize from existing corrected_text (no rewrite)
+
+    Updates: corrected_text, summary, type, topic, rewrite_ratio, status → pending.
+    """
+    mode = (request.get_json(silent=True) or {}).get("mode", "full")
+
+    session = get_scoped_session()
+    chunk = session.get(DocumentChunk, chunk_id)
+    if chunk is None:
+        abort(404, f"Chunk {chunk_id} not found")
+
+    run = session.get(DocumentAnalysisRun, chunk.run_id)
+    if run is None:
+        abort(404, f"Run {chunk.run_id} not found")
+
+    model = run.model
+
+    speakers = run.speakers or []
+
+    try:
+        if mode == "semantic" and chunk.corrected_text and chunk.corrected_text.strip():
+            from library.chunk_llm_analysis import analyze_chunk_semantic
+            result = analyze_chunk_semantic(chunk.corrected_text, model, speakers=speakers)
+        else:
+            text_to_analyze = chunk.original_text or ""
+            if not text_to_analyze.strip():
+                return jsonify({"status": "error", "message": "Chunk has no original_text to analyze"}), 400
+            all_chunks = session.scalars(
+                select(DocumentChunk)
+                .where(DocumentChunk.run_id == chunk.run_id)
+                .order_by(DocumentChunk.position)
+            ).all()
+            from library.chunk_llm_analysis import analyze_chunk
+            result = analyze_chunk(text_to_analyze, model, position=chunk.position,
+                                   total=len(all_chunks), speakers=speakers)
+    except Exception:
+        logger.exception("LLM call failed for chunk %d (mode=%s)", chunk_id, mode)
+        return jsonify({"status": "error", "message": "LLM call failed"}), 500
+
+    chunk.type = result["type"]
+    chunk.topic = result["topic"] or None
+    chunk.corrected_text = result["corrected_text"] or None
+    chunk.summary = result["summary"] or None
+    chunk.rewrite_ratio = result["rewrite_ratio"]
+    chunk.status = "pending"
+    chunk.updated_at = datetime.utcnow()
+
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for reanalyzed chunk %d", chunk_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "chunk": _chunk_to_dict(chunk)})
+
+
+# ---------------------------------------------------------------------------
+# HTML review page
+# ---------------------------------------------------------------------------
+
+_HTML = r"""<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Przegląd chunków — Lenie AI</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:Arial,sans-serif;background:#f5f5f5;color:#222;font-size:14px}
+#header{background:#1e293b;color:#fff;padding:14px 20px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+#header h1{font-size:1.05em;font-weight:bold;flex:1}
+#header select,#header input{background:#334155;color:#fff;border:1px solid #475569;border-radius:4px;padding:5px 9px;font-size:0.88em}
+#progress-bar{background:#0f172a;padding:8px 20px;display:flex;align-items:center;gap:12px;font-size:0.82em;color:#94a3b8}
+#progress-fill{height:8px;border-radius:4px;background:#22c55e;transition:width .3s}
+#progress-track{flex:1;background:#334155;border-radius:4px;height:8px}
+#chunks{padding:16px 20px;display:flex;flex-direction:column;gap:14px}
+.chunk{background:#fff;border-radius:6px;box-shadow:0 1px 3px rgba(0,0,0,.12);overflow:hidden}
+.chunk-header{display:flex;align-items:center;gap:8px;padding:8px 14px;background:#f8fafc;border-bottom:1px solid #e2e8f0;flex-wrap:wrap}
+.pos{font-size:0.8em;color:#64748b;font-weight:bold;min-width:28px}
+.badge{display:inline-block;padding:2px 8px;border-radius:3px;font-size:0.78em;font-weight:bold;cursor:pointer;user-select:none;transition:opacity .15s}
+.badge:hover{opacity:.8}
+.badge.TEMAT{background:#dbeafe;color:#1d4ed8}
+.badge.REKLAMA{background:#fef3c7;color:#92400e}
+.badge.pending{background:#e2e8f0;color:#475569}
+.badge.approved{background:#dcfce7;color:#15803d}
+.badge.needs_reanalysis{background:#fee2e2;color:#b91c1c}
+.badge.split_requested{background:#fef9c3;color:#713f12}
+.badge.split{background:#f1f5f9;color:#94a3b8}
+.topic-input{flex:1;border:none;border-bottom:1px dashed #cbd5e1;background:transparent;font-size:0.88em;padding:2px 4px;color:#334155;min-width:120px}
+.topic-input:focus{outline:none;border-bottom-color:#3b82f6}
+.btn-save{margin-left:auto;padding:3px 12px;border-radius:3px;border:none;background:#3b82f6;color:#fff;font-size:0.8em;cursor:pointer;font-weight:bold}
+.btn-save:hover{background:#2563eb}
+.btn-save:disabled{background:#94a3b8;cursor:default}
+.chunk-body{display:grid;grid-template-columns:58% 42%;min-height:60px}
+.tc{padding:10px 14px;border-right:1px solid #e2e8f0;font-size:0.84em;line-height:1.6;overflow-wrap:anywhere}
+.sc-col{padding:10px 14px;background:#f8fafc;font-size:0.84em;line-height:1.6}
+/* segment row */
+.seg{margin:0 0 8px;position:relative;padding-right:28px}
+.seg:hover .split-btn{opacity:1}
+.split-btn{position:absolute;right:2px;top:0;background:none;border:1px solid #e2e8f0;border-radius:3px;
+  font-size:0.82em;cursor:pointer;padding:1px 4px;color:#94a3b8;opacity:0;transition:opacity .15s}
+.split-btn:hover{background:#fef3c7;border-color:#fbbf24;color:#92400e}
+.seg.split-mark{background:#fff7ed;border-left:3px solid #f97316;padding-left:6px;border-radius:2px}
+.ts{color:#c00;text-decoration:none;font-weight:bold;font-size:0.8em;white-space:nowrap}
+.ts:hover{text-decoration:underline}
+.spname{font-size:0.76em;font-weight:bold;padding:1px 5px;border-radius:3px;margin-right:4px}
+.sp1{background:#dbeafe;color:#1d4ed8}
+.sp2{background:#dcfce7;color:#15803d}
+.sc-arrow{color:#aaa;font-size:0.9em}
+.summary-text{color:#334155}
+em{color:#94a3b8}
+#loading{text-align:center;padding:60px;color:#64748b;font-size:1.1em}
+#error-msg{background:#fee2e2;color:#b91c1c;padding:12px 20px;border-radius:4px;margin:20px}
+.saved-flash{color:#15803d;font-size:0.78em;margin-left:6px;opacity:0;transition:opacity .3s}
+.btn-reanalyze{padding:3px 11px;border-radius:3px;border:none;background:#7c3aed;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold}
+.btn-reanalyze:hover{background:#6d28d9}
+.btn-reanalyze:disabled{background:#94a3b8;cursor:default}
+.analyzing-spinner{display:inline-block;width:12px;height:12px;border:2px solid #fff;
+  border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;margin-right:4px;vertical-align:middle}
+@keyframes spin{to{transform:rotate(360deg)}}
+#btn-ads{padding:3px 11px;border-radius:3px;border:none;color:#fff;font-size:0.8em;cursor:pointer;font-weight:bold}
+#btn-ads.hide-mode{background:#475569}
+#btn-ads.show-mode{background:#b91c1c}
+#btn-analyze-all{padding:3px 11px;border-radius:3px;border:none;background:#0369a1;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold}
+#btn-analyze-all:hover{background:#0284c7}
+#btn-analyze-all:disabled{background:#94a3b8;cursor:default}
+#btn-view{padding:3px 11px;border-radius:3px;border:none;background:#0f766e;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold}
+#btn-view:hover{background:#0d9488}
+#speakers-bar{background:#1e3a5f;color:#bfdbfe;padding:6px 20px;font-size:0.82em;display:none;
+  align-items:center;gap:12px;flex-wrap:wrap}
+#speakers-bar strong{color:#fff}
+#btn-extract-speakers{padding:3px 10px;border-radius:3px;border:none;background:#1d4ed8;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold;margin-left:auto}
+#btn-extract-speakers:disabled{background:#94a3b8;cursor:default}
+.btn-reanalyze-sem{padding:3px 9px;border-radius:3px;border:none;background:#059669;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold;margin-left:4px}
+.btn-reanalyze-sem:hover{background:#047857}
+.btn-reanalyze-sem:disabled{background:#94a3b8;cursor:default}
+.tc-corrected{white-space:pre-wrap;font-size:0.85em;line-height:1.6;color:#1e293b}
+/* split panel */
+.split-panel{margin-top:10px;padding:10px 12px;background:#fff7ed;border:1px solid #fed7aa;
+  border-radius:5px;font-size:0.84em}
+.split-panel strong{color:#92400e}
+.split-panel .sp-row{display:flex;align-items:center;gap:10px;margin-top:8px;flex-wrap:wrap}
+.split-panel select{padding:3px 6px;border-radius:3px;border:1px solid #d1d5db;font-size:0.85em}
+.split-panel .btn-confirm{padding:4px 12px;background:#f97316;color:#fff;border:none;border-radius:3px;
+  cursor:pointer;font-weight:bold;font-size:0.82em}
+.split-panel .btn-confirm:hover{background:#ea580c}
+.split-panel .btn-cancel{padding:4px 10px;background:#e2e8f0;color:#475569;border:none;
+  border-radius:3px;cursor:pointer;font-size:0.82em}
+.split-panel .btn-cancel:hover{background:#cbd5e1}
+.split-panel .split-hint{color:#92400e;font-size:0.8em;margin-top:4px}
+</style>
+</head>
+<body>
+<div id="header">
+  <h1 id="doc-title">Lenie AI — przegląd chunków</h1>
+  <label>Run:
+    <select id="run-select" onchange="loadRun(this.value)"></select>
+  </label>
+  <label>API key:
+    <input type="password" id="api-key-input" placeholder="x-api-key" oninput="saveKey(this.value)">
+  </label>
+</div>
+<div id="progress-bar">
+  <span id="progress-text">Ładowanie...</span>
+  <div id="progress-track"><div id="progress-fill" style="width:0%"></div></div>
+  <button id="btn-analyze-all" onclick="reanalyzeAll()" style="display:none">Analizuj wszystkie</button>
+  <button id="btn-view" onclick="toggleView()">Pokaż poprawiony</button>
+  <button id="btn-ads" class="hide-mode" onclick="toggleAds()">Ukryj reklamy</button>
+</div>
+<div id="speakers-bar">
+  <strong>Rozmówcy:</strong>
+  <span id="speakers-list"></span>
+  <button id="btn-extract-speakers" onclick="extractSpeakers()">Wykryj rozmówców</button>
+</div>
+<div id="chunks"><div id="loading">Ładowanie danych...</div></div>
+
+<script>
+const params = new URLSearchParams(location.search);
+let DOC_ID = parseInt(params.get("doc_id") || "0");
+let RUN_ID = parseInt(params.get("run_id") || "0");
+let API_KEY = params.get("api_key") || localStorage.getItem("lenie_api_key") || "";
+let _data = null;
+let _hideAds = false;
+let _showCorrected = false;
+const _splitState = {};  // chunkId → {segIdx, ts, firstType, secondType}
+
+document.getElementById("api-key-input").value = API_KEY;
+
+function saveKey(v) {
+  API_KEY = v;
+  localStorage.setItem("lenie_api_key", v);
+}
+
+function headers() {
+  return {"Content-Type": "application/json", "x-api-key": API_KEY};
+}
+
+async function apiFetch(path, opts = {}) {
+  const r = await fetch(path, {...opts, headers: {...headers(), ...(opts.headers || {})}});
+  if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+  return r.json();
+}
+
+function secs2ts(s) {
+  s = Math.floor(s);
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+  return h ? `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}:${String(sec).padStart(2,"0")}`
+           : `${String(m).padStart(2,"0")}:${String(sec).padStart(2,"0")}`;
+}
+
+function ytUrl(videoId, secs) {
+  return videoId ? `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(secs)}` : "#";
+}
+
+// Renders transcript segments. absOffset = chunk.seg_start (absolute index in full segments array).
+// Each paragraph gets a scissors button storing the absolute segment index where it starts.
+function renderSegments(segs, videoId, chunkId, absOffset) {
+  if (!segs || !segs.length) return "<em>brak segmentów</em>";
+  const MAX = 8;
+  const groups = [];
+  let cur = [], curStart = null, curSc = false, curRawIdx = 0;
+  let rawIdx = 0;
+
+  function flush() {
+    if (cur.length) {
+      groups.push({start: curStart, text: cur.join(" "), sc: curSc, rawIdx: curRawIdx});
+      cur = []; curStart = null; curSc = false;
+    }
+  }
+
+  for (const seg of segs) {
+    const raw = (seg.text || "").trim();
+    if (!raw) { rawIdx++; continue; }
+    const isSc = raw.startsWith(">>");
+    const text = isSc ? raw.slice(2).trim() : raw;
+    if (isSc && cur.length) flush();
+    if (curStart === null) { curStart = seg.start; curSc = isSc; curRawIdx = rawIdx; }
+    cur.push(text);
+    rawIdx++;
+    if (text.match(/[.?!…]$/) || cur.length >= MAX) flush();
+  }
+  flush();
+
+  const markedAbsIdx = _splitState[chunkId] ? _splitState[chunkId].segIdx : null;
+
+  return groups.map(g => {
+    const absIdx = absOffset + g.rawIdx;
+    const ts = secs2ts(g.start);
+    const url = ytUrl(videoId, g.start);
+    const tsLink = `<a href="${url}" target="_blank" class="ts">[${ts}]</a>`;
+    const prefix = g.sc ? `<span class="sc-arrow">▶</span> ` : "";
+    const escaped = g.text.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+    const isMarked = markedAbsIdx === absIdx;
+    const markClass = isMarked ? " split-mark" : "";
+    const splitBtn = chunkId != null
+      ? `<button class="split-btn" onclick="markSplit(${chunkId},${absIdx},'${ts}')" title="Podziel tutaj">✂</button>`
+      : "";
+    return `<p class="seg${markClass}" id="seg-${chunkId}-${absIdx}">${prefix}${tsLink}<br>${escaped}${splitBtn}</p>`;
+  }).join("\n");
+}
+
+// --- split workflow ---
+
+function markSplit(chunkId, absSegIdx, ts) {
+  _splitState[chunkId] = {
+    segIdx: absSegIdx,
+    ts,
+    firstType: "REKLAMA",
+    secondType: "TEMAT",
+  };
+  rerenderChunkTranscript(chunkId);
+}
+
+function cancelSplit(chunkId) {
+  delete _splitState[chunkId];
+  rerenderChunkTranscript(chunkId);
+}
+
+async function confirmSplit(chunkId) {
+  const st = _splitState[chunkId];
+  if (!st) return;
+  const ft = document.getElementById(`split-first-type-${chunkId}`)?.value || st.firstType;
+  const st2 = document.getElementById(`split-second-type-${chunkId}`)?.value || st.secondType;
+  const btn = document.querySelector(`#chunk-${chunkId} .btn-confirm`);
+  if (btn) { btn.disabled = true; btn.textContent = "Dzielę..."; }
+  try {
+    const res = await apiFetch(`/chunk/${chunkId}/execute_split`, {
+      method: "POST",
+      body: JSON.stringify({
+        split_at_seg: st.segIdx,
+        split_first_type: ft,
+        split_second_type: st2,
+      }),
+    });
+    if (res.status === "success") {
+      delete _splitState[chunkId];
+      await loadRun(RUN_ID);  // reload all chunks to reflect new positions
+    }
+  } catch (e) {
+    alert(`Błąd podziału: ${e.message}`);
+    if (btn) { btn.disabled = false; btn.textContent = "Wykonaj podział"; }
+  }
+}
+
+function renderSplitPanel(chunkId) {
+  const st = _splitState[chunkId];
+  const chunk = _data.chunks.find(c => c.id === chunkId);
+  if (!st && !(chunk && chunk.split_at_seg != null)) return "";
+
+  if (!st) return "";
+
+  return `<div class="split-panel">
+    <strong>✂ Punkt podziału: [${st.ts}]</strong>
+    <div class="sp-row">
+      <label>Część 1 (przed):
+        <select id="split-first-type-${chunkId}">
+          <option value="REKLAMA" ${st.firstType==="REKLAMA"?"selected":""}>REKLAMA</option>
+          <option value="TEMAT" ${st.firstType==="TEMAT"?"selected":""}>TEMAT</option>
+        </select>
+      </label>
+      <label>Część 2 (po):
+        <select id="split-second-type-${chunkId}">
+          <option value="TEMAT" ${st.secondType==="TEMAT"?"selected":""}>TEMAT</option>
+          <option value="REKLAMA" ${st.secondType==="REKLAMA"?"selected":""}>REKLAMA</option>
+        </select>
+      </label>
+      <button class="btn-confirm" onclick="confirmSplit(${chunkId})">Wykonaj podział</button>
+      <button class="btn-cancel" onclick="cancelSplit(${chunkId})">Anuluj</button>
+    </div>
+    <div class="split-hint">Kliknij ✂ przy innym akapicie aby zmienić punkt podziału.</div>
+  </div>`;
+}
+
+
+function rerenderChunkTranscript(chunkId) {
+  const chunk = _data.chunks.find(c => c.id === chunkId);
+  if (!chunk) return;
+  const segs = _data.segments || [];
+  const videoId = _data.document.original_id || "";
+  const chunkSegs = segs.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segs.length);
+  const tcEl = document.querySelector(`#chunk-${chunkId} .tc`);
+  if (tcEl) {
+    tcEl.innerHTML = renderSegments(chunkSegs, videoId, chunkId, chunk.seg_start ?? 0)
+                   + renderSplitPanel(chunkId);
+  }
+}
+
+// --- status / type / topic ---
+
+function updateProgress() {
+  if (!_data) return;
+  const temat = _data.chunks.filter(c => c.type !== "REKLAMA");
+  const reklama = _data.chunks.filter(c => c.type === "REKLAMA");
+  const approved = temat.filter(c => c.status === "approved").length;
+  const pct = temat.length ? Math.round(approved / temat.length * 100) : 0;
+  const adsPart = reklama.length
+    ? ` • ${reklama.length} reklam${_hideAds ? " (ukryte)" : ""}`
+    : "";
+  document.getElementById("progress-text").textContent =
+    `TEMAT: ${approved}/${temat.length} zatwierdzonych (${pct}%)${adsPart}`;
+  document.getElementById("progress-fill").style.width = pct + "%";
+  updateAdsButton();
+  updateAnalyzeAllButton();
+}
+
+function cycleStatus(chunkId) {
+  const order = ["pending", "approved", "needs_reanalysis"];
+  const chunk = _data.chunks.find(c => c.id === chunkId);
+  if (!chunk) return;
+  const idx = order.indexOf(chunk.status);
+  const next = order[(idx + 1) % order.length];
+  saveChunk(chunkId, {status: next});
+}
+
+function toggleType(chunkId) {
+  const chunk = _data.chunks.find(c => c.id === chunkId);
+  if (!chunk) return;
+  saveChunk(chunkId, {type: chunk.type === "TEMAT" ? "REKLAMA" : "TEMAT"});
+}
+
+function saveTopic(chunkId) {
+  const input = document.getElementById(`topic-${chunkId}`);
+  saveChunk(chunkId, {topic: input.value});
+}
+
+async function saveChunk(chunkId, updates) {
+  const btn = document.getElementById(`save-${chunkId}`);
+  if (btn) btn.disabled = true;
+  try {
+    const res = await apiFetch(`/chunk/${chunkId}`, {
+      method: "PATCH",
+      body: JSON.stringify(updates),
+    });
+    if (res.status === "success") {
+      const chunk = _data.chunks.find(c => c.id === chunkId);
+      if (chunk) Object.assign(chunk, res.chunk);
+      refreshChunkHeader(chunkId);
+      updateProgress();
+      const flash = document.getElementById(`flash-${chunkId}`);
+      if (flash) { flash.style.opacity = "1"; setTimeout(() => flash.style.opacity = "0", 1500); }
+    }
+  } catch (e) {
+    alert(`Błąd zapisu chunka ${chunkId}: ${e.message}`);
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+function refreshChunkHeader(chunkId) {
+  const chunk = _data.chunks.find(c => c.id === chunkId);
+  if (!chunk) return;
+  const typeBadge = document.getElementById(`type-${chunkId}`);
+  if (typeBadge) {
+    typeBadge.textContent = chunk.type;
+    typeBadge.className = `badge ${chunk.type}`;
+  }
+  const stBadge = document.getElementById(`status-${chunkId}`);
+  if (stBadge) {
+    stBadge.textContent = chunk.status;
+    stBadge.className = `badge ${chunk.status}`;
+  }
+}
+
+function renderChunk(chunk, segs, videoId) {
+  const chunkSegs = segs.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segs.length);
+  const transcript = renderSegments(chunkSegs, videoId, chunk.id, chunk.seg_start ?? 0);
+  const splitPanel = renderSplitPanel(chunk.id);
+  const summary = chunk.summary
+    ? `<div class="summary-text">${chunk.summary.replace(/\n/g,"<br>")}</div>`
+    : `<em>${chunk.type === "REKLAMA" ? "brak streszczenia (reklama)" : "brak streszczenia"}</em>`;
+
+  return `
+<div class="chunk" id="chunk-${chunk.id}">
+  <div class="chunk-header">
+    <span class="pos">#${chunk.position}</span>
+    <span class="badge ${chunk.type}" id="type-${chunk.id}"
+          onclick="toggleType(${chunk.id})" title="Kliknij aby zmienić typ">${chunk.type}</span>
+    <span class="badge ${chunk.status}" id="status-${chunk.id}"
+          onclick="cycleStatus(${chunk.id})" title="Kliknij aby zmienić status">${chunk.status}</span>
+    <input class="topic-input" id="topic-${chunk.id}" value="${(chunk.topic||"").replace(/"/g,"&quot;")}"
+           placeholder="temat" title="Edytuj temat">
+    <button class="btn-save" id="save-${chunk.id}"
+            onclick="saveTopic(${chunk.id})">Zapisz</button>
+    <span class="saved-flash" id="flash-${chunk.id}">✓ zapisano</span>
+    <button class="btn-reanalyze" id="reanalyze-${chunk.id}"
+            onclick="reanalyzeChunk(${chunk.id},'full')">▶ Pełna</button>
+    ${chunk.corrected_text
+      ? `<button class="btn-reanalyze-sem" id="reanalyze-sem-${chunk.id}"
+               onclick="reanalyzeChunk(${chunk.id},'semantic')">▶ Sem.</button>`
+      : ""}
+  </div>
+  <div class="chunk-body">
+    <div class="tc">
+      <div class="tc-raw">${transcript}${splitPanel}</div>
+      <div class="tc-corrected" style="display:${_showCorrected ? "block" : "none"}">${(chunk.corrected_text||"(brak poprawionego tekstu)").replace(/\n/g,"<br>")}</div>
+    </div>
+    <div class="sc-col">${summary}</div>
+  </div>
+</div>`;
+}
+
+async function reanalyzeChunk(chunkId, mode) {
+  mode = mode || "full";
+  const btnFull = document.getElementById(`reanalyze-${chunkId}`);
+  const btnSem  = document.getElementById(`reanalyze-sem-${chunkId}`);
+  const activeBtn = mode === "semantic" ? (btnSem || btnFull) : btnFull;
+  if (btnFull) { btnFull.disabled = true; }
+  if (btnSem)  { btnSem.disabled  = true; }
+  if (activeBtn) activeBtn.innerHTML = '<span class="analyzing-spinner"></span>...';
+  try {
+    const res = await apiFetch(`/chunk/${chunkId}/reanalyze`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({mode}),
+    });
+    if (res.status === "success") {
+      const chunk = _data.chunks.find(c => c.id === chunkId);
+      if (chunk) Object.assign(chunk, res.chunk);
+      const el = document.getElementById(`chunk-${chunkId}`);
+      if (el && _data) {
+        const segs = _data.segments || [];
+        const videoId = _data.document.original_id || "";
+        el.outerHTML = renderChunk(res.chunk, segs, videoId);
+        if (_showCorrected) applyViewToggle();
+      }
+      updateProgress();
+    }
+  } catch (e) {
+    alert(`Błąd analizy chunka ${chunkId}: ${e.message}`);
+    if (btnFull) { btnFull.disabled = false; btnFull.innerHTML = "▶ Pełna"; }
+    if (btnSem)  { btnSem.disabled  = false; btnSem.innerHTML  = "▶ Sem."; }
+  }
+}
+
+function renderSpeakers(speakers) {
+  const bar = document.getElementById("speakers-bar");
+  const list = document.getElementById("speakers-list");
+  if (!bar || !list) return;
+  if (speakers && speakers.length > 0) {
+    list.innerHTML = speakers.map(sp =>
+      `<span><b>${sp.name}</b>${sp.role ? ` (${sp.role})` : ""}</span>`
+    ).join(" &nbsp;|&nbsp; ");
+    bar.style.display = "flex";
+  } else {
+    list.innerHTML = "";
+    bar.style.display = "flex";  // show bar with just the button
+  }
+}
+
+async function extractSpeakers() {
+  const btn = document.getElementById("btn-extract-speakers");
+  btn.disabled = true;
+  btn.textContent = "Wykrywam...";
+  try {
+    const res = await apiFetch(`/analysis_run/${RUN_ID}/extract_speakers`, {method: "POST"});
+    if (res.status === "success") {
+      if (_data) _data.run.speakers = res.speakers;
+      renderSpeakers(res.speakers);
+      btn.textContent = res.speakers.length
+        ? `Wykryj ponownie (${res.speakers.length})`
+        : "Nie wykryto — spróbuj ponownie";
+    }
+  } catch (e) {
+    alert(`Błąd wykrywania rozmówców: ${e.message}`);
+    btn.textContent = "Wykryj rozmówców";
+  }
+  btn.disabled = false;
+}
+
+function updateAdsButton() {
+  const btn = document.getElementById("btn-ads");
+  if (!btn || !_data) return;
+  const count = _data.chunks.filter(c => c.type === "REKLAMA").length;
+  if (_hideAds) {
+    btn.textContent = `Pokaż reklamy (${count})`;
+    btn.className = "show-mode";
+  } else {
+    btn.textContent = `Ukryj reklamy (${count})`;
+    btn.className = "hide-mode";
+  }
+}
+
+function updateAnalyzeAllButton() {
+  const btn = document.getElementById("btn-analyze-all");
+  if (!btn || !_data) return;
+  const count = _data.chunks.filter(c => c.status === "needs_reanalysis").length;
+  if (count > 0) {
+    btn.textContent = `Analizuj wszystkie (${count})`;
+    btn.style.display = "";
+    btn.disabled = false;
+  } else {
+    btn.style.display = "none";
+  }
+}
+
+function applyChunkFilter() {
+  if (!_data) return;
+  document.querySelectorAll(".chunk").forEach(el => {
+    const chunkId = parseInt(el.id.replace("chunk-", ""));
+    const chunk = _data.chunks.find(c => c.id === chunkId);
+    if (chunk) el.style.display = (_hideAds && chunk.type === "REKLAMA") ? "none" : "";
+  });
+}
+
+async function reanalyzeAll() {
+  const btn = document.getElementById("btn-analyze-all");
+  const pending = _data.chunks.filter(c => c.status === "needs_reanalysis");
+  if (!pending.length) return;
+  btn.disabled = true;
+  for (let i = 0; i < pending.length; i++) {
+    btn.textContent = `Analizuję ${i + 1}/${pending.length}...`;
+    const mode = pending[i].corrected_text ? "semantic" : "full";
+    await reanalyzeChunk(pending[i].id, mode);
+  }
+  updateProgress();
+}
+
+function applyViewToggle() {
+  document.querySelectorAll(".tc-raw").forEach(el => el.style.display = _showCorrected ? "none" : "block");
+  document.querySelectorAll(".tc-corrected").forEach(el => el.style.display = _showCorrected ? "block" : "none");
+  const btn = document.getElementById("btn-view");
+  if (btn) btn.textContent = _showCorrected ? "Pokaż surowy" : "Pokaż poprawiony";
+}
+
+function toggleView() {
+  _showCorrected = !_showCorrected;
+  applyViewToggle();
+}
+
+function toggleAds() {
+  _hideAds = !_hideAds;
+  localStorage.setItem(`lenie_hide_ads_${RUN_ID}`, _hideAds ? "1" : "0");
+  applyChunkFilter();
+  updateProgress();
+}
+
+function renderAll() {
+  if (!_data) return;
+  const videoId = _data.document.original_id || "";
+  const segs = _data.segments || [];
+  document.getElementById("doc-title").textContent = _data.document.title || "Lenie AI";
+  document.getElementById("chunks").innerHTML =
+    _data.chunks.map(c => renderChunk(c, segs, videoId)).join("\n");
+  renderSpeakers(_data.run.speakers || []);
+  const extractBtn = document.getElementById("btn-extract-speakers");
+  if (extractBtn) extractBtn.textContent = (_data.run.speakers || []).length
+    ? `Wykryj ponownie (${_data.run.speakers.length})`
+    : "Wykryj rozmówców";
+  updateProgress();
+  applyChunkFilter();
+}
+
+async function loadRun(runId) {
+  RUN_ID = parseInt(runId);
+  _hideAds = localStorage.getItem(`lenie_hide_ads_${RUN_ID}`) === "1";
+  document.getElementById("chunks").innerHTML = '<div id="loading">Ładowanie...</div>';
+  try {
+    _data = await apiFetch(`/analysis_run/${RUN_ID}/chunks`);
+    renderAll();
+  } catch (e) {
+    document.getElementById("chunks").innerHTML =
+      `<div id="error-msg">Błąd: ${e.message}. Sprawdź API key i uruchomiony backend.</div>`;
+  }
+}
+
+async function loadRuns() {
+  if (!DOC_ID) {
+    document.getElementById("chunks").innerHTML =
+      '<div id="error-msg">Podaj <code>?doc_id=&lt;id&gt;</code> w URL.</div>';
+    return;
+  }
+  try {
+    const res = await apiFetch(`/analysis_runs?doc_id=${DOC_ID}`);
+    const sel = document.getElementById("run-select");
+    sel.innerHTML = res.runs.map(r =>
+      `<option value="${r.id}" ${r.id === RUN_ID ? "selected" : ""}>` +
+      `Run #${r.id} — ${r.model} — ${r.created_at.slice(0,16).replace("T"," ")}</option>`
+    ).join("");
+    if (!RUN_ID && res.runs.length) RUN_ID = res.runs[0].id;
+    if (RUN_ID) await loadRun(RUN_ID);
+  } catch (e) {
+    document.getElementById("chunks").innerHTML =
+      `<div id="error-msg">Błąd ładowania runów: ${e.message}.<br>Sprawdź czy backend działa i API key jest poprawny.</div>`;
+  }
+}
+
+loadRuns();
+</script>
+</body>
+</html>"""
+
+
+@bp.route("/chunk_review", methods=["GET"])
+def chunk_review_page():
+    from flask import Response
+    return Response(_HTML, mimetype="text/html")

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -18,13 +18,14 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     Numeric,
+    SmallInteger,
     String,
     Text,
     func,
     select,
     text as sa_text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from pgvector.sqlalchemy import Vector
@@ -553,3 +554,108 @@ class ImportLog(Base):
             f"ImportLog(id={self.id!r}, script_name={self.script_name!r}, "
             f"status={self.status!r}, started_at={self.started_at!r})"
         )
+
+
+# ---------------------------------------------------------------------------
+# Document Analysis — runs, chunks, topic sections
+# ---------------------------------------------------------------------------
+
+
+class DocumentAnalysisRun(Base):
+    __tablename__ = "document_analysis_runs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    chunk_size: Mapped[int] = mapped_column(Integer, nullable=False, server_default=sa_text("5000"))
+    synthesis: Mapped[str | None] = mapped_column(Text)
+    speakers: Mapped[list] = mapped_column(JSONB, nullable=False, server_default=sa_text("'[]'"))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+    chunks: Mapped[list["DocumentChunk"]] = relationship(
+        back_populates="run",
+        cascade="all, delete-orphan",
+        order_by="DocumentChunk.position",
+    )
+    topic_sections: Mapped[list["DocumentTopicSection"]] = relationship(
+        back_populates="run",
+        cascade="all, delete-orphan",
+        order_by="DocumentTopicSection.position",
+    )
+
+    def __repr__(self) -> str:
+        return f"DocumentAnalysisRun(id={self.id!r}, document_id={self.document_id!r}, model={self.model!r})"
+
+
+class DocumentChunk(Base):
+    __tablename__ = "document_chunks"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    run_id: Mapped[int] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA
+    topic: Mapped[str | None] = mapped_column(String(500))
+    original_text: Mapped[str] = mapped_column(Text, nullable=False)
+    corrected_text: Mapped[str | None] = mapped_column(Text)
+    summary: Mapped[str | None] = mapped_column(Text)
+    seg_start: Mapped[int | None] = mapped_column(Integer)
+    seg_end: Mapped[int | None] = mapped_column(Integer)
+    rewrite_ratio: Mapped[int | None] = mapped_column(SmallInteger)
+    # status: pending | approved | needs_reanalysis | split_requested | split
+    status: Mapped[str] = mapped_column(
+        String(30), nullable=False, server_default=sa_text("'pending'"),
+    )
+    split_at_seg: Mapped[int | None] = mapped_column(Integer)
+    split_first_type: Mapped[str | None] = mapped_column(String(20))
+    split_second_type: Mapped[str | None] = mapped_column(String(20))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    run: Mapped["DocumentAnalysisRun"] = relationship(back_populates="chunks")
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return f"DocumentChunk(id={self.id!r}, run_id={self.run_id!r}, position={self.position!r}, type={self.type!r})"
+
+
+class DocumentTopicSection(Base):
+    __tablename__ = "document_topic_sections"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    run_id: Mapped[int] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA
+    title: Mapped[str | None] = mapped_column(String(500))
+    summary: Mapped[str | None] = mapped_column(Text)
+    chunk_positions: Mapped[list[int]] = mapped_column(ARRAY(Integer), nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    run: Mapped["DocumentAnalysisRun"] = relationship(back_populates="topic_sections")
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return f"DocumentTopicSection(id={self.id!r}, run_id={self.run_id!r}, position={self.position!r})"

--- a/backend/library/text_functions.py
+++ b/backend/library/text_functions.py
@@ -45,6 +45,92 @@ def remove_matching_lines(input_text):
     return '\n'.join(cleaned_lines)
 
 
+_SENT_BOUNDARY = re.compile(r'(?<=[.!?…])\s+')
+
+
+def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
+    """Split text at sentence boundaries, accumulating up to max_chars per chunk.
+
+    Designed for YouTube transcripts where \\n appears every few words (not at sentence ends).
+    First flattens single newlines to spaces so sentences are not broken by line wrapping,
+    then splits on sentence-ending punctuation.
+
+    Falls back to mid-sentence split only when a single sentence exceeds max_chars.
+    """
+    flat = re.sub(r'\n(?!\n)', ' ', text)
+    flat = re.sub(r' {2,}', ' ', flat)
+
+    sentences = [s.strip() for s in _SENT_BOUNDARY.split(flat) if s.strip()]
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+
+    for sent in sentences:
+        if len(sent) > max_chars:
+            if current:
+                chunks.append(' '.join(current))
+                current = []
+                current_size = 0
+            for i in range(0, len(sent), max_chars):
+                chunks.append(sent[i:i + max_chars])
+        elif current_size + len(sent) + 1 > max_chars and current:
+            chunks.append(' '.join(current))
+            current = [sent]
+            current_size = len(sent)
+        else:
+            current.append(sent)
+            current_size += len(sent) + 1
+
+    if current:
+        chunks.append(' '.join(current))
+
+    return chunks
+
+
+def split_text_into_chunks(text: str, max_chars: int) -> list[str]:
+    """Split text at double-newline boundaries, respecting max_chars per chunk.
+
+    Falls back to single-newline splitting when a single paragraph exceeds max_chars.
+    Suitable for both LLM batch analysis (large chunks) and any other chunking need.
+    """
+    paragraphs = [p.strip() for p in text.split('\n\n') if p.strip()]
+    chunks: list[str] = []
+    current_parts: list[str] = []
+    current_size = 0
+
+    for para in paragraphs:
+        if len(para) > max_chars:
+            if current_parts:
+                chunks.append('\n\n'.join(current_parts))
+                current_parts = []
+                current_size = 0
+            line_parts: list[str] = []
+            line_size = 0
+            for line in [l.strip() for l in para.split('\n') if l.strip()]:
+                if line_size + len(line) + 1 > max_chars and line_parts:
+                    chunks.append('\n'.join(line_parts))
+                    line_parts = [line]
+                    line_size = len(line)
+                else:
+                    line_parts.append(line)
+                    line_size += len(line) + 1
+            if line_parts:
+                chunks.append('\n'.join(line_parts))
+        elif current_size + len(para) + 2 > max_chars and current_parts:
+            chunks.append('\n\n'.join(current_parts))
+            current_parts = [para]
+            current_size = len(para)
+        else:
+            current_parts.append(para)
+            current_size += len(para) + 2
+
+    if current_parts:
+        chunks.append('\n\n'.join(current_parts))
+
+    return chunks
+
+
 def split_text_for_embedding(text, paragraph_titles=[], max_words_in_line=300, max_characters_in_line=1000):
     sentences2 = []
     paragraphs = text.split("\n\n")

--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -211,7 +211,7 @@ def process_youtube_url(
                         f"captions language mismatch"
                     )
                     web_document.text = youtube_titles_to_text(transcript_text)
-                    web_document.text_raw = web_document.text
+                    web_document.text_raw = transcript_text
                     web_document.language = language_detected
                     web_document.document_state = StalkerDocumentStatus.ERROR.name
                     web_document.document_state_error = StalkerDocumentStatusError.CAPTIONS_LANGUAGE_MISMATCH.name
@@ -230,7 +230,10 @@ def process_youtube_url(
                         web_document.document_state = StalkerDocumentStatus.NEED_MANUAL_REVIEW.name
                         session.commit()
 
-                web_document.text_raw = web_document.text
+                # Store raw JSON (with start/duration timestamps) in text_raw.
+                # text holds human-readable plain text; text_raw holds structured data
+                # for tools that need per-segment timestamps (e.g. youtube_batch_analyze.py).
+                web_document.text_raw = transcript_text
                 session.commit()
 
         except TranscriptsDisabled:

--- a/backend/server.py
+++ b/backend/server.py
@@ -13,6 +13,7 @@ from library.ai_intent_parser import parse_intent
 from library.models.stalker_document_status import StalkerDocumentStatus
 from library.models.stalker_document_type import StalkerDocumentType
 from library.models.stalker_document_status_error import StalkerDocumentStatusError
+from library.chunk_review_routes import bp as chunk_review_bp
 
 logging.basicConfig(level=logging.INFO)
 
@@ -77,6 +78,8 @@ app = Flask(__name__)
 logging.info("Flask - enabling CORS for all routes")
 CORS(app)  # This will enable CORS for all routes
 
+app.register_blueprint(chunk_review_bp)
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
@@ -86,7 +89,7 @@ def shutdown_session(exception=None):
 
 @app.before_request
 def before_request_func():
-    exempt_paths = ['/healthz', '/startup', '/readiness', '/liveness', '/version']
+    exempt_paths = ['/healthz', '/startup', '/readiness', '/liveness', '/version', '/chunk_review']
     if request.path not in exempt_paths and request.method != 'OPTIONS':
         check_auth_header()
 

--- a/backend/test_code/_regen_html.py
+++ b/backend/test_code/_regen_html.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Regenerate HTML view from existing JSON analysis file (no LLM calls)."""
+import json
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unified_config_loader import load_config
+from library.db.engine import get_session
+from library.db.models import WebDocument
+
+from youtube_batch_analyze import save_html, _load_transcript_segments
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python _regen_html.py <json_file>")
+        sys.exit(1)
+
+    json_path = sys.argv[1]
+    if not os.path.exists(json_path):
+        print(f"BŁĄD: Nie znaleziono pliku: {json_path}")
+        sys.exit(1)
+
+    with open(json_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    meta = data["meta"]
+    doc_id = meta["doc_id"]
+    title = meta["title"]
+    model = meta["model"]
+    fmt = meta.get("format", {})
+    speaker_info = meta.get("speakers", [])
+
+    sections = [
+        {
+            "original": c["original"],
+            "text": c["corrected"],
+            "type": c["type"],
+            "topic": c["topic"],
+            "ratio": c["ratio"],
+            "summary": c["summary"],
+        }
+        for c in data["chunks"]
+    ]
+
+    topic_sections = [
+        {
+            "title": t["title"],
+            "type": t["type"],
+            "chunk_indices": t["chunk_indices"],
+            "text": "",
+            "summary": t["summary"],
+        }
+        for t in data["topics"]
+    ]
+
+    load_config()
+    session = get_session()
+    doc = WebDocument.get_by_id(session, doc_id)
+    if doc is None:
+        print(f"BŁĄD: Dokument {doc_id} nie znaleziony.")
+        sys.exit(1)
+
+    video_id = getattr(doc, "original_id", "") or ""
+    segments = _load_transcript_segments(getattr(doc, "text_raw", "") or "")
+    if not segments:
+        print("BŁĄD: Brak JSON z timestampami w text_raw.")
+        sys.exit(1)
+
+    print(f"Regeneruję HTML dla doc {doc_id}: {title}")
+    print(f"Segmentów: {len(segments)}, Sekcji: {len(topic_sections)}, Chunków: {len(sections)}")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    html_file = save_html(
+        doc_id, title, model,
+        topic_sections, sections, segments, video_id,
+        timestamp, fmt=fmt, speaker_info=speaker_info,
+    )
+    print(f"✓ Widok HTML: {html_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/test_code/youtube_batch_analyze.py
+++ b/backend/test_code/youtube_batch_analyze.py
@@ -1,0 +1,953 @@
+#!/usr/bin/env python3
+"""
+Batch analysis of long YouTube transcripts using Bielik LLM via CloudFerro Sherlock.
+
+Pipeline (two passes per chunk — tasks separated to avoid summarizing instead of rewriting):
+  Pass 1 — rewrite:   label section (REKLAMA/TEMAT) + correct transcript verbatim
+  Pass 2 — summarize: 2-3 sentence summary of corrected text (skipped for REKLAMA)
+  Final  — synthesis: overall conclusions from all summaries
+
+Why two passes:
+  - Single prompt mixing "rewrite + summarize" caused Bielik to skip rewriting and jump
+    straight to a summary. Separating tasks forces the model to do each job fully.
+
+Why ~5,000 chars (≈1,500 tokens) per chunk:
+  - Rewrite output ≈ same size as input → needs max_tokens=2,500 (fits comfortably)
+  - Summary output is small → max_tokens=400
+
+Cost at 0.56 EUR/M tokens: ~0.05 EUR for a 90K-char transcript
+  (19 chunks × ~4,700 tok/chunk = 89K tokens).
+
+Text splitting: library.text_functions.split_text_into_chunks (shared utility).
+
+Usage (from backend/ directory):
+    # Windows PowerShell
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158 --dry_run
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158 --no_synthesis
+
+    # WSL / Linux (Bash)
+    PYTHONPATH=. .venv/bin/python test_code/youtube_batch_analyze.py --doc_id 9158
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unified_config_loader import load_config
+from library.db.engine import get_session
+from library.db.models import WebDocument, DocumentAnalysisRun, DocumentChunk, DocumentTopicSection
+from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
+from library.api.arklabs.arklabs_completion import arklabs_get_completion
+from library.text_functions import split_text_into_sentence_chunks
+
+
+CHUNK_CHARS = 5_000          # ≈1,500 text tokens — safe for verbatim reproduction
+REWRITE_MAX_TOKENS = 2_500   # rewrite task: reproduce full text with corrections
+REWRITE_MIN_RATIO = 0.80     # retry rewrite if output < 80% of input length
+SUMMARY_MAX_TOKENS = 400     # summarize task: 2-3 sentences only
+SYNTHESIS_MAX_TOKENS = 2_000
+SYNTHESIS_MAX_INPUT_CHARS = 20_000
+
+SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT): ?(.+)$', re.MULTILINE)
+
+# Filler words common in YouTube auto-transcripts (Polish hesitation sounds)
+_FILLER_RE = re.compile(r'\b[Yy]{2,}\b|\b[Ee]{3,}\b|\b[Mm]{3,}\b', re.IGNORECASE)
+_STANDALONE_Y_RE = re.compile(r'(?<!\w)[Yy](?!\w)')
+
+
+def clean_fillers(text: str) -> str:
+    """Remove YouTube transcript filler sounds (yyy, eee, standalone y) and fix spacing."""
+    text = _FILLER_RE.sub('', text)
+    text = _STANDALONE_Y_RE.sub('', text)
+    text = re.sub(r'[ \t]{2,}', ' ', text)
+    text = re.sub(r' ([,.])', r'\1', text)
+    return text
+
+
+def _tail(text: str, max_chars: int = 300) -> str:
+    """Last up to max_chars of text, preferring a sentence boundary start."""
+    if len(text) <= max_chars:
+        return text
+    seg = text[-max_chars:]
+    for sep in ('. ', '.\n', '? ', '! '):
+        idx = seg.find(sep)
+        if idx != -1:
+            return seg[idx + len(sep):]
+    return seg
+
+
+def _head(text: str, max_chars: int = 300) -> str:
+    """First up to max_chars of text, preferring a sentence boundary end."""
+    if len(text) <= max_chars:
+        return text
+    seg = text[:max_chars]
+    for sep in ('. ', '.\n', '? ', '! '):
+        idx = seg.rfind(sep)
+        if idx != -1:
+            return seg[:idx + 1]
+    return seg
+
+SHERLOCK_MODELS = ["Bielik-11B-v3.0-Instruct"]
+ARKLABS_PREFIX = "arklabs/"
+ARKLABS_MODELS = [f"{ARKLABS_PREFIX}Bielik-11B-v3.0-Instruct"]
+ALL_MODELS = SHERLOCK_MODELS + ARKLABS_MODELS
+
+
+def detect_format(text: str) -> dict:
+    """Detect monologue vs conversation by counting >> speaker-change markers."""
+    changes = len(re.findall(r'>>', text))
+    return {"is_multi_speaker": changes > 0, "speaker_changes": changes}
+
+
+def extract_speaker_info(intro_text: str, model: str) -> list[dict]:
+    """Ask LLM to extract speaker names/roles/descriptions from transcript intro.
+
+    Returns list of dicts: [{"name": ..., "role": ..., "description": ...}]
+    Returns [] if extraction fails.
+    """
+    import json as _json
+    prompt = f"""Z poniższego fragmentu transkrypcji podcastu wyekstrahuj informacje o rozmówcach.
+Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:
+[{{"name": "Imię Nazwisko", "role": "prowadzący", "description": "krótki opis stanowiska/roli"}}]
+
+Jeśli nie możesz zidentyfikować rozmówców, zwróć pustą tablicę: []
+
+Fragment transkrypcji:
+{intro_text}"""
+
+    print("  [meta] Ekstrakcja rozmówców z intro...", flush=True)
+    response_text, _ = call_model(prompt, model, max_tokens=300)
+    try:
+        match = re.search(r'\[.*\]', response_text, re.DOTALL)
+        if match:
+            return _json.loads(match.group())
+    except (ValueError, AttributeError):
+        pass
+    return []
+
+
+def assign_speakers(text: str, speaker1: str, speaker2: str) -> str:
+    """Parse >> speaker-change markers from YouTube auto-transcript and label each turn.
+
+    YouTube inserts >> when it detects a speaker change. The first segment belongs to
+    speaker1 (the host / first voice), then speakers alternate.
+    Short segments (< 10 chars) that are just acknowledgments are still labeled.
+    """
+    segments = re.split(r'\s*>>\s*', text)
+    speakers = [speaker1, speaker2]
+    labeled = []
+    for i, seg in enumerate(segments):
+        seg = seg.strip()
+        if not seg:
+            continue
+        label = speakers[i % 2]
+        labeled.append(f"[{label}]: {seg}")
+    return "\n\n".join(labeled)
+
+
+def _seconds_to_ts(secs: float) -> str:
+    """Convert float seconds to HH:MM:SS or MM:SS string."""
+    h = int(secs // 3600)
+    m = int((secs % 3600) // 60)
+    s = int(secs % 60)
+    return f"{h:02d}:{m:02d}:{s:02d}" if h else f"{m:02d}:{s:02d}"
+
+
+def _load_transcript_segments(text_raw: str) -> list[dict] | None:
+    """Parse YouTube transcript JSON from text_raw.
+
+    Returns list of {text, start, duration} dicts, or None if not valid JSON.
+    """
+    import json as _json
+    if not text_raw or not text_raw.strip().startswith('['):
+        return None
+    try:
+        segs = _json.loads(text_raw.strip())
+        if isinstance(segs, list) and segs and isinstance(segs[0], dict) and 'start' in segs[0]:
+            return segs
+    except (ValueError, KeyError, IndexError):
+        pass
+    return None
+
+
+def _map_chunks_to_segments(chunk_texts: list[str], segments: list[dict]) -> list[tuple[int, int]]:
+    """Map each chunk to an approximate range of segment indices (proportional by chars).
+
+    Returns list of (start_seg_idx, end_seg_idx) per chunk.
+    """
+    total = sum(len(c) for c in chunk_texts)
+    if not total:
+        return [(0, len(segments))] * len(chunk_texts)
+    n = len(segments)
+    result = []
+    cum = 0
+    for chunk in chunk_texts:
+        start = round(n * cum / total)
+        cum += len(chunk)
+        end = round(n * cum / total)
+        result.append((min(start, n), min(end, n)))
+    return result
+
+
+def get_text_for_analysis(doc: WebDocument) -> tuple[str, str]:
+    # Primary: plain text fields — LLM must receive plain text, not JSON
+    for field in ("text", "text_md"):
+        value = getattr(doc, field, None)
+        if value and len(value) > 100:
+            return value, field
+    # text_raw may be YouTube transcript JSON — extract plain text for LLM
+    raw = getattr(doc, "text_raw", None)
+    if raw and len(raw) > 100:
+        segs = _load_transcript_segments(raw)
+        if segs:
+            return "\n".join(s["text"] for s in segs), "text_raw (JSON→plain)"
+        return raw, "text_raw"
+    return "", ""
+
+
+def call_model(prompt: str, model: str, max_tokens: int) -> tuple[str, int]:
+    if model.startswith(ARKLABS_PREFIX):
+        actual_model = f"speakleash/{model.removeprefix(ARKLABS_PREFIX)}"
+        result = arklabs_get_completion(prompt, model=actual_model, max_tokens=max_tokens, temperature=0.2)
+    else:
+        result = sherlock_get_completion(prompt, model=model, max_tokens=max_tokens, temperature=0.2)
+    tokens_in = getattr(result, "prompt_tokens", 0) or 0
+    return result.response_text, tokens_in
+
+
+def rewrite_chunk(chunk: str, chunk_num: int, total: int, model: str,
+                  prev_context: str = "", next_context: str = "") -> str:
+    """Pass 1: label section + correct transcript verbatim (no summarizing).
+
+    prev_context / next_context: boundary sentences from adjacent chunks — shown to the model
+    as read-only context to improve coherence at chunk boundaries, not to be reproduced.
+    Retries once if output is shorter than REWRITE_MIN_RATIO of input — keeps the longer result.
+    """
+    ctx_prev = (
+        f"\n[KONTEKST — koniec poprzedniego fragmentu, NIE przepisuj tego]:\n{prev_context}\n"
+        if prev_context else ""
+    )
+    ctx_next = (
+        f"\n[KONTEKST — początek następnego fragmentu, NIE przepisuj tego]:\n{next_context}\n"
+        if next_context else ""
+    )
+    prompt = f"""Fragment {chunk_num}/{total} surowej transkrypcji podcastu YouTube.
+{ctx_prev}
+Wykonaj DWIE rzeczy — nic więcej:
+
+1. W PIERWSZEJ LINII wpisz etykietę sekcji (tylko jedną z dwóch opcji):
+   ### REKLAMA: nazwa_sponsora      (gdy to blok reklamowy lub sponsorski)
+   ### TEMAT: opis_3_4_słowa        (gdy to merytoryczna treść rozmowy)
+
+2. Przepisz poniższy tekst DOSŁOWNIE — każde słowo musi zostać zachowane. Popraw tylko:
+   - Interpunkcję i podział na zdania.
+   - Oczywiste błędy transkrypcji (zamienione lub zlepione wyrazy).
+   - Zachowaj etykiety [Mówca]: na początku każdej wypowiedzi — nie usuwaj ich.
+   NIE skracaj. NIE streszczaj. NIE pomijaj żadnej informacji.
+
+--- FRAGMENT DO PRZEPISANIA ---
+{chunk}
+--- KONIEC FRAGMENTU ---
+{ctx_next}"""
+
+    best = ""
+    for attempt in range(1, 3):  # max 2 attempts
+        print(f"  [{chunk_num:>2}/{total}] rewrite ({len(chunk):,} znaków, próba {attempt})...", flush=True)
+        response_text, tokens_in = call_model(prompt, model, REWRITE_MAX_TOKENS)
+        out_len = len(response_text)
+        ratio = round(out_len / len(chunk) * 100)
+        print(f"  [{chunk_num:>2}/{total}] rewrite gotowe — {out_len:,} znaków ({ratio}% wejścia), tokeny: {tokens_in}",
+              flush=True)
+        if len(response_text) > len(best):
+            best = response_text
+        if out_len >= len(chunk) * REWRITE_MIN_RATIO:
+            break
+        if attempt < 2:
+            print(f"  [{chunk_num:>2}/{total}] Wynik zbyt krótki ({ratio}% < {round(REWRITE_MIN_RATIO*100)}%) — ponawiam...",
+                  flush=True)
+    return best
+
+
+def summarize_chunk(corrected_text: str, chunk_num: int, total: int, model: str) -> str:
+    """Pass 2: summarize the already-corrected text in 2-3 sentences."""
+    prompt = f"""Napisz streszczenie poniższego fragmentu merytorycznej rozmowy w 2-3 zdaniach.
+Skup się na głównych tezach i wnioskach. Odpowiedz po polsku.
+
+--- TEKST ---
+{corrected_text}
+--- KONIEC ---"""
+
+    print(f"  [{chunk_num:>2}/{total}] summarize ({len(corrected_text):,} znaków)...", flush=True)
+    response_text, tokens_in = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    print(f"  [{chunk_num:>2}/{total}] summarize gotowe — tokeny: {tokens_in}", flush=True)
+    return response_text.strip()
+
+
+def parse_rewritten_chunk(raw: str) -> tuple[str, str, str]:
+    """Extract (section_type, topic, corrected_text) from rewrite output."""
+    header_match = SECTION_HEADER_RE.search(raw)
+    section_type = header_match.group(1) if header_match else "TEMAT"
+    topic = header_match.group(2).strip() if header_match else "Nieznany"
+    text = raw[header_match.end():].strip() if header_match else raw.strip()
+    return section_type, topic, text
+
+
+def merge_topics(sections: list[dict], model: str) -> list[dict]:
+    """Ask LLM to group adjacent chunks into logical topic sections.
+
+    Returns list of dicts: [{"title": ..., "type": ..., "chunks": [1, 2, ...]}]
+    where chunk numbers are 1-based. Returns [] if LLM call fails.
+    """
+    import json as _json
+    chunk_list = "\n".join(
+        f"{i + 1}. [{s['type']}] {s['topic']}"
+        for i, s in enumerate(sections)
+    )
+    prompt = f"""Poniżej lista {len(sections)} fragmentów transkrypcji podcastu z ich tematami.
+Pogrupuj SĄSIADUJĄCE fragmenty w logiczne sekcje tematyczne (zwykle 5-10 sekcji).
+Fragmenty reklamowe (REKLAMA) możesz pominąć lub zgrupować razem pod jedną sekcją REKLAMA.
+
+Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:
+[{{"title": "Tytuł sekcji tematycznej", "type": "TEMAT", "chunks": [1, 2]}}]
+Gdzie "chunks" to numery fragmentów (numeracja od 1), "type" to "TEMAT" lub "REKLAMA".
+
+Fragmenty:
+{chunk_list}"""
+
+    print("  [tematy] Grupowanie fragmentów w logiczne sekcje...", flush=True)
+    response_text, _ = call_model(prompt, model, max_tokens=600)
+    try:
+        match = re.search(r'\[.*\]', response_text, re.DOTALL)
+        if match:
+            groups = _json.loads(match.group())
+            print(f"  [tematy] {len(groups)} sekcji tematycznych.", flush=True)
+            return groups
+    except (ValueError, AttributeError):
+        pass
+    print("  [tematy] Nie udało się zgrupować — fallback do chunków.", flush=True)
+    return []
+
+
+def build_topic_sections(sections: list[dict], topic_groups: list[dict]) -> list[dict]:
+    """Merge chunk texts and summaries according to topic grouping from merge_topics()."""
+    result = []
+    for group in topic_groups:
+        indices = [i - 1 for i in group.get("chunks", [])]
+        valid = [i for i in indices if 0 <= i < len(sections)]
+        if not valid:
+            continue
+        merged_text = "\n\n".join(s["text"] for i in valid if (s := sections[i])["text"])
+        merged_summary = " ".join(s["summary"] for i in valid if (s := sections[i])["summary"])
+        result.append({
+            "title": group.get("title", ""),
+            "type": group.get("type", "TEMAT"),
+            "chunk_indices": [i + 1 for i in valid],  # 1-based for display
+            "text": merged_text,
+            "summary": merged_summary.strip(),
+        })
+    return result
+
+
+def build_toc(topic_sections: list[dict]) -> str:
+    """Build table of contents from logical topic sections."""
+    lines = ["## SPIS TREŚCI\n"]
+    for i, s in enumerate(topic_sections, 1):
+        marker = "📢" if s["type"] == "REKLAMA" else "💬"
+        chunks_label = f"  *(fragmenty: {', '.join(str(c) for c in s['chunk_indices'])})*"
+        lines.append(f"{i:>2}. {marker} {s['title']}{chunks_label}")
+    return "\n".join(lines)
+
+
+def synthesize(sections: list[dict], title: str, model: str) -> str:
+    content_sections = [s for s in sections if s["type"] == "TEMAT" and s["summary"]]
+    if not content_sections:
+        return ""
+
+    summaries = "\n\n".join(
+        [f"**{s.get('title') or s.get('topic', '')}**: {s['summary']}" for s in content_sections]
+    )
+
+    if len(summaries) > SYNTHESIS_MAX_INPUT_CHARS:
+        print(f"  [synteza] Streszczenia zbyt długie ({len(summaries):,} znaków) — pomijam.")
+        return ""
+
+    prompt = f"""Poniżej są streszczenia kolejnych sekcji merytorycznych podcastu YouTube pt.: „{title}".
+
+Na ich podstawie przygotuj:
+1. GŁÓWNE WNIOSKI: 5-7 najważniejszych wniosków (lista punktowana).
+2. SYNTEZA: Spójne streszczenie całości (6-8 zdań).
+
+Odpowiedz wyłącznie po polsku.
+
+--- STRESZCZENIA SEKCJI ---
+{summaries}
+--- KONIEC ---"""
+
+    print(f"  [synteza] ({len(prompt):,} znaków)...", flush=True)
+    response_text, _ = call_model(prompt, model, SYNTHESIS_MAX_TOKENS)
+    print("  [synteza] Gotowe.", flush=True)
+    return response_text
+
+
+def save_html(doc_id: int, title: str, model: str,
+              topic_sections: list[dict], sections: list[dict],
+              segments: list[dict], video_id: str,
+              timestamp: str,
+              fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
+    """Generate HTML review table: per topic section, original transcript (with YT links) vs summary."""
+    import html as _html
+    exports_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
+    )
+    os.makedirs(exports_dir, exist_ok=True)
+    filename = os.path.join(exports_dir, f"youtube_view_{doc_id}_{timestamp}.html")
+
+    chunk_seg_map = _map_chunks_to_segments([s["original"] for s in sections], segments)
+
+    def yt_url(secs: float) -> str:
+        t = int(secs)
+        return f"https://www.youtube.com/watch?v={video_id}&t={t}" if video_id else "#"
+
+    def render_segments(seg_list: list[dict]) -> str:
+        """Group segments into sentences; each sentence: speaker + timestamp on its own line, then full text."""
+        if not seg_list:
+            return ""
+
+        MAX_SEGS_PER_GROUP = 8  # fallback grouping when no sentence boundary found
+
+        sp_names = [sp["name"] for sp in (speaker_info or [])] if speaker_info else []
+        cur_sp_idx = 0  # index into sp_names; alternates on each >>
+
+        groups: list[dict] = []
+        cur_texts: list[str] = []
+        cur_start: float | None = None
+
+        def flush_group(sp_idx: int) -> None:
+            nonlocal cur_texts, cur_start
+            if cur_texts:
+                groups.append({
+                    "start": cur_start,
+                    "text": " ".join(cur_texts),
+                    "speaker": sp_names[sp_idx] if sp_names else None,
+                    "sp_idx": sp_idx,
+                })
+                cur_texts = []
+                cur_start = None
+
+        for seg in seg_list:
+            raw = seg["text"].strip()
+            if not raw:
+                continue
+            is_sc = raw.startswith(">>")
+            text = raw[2:].strip() if is_sc else raw
+            if is_sc:
+                if cur_texts:
+                    flush_group(cur_sp_idx)
+                if sp_names:
+                    cur_sp_idx = 1 - cur_sp_idx  # alternate between 0 and 1
+            if cur_start is None:
+                cur_start = seg["start"]
+            cur_texts.append(text)
+            ends_sentence = text.rstrip().endswith((".", "?", "!", "...", "…"))
+            if ends_sentence or len(cur_texts) >= MAX_SEGS_PER_GROUP:
+                flush_group(cur_sp_idx)
+
+        flush_group(cur_sp_idx)
+
+        parts = []
+        for grp in groups:
+            label = _seconds_to_ts(grp["start"])
+            url = yt_url(grp["start"])
+            ts_link = f'<a href="{url}" target="_blank" class="ts">[{label}]</a>'
+            escaped = _html.escape(grp["text"])
+            sp_class = f'sp{grp["sp_idx"] + 1}' if grp["speaker"] else ""
+            sp_label = (
+                f'<span class="spname {sp_class}">{_html.escape(grp["speaker"])}</span> '
+                if grp["speaker"] else ""
+            )
+            parts.append(f'<p class="seg">{sp_label}{ts_link}<br>{escaped}</p>')
+
+        return "\n".join(parts)
+
+    date_str = f"{timestamp[:4]}-{timestamp[4:6]}-{timestamp[6:8]} {timestamp[9:11]}:{timestamp[11:13]}"
+    fmt_str = ""
+    if fmt and fmt.get("is_multi_speaker"):
+        fmt_str = f" | Rozmowa ({fmt['speaker_changes']} zmian mówcy)"
+
+    speakers_html = ""
+    if speaker_info:
+        sp_parts = []
+        for sp in speaker_info:
+            name = _html.escape(sp["name"])
+            role = _html.escape(sp.get("role", ""))
+            sp_parts.append(f"<b>{name}</b>" + (f" ({role})" if role else ""))
+        speakers_html = f'<p class="meta">Rozmówcy: {" | ".join(sp_parts)}</p>'
+
+    sections_html_parts = []
+    for i, section in enumerate(topic_sections, 1):
+        is_ad = section["type"] == "REKLAMA"
+        icon = "📢" if is_ad else "💬"
+        sec_class = ' class="ad-sec"' if is_ad else ""
+
+        chunk_indices_0 = [c - 1 for c in section["chunk_indices"] if 0 <= c - 1 < len(sections)]
+        if chunk_indices_0:
+            seg_start = chunk_seg_map[chunk_indices_0[0]][0]
+            seg_end = chunk_seg_map[chunk_indices_0[-1]][1]
+        else:
+            seg_start, seg_end = 0, 0
+        sec_segments = segments[seg_start:seg_end] if segments else []
+
+        first_link = ""
+        if sec_segments:
+            label0 = _seconds_to_ts(sec_segments[0]["start"])
+            url0 = yt_url(sec_segments[0]["start"])
+            first_link = f' <a href="{url0}" target="_blank" class="ts">[{label0}]</a>'
+
+        summary_html = _html.escape(section["summary"]).replace("\n", "<br>") if section["summary"] else "<em>brak streszczenia</em>"
+
+        sections_html_parts.append(f"""
+<div{sec_class}>
+<h2>{i}. {icon} {_html.escape(section['title'])}{first_link}</h2>
+<table>
+<tr><th class="tc">Transkrypcja oryginalna</th><th class="sc-col">Streszczenie</th></tr>
+<tr>
+<td class="tc">{render_segments(sec_segments)}</td>
+<td class="sc-col">{summary_html}</td>
+</tr>
+</table>
+</div>""")
+
+    html = f"""<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="UTF-8">
+<title>{_html.escape(title)}</title>
+<style>
+body {{ font-family: Arial, sans-serif; max-width: 1400px; margin: 20px auto; padding: 0 20px; color: #222; }}
+h1 {{ font-size: 1.2em; border-bottom: 3px solid #c00; padding-bottom: 6px; }}
+h2 {{ font-size: 1em; color: #333; margin-top: 36px; margin-bottom: 6px; }}
+.meta {{ color: #666; font-size: 0.88em; margin: 4px 0; }}
+table {{ width: 100%; border-collapse: collapse; margin-bottom: 10px; font-size: 0.88em; }}
+th {{ background: #444; color: #fff; padding: 7px 10px; text-align: left; }}
+td {{ vertical-align: top; padding: 9px 11px; border: 1px solid #ddd; }}
+.tc {{ width: 58%; line-height: 1.65; }}
+.sc-col {{ width: 42%; background: #f8f8f8; line-height: 1.6; }}
+.ts {{ color: #c00; text-decoration: none; font-weight: bold; font-size: 0.82em; white-space: nowrap; }}
+.ts:hover {{ text-decoration: underline; }}
+.sc {{ color: #aaa; }}
+.seg {{ margin: 0 0 10px 0; }}
+.spname {{ font-size: 0.78em; font-weight: bold; padding: 1px 5px; border-radius: 3px; margin-right: 4px; }}
+.sp1 {{ background: #dbeafe; color: #1d4ed8; }}
+.sp2 {{ background: #dcfce7; color: #15803d; }}
+.ad-sec h2 {{ color: #999; }}
+.ad-sec th {{ background: #999; }}
+</style>
+</head>
+<body>
+<h1>{_html.escape(title)}</h1>
+<p class="meta">ID: {doc_id} | Model: {_html.escape(model)} | Data: {date_str}{fmt_str}</p>
+{speakers_html}
+{"".join(sections_html_parts)}
+</body>
+</html>"""
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(html)
+    return filename
+
+
+def save_results(doc_id: int, title: str, model: str,
+                 toc: str, topic_sections: list[dict], synthesis: str, timestamp: str,
+                 fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
+    exports_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
+    )
+    os.makedirs(exports_dir, exist_ok=True)
+    filename = os.path.join(exports_dir, f"youtube_analysis_{doc_id}_{timestamp}.md")
+
+    content_count = sum(1 for s in topic_sections if s["type"] == "TEMAT")
+    ad_count = sum(1 for s in topic_sections if s["type"] == "REKLAMA")
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f"# Analiza YouTube: {title or f'Dokument {doc_id}'}\n\n")
+        f.write(f"**ID**: {doc_id} | **Model**: {model} | **Data**: {timestamp[:4]}-{timestamp[4:6]}-{timestamp[6:8]} {timestamp[9:11]}:{timestamp[11:13]}\n\n")
+        f.write(f"**Sekcji merytorycznych**: {content_count} | **Reklam**: {ad_count}\n\n")
+
+        if fmt:
+            if fmt["is_multi_speaker"]:
+                f.write(f"**Format**: Rozmowa ({fmt['speaker_changes']} zmian mówcy)\n\n")
+            else:
+                f.write("**Format**: Monolog\n\n")
+        if speaker_info:
+            f.write("**Rozmówcy**:\n\n")
+            for sp in speaker_info:
+                role = sp.get("role", "")
+                desc = sp.get("description", "")
+                line = f"- **{sp['name']}**"
+                if role:
+                    line += f" ({role})"
+                if desc:
+                    line += f" — {desc}"
+                f.write(line + "\n")
+            f.write("\n")
+
+        f.write("---\n\n")
+
+        f.write(toc)
+        f.write("\n\n---\n\n")
+
+        if synthesis:
+            f.write("## SYNTEZA KOŃCOWA\n\n")
+            f.write(synthesis)
+            f.write("\n\n---\n\n")
+
+        f.write("## TRANSKRYPCJA TEMATYCZNA\n\n")
+        for i, s in enumerate(topic_sections, 1):
+            marker = "📢" if s["type"] == "REKLAMA" else "💬"
+            chunks_ref = ", ".join(str(c) for c in s["chunk_indices"])
+            f.write(f"### {i}. {marker} {s['title']}\n\n")
+            f.write(f"*fragmenty źródłowe: {chunks_ref}*\n\n")
+            if s["summary"] and s["type"] == "TEMAT":
+                f.write(f"**Streszczenie sekcji**: {s['summary']}\n\n")
+            if s["text"]:
+                f.write(s["text"])
+                f.write("\n\n")
+
+    return filename
+
+
+def save_json(doc_id: int, title: str, model: str,
+              sections: list[dict], topic_sections: list[dict],
+              synthesis: str, timestamp: str,
+              fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
+    """Save full analysis as JSON for programmatic processing."""
+    exports_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
+    )
+    os.makedirs(exports_dir, exist_ok=True)
+    filename = os.path.join(exports_dir, f"youtube_analysis_{doc_id}_{timestamp}.json")
+
+    import json
+    payload = {
+        "meta": {
+            "doc_id": doc_id,
+            "title": title,
+            "model": model,
+            "timestamp": timestamp,
+            "chunk_count": len(sections),
+            "content_chunks": sum(1 for s in sections if s["type"] == "TEMAT"),
+            "ad_chunks": sum(1 for s in sections if s["type"] == "REKLAMA"),
+            "short_chunks": sum(1 for s in sections if s["ratio"] < 80),
+            "format": fmt or {"is_multi_speaker": False, "speaker_changes": 0},
+            "speakers": speaker_info or [],
+        },
+        "synthesis": synthesis,
+        "topics": [
+            {
+                "index": i + 1,
+                "title": s["title"],
+                "type": s["type"],
+                "chunk_indices": s["chunk_indices"],
+                "summary": s["summary"],
+            }
+            for i, s in enumerate(topic_sections)
+        ],
+        "chunks": [
+            {
+                "index": i + 1,
+                "type": s["type"],
+                "topic": s["topic"],
+                "ratio": s["ratio"],
+                "original": s["original"],
+                "corrected": s["text"],
+                "summary": s["summary"],
+            }
+            for i, s in enumerate(sections)
+        ],
+    }
+
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+    return filename
+
+
+def save_debug(doc_id: int, title: str, model: str, sections: list[dict], timestamp: str) -> str:
+    """Save per-chunk debug file: original → rewritten → summary."""
+    exports_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
+    )
+    os.makedirs(exports_dir, exist_ok=True)
+    filename = os.path.join(exports_dir, f"youtube_debug_{doc_id}_{timestamp}.md")
+
+    ok = sum(1 for s in sections if s["ratio"] >= 80)
+    short = sum(1 for s in sections if s["ratio"] < 80)
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(f"# DEBUG: {title or f'Dokument {doc_id}'}\n\n")
+        f.write(f"**Model**: {model} | **Data**: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n\n")
+        f.write(f"**Chunki**: {len(sections)} | **OK (≥80%)**: {ok} | **Skrócone (<80%)**: {short}\n\n")
+
+        ratio_list = " | ".join(
+            f"[{i+1}] {s['ratio']}%{'⚠' if s['ratio'] < 80 else ''}"
+            for i, s in enumerate(sections)
+        )
+        f.write(f"**Ratio**: {ratio_list}\n\n")
+        f.write("---\n\n")
+
+        for i, s in enumerate(sections, 1):
+            marker = "📢 REKLAMA" if s["type"] == "REKLAMA" else "💬 TEMAT"
+            f.write(f"## Chunk {i:>2} — {marker}: {s['topic']}  (ratio: {s['ratio']}%)\n\n")
+
+            f.write(f"### ORYGINAŁ ({len(s['original']):,} znaków)\n\n")
+            f.write("```\n")
+            f.write(s["original"])
+            f.write("\n```\n\n")
+
+            f.write(f"### POPRAWIONY ({len(s['text']):,} znaków)\n\n")
+            f.write(s["text"] or "_brak_")
+            f.write("\n\n")
+
+            if s["summary"]:
+                f.write(f"### STRESZCZENIE\n\n")
+                f.write(s["summary"])
+                f.write("\n\n")
+
+            f.write("---\n\n")
+
+    return filename
+
+
+def save_to_db(
+    session,
+    doc: WebDocument,
+    model: str,
+    chunk_size: int,
+    sections: list[dict],
+    topic_sections: list[dict],
+    synthesis: str,
+    segments: list[dict] | None,
+) -> DocumentAnalysisRun:
+    """Persist analysis results to DB: one run + N chunks + M topic sections."""
+    seg_map = (
+        _map_chunks_to_segments([s["original"] for s in sections], segments)
+        if segments else [(None, None)] * len(sections)
+    )
+
+    run = DocumentAnalysisRun(
+        document_id=doc.id,
+        model=model,
+        chunk_size=chunk_size,
+        synthesis=synthesis or None,
+    )
+    session.add(run)
+    session.flush()  # get run.id before adding children
+
+    for i, s in enumerate(sections):
+        seg_start, seg_end = seg_map[i]
+        session.add(DocumentChunk(
+            run_id=run.id,
+            document_id=doc.id,
+            position=i + 1,
+            type=s["type"],
+            topic=s["topic"],
+            original_text=s["original"],
+            corrected_text=s["text"] or None,
+            summary=s["summary"] or None,
+            seg_start=seg_start,
+            seg_end=seg_end,
+            rewrite_ratio=s["ratio"],
+            status="pending",
+        ))
+
+    for i, ts in enumerate(topic_sections):
+        session.add(DocumentTopicSection(
+            run_id=run.id,
+            document_id=doc.id,
+            position=i + 1,
+            type=ts["type"],
+            title=ts["title"] or None,
+            summary=ts["summary"] or None,
+            chunk_positions=ts["chunk_indices"],
+        ))
+
+    session.commit()
+    return run
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="YouTube transcript: correct + segment + summarize (Bielik LLM)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--doc_id", type=int, required=True,
+                        help="Document ID in the database")
+    parser.add_argument("--model", default="Bielik-11B-v3.0-Instruct",
+                        choices=ALL_MODELS,
+                        help="Model to use")
+    parser.add_argument("--chunk_size", type=int, default=CHUNK_CHARS,
+                        help="Characters per chunk (≈1,500 tokens at default 5,000)")
+    parser.add_argument("--speaker1", default="",
+                        help="Name of first speaker (segments before first >>). "
+                             "If omitted, >> markers are not parsed.")
+    parser.add_argument("--speaker2", default="",
+                        help="Name of second speaker (segments after first >>).")
+    parser.add_argument("--no_synthesis", action="store_true",
+                        help="Skip final synthesis step")
+    parser.add_argument("--dry_run", action="store_true",
+                        help="Show chunk breakdown without calling the API")
+    args = parser.parse_args()
+
+    load_config()
+
+    print(f"Pobieranie dokumentu {args.doc_id}...")
+    session = get_session()
+    doc = WebDocument.get_by_id(session, args.doc_id)
+    if doc is None:
+        print(f"BŁĄD: Dokument {args.doc_id} nie znaleziony.")
+        sys.exit(1)
+
+    print(f"Tytuł  : {doc.title}")
+    print(f"Typ    : {doc.document_type} | Stan: {doc.document_state}")
+    if doc.author:
+        print(f"Autor  : {doc.author}")
+
+    video_id = getattr(doc, "original_id", "") or ""
+    segments = _load_transcript_segments(getattr(doc, "text_raw", "") or "")
+    if segments:
+        print(f"Segm.  : {len(segments)} segmentów z timestampami w text_raw")
+    else:
+        print("Segm.  : brak JSON w text_raw — widok HTML bez linków YT")
+
+    text, text_field = get_text_for_analysis(doc)
+    if not text:
+        print("BŁĄD: Brak tekstu w polach text / text_raw / text_md.")
+        sys.exit(1)
+    fmt = detect_format(text)
+    speaker_info: list[dict] = []
+
+    if fmt["is_multi_speaker"]:
+        print(f"Format : Rozmowa ({fmt['speaker_changes']} zmian mówcy)")
+        if args.speaker1 and args.speaker2:
+            speaker_info = [
+                {"name": args.speaker1, "role": "prowadzący", "description": ""},
+                {"name": args.speaker2, "role": "gość", "description": ""},
+            ]
+        elif not args.dry_run:
+            # Sponsor ads typically fill the first ~900 chars; the host intro
+            # with speaker names follows immediately after in the same segment.
+            # Take chars 800-2400 to reliably capture names without ad noise.
+            intro_text = text[800:2400].strip()
+            speaker_info = extract_speaker_info(intro_text, args.model)
+            if len(speaker_info) >= 2:
+                args.speaker1 = speaker_info[0]["name"]
+                args.speaker2 = speaker_info[1]["name"]
+                print(f"  → [{args.speaker1}] / [{args.speaker2}]")
+    else:
+        print("Format : Monolog (brak znaczników >>)")
+
+    if args.speaker1 and args.speaker2:
+        text = assign_speakers(text, args.speaker1, args.speaker2)
+        turns = text.count(f"[{args.speaker1}]:") + text.count(f"[{args.speaker2}]:")
+        print(f"Mówcy  : [{args.speaker1}] / [{args.speaker2}] — {turns} wypowiedzi")
+
+    cleaned_text = clean_fillers(text)
+    saved = len(text) - len(cleaned_text)
+    print(f"Tekst  : pole '{text_field}', {len(text):,} znaków → po usunięciu fillerów: {len(cleaned_text):,} znaków (zaoszczędzono {saved:,})\n")
+
+    chunks = split_text_into_sentence_chunks(cleaned_text, args.chunk_size)
+    est_tokens_total = len(chunks) * (args.chunk_size // 3 * 2)  # rough: in+out
+    est_cost = est_tokens_total / 1_000_000 * 0.56
+    print(f"Podział: {len(chunks)} fragmentów po max {args.chunk_size:,} znaków")
+    print(f"Szacowany koszt: ~{est_tokens_total:,} tokenów ≈ {est_cost:.3f} EUR\n")
+    for i, ch in enumerate(chunks):
+        print(f"  [{i + 1:>2}] {len(ch):>6,} znaków")
+
+    if args.dry_run:
+        print("\n[dry_run] Tryb podglądu — API nie zostało wywołane.")
+        return
+
+    print(f"\n=== PRZETWARZANIE: {len(chunks)} fragmentów → {args.model} ===\n")
+    sections: list[dict] = []
+    for i, chunk in enumerate(chunks):
+        prev_ctx = _tail(chunks[i - 1]) if i > 0 else ""
+        next_ctx = _head(chunks[i + 1]) if i < len(chunks) - 1 else ""
+        rewritten = rewrite_chunk(chunk, i + 1, len(chunks), args.model, prev_ctx, next_ctx)
+        section_type, topic, corrected_text = parse_rewritten_chunk(rewritten)
+
+        summary = ""
+        if section_type == "TEMAT" and corrected_text:
+            summary = summarize_chunk(corrected_text, i + 1, len(chunks), args.model)
+
+        ratio = round(len(corrected_text) / len(chunk) * 100) if chunk else 0
+        sections.append({
+            "type": section_type,
+            "topic": topic,
+            "original": chunk,
+            "text": corrected_text,
+            "ratio": ratio,
+            "summary": summary,
+        })
+    print("\n=== GRUPOWANIE TEMATYCZNE ===\n")
+    topic_groups = merge_topics(sections, args.model)
+    if topic_groups:
+        topic_sections = build_topic_sections(sections, topic_groups)
+    else:
+        topic_sections = [
+            {
+                "title": s["topic"],
+                "type": s["type"],
+                "chunk_indices": [i + 1],
+                "text": s["text"],
+                "summary": s["summary"],
+            }
+            for i, s in enumerate(sections)
+        ]
+
+    toc = build_toc(topic_sections)
+    print(f"\n{toc}\n")
+
+    synthesis = ""
+    if not args.no_synthesis:
+        print("=== SYNTEZA ===\n")
+        synthesis = synthesize(topic_sections, doc.title or f"Dokument {args.doc_id}", args.model)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_file = save_results(
+        args.doc_id, doc.title or "", args.model, toc, topic_sections, synthesis, timestamp,
+        fmt=fmt, speaker_info=speaker_info,
+    )
+    json_file = save_json(
+        args.doc_id, doc.title or "", args.model, sections, topic_sections, synthesis, timestamp,
+        fmt=fmt, speaker_info=speaker_info,
+    )
+    debug_file = save_debug(args.doc_id, doc.title or "", args.model, sections, timestamp)
+    html_file = None
+    if segments:
+        html_file = save_html(
+            args.doc_id, doc.title or "", args.model,
+            topic_sections, sections, segments, video_id,
+            timestamp, fmt=fmt, speaker_info=speaker_info,
+        )
+    print("\n=== ZAPIS DO BAZY DANYCH ===\n")
+    run = save_to_db(
+        session, doc, args.model, args.chunk_size,
+        sections, topic_sections, synthesis, segments,
+    )
+    print(f"  Run ID: {run.id} ({len(sections)} chunków, {len(topic_sections)} sekcji tematycznych)")
+
+    print(f"\n✓ Analiza (MD):  {output_file}")
+    print(f"✓ Dane (JSON):   {json_file}")
+    print(f"✓ Debug (MD):    {debug_file}")
+    if html_file:
+        print(f"✓ Widok HTML:    {html_file}")
+    print(f"✓ DB Run ID:     {run.id}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds interactive web UI (`/chunk_review`) for reviewing LLM analysis of YouTube transcripts — split chunks, re-analyze, approve, toggle views
- Extracts LLM pipeline into `chunk_llm_analysis.py` with `remove_speech_fillers()` pre-processing (regex removes yyy/eee before LLM call)
- Two re-analysis modes: **full** (rewrite from raw STT) and **semantic** (classify+summarize on existing corrected text)
- Speaker auto-detection from intro chunks — real names used in summaries instead of generic "Rozmówca"
- DB migrations: analysis tables (chunks, runs, topic sections) + `speakers JSONB` column

## Key endpoints

- `GET /chunk_review` — single-page HTML interface
- `GET /analysis_run/<id>/chunks` — load run data
- `POST /chunk/<id>/reanalyze` — re-analyze with `mode=full|semantic`
- `POST /chunk/<id>/execute_split` — split chunk at transcript paragraph boundary
- `POST /analysis_run/<id>/extract_speakers` — LLM speaker detection from intro

## Test plan

- [ ] Open `/chunk_review?doc_id=<id>` and verify chunks load
- [ ] Click "Wykryj rozmówców" — verify speaker names appear in blue bar
- [ ] Click "▶ Sem." on a chunk with corrected_text — verify summary uses real speaker names
- [ ] Click "▶ Pełna" on a chunk — verify yyy/eee removed from corrected_text
- [ ] Split a chunk at a paragraph boundary — verify two new chunks created
- [ ] Click "Analizuj wszystkie" — verify batch re-analysis runs sequentially
- [ ] Toggle "Pokaż poprawiony" / "Pokaż surowy" — verify left panel switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)