### PR TITLE
feat: DocumentAnalysisService, async chunk analysis, UI improvements

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1,14 +1,20 @@
 """Flask blueprint: chunk review API + interactive HTML page.
 
 Endpoints:
-  GET  /analysis_runs?doc_id=<id>         — list runs for a document
-  GET  /analysis_run/<run_id>/chunks      — full run data (chunks + segments)
-  PATCH /chunk/<chunk_id>                 — update status / type / topic / split_at_seg
-  GET  /chunk_review                      — interactive HTML review page
+  GET  /analysis_runs?doc_id=<id>            — list runs for a document
+  POST /document/<doc_id>/analyze_chunks     — create a new analysis run
+  GET  /analysis_run/<run_id>/chunks         — full run data (chunks + segments)
+  POST /analysis_run/<run_id>/extract_speakers
+  PATCH /chunk/<chunk_id>                    — update status / type / topic / split_at_seg
+  POST /chunk/<chunk_id>/execute_split
+  POST /chunk/<chunk_id>/reanalyze
+  GET  /chunk_review                         — interactive HTML review page
 """
 
 import json
 import logging
+import threading
+import uuid
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request, abort
@@ -22,6 +28,10 @@ from library.db.models import (
 logger = logging.getLogger(__name__)
 
 bp = Blueprint("chunk_review", __name__)
+
+# In-memory job registry for async analysis runs.
+# Keyed by job_id (short UUID). Lives as long as the server process.
+_analysis_jobs: dict[str, dict] = {}
 
 ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split"}
 ALLOWED_TYPES = {"TEMAT", "REKLAMA"}
@@ -60,6 +70,87 @@ def _chunk_to_dict(c: DocumentChunk) -> dict:
 # ---------------------------------------------------------------------------
 # API: GET /analysis_runs
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# API: POST /document/<doc_id>/analyze_chunks
+# ---------------------------------------------------------------------------
+
+@bp.route("/document/<int:doc_id>/analyze_chunks", methods=["POST"])
+def analyze_document_chunks(doc_id: int):
+    """Start an async chunk analysis run for an existing document.
+
+    Body (JSON, all optional):
+        model        — LLM model name (default: Bielik-11B-v3.0-Instruct)
+        chunk_size   — max chars per chunk (default: 5000)
+        no_synthesis — skip final synthesis step (default: false)
+
+    Returns immediately with {job_id}. Poll GET /analysis_job/<job_id> for status.
+    """
+    data = request.get_json(silent=True) or {}
+    model = data.get("model", "Bielik-11B-v3.0-Instruct")
+    chunk_size = int(data.get("chunk_size", 5000))
+    no_synthesis = bool(data.get("no_synthesis", False))
+
+    job_id = uuid.uuid4().hex[:8]
+    _analysis_jobs[job_id] = {
+        "status": "running",
+        "doc_id": doc_id,
+        "model": model,
+        "run_id": None,
+        "chunk_count": None,
+        "ad_count": None,
+        "topic_section_count": None,
+        "error": None,
+        "progress": "Startowanie...",
+    }
+
+    def _run_analysis() -> None:
+        from library.db.engine import get_session
+        from library.document_analysis_service import DocumentAnalysisService
+
+        session = get_session()
+        try:
+            def _progress(msg: str) -> None:
+                _analysis_jobs[job_id]["progress"] = msg
+
+            service = DocumentAnalysisService(session)
+            run = service.create_run(
+                doc_id=doc_id,
+                model=model,
+                chunk_size=chunk_size,
+                no_synthesis=no_synthesis,
+                progress_fn=_progress,
+            )
+            ad_count = sum(1 for c in run.chunks if c.type == "REKLAMA")
+            _analysis_jobs[job_id].update({
+                "status": "done",
+                "run_id": run.id,
+                "chunk_count": len(run.chunks),
+                "ad_count": ad_count,
+                "topic_section_count": len(run.topic_sections),
+                "progress": f"Gotowe: {len(run.chunks)} chunków, {len(run.topic_sections)} sekcji",
+            })
+        except ValueError as exc:
+            _analysis_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        except Exception as exc:
+            logger.exception("background analysis failed for doc %d", doc_id)
+            _analysis_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        finally:
+            session.close()
+
+    t = threading.Thread(target=_run_analysis, daemon=True, name=f"analysis-{job_id}")
+    t.start()
+
+    return jsonify({"status": "started", "job_id": job_id, "doc_id": doc_id})
+
+
+@bp.route("/analysis_job/<job_id>", methods=["GET"])
+def get_analysis_job(job_id: str):
+    """Poll status of an async analysis job started by POST /document/<id>/analyze_chunks."""
+    job = _analysis_jobs.get(job_id)
+    if job is None:
+        return jsonify({"status": "error", "message": "Job not found"}), 404
+    return jsonify({"status": "success", "job": job})
 
 @bp.route("/analysis_runs", methods=["GET"])
 def list_runs():
@@ -481,9 +572,13 @@ body{font-family:Arial,sans-serif;background:#f5f5f5;color:#222;font-size:14px}
 .btn-save{margin-left:auto;padding:3px 12px;border-radius:3px;border:none;background:#3b82f6;color:#fff;font-size:0.8em;cursor:pointer;font-weight:bold}
 .btn-save:hover{background:#2563eb}
 .btn-save:disabled{background:#94a3b8;cursor:default}
-.chunk-body{display:grid;grid-template-columns:58% 42%;min-height:60px}
-.tc{padding:10px 14px;border-right:1px solid #e2e8f0;font-size:0.84em;line-height:1.6;overflow-wrap:anywhere}
-.sc-col{padding:10px 14px;background:#f8fafc;font-size:0.84em;line-height:1.6}
+.chunk-body{min-height:60px}
+.tc{padding:10px 14px;font-size:0.84em;line-height:1.6;overflow-wrap:anywhere}
+.summary-box{padding:8px 14px 10px;background:#f8fafc;border-top:1px solid #e2e8f0;
+  font-size:0.84em;line-height:1.6;color:#334155}
+.summary-box em{color:#94a3b8}
+.summary-label{font-size:0.76em;font-weight:bold;color:#64748b;text-transform:uppercase;
+  letter-spacing:.03em;margin-bottom:4px}
 /* segment row */
 .seg{margin:0 0 8px;position:relative;padding-right:28px}
 .seg:hover .split-btn{opacity:1}
@@ -516,9 +611,9 @@ em{color:#94a3b8}
   font-size:0.8em;cursor:pointer;font-weight:bold}
 #btn-analyze-all:hover{background:#0284c7}
 #btn-analyze-all:disabled{background:#94a3b8;cursor:default}
-#btn-view{padding:3px 11px;border-radius:3px;border:none;background:#0f766e;color:#fff;
-  font-size:0.8em;cursor:pointer;font-weight:bold}
-#btn-view:hover{background:#0d9488}
+.btn-view-chunk{padding:2px 8px;border-radius:3px;border:1px solid #94a3b8;background:#f1f5f9;
+  color:#475569;font-size:0.75em;cursor:pointer}
+.btn-view-chunk:hover{background:#e2e8f0}
 #speakers-bar{background:#1e3a5f;color:#bfdbfe;padding:6px 20px;font-size:0.82em;display:none;
   align-items:center;gap:12px;flex-wrap:wrap}
 #speakers-bar strong{color:#fff}
@@ -530,6 +625,20 @@ em{color:#94a3b8}
 .btn-reanalyze-sem:hover{background:#047857}
 .btn-reanalyze-sem:disabled{background:#94a3b8;cursor:default}
 .tc-corrected{white-space:pre-wrap;font-size:0.85em;line-height:1.6;color:#1e293b}
+/* new-run panel */
+#new-run-panel{display:none;background:#0f172a;padding:10px 20px;border-top:1px solid #334155;
+  font-size:0.84em;color:#cbd5e1;flex-wrap:wrap;gap:10px;align-items:center}
+#new-run-panel label{display:flex;align-items:center;gap:6px}
+#new-run-panel select,#new-run-panel input[type=number]{
+  background:#334155;color:#fff;border:1px solid #475569;border-radius:4px;padding:4px 8px;font-size:0.85em}
+#btn-new-run{padding:3px 11px;border-radius:3px;border:none;background:#0369a1;color:#fff;
+  font-size:0.8em;cursor:pointer;font-weight:bold}
+#btn-new-run:hover{background:#0284c7}
+#btn-new-run:disabled{background:#94a3b8;cursor:default}
+#btn-toggle-new-run{padding:3px 9px;border-radius:3px;border:1px solid #475569;background:#1e293b;
+  color:#94a3b8;font-size:0.8em;cursor:pointer}
+#btn-toggle-new-run:hover{background:#334155;color:#fff}
+#new-run-status{color:#fbbf24;font-size:0.82em}
 /* split panel */
 .split-panel{margin-top:10px;padding:10px 12px;background:#fff7ed;border:1px solid #fed7aa;
   border-radius:5px;font-size:0.84em}
@@ -551,15 +660,30 @@ em{color:#94a3b8}
   <label>Run:
     <select id="run-select" onchange="loadRun(this.value)"></select>
   </label>
+  <button id="btn-toggle-new-run" onclick="toggleNewRunPanel()" title="Nowa analiza">+ Nowa</button>
   <label>API key:
     <input type="password" id="api-key-input" placeholder="x-api-key" oninput="saveKey(this.value)">
   </label>
+</div>
+<div id="new-run-panel">
+  <label>Model:
+    <select id="new-run-model">
+      <option value="Bielik-11B-v3.0-Instruct">Bielik-11B v3.0 (Sherlock)</option>
+      <option value="arklabs/Bielik-11B-v3.0-Instruct">Bielik-11B v3.0 (ArkLabs)</option>
+    </select>
+  </label>
+  <label>Chunk:
+    <input type="number" id="new-run-chunk-size" value="5000" min="1000" max="20000" step="500" style="width:80px">
+    znaków
+  </label>
+  <label><input type="checkbox" id="new-run-no-synthesis"> Pomiń syntezę</label>
+  <button id="btn-new-run" onclick="createNewRun()">▶ Utwórz analizę</button>
+  <span id="new-run-status"></span>
 </div>
 <div id="progress-bar">
   <span id="progress-text">Ładowanie...</span>
   <div id="progress-track"><div id="progress-fill" style="width:0%"></div></div>
   <button id="btn-analyze-all" onclick="reanalyzeAll()" style="display:none">Analizuj wszystkie</button>
-  <button id="btn-view" onclick="toggleView()">Pokaż poprawiony</button>
   <button id="btn-ads" class="hide-mode" onclick="toggleAds()">Ukryj reklamy</button>
 </div>
 <div id="speakers-bar">
@@ -576,7 +700,6 @@ let RUN_ID = parseInt(params.get("run_id") || "0");
 let API_KEY = params.get("api_key") || localStorage.getItem("lenie_api_key") || "";
 let _data = null;
 let _hideAds = false;
-let _showCorrected = false;
 const _splitState = {};  // chunkId → {segIdx, ts, firstType, secondType}
 
 document.getElementById("api-key-input").value = API_KEY;
@@ -820,8 +943,15 @@ function renderChunk(chunk, segs, videoId) {
   const chunkSegs = segs.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segs.length);
   const transcript = renderSegments(chunkSegs, videoId, chunk.id, chunk.seg_start ?? 0);
   const splitPanel = renderSplitPanel(chunk.id);
-  const summary = chunk.summary
-    ? `<div class="summary-text">${chunk.summary.replace(/\n/g,"<br>")}</div>`
+
+  // Default: show corrected text when available, fall back to raw transcript
+  const hasCorrected = !!chunk.corrected_text;
+  const rawStyle    = hasCorrected ? 'display:none'  : 'display:block';
+  const corStyle    = hasCorrected ? 'display:block' : 'display:none';
+  const viewBtnLabel = hasCorrected ? "Surowy" : "Poprawiony";
+
+  const summaryContent = chunk.summary
+    ? chunk.summary.replace(/\n/g,"<br>")
     : `<em>${chunk.type === "REKLAMA" ? "brak streszczenia (reklama)" : "brak streszczenia"}</em>`;
 
   return `
@@ -839,17 +969,24 @@ function renderChunk(chunk, segs, videoId) {
     <span class="saved-flash" id="flash-${chunk.id}">✓ zapisano</span>
     <button class="btn-reanalyze" id="reanalyze-${chunk.id}"
             onclick="reanalyzeChunk(${chunk.id},'full')">▶ Pełna</button>
-    ${chunk.corrected_text
+    ${hasCorrected
       ? `<button class="btn-reanalyze-sem" id="reanalyze-sem-${chunk.id}"
                onclick="reanalyzeChunk(${chunk.id},'semantic')">▶ Sem.</button>`
+      : ""}
+    ${hasCorrected
+      ? `<button class="btn-view-chunk" id="btn-view-${chunk.id}"
+               onclick="toggleChunkView(${chunk.id})">${viewBtnLabel}</button>`
       : ""}
   </div>
   <div class="chunk-body">
     <div class="tc">
-      <div class="tc-raw">${transcript}${splitPanel}</div>
-      <div class="tc-corrected" style="display:${_showCorrected ? "block" : "none"}">${(chunk.corrected_text||"(brak poprawionego tekstu)").replace(/\n/g,"<br>")}</div>
+      <div class="tc-raw" style="${rawStyle}">${transcript}${splitPanel}</div>
+      <div class="tc-corrected" style="${corStyle}">${(chunk.corrected_text||"").replace(/\n/g,"<br>")}</div>
     </div>
-    <div class="sc-col">${summary}</div>
+    <div class="summary-box">
+      <div class="summary-label">Streszczenie</div>
+      ${summaryContent}
+    </div>
   </div>
 </div>`;
 }
@@ -876,7 +1013,6 @@ async function reanalyzeChunk(chunkId, mode) {
         const segs = _data.segments || [];
         const videoId = _data.document.original_id || "";
         el.outerHTML = renderChunk(res.chunk, segs, videoId);
-        if (_showCorrected) applyViewToggle();
       }
       updateProgress();
     }
@@ -970,16 +1106,15 @@ async function reanalyzeAll() {
   updateProgress();
 }
 
-function applyViewToggle() {
-  document.querySelectorAll(".tc-raw").forEach(el => el.style.display = _showCorrected ? "none" : "block");
-  document.querySelectorAll(".tc-corrected").forEach(el => el.style.display = _showCorrected ? "block" : "none");
-  const btn = document.getElementById("btn-view");
-  if (btn) btn.textContent = _showCorrected ? "Pokaż surowy" : "Pokaż poprawiony";
-}
-
-function toggleView() {
-  _showCorrected = !_showCorrected;
-  applyViewToggle();
+function toggleChunkView(chunkId) {
+  const raw = document.querySelector(`#chunk-${chunkId} .tc-raw`);
+  const cor = document.querySelector(`#chunk-${chunkId} .tc-corrected`);
+  const btn = document.getElementById(`btn-view-${chunkId}`);
+  if (!raw || !cor || !btn) return;
+  const showingCorrected = cor.style.display !== "none";
+  raw.style.display = showingCorrected ? "block" : "none";
+  cor.style.display = showingCorrected ? "none" : "block";
+  btn.textContent = showingCorrected ? "Poprawiony" : "Surowy";
 }
 
 function toggleAds() {
@@ -1037,6 +1172,65 @@ async function loadRuns() {
     document.getElementById("chunks").innerHTML =
       `<div id="error-msg">Błąd ładowania runów: ${e.message}.<br>Sprawdź czy backend działa i API key jest poprawny.</div>`;
   }
+}
+
+function toggleNewRunPanel() {
+  const panel = document.getElementById("new-run-panel");
+  panel.style.display = panel.style.display === "flex" ? "none" : "flex";
+}
+
+async function createNewRun() {
+  if (!DOC_ID) { alert("Brak doc_id w URL — odśwież stronę z ?doc_id=<id>"); return; }
+  const model = document.getElementById("new-run-model").value;
+  const chunkSize = parseInt(document.getElementById("new-run-chunk-size").value) || 5000;
+  const noSynthesis = document.getElementById("new-run-no-synthesis").checked;
+  const btn = document.getElementById("btn-new-run");
+  const statusEl = document.getElementById("new-run-status");
+
+  btn.disabled = true;
+  btn.textContent = "Analizuję...";
+  statusEl.textContent = "⏳ Startowanie...";
+
+  let jobId = null;
+  try {
+    const res = await apiFetch(`/document/${DOC_ID}/analyze_chunks`, {
+      method: "POST",
+      body: JSON.stringify({model, chunk_size: chunkSize, no_synthesis: noSynthesis}),
+    });
+    if (res.status !== "started") throw new Error(res.message || "Nieznany błąd");
+    jobId = res.job_id;
+  } catch (e) {
+    statusEl.textContent = `✗ Błąd: ${e.message}`;
+    btn.textContent = "▶ Utwórz analizę";
+    btn.disabled = false;
+    return;
+  }
+
+  // Poll until done or failed
+  const poll = setInterval(async () => {
+    try {
+      const res = await apiFetch(`/analysis_job/${jobId}`);
+      const job = res.job;
+      statusEl.textContent = `⏳ ${job.progress || job.status}`;
+
+      if (job.status === "done") {
+        clearInterval(poll);
+        statusEl.textContent =
+          `✓ Gotowe: run #${job.run_id}, ${job.chunk_count} chunków (${job.ad_count} reklam), ${job.topic_section_count} sekcji`;
+        btn.textContent = "▶ Utwórz analizę";
+        btn.disabled = false;
+        await loadRuns();
+      } else if (job.status === "failed") {
+        clearInterval(poll);
+        statusEl.textContent = `✗ Błąd: ${job.error || "nieznany"}`;
+        btn.textContent = "▶ Utwórz analizę";
+        btn.disabled = false;
+      }
+    } catch (e) {
+      // transient network error — keep polling
+      statusEl.textContent = `⏳ Sprawdzam... (${e.message})`;
+    }
+  }, 5000);  // poll every 5 seconds
 }
 
 loadRuns();

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -1,0 +1,345 @@
+"""Service for creating chunk analysis runs on existing documents.
+
+Full pipeline:
+  text extraction → speech filler removal → chunk splitting → LLM analysis
+  → topic grouping → optional synthesis → DB persistence
+
+Designed to be called from Flask endpoints (via REST API) and batch scripts.
+The batch script (test_code/youtube_batch_analyze.py) keeps its own HTML/JSON/MD
+export logic; this service handles only DB-backed pipeline execution.
+"""
+
+import json
+import logging
+import re
+from typing import Callable
+
+from library.db.models import (
+    DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument,
+)
+
+logger = logging.getLogger(__name__)
+
+CHUNK_CHARS = 5_000
+SYNTHESIS_MAX_TOKENS = 2_000
+SYNTHESIS_MAX_INPUT_CHARS = 20_000
+_SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT): ?(.+)$', re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_segments(text_raw: str | None) -> list[dict]:
+    """Parse YouTube transcript JSON from text_raw — returns [] when not valid JSON."""
+    if not text_raw or not text_raw.strip().startswith("["):
+        return []
+    try:
+        segs = json.loads(text_raw.strip())
+        if isinstance(segs, list) and segs and "start" in segs[0]:
+            return segs
+    except (ValueError, KeyError, IndexError):
+        pass
+    return []
+
+
+def _map_chunks_to_segments(
+    chunk_texts: list[str], segments: list[dict]
+) -> list[tuple[int | None, int | None]]:
+    """Map each chunk to proportional range of segment indices (by character count)."""
+    total = sum(len(c) for c in chunk_texts)
+    if not total or not segments:
+        return [(None, None)] * len(chunk_texts)
+    n = len(segments)
+    result = []
+    cum = 0
+    for chunk in chunk_texts:
+        start = round(n * cum / total)
+        cum += len(chunk)
+        end = round(n * cum / total)
+        result.append((min(start, n), min(end, n)))
+    return result
+
+
+def _extract_text(doc: WebDocument) -> tuple[str, str]:
+    """Return (text, field_name) from best available field.
+
+    Priority: text → text_md → text_raw (JSON transcript → plain text).
+    Returns ("", "") when no usable text found.
+    """
+    for field in ("text", "text_md"):
+        val = getattr(doc, field, None)
+        if val and len(val) > 100:
+            return val, field
+    raw = getattr(doc, "text_raw", None)
+    if raw and len(raw) > 100:
+        segs = _load_segments(raw)
+        if segs:
+            return "\n".join(s["text"] for s in segs), "text_raw (JSON→plain)"
+        return raw, "text_raw"
+    return "", ""
+
+
+def _merge_topics(sections: list[dict], model: str) -> list[dict]:
+    """Ask LLM to group adjacent chunks into logical topic sections.
+
+    Returns list of {title, type, chunks: [1-based indices]}.
+    Returns [] if LLM call fails — caller falls back to one section per chunk.
+    """
+    from library.chunk_llm_analysis import call_model
+
+    chunk_list = "\n".join(
+        f"{i + 1}. [{s['type']}] {s['topic']}"
+        for i, s in enumerate(sections)
+    )
+    prompt = (
+        f"Poniżej lista {len(sections)} fragmentów transkrypcji podcastu z ich tematami.\n"
+        "Pogrupuj SĄSIADUJĄCE fragmenty w logiczne sekcje tematyczne (zwykle 5-10 sekcji).\n"
+        "Fragmenty reklamowe (REKLAMA) możesz pominąć lub zgrupować razem pod jedną sekcją REKLAMA.\n\n"
+        "Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:\n"
+        '[{"title": "Tytuł sekcji tematycznej", "type": "TEMAT", "chunks": [1, 2]}]\n'
+        'Gdzie "chunks" to numery fragmentów (numeracja od 1), "type" to "TEMAT" lub "REKLAMA".\n\n'
+        f"Fragmenty:\n{chunk_list}"
+    )
+    try:
+        response_text, _ = call_model(prompt, model, max_tokens=600)
+        match = re.search(r'\[.*\]', response_text, re.DOTALL)
+        if match:
+            groups = json.loads(match.group())
+            logger.info("merge_topics: %d sections", len(groups))
+            return groups
+    except Exception:
+        logger.exception("merge_topics LLM call failed")
+    return []
+
+
+def _synthesize(sections: list[dict], title: str, model: str) -> str:
+    """Generate overall synthesis from all TEMAT chunk summaries.
+
+    Returns "" if no summaries available or LLM call fails.
+    """
+    from library.chunk_llm_analysis import call_model
+
+    content = [s for s in sections if s["type"] == "TEMAT" and s["summary"]]
+    if not content:
+        return ""
+
+    summaries = "\n\n".join(
+        f"**{s.get('topic', '')}**: {s['summary']}" for s in content
+    )
+    if len(summaries) > SYNTHESIS_MAX_INPUT_CHARS:
+        logger.warning("synthesis input too long (%d chars), skipping", len(summaries))
+        return ""
+
+    prompt = (
+        f'Poniżej są streszczenia kolejnych sekcji merytorycznych podcastu YouTube pt.: „{title}".\n\n'
+        "Na ich podstawie przygotuj:\n"
+        "1. GŁÓWNE WNIOSKI: 5-7 najważniejszych wniosków (lista punktowana).\n"
+        "2. SYNTEZA: Spójne streszczenie całości (6-8 zdań).\n\n"
+        "Odpowiedz wyłącznie po polsku.\n\n"
+        f"--- STRESZCZENIA SEKCJI ---\n{summaries}\n--- KONIEC ---"
+    )
+    try:
+        response_text, _ = call_model(prompt, model, SYNTHESIS_MAX_TOKENS)
+        return response_text.strip()
+    except Exception:
+        logger.exception("synthesis LLM call failed")
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class DocumentAnalysisService:
+    """Full pipeline: load doc → split → LLM analysis → topic grouping → DB save."""
+
+    def __init__(self, session):
+        self.session = session
+
+    def create_run(
+        self,
+        doc_id: int,
+        model: str,
+        chunk_size: int = CHUNK_CHARS,
+        no_synthesis: bool = False,
+        progress_fn: Callable[[str], None] | None = None,
+    ) -> DocumentAnalysisRun:
+        """Create a new analysis run for an existing document and persist to DB.
+
+        Args:
+            doc_id:       ID of document in web_documents.
+            model:        LLM model name (Bielik via Sherlock or "arklabs/<model>").
+            chunk_size:   Max characters per chunk (default 5 000 ≈ 1 500 tokens).
+            no_synthesis: Skip the final synthesis step.
+            progress_fn:  Optional callback for progress messages (used by batch scripts).
+
+        Returns:
+            Persisted DocumentAnalysisRun with .chunks and .topic_sections populated.
+
+        Raises:
+            ValueError:   Document not found or has no text content.
+            RuntimeError: LLM call failed or DB commit failed.
+        """
+        from library.chunk_llm_analysis import (
+            analyze_chunk, extract_speaker_info, remove_speech_fillers,
+        )
+        from library.text_functions import split_text_into_sentence_chunks
+
+        def log(msg: str) -> None:
+            logger.info(msg)
+            if progress_fn:
+                progress_fn(msg)
+
+        session = self.session
+
+        # 1. Load document
+        doc = WebDocument.get_by_id(session, doc_id)
+        if doc is None:
+            raise ValueError(f"Document {doc_id} not found")
+
+        # 2. Extract text
+        text, text_field = _extract_text(doc)
+        if not text:
+            raise ValueError(f"Document {doc_id} has no usable text (checked: text, text_md, text_raw)")
+
+        log(f"doc={doc_id} field={text_field} len={len(text):,}")
+
+        # 3. Detect format (multi-speaker = has >> speaker markers)
+        speaker_changes = len(re.findall(r'>>', text))
+        is_multi_speaker = speaker_changes > 0
+        log(f"format={'multi-speaker' if is_multi_speaker else 'monologue'} ({speaker_changes} >>)")
+
+        # 4. Remove speech fillers before splitting (cheaper than asking LLM)
+        text = remove_speech_fillers(text)
+
+        # 5. Split into chunks at sentence boundaries
+        chunk_texts = split_text_into_sentence_chunks(text, chunk_size)
+        log(f"split={len(chunk_texts)} chunks, max {chunk_size:,} chars")
+
+        # 6. Extract speakers from intro text (only for multi-speaker conversations)
+        speakers: list[dict] = []
+        if is_multi_speaker:
+            intro_text = text[800:2400].strip()
+            try:
+                speakers = extract_speaker_info(intro_text, model)
+                log(f"speakers={[sp['name'] for sp in speakers]}")
+            except Exception:
+                logger.exception("speaker extraction failed, continuing without speakers")
+
+        # 7. Map chunks to transcript segments (for timestamp links)
+        segments = _load_segments(getattr(doc, "text_raw", None) or "")
+        seg_map = (
+            _map_chunks_to_segments(chunk_texts, segments)
+            if segments else [(None, None)] * len(chunk_texts)
+        )
+
+        # 8. Analyze each chunk via LLM
+        sections: list[dict] = []
+        total = len(chunk_texts)
+        for i, chunk_text in enumerate(chunk_texts):
+            log(f"chunk {i + 1}/{total} ({len(chunk_text):,} chars)...")
+            try:
+                result = analyze_chunk(
+                    chunk_text, model,
+                    position=i + 1, total=total,
+                    speakers=speakers or None,
+                )
+            except Exception as exc:
+                raise RuntimeError(f"LLM call failed for chunk {i + 1}/{total}: {exc}") from exc
+
+            sections.append({
+                "type": result["type"],
+                "topic": result["topic"],
+                "original": chunk_text,
+                "text": result["corrected_text"],
+                "ratio": result["rewrite_ratio"],
+                "summary": result["summary"],
+            })
+
+        # 9. Group chunks into logical topic sections
+        topic_groups = _merge_topics(sections, model)
+        if topic_groups:
+            topic_sections_data = []
+            for group in topic_groups:
+                indices = [i - 1 for i in group.get("chunks", [])]
+                valid = [i for i in indices if 0 <= i < len(sections)]
+                if not valid:
+                    continue
+                merged_summary = " ".join(
+                    sections[i]["summary"] for i in valid if sections[i]["summary"]
+                )
+                topic_sections_data.append({
+                    "title": group.get("title", ""),
+                    "type": group.get("type", "TEMAT"),
+                    "chunk_indices": [i + 1 for i in valid],
+                    "summary": merged_summary.strip(),
+                })
+        else:
+            # Fallback: each chunk is its own section
+            topic_sections_data = [
+                {
+                    "title": s["topic"] or "",
+                    "type": s["type"],
+                    "chunk_indices": [i + 1],
+                    "summary": s["summary"] or "",
+                }
+                for i, s in enumerate(sections)
+            ]
+        log(f"topic_sections={len(topic_sections_data)}")
+
+        # 10. Optional synthesis
+        synthesis = ""
+        if not no_synthesis:
+            log("generating synthesis...")
+            synthesis = _synthesize(sections, doc.title or f"Dokument {doc_id}", model)
+
+        # 11. Persist to DB
+        run = DocumentAnalysisRun(
+            document_id=doc_id,
+            model=model,
+            chunk_size=chunk_size,
+            synthesis=synthesis or None,
+            speakers=speakers,
+        )
+        session.add(run)
+        session.flush()  # get run.id before adding children
+
+        for i, s in enumerate(sections):
+            seg_start, seg_end = seg_map[i]
+            session.add(DocumentChunk(
+                run_id=run.id,
+                document_id=doc_id,
+                position=i + 1,
+                type=s["type"],
+                topic=s["topic"] or None,
+                original_text=s["original"],
+                corrected_text=s["text"] or None,
+                summary=s["summary"] or None,
+                seg_start=seg_start,
+                seg_end=seg_end,
+                rewrite_ratio=s["ratio"],
+                status="pending",
+            ))
+
+        for i, ts in enumerate(topic_sections_data):
+            session.add(DocumentTopicSection(
+                run_id=run.id,
+                document_id=doc_id,
+                position=i + 1,
+                type=ts["type"],
+                title=ts["title"] or None,
+                summary=ts["summary"] or None,
+                chunk_positions=ts["chunk_indices"],
+            ))
+
+        try:
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            raise RuntimeError(f"DB commit failed: {exc}") from exc
+
+        log(f"saved run_id={run.id} chunks={len(sections)} topic_sections={len(topic_sections_data)}")
+        return run

--- a/backend/server.py
+++ b/backend/server.py
@@ -108,46 +108,95 @@ def root():
     from flask import Response
     html = f"""<!DOCTYPE html>
 <html lang="pl">
-<head><meta charset="UTF-8"><title>Lenie AI API</title>
+<head><meta charset="UTF-8"><title>Lenie AI</title>
 <style>
-body{{font-family:Arial,sans-serif;max-width:600px;margin:60px auto;padding:0 20px;color:#222}}
-h1{{font-size:1.3em;color:#1e293b}}
-.meta{{color:#64748b;font-size:0.9em;margin:6px 0 24px}}
-label{{display:block;margin-bottom:6px;font-size:0.9em;font-weight:bold}}
-input{{width:100%;padding:8px 10px;border:1px solid #cbd5e1;border-radius:4px;
-  font-size:0.9em;box-sizing:border-box;margin-bottom:10px}}
-.row{{display:flex;gap:8px}}
-.row input{{flex:1}}
-button{{padding:8px 18px;background:#0369a1;color:#fff;border:none;border-radius:4px;
-  font-size:0.9em;cursor:pointer;font-weight:bold}}
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{font-family:Arial,sans-serif;background:#f8fafc;color:#1e293b;min-height:100vh;padding:40px 20px}}
+.container{{max-width:700px;margin:0 auto}}
+h1{{font-size:1.6em;font-weight:700;margin-bottom:4px}}
+.version{{color:#94a3b8;font-size:0.85em;margin-bottom:32px}}
+.section{{margin-bottom:28px}}
+.section h2{{font-size:0.8em;font-weight:700;text-transform:uppercase;letter-spacing:.08em;
+  color:#64748b;margin-bottom:12px;padding-bottom:6px;border-bottom:1px solid #e2e8f0}}
+.cards{{display:grid;grid-template-columns:1fr 1fr;gap:10px}}
+.card{{background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:16px 18px;
+  text-decoration:none;color:#1e293b;transition:border-color .15s,box-shadow .15s}}
+.card:hover{{border-color:#0369a1;box-shadow:0 2px 8px rgba(3,105,161,.1)}}
+.card-title{{font-size:0.95em;font-weight:600;margin-bottom:3px}}
+.card-desc{{font-size:0.8em;color:#64748b}}
+.card.ext .card-title::after{{content:" ↗";color:#94a3b8;font-weight:400}}
+.api-key-box{{background:#fff;border:1px solid #e2e8f0;border-radius:8px;padding:16px 18px}}
+label{{font-size:0.85em;font-weight:600;display:block;margin-bottom:6px}}
+input{{width:100%;padding:8px 10px;border:1px solid #cbd5e1;border-radius:5px;
+  font-size:0.88em;margin-bottom:8px}}
+.saved{{color:#16a34a;font-size:0.8em}}
+.chunk-row{{display:flex;gap:8px;align-items:flex-end}}
+.chunk-row input{{margin-bottom:0;flex:1}}
+button{{padding:8px 16px;background:#0369a1;color:#fff;border:none;border-radius:5px;
+  font-size:0.88em;cursor:pointer;font-weight:600;white-space:nowrap}}
 button:hover{{background:#0284c7}}
-.note{{color:#64748b;font-size:0.82em;margin-top:16px}}
 </style>
 </head>
 <body>
-<h1>Lenie AI — API</h1>
-<p class="meta">Wersja: {APP_VERSION}</p>
-<form onsubmit="go(event)">
-  <label>Document ID</label>
-  <div class="row">
-    <input type="number" id="doc-id" placeholder="np. 9158" min="1">
-    <button type="submit">Otwórz przegląd chunków</button>
+<div class="container">
+  <h1>Lenie AI</h1>
+  <p class="version">Wersja {APP_VERSION} &nbsp;·&nbsp; API serwer</p>
+
+  <div class="section">
+    <h2>Interfejsy użytkownika</h2>
+    <div class="cards" id="ui-cards">
+      <a class="card ext" id="link-frontend" href="#"><div class="card-title">Interfejs główny</div><div class="card-desc">Lista dokumentów, wyszukiwanie, edycja</div></a>
+      <a class="card ext" id="link-admin" href="#"><div class="card-title">Panel administracyjny</div><div class="card-desc">Zarządzanie, infrastruktura AWS</div></a>
+    </div>
   </div>
-  <label>API key (opcjonalnie — możesz wpisać w interfejsie)</label>
-  <input type="password" id="api-key" placeholder="x-api-key">
-</form>
-<p class="note">Klucz API jest zapisywany w localStorage przeglądarki — wystarczy wpisać raz.</p>
+
+  <div class="section">
+    <h2>Narzędzia API</h2>
+    <div class="cards">
+      <a class="card" href="/chunk_review"><div class="card-title">Przegląd chunków</div><div class="card-desc">Analiza fragmentów dokumentu (YouTube, transkrypcje)</div></a>
+      <a class="card" href="/version"><div class="card-title">Wersja API</div><div class="card-desc">Informacje o wersji i czasie budowania</div></a>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Klucz API &amp; szybki dostęp</h2>
+    <div class="api-key-box">
+      <label>API key</label>
+      <input type="password" id="api-key" placeholder="x-api-key">
+      <span class="saved" id="saved-info" style="display:none">✓ Klucz zapisany</span>
+      <label style="margin-top:12px">Otwórz przegląd chunków dla dokumentu</label>
+      <div class="chunk-row">
+        <input type="number" id="doc-id" placeholder="Document ID (np. 9158)" min="1">
+        <button onclick="goChunk()">Otwórz</button>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
-function go(e) {{
-  e.preventDefault();
-  const id = document.getElementById('doc-id').value;
-  const key = document.getElementById('api-key').value;
+(function() {{
+  var host = window.location.hostname;
+  document.getElementById('link-frontend').href = 'http://' + host + ':3000';
+  document.getElementById('link-admin').href   = 'http://' + host + ':3001';
+
+  var saved = localStorage.getItem('lenie_api_key');
+  if (saved) {{
+    document.getElementById('api-key').value = saved;
+    document.getElementById('saved-info').style.display = 'inline';
+  }}
+  document.getElementById('api-key').addEventListener('change', function() {{
+    if (this.value) {{
+      localStorage.setItem('lenie_api_key', this.value);
+      document.getElementById('saved-info').style.display = 'inline';
+    }}
+  }});
+}})();
+function goChunk() {{
+  var id  = document.getElementById('doc-id').value;
+  var key = document.getElementById('api-key').value;
   if (!id) {{ alert('Podaj Document ID'); return; }}
   if (key) localStorage.setItem('lenie_api_key', key);
   location.href = '/chunk_review?doc_id=' + id;
 }}
-const saved = localStorage.getItem('lenie_api_key');
-if (saved) document.getElementById('api-key').value = saved;
 </script>
 </body>
 </html>"""

--- a/backend/server.py
+++ b/backend/server.py
@@ -89,23 +89,69 @@ def shutdown_session(exception=None):
 
 @app.before_request
 def before_request_func():
-    exempt_paths = ['/healthz', '/startup', '/readiness', '/liveness', '/version', '/chunk_review']
+    exempt_paths = ['/', '/healthz', '/startup', '/readiness', '/liveness', '/version', '/chunk_review']
     if request.path not in exempt_paths and request.method != 'OPTIONS':
         check_auth_header()
 
 @app.route('/', methods=['GET', 'OPTIONS'])
 def root():
-    """
-    Główna trasa aplikacji - endpoint informacyjny
-    """
-    response = {
-        "status": "success",
-        "message": "Stalker Web Documents API",
-        "app_version": APP_VERSION,
-        "app_build_time": BUILD_TIME,
-        "encoding": "utf8"
-    }
-    return response, 200
+    """Landing page — HTML for browsers, JSON for API clients (Accept: application/json)."""
+    if 'application/json' in request.headers.get('Accept', ''):
+        return {
+            "status": "success",
+            "message": "Stalker Web Documents API",
+            "app_version": APP_VERSION,
+            "app_build_time": BUILD_TIME,
+            "encoding": "utf8",
+        }, 200
+
+    from flask import Response
+    html = f"""<!DOCTYPE html>
+<html lang="pl">
+<head><meta charset="UTF-8"><title>Lenie AI API</title>
+<style>
+body{{font-family:Arial,sans-serif;max-width:600px;margin:60px auto;padding:0 20px;color:#222}}
+h1{{font-size:1.3em;color:#1e293b}}
+.meta{{color:#64748b;font-size:0.9em;margin:6px 0 24px}}
+label{{display:block;margin-bottom:6px;font-size:0.9em;font-weight:bold}}
+input{{width:100%;padding:8px 10px;border:1px solid #cbd5e1;border-radius:4px;
+  font-size:0.9em;box-sizing:border-box;margin-bottom:10px}}
+.row{{display:flex;gap:8px}}
+.row input{{flex:1}}
+button{{padding:8px 18px;background:#0369a1;color:#fff;border:none;border-radius:4px;
+  font-size:0.9em;cursor:pointer;font-weight:bold}}
+button:hover{{background:#0284c7}}
+.note{{color:#64748b;font-size:0.82em;margin-top:16px}}
+</style>
+</head>
+<body>
+<h1>Lenie AI — API</h1>
+<p class="meta">Wersja: {APP_VERSION}</p>
+<form onsubmit="go(event)">
+  <label>Document ID</label>
+  <div class="row">
+    <input type="number" id="doc-id" placeholder="np. 9158" min="1">
+    <button type="submit">Otwórz przegląd chunków</button>
+  </div>
+  <label>API key (opcjonalnie — możesz wpisać w interfejsie)</label>
+  <input type="password" id="api-key" placeholder="x-api-key">
+</form>
+<p class="note">Klucz API jest zapisywany w localStorage przeglądarki — wystarczy wpisać raz.</p>
+<script>
+function go(e) {{
+  e.preventDefault();
+  const id = document.getElementById('doc-id').value;
+  const key = document.getElementById('api-key').value;
+  if (!id) {{ alert('Podaj Document ID'); return; }}
+  if (key) localStorage.setItem('lenie_api_key', key);
+  location.href = '/chunk_review?doc_id=' + id;
+}}
+const saved = localStorage.getItem('lenie_api_key');
+if (saved) document.getElementById('api-key').value = saved;
+</script>
+</body>
+</html>"""
+    return Response(html, mimetype='text/html')
 
 
 @app.route('/url_add', methods=['POST', 'OPTIONS'])

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -11,6 +11,7 @@ import Search from "./modules/shared/pages/search";
 import List from "./modules/shared/pages/list";
 import UploadFile from "./modules/shared/pages/file";
 import Connect from "./modules/shared/pages/connect";
+import Chunks from "./modules/shared/pages/chunks";
 import { AuthorizationContext } from "./modules/shared/context/authorizationContext";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -39,6 +40,7 @@ function App() {
                   <Route path="/movie/:id?" element={<Movie />} />
                   <Route path="/youtube/:id?" element={<Youtube />} />
                   <Route path="/email/:id?" element={<Email />} />
+                  <Route path="/chunks/:id" element={<Chunks />} />
                   <Route path="/list" element={<List />} />
                   <Route path="/search" element={<Search />} />
                   <Route path="/upload-file" element={<UploadFile />} />

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -2,15 +2,29 @@ import React from "react";
 import { useParams, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Segment {
+  start: number;
+  text: string;
+}
+
 interface Chunk {
   id: number;
-  order_index: number;
-  text: string;
+  position: number;
   corrected_text: string | null;
   summary: string | null;
   topic: string | null;
-  chunk_type: string | null;
+  type: string | null;
   speaker: string | null;
+  status: string;
+  seg_start: number | null;
+  seg_end: number | null;
+}
+
+interface Speaker {
+  name: string;
+  role: string | null;
 }
 
 interface AnalysisRun {
@@ -20,6 +34,22 @@ interface AnalysisRun {
   chunk_count: number;
 }
 
+interface SplitState {
+  segIdx: number;
+  ts: string;
+  firstType: "TEMAT" | "REKLAMA";
+  secondType: "TEMAT" | "REKLAMA";
+}
+
+interface SegGroup {
+  absIdx: number;
+  start: number;
+  text: string;
+  isSpeakerChange: boolean;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
 const MODELS = [
   "Bielik-11B-v3.0-Instruct",
   "Bielik-4.5B-v3.0-Instruct",
@@ -27,22 +57,150 @@ const MODELS = [
   "gpt-4o",
 ];
 
+const STATUS_CYCLE = ["pending", "approved", "needs_reanalysis"] as const;
+
+function secs2ts(s: number): string {
+  s = Math.floor(s);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(sec).padStart(2, "0");
+  return h ? `${String(h).padStart(2, "0")}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+function groupSegments(segs: Segment[], absOffset: number): SegGroup[] {
+  const MAX = 8;
+  const groups: SegGroup[] = [];
+  let curTexts: string[] = [];
+  let curStart: number | null = null;
+  let curIsSc = false;
+  let curFirstRawIdx = 0;
+
+  function flush() {
+    if (curTexts.length > 0 && curStart !== null) {
+      groups.push({ absIdx: absOffset + curFirstRawIdx, start: curStart, text: curTexts.join(" "), isSpeakerChange: curIsSc });
+      curTexts = []; curStart = null; curIsSc = false;
+    }
+  }
+
+  segs.forEach((seg, rawIdx) => {
+    const raw = (seg.text || "").trim();
+    if (!raw) return;
+    const isSc = raw.startsWith(">>");
+    const text = isSc ? raw.slice(2).trim() : raw;
+    if (isSc && curTexts.length > 0) flush();
+    if (curStart === null) { curStart = seg.start; curIsSc = isSc; curFirstRawIdx = rawIdx; }
+    curTexts.push(text);
+    if (/[.?!…]$/.test(text) || curTexts.length >= MAX) flush();
+  });
+  flush();
+  return groups;
+}
+
+function statusColor(status: string): React.CSSProperties {
+  switch (status) {
+    case "approved":         return { background: "#dcfce7", color: "#15803d" };
+    case "needs_reanalysis": return { background: "#fee2e2", color: "#b91c1c" };
+    case "split_requested":  return { background: "#fef9c3", color: "#713f12" };
+    default:                 return { background: "#e2e8f0", color: "#475569" };
+  }
+}
+
+// ── Segments sub-component ───────────────────────────────────────────────────
+
+const SegmentsView: React.FC<{
+  segs: Segment[];
+  videoId: string;
+  chunkId: number;
+  absOffset: number;
+  splitState: SplitState | undefined;
+  onMarkSplit: (chunkId: number, absIdx: number, ts: string) => void;
+}> = ({ segs, videoId, chunkId, absOffset, splitState, onMarkSplit }) => {
+  const groups = groupSegments(segs, absOffset);
+  if (groups.length === 0) return <em style={{ color: "#94a3b8" }}>brak segmentów</em>;
+
+  return (
+    <div>
+      {groups.map(g => {
+        const ts = secs2ts(g.start);
+        const ytUrl = videoId ? `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(g.start)}` : undefined;
+        const isMarked = splitState?.segIdx === g.absIdx;
+        return (
+          <div
+            key={g.absIdx}
+            style={{
+              position: "relative", marginBottom: 8, paddingRight: 32,
+              ...(isMarked ? { background: "#fff7ed", borderLeft: "3px solid #f97316", paddingLeft: 6, borderRadius: 2 } : {}),
+            }}
+          >
+            <div style={{ fontSize: "0.8em", color: "#94a3b8", marginBottom: 1 }}>
+              {g.isSpeakerChange && <span style={{ marginRight: 4 }}>▶</span>}
+              {ytUrl ? (
+                <a href={ytUrl} target="_blank" rel="noopener noreferrer"
+                  style={{ color: "#c00", fontWeight: "bold", textDecoration: "none" }}>
+                  [{ts}]
+                </a>
+              ) : (
+                <span>[{ts}]</span>
+              )}
+            </div>
+            <span style={{ fontSize: "0.88em", lineHeight: 1.6 }}>{g.text}</span>
+            <button
+              onClick={() => onMarkSplit(chunkId, g.absIdx, ts)}
+              title="Podziel tutaj"
+              style={{
+                position: "absolute", right: 2, top: 2,
+                background: "none", border: "1px solid #e2e8f0", borderRadius: 3,
+                fontSize: "0.82em", cursor: "pointer", padding: "1px 5px", color: "#94a3b8",
+              }}
+              onMouseEnter={e => { e.currentTarget.style.background = "#fef3c7"; e.currentTarget.style.color = "#92400e"; }}
+              onMouseLeave={e => { e.currentTarget.style.background = "none"; e.currentTarget.style.color = "#94a3b8"; }}
+            >
+              ✂
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ── Main component ───────────────────────────────────────────────────────────
+
 const Chunks = () => {
   const { id } = useParams<{ id: string }>();
   const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
 
-  const [runs, setRuns] = React.useState<AnalysisRun[]>([]);
+  const [runs, setRuns]             = React.useState<AnalysisRun[]>([]);
   const [selectedRun, setSelectedRun] = React.useState<number | null>(null);
-  const [chunks, setChunks] = React.useState<Chunk[]>([]);
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState("");
-  const [jobStatus, setJobStatus] = React.useState<string | null>(null);
-  const [jobId, setJobId] = React.useState<string | null>(null);
-  const [newModel, setNewModel] = React.useState(MODELS[0]);
-  const [chunkSize, setChunkSize] = React.useState(5000);
-  const [showRaw, setShowRaw] = React.useState<Record<number, boolean>>({});
+  const [chunks, setChunks]         = React.useState<Chunk[]>([]);
+  const [segments, setSegments]     = React.useState<Segment[]>([]);
+  const [videoId, setVideoId]       = React.useState("");
+  const [speakers, setSpeakers]     = React.useState<Speaker[]>([]);
+
+  const [loading, setLoading]       = React.useState(false);
+  const [error, setError]           = React.useState("");
+  const [jobStatus, setJobStatus]   = React.useState<string | null>(null);
+  const [jobId, setJobId]           = React.useState<string | null>(null);
+  const [newModel, setNewModel]     = React.useState(MODELS[0]);
+  const [chunkSize, setChunkSize]   = React.useState(5000);
+  const [hideAds, setHideAds]       = React.useState(false);
+
+  const [showCorrected, setShowCorrected] = React.useState<Record<number, boolean>>({});
+  const [topicEdits, setTopicEdits]       = React.useState<Record<number, string>>({});
+  const [savingTopics, setSavingTopics]   = React.useState<Record<number, boolean>>({});
+  const [savedFlash, setSavedFlash]       = React.useState<Record<number, boolean>>({});
+  const [reanalyzing, setReanalyzing]     = React.useState<Record<number, boolean>>({});
+  const [reanalyzingAll, setReanalyzingAll] = React.useState(false);
+  const [splitStates, setSplitStates]     = React.useState<Record<number, SplitState>>({});
+  const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
+  const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
+  const [hiddenChunks, setHiddenChunks] = React.useState<Set<number>>(new Set());
 
   const headers = { "x-api-key": apiKey ?? "", "Content-Type": "application/json" };
+
+  // ── Fetch ──
 
   const fetchRuns = React.useCallback(async () => {
     if (!id) return;
@@ -51,9 +209,7 @@ const Chunks = () => {
       const data = await r.json();
       const list: AnalysisRun[] = data.runs ?? [];
       setRuns(list);
-      if (list.length > 0 && selectedRun === null) {
-        setSelectedRun(list[0].id);
-      }
+      if (list.length > 0 && selectedRun === null) setSelectedRun(list[0].id);
     } catch {
       setError("Błąd ładowania listy analiz");
     }
@@ -65,7 +221,21 @@ const Chunks = () => {
     try {
       const r = await fetch(`${apiUrl}/analysis_run/${runId}/chunks`, { headers });
       const data = await r.json();
-      setChunks(data.chunks ?? []);
+      const loaded: Chunk[] = data.chunks ?? [];
+      setChunks(loaded);
+      setSegments(data.segments ?? []);
+      setVideoId(data.document?.original_id ?? "");
+      setSpeakers(data.run?.speakers ?? []);
+      const edits: Record<number, string> = {};
+      const correctedDefaults: Record<number, boolean> = {};
+      loaded.forEach(c => {
+        edits[c.id] = c.topic ?? "";
+        correctedDefaults[c.id] = !!c.corrected_text;
+      });
+      setTopicEdits(edits);
+      setShowCorrected(correctedDefaults);
+      setSplitStates({});
+      setHiddenChunks(new Set());
     } catch {
       setError("Błąd ładowania chunków");
     } finally {
@@ -74,28 +244,25 @@ const Chunks = () => {
   }, [apiUrl, apiKey]);
 
   React.useEffect(() => { fetchRuns(); }, [fetchRuns]);
+  React.useEffect(() => { if (selectedRun !== null) fetchChunks(selectedRun); }, [selectedRun, fetchChunks]);
 
-  React.useEffect(() => {
-    if (selectedRun !== null) fetchChunks(selectedRun);
-  }, [selectedRun, fetchChunks]);
+  // ── Job polling ──
 
   const pollJob = React.useCallback((jid: string) => {
     const interval = setInterval(async () => {
       try {
         const r = await fetch(`${apiUrl}/analysis_job/${jid}`, { headers });
         const data = await r.json();
-        setJobStatus(data.status);
-        if (data.status === "done") {
+        setJobStatus(data.job?.status ?? data.status);
+        if (data.job?.status === "done") {
           clearInterval(interval);
           setJobId(null);
           await fetchRuns();
-          if (data.run_id) {
-            setSelectedRun(data.run_id);
-          }
-        } else if (data.status === "failed") {
+          if (data.job.run_id) setSelectedRun(data.job.run_id);
+        } else if (data.job?.status === "failed") {
           clearInterval(interval);
           setJobId(null);
-          setError("Analiza nie powiodła się: " + (data.error ?? ""));
+          setError("Analiza nie powiodła się: " + (data.job.error ?? ""));
         }
       } catch {
         clearInterval(interval);
@@ -104,70 +271,166 @@ const Chunks = () => {
     }, 5000);
   }, [apiUrl, apiKey, fetchRuns]);
 
+  // ── Analysis ──
+
   const startAnalysis = async () => {
     if (!id) return;
-    setError("");
-    setJobStatus("starting");
+    setError(""); setJobStatus("starting");
     try {
       const r = await fetch(`${apiUrl}/document/${id}/analyze_chunks`, {
-        method: "POST",
-        headers,
+        method: "POST", headers,
         body: JSON.stringify({ model: newModel, chunk_size: chunkSize }),
       });
       const data = await r.json();
-      if (data.job_id) {
-        setJobId(data.job_id);
-        setJobStatus("running");
-        pollJob(data.job_id);
-      } else {
-        setError("Nie udało się uruchomić analizy");
-        setJobStatus(null);
+      if (data.job_id) { setJobId(data.job_id); setJobStatus("running"); pollJob(data.job_id); }
+      else { setError("Nie udało się uruchomić analizy"); setJobStatus(null); }
+    } catch { setError("Błąd połączenia"); setJobStatus(null); }
+  };
+
+  // ── Chunk patch ──
+
+  const patchChunk = async (chunkId: number, updates: Record<string, unknown>) => {
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunkId}`, {
+        method: "PATCH", headers, body: JSON.stringify(updates),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        setChunks(prev => prev.map(c => c.id === chunkId ? { ...c, ...data.chunk } : c));
       }
+      return data;
     } catch {
-      setError("Błąd połączenia");
-      setJobStatus(null);
+      setError("Błąd zapisu"); return null;
     }
   };
 
-  const toggleRaw = (chunkId: number) => {
-    setShowRaw(prev => ({ ...prev, [chunkId]: !prev[chunkId] }));
+  const saveTopic = async (chunkId: number) => {
+    setSavingTopics(prev => ({ ...prev, [chunkId]: true }));
+    const res = await patchChunk(chunkId, { topic: topicEdits[chunkId] || null });
+    setSavingTopics(prev => ({ ...prev, [chunkId]: false }));
+    if (res?.status === "success") {
+      setSavedFlash(prev => ({ ...prev, [chunkId]: true }));
+      setTimeout(() => setSavedFlash(prev => ({ ...prev, [chunkId]: false })), 1500);
+    }
   };
 
-  const docType = chunks.length > 0 ? null : null;
+  const cycleStatus = (chunk: Chunk) => {
+    const idx = STATUS_CYCLE.indexOf(chunk.status as typeof STATUS_CYCLE[number]);
+    const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
+    patchChunk(chunk.id, { status: next });
+  };
+
+  const toggleType = (chunk: Chunk) => {
+    patchChunk(chunk.id, { type: chunk.type === "TEMAT" ? "REKLAMA" : "TEMAT" });
+  };
+
+  // ── Re-analysis ──
+
+  const reanalyzeChunk = async (chunkId: number, mode: "full" | "semantic") => {
+    setReanalyzing(prev => ({ ...prev, [chunkId]: true }));
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunkId}/reanalyze`, {
+        method: "POST", headers, body: JSON.stringify({ mode }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        setChunks(prev => prev.map(c => c.id === chunkId ? { ...c, ...data.chunk } : c));
+        setTopicEdits(prev => ({ ...prev, [chunkId]: data.chunk.topic ?? "" }));
+        setShowCorrected(prev => ({ ...prev, [chunkId]: !!data.chunk.corrected_text }));
+      } else { setError("Błąd re-analizy"); }
+    } catch { setError("Błąd połączenia przy re-analizie"); }
+    finally { setReanalyzing(prev => ({ ...prev, [chunkId]: false })); }
+  };
+
+  const reanalyzeAll = async () => {
+    const pending = chunks.filter(c => c.status === "needs_reanalysis");
+    if (!pending.length) return;
+    setReanalyzingAll(true);
+    for (const chunk of pending) {
+      await reanalyzeChunk(chunk.id, chunk.corrected_text ? "semantic" : "full");
+    }
+    setReanalyzingAll(false);
+  };
+
+  // ── Split ──
+
+  const markSplit = (chunkId: number, absIdx: number, ts: string) => {
+    setSplitStates(prev => ({
+      ...prev,
+      [chunkId]: { segIdx: absIdx, ts, firstType: "REKLAMA", secondType: "TEMAT" },
+    }));
+  };
+
+  const cancelSplit = (chunkId: number) => {
+    setSplitStates(prev => { const n = { ...prev }; delete n[chunkId]; return n; });
+  };
+
+  const confirmSplit = async (chunkId: number) => {
+    const st = splitStates[chunkId];
+    if (!st) return;
+    setConfirmingSplit(prev => ({ ...prev, [chunkId]: true }));
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunkId}/execute_split`, {
+        method: "POST", headers,
+        body: JSON.stringify({ split_at_seg: st.segIdx, split_first_type: st.firstType, split_second_type: st.secondType }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        setSplitStates(prev => { const n = { ...prev }; delete n[chunkId]; return n; });
+        if (selectedRun !== null) await fetchChunks(selectedRun);
+      } else { setError("Błąd podziału: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy podziale"); }
+    finally { setConfirmingSplit(prev => ({ ...prev, [chunkId]: false })); }
+  };
+
+  // ── Speakers ──
+
+  const extractSpeakers = async () => {
+    if (!selectedRun) return;
+    setExtractingSpeakers(true);
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/extract_speakers`, { method: "POST", headers });
+      const data = await r.json();
+      if (data.status === "success") setSpeakers(data.speakers ?? []);
+      else setError("Błąd wykrywania rozmówców");
+    } catch { setError("Błąd połączenia przy wykrywaniu rozmówców"); }
+    finally { setExtractingSpeakers(false); }
+  };
+
+  // ── Progress ──
+
+  const tematChunks = chunks.filter(c => c.type !== "REKLAMA");
+  const approvedCount = tematChunks.filter(c => c.status === "approved").length;
+  const pct = tematChunks.length ? Math.round(approvedCount / tematChunks.length * 100) : 0;
+  const reklamaCount = chunks.filter(c => c.type === "REKLAMA").length;
+  const visibleReklamaCount = chunks.filter(c => c.type === "REKLAMA" && !hiddenChunks.has(c.id)).length;
+  const needsReanalysisCount = chunks.filter(c => c.status === "needs_reanalysis").length;
+  const visibleChunks = chunks.filter(c =>
+    !hiddenChunks.has(c.id) && (!hideAds || c.type !== "REKLAMA")
+  );
+
+  // ── Render ───────────────────────────────────────────────────────────────
 
   return (
-    <div style={{ maxWidth: 900 }}>
-      <h2 style={{ marginBottom: 6 }}>
-        Przegląd chunków — dokument #{id}
-      </h2>
-      <NavLink to={`/youtube/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>
-        ← Edytuj dokument
-      </NavLink>
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 6, flexWrap: "wrap" }}>
+        <h2 style={{ margin: 0 }}>Przegląd chunków — dokument #{id}</h2>
+        <NavLink to={`/youtube/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>← Edytuj dokument</NavLink>
+      </div>
 
       {/* Nowa analiza */}
-      <div style={{ margin: "20px 0", padding: "14px 16px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
+      <div style={{ margin: "16px 0", padding: "12px 16px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
         <strong style={{ fontSize: "0.9em" }}>Nowa analiza</strong>
-        <div style={{ display: "flex", gap: 10, marginTop: 10, flexWrap: "wrap", alignItems: "center" }}>
-          <select value={newModel} onChange={e => setNewModel(e.target.value)} style={{ padding: "5px 8px", fontSize: "0.88em" }}>
+        <div style={{ display: "flex", gap: 10, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <select value={newModel} onChange={e => setNewModel(e.target.value)} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
             {MODELS.map(m => <option key={m} value={m}>{m}</option>)}
           </select>
           <label style={{ fontSize: "0.85em" }}>
-            Rozmiar chunka:&nbsp;
-            <input
-              type="number"
-              value={chunkSize}
-              onChange={e => setChunkSize(Number(e.target.value))}
-              style={{ width: 80, padding: "4px 6px", fontSize: "0.88em" }}
-              min={500}
-              max={20000}
-              step={500}
-            />
+            Chunk:&nbsp;
+            <input type="number" value={chunkSize} onChange={e => setChunkSize(Number(e.target.value))}
+              style={{ width: 75, padding: "3px 6px", fontSize: "0.88em" }} min={500} max={20000} step={500} />
           </label>
-          <button
-            className="button"
-            onClick={startAnalysis}
-            disabled={!!jobId}
-          >
+          <button className="button" onClick={startAnalysis} disabled={!!jobId}>
             {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
           </button>
         </div>
@@ -175,13 +438,9 @@ const Chunks = () => {
 
       {/* Wybór runu */}
       {runs.length > 0 && (
-        <div style={{ marginBottom: 16 }}>
+        <div style={{ marginBottom: 12 }}>
           <label style={{ fontSize: "0.85em", fontWeight: 600 }}>Analiza: </label>
-          <select
-            value={selectedRun ?? ""}
-            onChange={e => setSelectedRun(Number(e.target.value))}
-            style={{ padding: "4px 8px", fontSize: "0.88em" }}
-          >
+          <select value={selectedRun ?? ""} onChange={e => setSelectedRun(Number(e.target.value))} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
             {runs.map(r => (
               <option key={r.id} value={r.id}>
                 #{r.id} — {r.model} ({r.chunk_count} chunków, {new Date(r.created_at).toLocaleString("pl")})
@@ -191,49 +450,202 @@ const Chunks = () => {
         </div>
       )}
 
+      {/* Pasek postępu */}
+      {chunks.length > 0 && (
+        <div style={{ marginBottom: 12, padding: "8px 14px", background: "#0f172a", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <span style={{ color: "#94a3b8", fontSize: "0.82em" }}>
+            TEMAT: {approvedCount}/{tematChunks.length} zatwierdzonych ({pct}%)
+            {reklamaCount > 0 && ` • ${reklamaCount} reklam${hideAds ? " (ukryte)" : ""}`}
+          </span>
+          <div style={{ flex: 1, minWidth: 80, background: "#334155", borderRadius: 4, height: 8 }}>
+            <div style={{ width: `${pct}%`, height: 8, background: "#22c55e", borderRadius: 4, transition: "width .3s" }} />
+          </div>
+          {needsReanalysisCount > 0 && (
+            <button className="button" onClick={reanalyzeAll} disabled={reanalyzingAll}
+              style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0369a1", color: "#fff", border: "none" }}>
+              {reanalyzingAll ? "Analizuję…" : `Analizuj wszystkie (${needsReanalysisCount})`}
+            </button>
+          )}
+          {reklamaCount > 0 && (visibleReklamaCount > 0 || hideAds) && (
+            <button className="button" onClick={() => setHideAds(h => !h)}
+              style={{ fontSize: "0.8em", padding: "3px 10px", background: hideAds ? "#475569" : "#b91c1c", color: "#fff", border: "none" }}>
+              {hideAds ? `Pokaż reklamy (${reklamaCount})` : `Ukryj reklamy (${visibleReklamaCount})`}
+            </button>
+          )}
+          {hiddenChunks.size > 0 && (
+            <button className="button" onClick={() => setHiddenChunks(new Set())}
+              style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0369a1", color: "#fff", border: "none" }}>
+              Pokaż ukryte ({hiddenChunks.size})
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Pasek rozmówców */}
+      {selectedRun !== null && (
+        <div style={{ marginBottom: 12, padding: "8px 14px", background: "#1e3a5f", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <strong style={{ color: "#fff", fontSize: "0.85em" }}>Rozmówcy:</strong>
+          {speakers.length > 0 ? (
+            <span style={{ fontSize: "0.85em" }}>
+              {speakers.map((sp, i) => (
+                <React.Fragment key={i}>
+                  {i > 0 && <span style={{ color: "#64748b" }}> &nbsp;|&nbsp; </span>}
+                  <strong style={{ color: "#fff" }}>{sp.name}</strong>
+                  {sp.role && <span style={{ color: "#93c5fd" }}> ({sp.role})</span>}
+                </React.Fragment>
+              ))}
+            </span>
+          ) : (
+            <span style={{ color: "#64748b", fontSize: "0.85em", fontStyle: "italic" }}>nie wykryto</span>
+          )}
+          <button className="button" onClick={extractSpeakers} disabled={extractingSpeakers}
+            style={{ marginLeft: "auto", fontSize: "0.82em", padding: "3px 10px" }}>
+            {extractingSpeakers ? "Wykrywam…" : speakers.length > 0 ? `Wykryj ponownie (${speakers.length})` : "Wykryj rozmówców"}
+          </button>
+        </div>
+      )}
+
       {error && <p style={{ color: "#dc2626", marginBottom: 12 }}>{error}</p>}
       {loading && <div className="loader" style={{ marginBottom: 12 }} />}
 
       {/* Chunki */}
-      {chunks.map((chunk, i) => {
+      {visibleChunks.map((chunk, i) => {
         const hasCorrected = !!chunk.corrected_text;
-        const isShowingRaw = showRaw[chunk.id] ?? false;
-        const displayText = (!hasCorrected || isShowingRaw) ? chunk.text : chunk.corrected_text!;
+        const isCorrectedView = showCorrected[chunk.id] ?? hasCorrected;
+        const isReklama = chunk.type === "REKLAMA";
+        const isReanalyzing = reanalyzing[chunk.id] ?? false;
+        const splitSt = splitStates[chunk.id];
+        const chunkSegs = segments.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segments.length);
 
         return (
-          <div key={chunk.id} style={{ marginBottom: 20, border: "1px solid #e2e8f0", borderRadius: 8, overflow: "hidden" }}>
-            {/* Nagłówek chunka */}
-            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: "#f1f5f9", borderBottom: "1px solid #e2e8f0", fontSize: "0.82em", color: "#64748b" }}>
-              <span style={{ fontWeight: 600, color: "#334155" }}>#{i + 1}</span>
-              {chunk.topic && <span style={{ background: "#dbeafe", color: "#1d4ed8", padding: "1px 8px", borderRadius: 4 }}>{chunk.topic}</span>}
-              {chunk.chunk_type && chunk.chunk_type !== "NORMAL" && (
-                <span style={{ background: chunk.chunk_type === "REKLAMA" ? "#fee2e2" : "#fef9c3", color: chunk.chunk_type === "REKLAMA" ? "#991b1b" : "#854d0e", padding: "1px 8px", borderRadius: 4 }}>
-                  {chunk.chunk_type}
-                </span>
-              )}
-              {chunk.speaker && <span>🎙 {chunk.speaker}</span>}
-              <span style={{ marginLeft: "auto" }}>
-                {hasCorrected && (
-                  <button
-                    onClick={() => toggleRaw(chunk.id)}
-                    style={{ fontSize: "0.9em", padding: "2px 10px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer" }}
-                  >
-                    {isShowingRaw ? "Pokaż poprawiony" : "Pokaż surowy"}
-                  </button>
-                )}
+          <div key={chunk.id} style={{ marginBottom: 18, border: "1px solid #e2e8f0", borderRadius: 8, overflow: "hidden" }}>
+
+            {/* Nagłówek */}
+            <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", background: "#f1f5f9", borderBottom: "1px solid #e2e8f0", fontSize: "0.82em", flexWrap: "wrap" }}>
+              <span style={{ fontWeight: 600, color: "#334155", minWidth: 24 }}>#{chunk.position}</span>
+
+              {/* Typ — klikalny */}
+              <span
+                onClick={() => toggleType(chunk)}
+                title="Kliknij aby zmienić typ"
+                style={{
+                  cursor: "pointer", padding: "1px 8px", borderRadius: 4, fontWeight: 600,
+                  background: isReklama ? "#fee2e2" : "#dbeafe",
+                  color: isReklama ? "#991b1b" : "#1d4ed8",
+                }}
+              >
+                {chunk.type ?? "?"}
               </span>
+
+              {/* Status — klikalny */}
+              <span
+                onClick={() => cycleStatus(chunk)}
+                title="Kliknij aby zmienić status"
+                style={{ cursor: "pointer", padding: "1px 8px", borderRadius: 4, fontWeight: 500, ...statusColor(chunk.status) }}
+              >
+                {chunk.status}
+              </span>
+
+              {chunk.speaker && <span style={{ color: "#64748b" }}>🎙 {chunk.speaker}</span>}
+
+              {/* Edycja tematu */}
+              <input
+                type="text"
+                value={topicEdits[chunk.id] ?? ""}
+                onChange={e => setTopicEdits(prev => ({ ...prev, [chunk.id]: e.target.value }))}
+                onKeyDown={e => { if (e.key === "Enter") saveTopic(chunk.id); }}
+                placeholder="temat"
+                style={{ flex: 1, minWidth: 100, border: "none", borderBottom: "1px dashed #cbd5e1", background: "transparent", fontSize: "0.88em", padding: "2px 4px", color: "#334155" }}
+              />
+              <button onClick={() => saveTopic(chunk.id)} disabled={savingTopics[chunk.id]}
+                style={{ padding: "2px 10px", borderRadius: 3, border: "none", background: "#3b82f6", color: "#fff", fontSize: "0.78em", cursor: "pointer", fontWeight: "bold" }}>
+                Zapisz
+              </button>
+              {savedFlash[chunk.id] && <span style={{ color: "#15803d", fontSize: "0.78em" }}>✓</span>}
+
+              {/* Re-analiza */}
+              <button onClick={() => reanalyzeChunk(chunk.id, "full")} disabled={isReanalyzing}
+                style={{ padding: "2px 9px", borderRadius: 3, border: "none", background: "#7c3aed", color: "#fff", fontSize: "0.78em", cursor: "pointer", fontWeight: "bold" }}>
+                {isReanalyzing ? "…" : "▶ Pełna"}
+              </button>
+              {hasCorrected && (
+                <button onClick={() => reanalyzeChunk(chunk.id, "semantic")} disabled={isReanalyzing}
+                  style={{ padding: "2px 9px", borderRadius: 3, border: "none", background: "#059669", color: "#fff", fontSize: "0.78em", cursor: "pointer", fontWeight: "bold" }}>
+                  {isReanalyzing ? "…" : "▶ Sem."}
+                </button>
+              )}
+
+              {/* Przełącznik widoku */}
+              {hasCorrected && (
+                <button onClick={() => setShowCorrected(prev => ({ ...prev, [chunk.id]: !prev[chunk.id] }))}
+                  style={{ padding: "2px 9px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em" }}>
+                  {isCorrectedView ? "Surowy" : "Poprawiony"}
+                </button>
+              )}
+              <button
+                onClick={() => setHiddenChunks(prev => new Set([...prev, chunk.id]))}
+                title="Ukryj ten chunk"
+                style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b", marginLeft: "auto" }}
+              >
+                ✕
+              </button>
             </div>
 
             {/* Treść */}
-            <div style={{ padding: "12px 14px", fontSize: "0.9em", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
-              {displayText}
+            <div style={{ padding: "12px 14px", fontSize: "0.88em", lineHeight: 1.6 }}>
+              {isCorrectedView && hasCorrected ? (
+                <div style={{ whiteSpace: "pre-wrap", color: "#1e293b" }}>{chunk.corrected_text}</div>
+              ) : (
+                <SegmentsView
+                  segs={chunkSegs}
+                  videoId={videoId}
+                  chunkId={chunk.id}
+                  absOffset={chunk.seg_start ?? 0}
+                  splitState={splitSt}
+                  onMarkSplit={markSplit}
+                />
+              )}
             </div>
+
+            {/* Panel podziału */}
+            {splitSt && (
+              <div style={{ margin: "0 14px 14px", padding: "10px 12px", background: "#fff7ed", border: "1px solid #fed7aa", borderRadius: 5, fontSize: "0.84em" }}>
+                <strong style={{ color: "#92400e" }}>✂ Punkt podziału: [{splitSt.ts}]</strong>
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 8, flexWrap: "wrap" }}>
+                  <label>Część 1 (przed):&nbsp;
+                    <select value={splitSt.firstType}
+                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], firstType: e.target.value as "TEMAT" | "REKLAMA" } }))}
+                      style={{ padding: "2px 6px", borderRadius: 3 }}>
+                      <option value="REKLAMA">REKLAMA</option>
+                      <option value="TEMAT">TEMAT</option>
+                    </select>
+                  </label>
+                  <label>Część 2 (po):&nbsp;
+                    <select value={splitSt.secondType}
+                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], secondType: e.target.value as "TEMAT" | "REKLAMA" } }))}
+                      style={{ padding: "2px 6px", borderRadius: 3 }}>
+                      <option value="TEMAT">TEMAT</option>
+                      <option value="REKLAMA">REKLAMA</option>
+                    </select>
+                  </label>
+                  <button onClick={() => confirmSplit(chunk.id)} disabled={confirmingSplit[chunk.id]}
+                    style={{ padding: "3px 12px", background: "#f97316", color: "#fff", border: "none", borderRadius: 3, cursor: "pointer", fontWeight: "bold", fontSize: "0.82em" }}>
+                    {confirmingSplit[chunk.id] ? "Dzielę…" : "Wykonaj podział"}
+                  </button>
+                  <button onClick={() => cancelSplit(chunk.id)}
+                    style={{ padding: "3px 10px", background: "#e2e8f0", color: "#475569", border: "none", borderRadius: 3, cursor: "pointer", fontSize: "0.82em" }}>
+                    Anuluj
+                  </button>
+                </div>
+                <div style={{ color: "#92400e", fontSize: "0.8em", marginTop: 4 }}>Kliknij ✂ przy innym akapicie aby zmienić punkt podziału.</div>
+              </div>
+            )}
 
             {/* Podsumowanie */}
             {chunk.summary && (
               <div style={{ padding: "10px 14px", background: "#f8fafc", borderTop: "1px solid #e2e8f0", fontSize: "0.85em", color: "#475569" }}>
-                <span style={{ fontWeight: 600, color: "#64748b", fontSize: "0.8em", textTransform: "uppercase", letterSpacing: "0.05em" }}>Podsumowanie</span>
-                <p style={{ margin: "4px 0 0", lineHeight: 1.5 }}>{chunk.summary}</p>
+                <div style={{ fontWeight: 600, color: "#64748b", fontSize: "0.8em", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>Podsumowanie</div>
+                <p style={{ margin: 0, lineHeight: 1.5 }}>{chunk.summary}</p>
               </div>
             )}
           </div>

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -1,0 +1,250 @@
+import React from "react";
+import { useParams, NavLink } from "react-router-dom";
+import { AuthorizationContext } from "../context/authorizationContext";
+
+interface Chunk {
+  id: number;
+  order_index: number;
+  text: string;
+  corrected_text: string | null;
+  summary: string | null;
+  topic: string | null;
+  chunk_type: string | null;
+  speaker: string | null;
+}
+
+interface AnalysisRun {
+  id: number;
+  model: string;
+  created_at: string;
+  chunk_count: number;
+}
+
+const MODELS = [
+  "Bielik-11B-v3.0-Instruct",
+  "Bielik-4.5B-v3.0-Instruct",
+  "gpt-4o-mini",
+  "gpt-4o",
+];
+
+const Chunks = () => {
+  const { id } = useParams<{ id: string }>();
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+
+  const [runs, setRuns] = React.useState<AnalysisRun[]>([]);
+  const [selectedRun, setSelectedRun] = React.useState<number | null>(null);
+  const [chunks, setChunks] = React.useState<Chunk[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const [jobStatus, setJobStatus] = React.useState<string | null>(null);
+  const [jobId, setJobId] = React.useState<string | null>(null);
+  const [newModel, setNewModel] = React.useState(MODELS[0]);
+  const [chunkSize, setChunkSize] = React.useState(5000);
+  const [showRaw, setShowRaw] = React.useState<Record<number, boolean>>({});
+
+  const headers = { "x-api-key": apiKey ?? "", "Content-Type": "application/json" };
+
+  const fetchRuns = React.useCallback(async () => {
+    if (!id) return;
+    try {
+      const r = await fetch(`${apiUrl}/analysis_runs?doc_id=${id}`, { headers });
+      const data = await r.json();
+      const list: AnalysisRun[] = data.runs ?? [];
+      setRuns(list);
+      if (list.length > 0 && selectedRun === null) {
+        setSelectedRun(list[0].id);
+      }
+    } catch {
+      setError("Błąd ładowania listy analiz");
+    }
+  }, [id, apiUrl, apiKey]);
+
+  const fetchChunks = React.useCallback(async (runId: number) => {
+    setLoading(true);
+    setError("");
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${runId}/chunks`, { headers });
+      const data = await r.json();
+      setChunks(data.chunks ?? []);
+    } catch {
+      setError("Błąd ładowania chunków");
+    } finally {
+      setLoading(false);
+    }
+  }, [apiUrl, apiKey]);
+
+  React.useEffect(() => { fetchRuns(); }, [fetchRuns]);
+
+  React.useEffect(() => {
+    if (selectedRun !== null) fetchChunks(selectedRun);
+  }, [selectedRun, fetchChunks]);
+
+  const pollJob = React.useCallback((jid: string) => {
+    const interval = setInterval(async () => {
+      try {
+        const r = await fetch(`${apiUrl}/analysis_job/${jid}`, { headers });
+        const data = await r.json();
+        setJobStatus(data.status);
+        if (data.status === "done") {
+          clearInterval(interval);
+          setJobId(null);
+          await fetchRuns();
+          if (data.run_id) {
+            setSelectedRun(data.run_id);
+          }
+        } else if (data.status === "failed") {
+          clearInterval(interval);
+          setJobId(null);
+          setError("Analiza nie powiodła się: " + (data.error ?? ""));
+        }
+      } catch {
+        clearInterval(interval);
+        setJobId(null);
+      }
+    }, 5000);
+  }, [apiUrl, apiKey, fetchRuns]);
+
+  const startAnalysis = async () => {
+    if (!id) return;
+    setError("");
+    setJobStatus("starting");
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/analyze_chunks`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: newModel, chunk_size: chunkSize }),
+      });
+      const data = await r.json();
+      if (data.job_id) {
+        setJobId(data.job_id);
+        setJobStatus("running");
+        pollJob(data.job_id);
+      } else {
+        setError("Nie udało się uruchomić analizy");
+        setJobStatus(null);
+      }
+    } catch {
+      setError("Błąd połączenia");
+      setJobStatus(null);
+    }
+  };
+
+  const toggleRaw = (chunkId: number) => {
+    setShowRaw(prev => ({ ...prev, [chunkId]: !prev[chunkId] }));
+  };
+
+  const docType = chunks.length > 0 ? null : null;
+
+  return (
+    <div style={{ maxWidth: 900 }}>
+      <h2 style={{ marginBottom: 6 }}>
+        Przegląd chunków — dokument #{id}
+      </h2>
+      <NavLink to={`/youtube/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>
+        ← Edytuj dokument
+      </NavLink>
+
+      {/* Nowa analiza */}
+      <div style={{ margin: "20px 0", padding: "14px 16px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
+        <strong style={{ fontSize: "0.9em" }}>Nowa analiza</strong>
+        <div style={{ display: "flex", gap: 10, marginTop: 10, flexWrap: "wrap", alignItems: "center" }}>
+          <select value={newModel} onChange={e => setNewModel(e.target.value)} style={{ padding: "5px 8px", fontSize: "0.88em" }}>
+            {MODELS.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+          <label style={{ fontSize: "0.85em" }}>
+            Rozmiar chunka:&nbsp;
+            <input
+              type="number"
+              value={chunkSize}
+              onChange={e => setChunkSize(Number(e.target.value))}
+              style={{ width: 80, padding: "4px 6px", fontSize: "0.88em" }}
+              min={500}
+              max={20000}
+              step={500}
+            />
+          </label>
+          <button
+            className="button"
+            onClick={startAnalysis}
+            disabled={!!jobId}
+          >
+            {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
+          </button>
+        </div>
+      </div>
+
+      {/* Wybór runu */}
+      {runs.length > 0 && (
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ fontSize: "0.85em", fontWeight: 600 }}>Analiza: </label>
+          <select
+            value={selectedRun ?? ""}
+            onChange={e => setSelectedRun(Number(e.target.value))}
+            style={{ padding: "4px 8px", fontSize: "0.88em" }}
+          >
+            {runs.map(r => (
+              <option key={r.id} value={r.id}>
+                #{r.id} — {r.model} ({r.chunk_count} chunków, {new Date(r.created_at).toLocaleString("pl")})
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {error && <p style={{ color: "#dc2626", marginBottom: 12 }}>{error}</p>}
+      {loading && <div className="loader" style={{ marginBottom: 12 }} />}
+
+      {/* Chunki */}
+      {chunks.map((chunk, i) => {
+        const hasCorrected = !!chunk.corrected_text;
+        const isShowingRaw = showRaw[chunk.id] ?? false;
+        const displayText = (!hasCorrected || isShowingRaw) ? chunk.text : chunk.corrected_text!;
+
+        return (
+          <div key={chunk.id} style={{ marginBottom: 20, border: "1px solid #e2e8f0", borderRadius: 8, overflow: "hidden" }}>
+            {/* Nagłówek chunka */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", background: "#f1f5f9", borderBottom: "1px solid #e2e8f0", fontSize: "0.82em", color: "#64748b" }}>
+              <span style={{ fontWeight: 600, color: "#334155" }}>#{i + 1}</span>
+              {chunk.topic && <span style={{ background: "#dbeafe", color: "#1d4ed8", padding: "1px 8px", borderRadius: 4 }}>{chunk.topic}</span>}
+              {chunk.chunk_type && chunk.chunk_type !== "NORMAL" && (
+                <span style={{ background: chunk.chunk_type === "REKLAMA" ? "#fee2e2" : "#fef9c3", color: chunk.chunk_type === "REKLAMA" ? "#991b1b" : "#854d0e", padding: "1px 8px", borderRadius: 4 }}>
+                  {chunk.chunk_type}
+                </span>
+              )}
+              {chunk.speaker && <span>🎙 {chunk.speaker}</span>}
+              <span style={{ marginLeft: "auto" }}>
+                {hasCorrected && (
+                  <button
+                    onClick={() => toggleRaw(chunk.id)}
+                    style={{ fontSize: "0.9em", padding: "2px 10px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer" }}
+                  >
+                    {isShowingRaw ? "Pokaż poprawiony" : "Pokaż surowy"}
+                  </button>
+                )}
+              </span>
+            </div>
+
+            {/* Treść */}
+            <div style={{ padding: "12px 14px", fontSize: "0.9em", lineHeight: 1.6, whiteSpace: "pre-wrap" }}>
+              {displayText}
+            </div>
+
+            {/* Podsumowanie */}
+            {chunk.summary && (
+              <div style={{ padding: "10px 14px", background: "#f8fafc", borderTop: "1px solid #e2e8f0", fontSize: "0.85em", color: "#475569" }}>
+                <span style={{ fontWeight: 600, color: "#64748b", fontSize: "0.8em", textTransform: "uppercase", letterSpacing: "0.05em" }}>Podsumowanie</span>
+                <p style={{ margin: "4px 0 0", lineHeight: 1.5 }}>{chunk.summary}</p>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {!loading && chunks.length === 0 && runs.length === 0 && (
+        <p style={{ color: "#64748b", fontStyle: "italic" }}>Brak analiz dla tego dokumentu. Uruchom pierwszą analizę powyżej.</p>
+      )}
+    </div>
+  );
+};
+
+export default Chunks;

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -18,7 +18,7 @@ const List = () => {
     onSubmit: () => {},
   });
 
-  const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState, databaseStatus } = React.useContext(AuthorizationContext);
+  const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState, databaseStatus, apiType } = React.useContext(AuthorizationContext);
   const { searchInDocument, setSearchInDocument} = React.useContext(AuthorizationContext);
   const { searchType, setSearchType} = React.useContext(AuthorizationContext);
 
@@ -40,7 +40,7 @@ const List = () => {
     handleGetList(selectedDocumentType, selectedDocumentState);
   };
 
-  const dbDown = databaseStatus !== "available";
+  const dbDown = apiType === "AWS Serverless" && databaseStatus !== "available";
 
   return (
     <div>

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -151,6 +151,15 @@ const List = () => {
               >
                 Edit
               </NavLink>
+              {(item.document_type === "youtube" || item.document_type === "movie") && (
+                <NavLink
+                  className={"button"}
+                  style={{ margin: "0 0 0 6px" }}
+                  to={`/chunks/${item.id}`}
+                >
+                  Chunki
+                </NavLink>
+              )}
               <button
                 className={"button"}
                 style={{ margin: "0 0 0 10px" }}


### PR DESCRIPTION
## Summary

- **Backend**: `DocumentAnalysisService` — async chunk analysis endpoint (`POST /document/<id>/analyze_chunks`), job polling (`GET /analysis_job/<id>`), per-chunk reanalysis (`POST /chunk/<id>/reanalyze`), split execution (`POST /chunk/<id>/execute_split`), speaker extraction (`POST /analysis_run/<id>/extract_speakers`)
- **React `/chunks/:id`**: pełne zastąpienie osobnej strony HTML na porcie 5055 — widok segmentów z linkami YouTube (timestamp), workflow podziału chunku (✂), cyklowanie statusu/typu, pasek postępu, analiza wszystkich chunków, pasek mówców (Rozmówcy)
- **Ukrywanie chunków**: globalny przycisk "Ukryj reklamy" + per-chunk ✕; `visibleReklamaCount` oddzielony od `reklamaCount` — przycisk globalny znika gdy wszystkie reklamy są już indywidualnie ukryte
- **Numeracja**: `chunk.position` z bazy zamiast indeksu na ekranie — numery stabilne niezależnie od filtrowania
- **Fix banner DB**: komunikat "Baza danych niedostępna" pokazuje się tylko w trybie AWS Serverless (nie Docker)

## Test plan

- [ ] Otworzyć `/chunks/<id>` dla dokumentu typu youtube/movie
- [ ] Sprawdzić widok segmentów z linkami do YouTube (timestamp)
- [ ] Ukryć reklamę przez ✕ — przycisk "Ukryj reklamy" powinien zniknąć
- [ ] Kliknąć "Ukryj reklamy" (globalny) — powinna pojawić się opcja "Pokaż reklamy"
- [ ] Sprawdzić numerację chunków po ukryciu — numery z bazy, nie przesuwają się
- [ ] W trybie Docker: brak banera "Baza danych niedostępna"

🤖 Generated with [Claude Code](https://claude.com/claude-code)