### PR TITLE
chore: remove empty networking stacks and app/app2 AWS hosting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,19 +149,7 @@ See `infra/aws/serverless/CLAUDE.md` for detailed comparison and known differenc
 
 ### Frontend Deployment (AWS)
 
-All three frontends are deployed to S3 + CloudFront. Deploy scripts resolve bucket names and distribution IDs from SSM Parameter Store (exported by CloudFormation). See `docs/frontend-deployment.md` for full details.
-
-```bash
-# React app (app.dev.lenie-ai.eu)
-cd web_interface_react && ./deploy.sh
-
-# Admin panel (app2.dev.lenie-ai.eu)
-cd web_interface_app2 && ./deploy.sh
-
-# Common options
-./deploy.sh --skip-build         # Deploy existing build/ only
-./deploy.sh --skip-invalidation  # Skip CloudFront cache invalidation
-```
+**Only the landing page** (`www.lenie-ai.eu`) is hosted on AWS (S3 + CloudFront). The `app.dev.lenie-ai.eu` and `app2.dev.lenie-ai.eu` hosting stacks were deleted 2026-07-02 — those frontends required the AWS document API (`app-server-db`), which was decommissioned; they now run only against the Docker/NAS backend (local dev or NAS deployment). Restoration: [docs/aws-serverless-restoration.md](docs/aws-serverless-restoration.md). See `docs/frontend-deployment.md` for landing page deployment details.
 
 ### CI/CD
 **Currently inactive** — all deployments are manual from the developer's machine. Configuration files from previous experimental setups remain in the repository:

--- a/docs/aws-serverless-restoration.md
+++ b/docs/aws-serverless-restoration.md
@@ -20,14 +20,20 @@ The active ingestion path is untouched and works end-to-end:
 | DynamoDB `lenie_dev_documents` | Sole cloud document store (daily writes) |
 | S3 `lenie-dev-website-content` | Webpage content (`{uuid}.txt` / `{uuid}.html`) |
 | API Gateway `lenie_split` (app) + `lenie_dev_infra` | `/url_add` + `/sqs/size`; custom domain `api.dev.lenie-ai.eu` |
-| CloudFront + S3 hosting | app, app2, landing page |
+| CloudFront + S3 hosting | landing page only (`www.lenie-ai.eu`) — app/app2 hosting deleted 2026-07-02, see below |
 | `imports/dynamodb_sync.py` (local) | The actual cloud→local sync path: DynamoDB + S3 → local PostgreSQL |
-
-⚠️ Known consequence: the **hosted frontends** (`app.dev.lenie-ai.eu`, `app2.dev.lenie-ai.eu`) can no longer browse documents against the AWS API (those endpoints are gone) — they are only useful pointed at a reachable Docker/NAS backend. The hosting itself (S3+CloudFront) was left in place.
 
 Sanitized configuration snapshots of the surviving Lambdas (runtime, layers, env **key names**, roles) are in [`infra/aws/serverless/config-snapshots/`](../infra/aws/serverless/config-snapshots/).
 
 ## 2. What was removed and when
+
+### 2026-07-02 (final cleanup pass) — frontend hosting
+
+Deleted stacks: `lenie-dev-cloudfront-app` + `lenie-dev-s3-app-web` (`app.dev.lenie-ai.eu`) and `lenie-dev-cloudfront-app2` + `lenie-dev-s3-app2-web` (`app2.dev.lenie-ai.eu`), including their Route53 A-records. Rationale: both hosted frontends required the `app-server-db` document endpoints, which are gone — Docker/NAS is the document UI. Local development and NAS deployment of `web_interface_react`/`web_interface_app2` are unaffected; only the AWS hosting is gone. Buckets were emptied before stack deletion (built artifacts only — rebuilt by `npm run build`). **Kept:** the landing page (`www.lenie-ai.eu`, `lenie-landing-prod-*` stacks), `api-gw-custom-domain` (`api.dev.lenie-ai.eu` — Chrome extension), and `acm-certificates` (wildcard cert also used by the helm CDN). To restore hosting: uncomment the four templates in `deploy.ini`, deploy, then run each app's `./deploy.sh`.
+
+### 2026-07-02 (final cleanup pass) — empty networking stacks
+
+Deleted stacks: `lenie-dev-vpc` (empty CF-managed VPC — all workloads had actually used the AWS **default** VPC), `lenie-dev-security-groups` (SSH SG guarding instances that no longer existed), `lenie-dev-ec2-lenie` (orphaned — its instance no longer existed). Deleting the VPC required peeling several orphaned resources CF didn't own: two manual SGs (`allowSSHfromall`, `webServer`), an unattached ENI, an orphaned route table, and — the hidden final blocker — a **VPC peering connection** (`pcx-…`, default VPC as requester → CF VPC as accepter; note peerings only show up when filtering by *both* requester and accepter VPC). Templates stay in the repo (commented out in `deploy.ini`). On restore, deploy real workloads into the CF-managed VPC from the start, so the topology isn't split between the default and managed VPCs. `lenie-dev-lenie-launch-template` was left deployed (candidate for later removal).
 
 ### 2026-07-02 — RDS and its support infrastructure (PR [#180](https://github.com/ziutus/ai_assistant_lenie/pull/180))
 

--- a/docs/frontend-deployment.md
+++ b/docs/frontend-deployment.md
@@ -2,15 +2,17 @@
 
 Manual deployment guide for Lenie AI frontend applications to AWS (S3 + CloudFront).
 
+> **2026-07-02:** The `app.dev.lenie-ai.eu` and `app2.dev.lenie-ai.eu` hosting stacks were **deleted** — those frontends required the AWS document API (`app-server-db`), which was decommissioned; they now run only against the Docker/NAS backend. Their `deploy.sh` scripts will fail (SSM parameters gone) until the stacks are restored. Restoration: [aws-serverless-restoration.md](aws-serverless-restoration.md). The sections below describing app/app2 are kept as reference for that restoration.
+
 ## Overview
 
-Three web frontends are hosted via S3 + CloudFront:
+Currently hosted via S3 + CloudFront:
 
-| App | URL | Deploy Script | S3 Bucket |
-|-----|-----|---------------|-----------|
-| React app | `app.dev.lenie-ai.eu` | `web_interface_react/deploy.sh` | `lenie-dev-app-web` |
-| Admin panel | `app2.dev.lenie-ai.eu` | `web_interface_app2/deploy.sh` | `lenie-dev-app2-web` |
-| Landing page | `www.lenie-ai.eu` | *(no script yet)* | `lenie-prod-landing-web` |
+| App | URL | Deploy Script | S3 Bucket | Status |
+|-----|-----|---------------|-----------|--------|
+| Landing page | `www.lenie-ai.eu` | *(no script yet)* | `lenie-prod-landing-web` | active |
+| React app | `app.dev.lenie-ai.eu` | `web_interface_react/deploy.sh` | `lenie-dev-app-web` | **hosting deleted 2026-07-02** |
+| Admin panel | `app2.dev.lenie-ai.eu` | `web_interface_app2/deploy.sh` | `lenie-dev-app2-web` | **hosting deleted 2026-07-02** |
 
 ## Prerequisites
 

--- a/infra/aws/CLAUDE.md
+++ b/infra/aws/CLAUDE.md
@@ -82,28 +82,28 @@ Jenkins target (`aws-start-jenkins`) was removed since Jenkins is not currently 
 
 | Service | Purpose |
 |---------|---------|
-| VPC | Networking with public/private/DB subnets (a separate, currently-empty leftover VPC also exists — see Known Issues) |
+| VPC | Only the AWS default VPC remains — the empty CF-managed VPC (`lenie-dev-vpc`) and its SSH security-groups stack were deleted 2026-07-02 |
 | DynamoDB | Document metadata store, cross-env sync (now the sole cloud document store — RDS decommissioned 2026-07-02) |
 | SQS | Document processing queue — currently has no consumer since the RDS pipeline was removed (see "Scalable Asynchronous Ingestion via SQS" above) |
 | SNS | Error notifications via email |
 | S3 | Lambda code artifacts, video transcriptions, web content |
 | Lambda | 3 functions: `url-add` (Chrome extension ingestion), `sqs-weblink-put-into`, `sqs-size`. The app-server-db/internet document-serving Lambdas were deleted 2026-07-02 — see [docs/aws-serverless-restoration.md](../../docs/aws-serverless-restoration.md) |
 | API Gateway | 2 REST APIs (app: 1 endpoint — `/url_add`; infra: 1 endpoint — `/sqs/size`) + custom domain `api.{env}.lenie-ai.eu` with base path mappings |
-| EC2 | Application server (currently orphaned/stale CF-tracked instance, see `serverless/CLAUDE.md`) |
+| EC2 | None running — the orphaned `ec2-lenie` stack was deleted 2026-07-02; only the (unused) launch template stack remains |
 | EKS | Kubernetes cluster (alternative deployment target) |
 | Route53 | DNS for lenie-ai.eu domain |
 | SSM Parameter Store | Cross-stack value sharing |
 | CloudWatch | Logging, Step Function execution monitoring |
 | Budgets | Cost alerts ($8/month threshold) |
 | Organizations + SCPs | Multi-account governance, region restrictions |
-| CloudFront | CDN for frontend app (`app.dev.lenie-ai.eu`), admin panel (`app2.dev.lenie-ai.eu`), and landing page (`www.lenie-ai.eu`) |
+| CloudFront | CDN for the landing page (`www.lenie-ai.eu`) only — app/app2 hosting deleted 2026-07-02 |
 
 ## Frontend Hosting
 
-Three web frontends are hosted via S3 + CloudFront:
-- **React app** (`web_interface_react/`) — `app.dev.lenie-ai.eu` via `s3-app-web` + `cloudfront-app` stacks
-- **Admin panel** (`web_interface_app2/`) — `app2.dev.lenie-ai.eu` via `s3-app2-web` + `cloudfront-app2` stacks
+Only the landing page is hosted via S3 + CloudFront:
 - **Landing page** (`web_landing_page/`, Next.js static export) — `www.lenie-ai.eu` via `s3-landing-web` + `cloudfront-landing` stacks
+
+The React app (`app.dev.lenie-ai.eu`) and admin panel (`app2.dev.lenie-ai.eu`) hosting stacks were **deleted 2026-07-02** — they required the AWS document API (`app-server-db`), which was decommissioned. Both frontends now run only against the Docker/NAS backend. Restoration: [docs/aws-serverless-restoration.md](../../docs/aws-serverless-restoration.md).
 
 ### Historical Context
 

--- a/infra/aws/cloudformation/CLAUDE.md
+++ b/infra/aws/cloudformation/CLAUDE.md
@@ -116,9 +116,9 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 | Template | Resources | Description |
 |----------|-----------|-------------|
 | `env-setup.yaml` | SSM Parameter | Runtime version configuration (python3.11) |
-| `vpc.yaml` | VPC, 6 Subnets, IGW, Route Table, SSM | Multi-AZ network (public, private, DB subnets). **Currently unused** — RDS and the OpenVPN bastion actually ran in the AWS default VPC, not this one; this stack has 0 attached instances. Kept deployed but not cleaned up (out of scope of the 2026-07-02 RDS decommission — see `CLAUDE.md` root "Known Issues" if tracked). |
+| ~~`vpc.yaml`~~ | ~~VPC, 6 Subnets, IGW, Route Table, SSM~~ | **Stack deleted 2026-07-02.** The CF-managed VPC was empty (0 instances) — RDS and the OpenVPN bastion actually ran in the AWS default VPC, not this one. Template kept in repo for a future proper VPC layout. |
 | `1-domain-route53.yaml` | Route53 Hosted Zone | DISABLED — creates duplicate zone. Domain `lenie-ai.eu` hosted zone is managed by legacy stack `lenie-domain-route53-definition` (with SSM exports for all environments). |
-| `security-groups.yaml` | Security Group | SSH access from specific IPs. Same unused-VPC caveat as `vpc.yaml`. |
+| ~~`security-groups.yaml`~~ | ~~Security Group~~ | **Stack deleted 2026-07-02.** SSH-access SG (in the default VPC) guarding instances that no longer exist. |
 | ~~`secrets.yaml`~~ | ~~Secrets Manager, SSM Parameter~~ | **Deleted 2026-07-02.** Held only the RDS password secret; removed along with RDS. |
 
 ### Database
@@ -142,8 +142,8 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 | `s3.yaml` | S3 Bucket | Video transcription bucket (`lenie-{stage}-video-to-text`) |
 | `s3-cloudformation.yaml` | S3 Bucket, SSM | Lambda code and CF artifacts bucket. Directory structure: `lambdas/` (Lambda ZIP packages), `layers/` (Lambda layers), `templates/` (exported API definitions) |
 | `s3-website-content.yaml` | S3 Bucket, Bucket Policy, SSM | Website content storage (`lenie-{stage}-website-content`, AES256) |
-| `s3-app-web.yaml` | S3 Bucket, Bucket Policy, SSM | Frontend hosting bucket (`lenie-{stage}-app-web`, CloudFront OAC) |
-| `s3-app2-web.yaml` | S3 Bucket, Bucket Policy, SSM | Target multi-user UI hosting bucket (`lenie-{stage}-app2-web`, CloudFront OAC) |
+| ~~`s3-app-web.yaml`~~ | ~~S3 Bucket, Bucket Policy, SSM~~ | **Stack deleted 2026-07-02** (hosted frontend had no backend after app-server-db removal) |
+| ~~`s3-app2-web.yaml`~~ | ~~S3 Bucket, Bucket Policy, SSM~~ | **Stack deleted 2026-07-02** (same reason as s3-app-web) |
 | `s3-landing-web.yaml` | S3 Bucket, Bucket Policy, SSM | Landing page hosting bucket (`lenie-{stage}-landing-web`, CloudFront OAC). Deployed in `[landing-prod]` section — production resource. |
 | `helm.yaml` | S3 Bucket, Bucket Policy, CloudFront OAI, CloudFront Distribution | Helm chart repository and CDN (`helm.{env}.lenie-ai.eu`). Certificate ARN resolved from SSM. |
 
@@ -159,7 +159,7 @@ Parameters can reference SSM Parameter Store (e.g. VPC ID, subnet ID) - values a
 
 | Template | Resources | Description |
 |----------|-----------|-------------|
-| `ec2-lenie.yaml` | EC2 (t4g.micro ARM64), SG, IAM | Instance with dynamic public IP and SSM |
+| ~~`ec2-lenie.yaml`~~ | ~~EC2 (t4g.micro ARM64), SG, IAM~~ | **Stack deleted 2026-07-02** — its instance no longer existed (stack was orphaned). |
 | `lenie-launch-template.yaml` | Launch Template | EC2 launch template |
 | `lambda-rds-start.yaml` | Lambda, IAM Role | REDUNDANT — commented out in deploy.ini; rds-start Lambda is managed by api-gw-infra.yaml. Delete stack `lenie-dev-lambda-rds-start` manually. |
 | `lambda-weblink-put-into-sqs.yaml` | Lambda | Function to put web links into SQS. Note: the queue it writes to has had no consumer since `sqs-to-rds-lambda` was deleted (2026-07-02) — messages just expire after 14 days. |
@@ -201,8 +201,8 @@ These settings apply to all methods/resources via wildcard `MethodSettings` (`Ht
 
 | Template | Resources | Description |
 |----------|-----------|-------------|
-| `cloudfront-app.yaml` | CloudFront Distribution, OAC, Route53 A-Record, SSM | CDN for frontend application (`app.{env}.lenie-ai.eu`) with SPA error responses (403/404 → index.html) and Route53 alias record. Certificate ARN resolved from SSM via `{{resolve:ssm:...}}` dynamic reference. |
-| `cloudfront-app2.yaml` | CloudFront Distribution, OAC, Route53 A-Record, SSM | CDN for target multi-user UI (`app2.{env}.lenie-ai.eu`) with SPA error responses and Route53 alias record. Certificate ARN resolved from SSM. |
+| ~~`cloudfront-app.yaml`~~ | ~~CloudFront Distribution, OAC, Route53 A-Record, SSM~~ | **Stack deleted 2026-07-02** (hosted frontend had no backend after app-server-db removal) |
+| ~~`cloudfront-app2.yaml`~~ | ~~CloudFront Distribution, OAC, Route53 A-Record, SSM~~ | **Stack deleted 2026-07-02** (same reason as cloudfront-app) |
 | `cloudfront-landing.yaml` | CloudFront Distribution, OAC, ACM Certificate, Route53 A-Record, SSM | CDN for landing page (`www.lenie-ai.eu`) with static 404 error page, Route53 alias record, and self-contained inline ACM certificate (DNS validation). Deployed in `[landing-prod]` section — production resource, not per-environment. |
 
 ### Email
@@ -248,8 +248,8 @@ Stacks have dependencies between them. When creating a new environment from scra
 - ~~`1-domain-route53.yaml`~~ - DISABLED (duplicate zone; managed by legacy stack `lenie-domain-route53-definition`)
 
 ### Layer 2: Networking
-- `vpc.yaml` - VPC, subnets, IGW
-- `security-groups.yaml` - SSH access rules
+- ~~`vpc.yaml`~~ - REMOVED 2026-07-02 (the CF VPC was empty; workloads used the default VPC)
+- ~~`security-groups.yaml`~~ - REMOVED 2026-07-02 (SSH SG for instances that no longer exist)
 
 ### Layer 3: Security
 - ~~`secrets.yaml`~~ - REMOVED 2026-07-02 (held only the RDS password secret, deleted with RDS)
@@ -259,8 +259,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 - `s3-cloudformation.yaml` - Lambda code and CF artifacts bucket
 - `dynamodb-documents.yaml` - documents table
 - `s3-website-content.yaml` - website content storage
-- `s3-app-web.yaml` - frontend hosting bucket
-- `s3-app2-web.yaml` - target multi-user UI hosting bucket
+- ~~`s3-app-web.yaml`~~ / ~~`s3-app2-web.yaml`~~ - REMOVED 2026-07-02 (frontend hosting, no backend after app-server-db removal)
 - `sqs-documents.yaml` - document processing queue (no consumer since the RDS pipeline was removed — see "Orchestration" above)
 - `sqs-application-errors.yaml` - DLQ with email notification
 - ~~`rds.yaml`~~ - RDS decommissioned 2026-07-02 (was never actually CF-managed despite the template; deleted directly via the RDS API, final snapshot retained)
@@ -269,8 +268,8 @@ Stacks have dependencies between them. When creating a new environment from scra
 - `lambda-layer-lenie-all.yaml` - shared library layer
 - `lambda-layer-openai.yaml` - OpenAI SDK layer
 - `lambda-layer-psycopg2.yaml` - PostgreSQL driver layer
-- `ec2-lenie.yaml` - application server (currently orphaned: the CF-tracked instance no longer exists, stack not yet cleaned up)
-- `lenie-launch-template.yaml` - EC2 launch template
+- ~~`ec2-lenie.yaml`~~ - REMOVED 2026-07-02 (orphaned: the CF-tracked instance no longer existed)
+- `lenie-launch-template.yaml` - EC2 launch template (still deployed; of limited use now that ec2-lenie is gone — candidate for removal)
 - ~~`lambda-rds-start.yaml`~~ - REDUNDANT, commented out (rds-start Lambda managed by api-gw-infra.yaml)
 - `lambda-weblink-put-into-sqs.yaml` - Lambda for SQS ingestion
 - ~~`sqs-to-rds-lambda.yaml`~~ - REMOVED 2026-07-02 (SQS to RDS transfer Lambda, deleted with RDS)
@@ -287,8 +286,7 @@ Stacks have dependencies between them. When creating a new environment from scra
 
 ### Layer 8: Certificates & CDN
 - `acm-certificates.yaml` - wildcard certificate for dev CloudFront distributions (SSM export)
-- `cloudfront-app.yaml` - CDN for frontend application (`app.{env}.lenie-ai.eu`, cert from SSM)
-- `cloudfront-app2.yaml` - CDN for target multi-user UI (`app2.{env}.lenie-ai.eu`, cert from SSM)
+- ~~`cloudfront-app.yaml`~~ / ~~`cloudfront-app2.yaml`~~ - REMOVED 2026-07-02 (frontend hosting CDNs)
 - `helm.yaml` - Helm chart repository and CDN (cert from SSM)
 
 This order is reflected in the `deploy.ini` file under the `[dev]` section. Run `./deploy.sh -p lenie -s dev` to deploy all templates in order.

--- a/infra/aws/cloudformation/deploy.ini
+++ b/infra/aws/cloudformation/deploy.ini
@@ -13,8 +13,10 @@ templates/budget.yaml
 ; templates/1-domain-route53.yaml  ; DUPLICATE — hosted zone managed by legacy stack lenie-domain-route53-definition (with SSM exports). This template creates a second empty zone.
 
 ; --- Layer 2: Networking ---
-templates/vpc.yaml
-templates/security-groups.yaml
+; vpc.yaml + security-groups.yaml - stacks deleted 2026-07-02: the CF VPC was empty (RDS/OpenVPN
+; actually ran in the AWS default VPC) and the SSH SG guarded instances that no longer exist.
+;templates/vpc.yaml
+;templates/security-groups.yaml
 
 ; --- Layer 3: Security ---
 ; secrets.yaml - stack lenie-dev-secrets deleted 2026-07-02, only held the RDS password secret; RDS decommissioned (unused since ~2026-04)
@@ -25,8 +27,10 @@ templates/s3.yaml
 templates/s3-cloudformation.yaml
 templates/dynamodb-documents.yaml
 templates/s3-website-content.yaml
-templates/s3-app-web.yaml
-templates/s3-app2-web.yaml
+; s3-app-web.yaml + s3-app2-web.yaml - stacks deleted 2026-07-02: hosted frontends had no backend
+; after app-server-db removal (Docker/NAS is the document UI). See docs/aws-serverless-restoration.md
+;templates/s3-app-web.yaml
+;templates/s3-app2-web.yaml
 templates/sqs-documents.yaml
 templates/sqs-application-errors.yaml
 ; rds.yaml - deployed separately, managed lifecycle via Step Functions
@@ -36,7 +40,8 @@ templates/sqs-application-errors.yaml
 templates/lambda-layer-lenie-all.yaml
 templates/lambda-layer-openai.yaml
 templates/lambda-layer-psycopg2.yaml
-templates/ec2-lenie.yaml
+; ec2-lenie.yaml - stack deleted 2026-07-02 (its instance no longer existed; stack was orphaned)
+;templates/ec2-lenie.yaml
 templates/lenie-launch-template.yaml
 ; templates/lambda-rds-start.yaml  ; REDUNDANT — rds-start Lambda is managed by api-gw-infra.yaml. Delete stack lenie-dev-lambda-rds-start manually.
 templates/lambda-weblink-put-into-sqs.yaml
@@ -60,8 +65,9 @@ templates/api-gw-custom-domain.yaml
 
 ; --- Layer 8: CDN ---
 templates/acm-certificates.yaml
-templates/cloudfront-app.yaml
-templates/cloudfront-app2.yaml
+; cloudfront-app.yaml + cloudfront-app2.yaml - stacks deleted 2026-07-02 (see s3-app-web note above)
+;templates/cloudfront-app.yaml
+;templates/cloudfront-app2.yaml
 templates/helm.yaml
 
 [landing-prod]

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -174,7 +174,7 @@ npm run lint      # TypeScript type check only
 
 ## AWS Deployment
 
-Deploy to S3 + CloudFront (`app.dev.lenie-ai.eu`). The script resolves S3 bucket and CloudFront distribution ID from SSM Parameter Store.
+**Hosting deleted 2026-07-02** — the `app.dev.lenie-ai.eu` S3+CloudFront stacks were removed (the frontend required the decommissioned AWS document API; it now runs only against Docker/NAS). `./deploy.sh` will fail until the stacks are restored — see [docs/aws-serverless-restoration.md](../docs/aws-serverless-restoration.md). Original flow (kept for restoration): the script resolves S3 bucket and CloudFront distribution ID from SSM Parameter Store.
 
 ```bash
 ./deploy.sh                      # Full build + deploy to S3 + CF invalidation


### PR DESCRIPTION
## Summary
Continuation of the serverless retirement (#180, #181).

**Deleted from AWS:**
- `lenie-dev-vpc` — empty CF-managed VPC (workloads had used the default VPC). Required peeling orphaned resources: 2 manual SGs, an unattached ENI, an orphaned route table, and a hidden **VPC peering** (CF VPC as accepter — invisible to requester-only filters)
- `lenie-dev-security-groups`, `lenie-dev-ec2-lenie` — orphaned
- `cloudfront-app` + `s3-app-web`, `cloudfront-app2` + `s3-app2-web` — hosted frontends required the decommissioned `app-server-db` API; Docker/NAS is the document UI

**Kept:** landing page (`www.lenie-ai.eu`), `api.dev.lenie-ai.eu` (Chrome extension `/url_add`), wildcard ACM cert (helm CDN).

## Verification
- [x] `/url_add` still routed + secured via custom domain after all deletions
- [x] `sqs-documents` confirmed CF-managed (`UPDATE_COMPLETE`)
- [x] Neither frontend ever wrote to DynamoDB (only Chrome extension via `/url_add`)
- [x] Buckets held only build artifacts (rebuilt by `npm run build`)
- [x] Pre-commit hooks passed