### PR TITLE
docs: fix WSL venv sync command and distro name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,17 +67,22 @@ make security-all   # Run all security checks (semgrep, pip-audit, bandit, safet
 
 ## WSL Linux Environment (`backend/.venv_wsl`)
 
-The developer works on Windows with a WSL (Fedora) environment for running Linux-specific scripts (imports, deploy scripts, shell scripts). A separate venv `.venv_wsl` exists in `backend/` for this purpose.
+The developer works on Windows with a WSL (Ubuntu 24.04) environment for running Linux-specific scripts (imports, deploy scripts, shell scripts). Two separate venvs exist in `backend/`:
+
+- **`.venv`** — Windows environment (default `uv sync` target when run from Windows)
+- **`.venv_wsl`** — Linux/WSL environment
 
 **When modifying Python dependencies** (adding/removing packages in `pyproject.toml`, adding path dependencies like `shared_python/`), you MUST also sync `.venv_wsl`:
 
 ```bash
-# Sync .venv_wsl after dependency changes
+# Sync .venv_wsl after dependency changes (path dep only)
 wsl bash -c "export PATH=\"\$HOME/.local/bin:\$PATH\" && cd /mnt/c/Users/ziutus/git/_lenie-all/lenie-server-2025/backend && uv pip install -e ../shared_python/unified-config-loader/ --python .venv_wsl/bin/python"
 
-# Or full sync (recreates from lock file)
-wsl bash -c "export PATH=\"\$HOME/.local/bin:\$PATH\" && cd /mnt/c/Users/ziutus/git/_lenie-all/lenie-server-2025/backend && uv sync --python .venv_wsl/bin/python --active"
+# Or full sync from lock file — UV_PROJECT_ENVIRONMENT is REQUIRED
+wsl bash -c "export PATH=\"\$HOME/.local/bin:\$PATH\" && cd /mnt/c/Users/ziutus/git/_lenie-all/lenie-server-2025/backend && UV_PROJECT_ENVIRONMENT=.venv_wsl uv sync"
 ```
+
+**WARNING**: Never run plain `uv sync` (or `uv sync --python .venv_wsl/bin/python --active`) from WSL — both target the default `.venv` and will overwrite the Windows environment with a Linux one (this happened 2026-07-03). `--python` selects the interpreter, not the target venv; `--active` needs `VIRTUAL_ENV` set. Only `UV_PROJECT_ENVIRONMENT=.venv_wsl` reliably targets `.venv_wsl`.
 
 **Checklist for dependency changes:**
 1. Update `pyproject.toml` and run `uv lock`

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -137,9 +137,14 @@ cd /mnt/c/Users/<user>/git/_lenie-all/lenie-server-2025/backend
 source .venv_wsl/bin/activate
 uv sync --active
 
+# Non-interactive variant (no activation needed, e.g. from scripts or Windows via `wsl bash -c`)
+UV_PROJECT_ENVIRONMENT=.venv_wsl uv sync
+
 # Or install a specific new path dependency
 uv pip install -e ../shared_python/unified-config-loader/ --python .venv_wsl/bin/python
 ```
+
+> **Warning:** Never run plain `uv sync` from WSL without activation or `UV_PROJECT_ENVIRONMENT` — it targets the default `.venv` and overwrites the Windows environment with a Linux one. Note that `uv sync --python .venv_wsl/bin/python` does NOT work either: for `uv sync`, `--python` selects the interpreter version, not the target venv (unlike `uv pip`, where `--python` does point at the venv).
 
 **When to sync:**
 - After running `uv lock` on Windows (changed `pyproject.toml`)


### PR DESCRIPTION
## Summary

- The full-sync command documented in CLAUDE.md (`uv sync --python .venv_wsl/bin/python --active`) does **not** target `.venv_wsl` — `--python` only selects the interpreter and `--active` needs `VIRTUAL_ENV` set. Run from WSL it silently overwrote the Windows `backend/.venv` with a Linux environment (2026-07-03). Replaced with `UV_PROJECT_ENVIRONMENT=.venv_wsl uv sync` (verified working) plus a warning in both CLAUDE.md and docs/development-guide.md.
- CLAUDE.md described the WSL distro as Fedora; it is Ubuntu 24.04 (Fedora removed 2026-06-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)