### PR TITLE
style: fix all ruff findings across backend

### DIFF
--- a/backend/email_import.py
+++ b/backend/email_import.py
@@ -318,7 +318,7 @@ def main():
     url = f"gmail://{msg_id}"
 
     # Print summary
-    print(f"\n--- Email Summary ---")
+    print("\n--- Email Summary ---")
     print(f"  Message ID: {msg_id}")
     print(f"  Subject:    {subject}")
     print(f"  From:       {from_header}")
@@ -327,7 +327,7 @@ def main():
     print(f"  Language:   {language}")
     print(f"  Text length: {len(text)} characters")
     print(f"  Source:     {args.source}")
-    print(f"---------------------")
+    print("---------------------")
 
     if args.dry_run:
         print("\n[DRY RUN] Would import this email. Text preview (first 500 chars):\n")

--- a/backend/library/api/arklabs/arklabs_completion.py
+++ b/backend/library/api/arklabs/arklabs_completion.py
@@ -92,7 +92,7 @@ def _completion_stateful(ai_response, prompt, model, max_tokens,
     try:
         response = session.post(url, json=payload, headers=headers, timeout=120)
         response.raise_for_status()
-    except (http_requests.exceptions.Timeout, http_requests.exceptions.HTTPError) as e:
+    except (http_requests.exceptions.Timeout, http_requests.exceptions.HTTPError):
         _reset_stateful_session()
         raise
     data = response.json()

--- a/backend/library/api/aws/s3_aws.py
+++ b/backend/library/api/aws/s3_aws.py
@@ -17,7 +17,7 @@ def s3_file_exist(s3_bucket: str, filename: str) -> bool:
         else:
             print("Unexpected error: ", e)
             raise Exception("An error occurred")
-    except NoCredentialsError as e:
+    except NoCredentialsError:
         print("S3 could not authenticate with AWS.")
         raise Exception("Authentication credentials were not provided.")
     except Exception as e:

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -509,7 +509,7 @@ def extract_article_by_markers(markdown_text: str, markers: dict, url: str = "")
         # Brak footera — użyj LLM markera
         logger.info(f"Article end: LLM line {end_line} (no footer marker found)")
     else:
-        logger.warning(f"Cannot find article end: no footer marker, no LLM marker")
+        logger.warning("Cannot find article end: no footer marker, no LLM marker")
         return None
 
     # Cofnij się przez puste linie na końcu
@@ -550,15 +550,15 @@ def generate_regex_draft(markdown_text: str, markers: dict, output_path: str) ->
 
     # Pobierz kontekst PRZED artykułem (5 linii) — to będzie "pre" pattern
     pre_start = max(0, start_line - 5)
-    pre_lines = [l for l in lines[pre_start:start_line] if l.strip()]
+    pre_lines = [ln for ln in lines[pre_start:start_line] if ln.strip()]
 
     # Pobierz kontekst PO artykule (5 linii) — to będzie "post" pattern
     post_end = min(len(lines), end_line + 6)
-    post_lines = [l for l in lines[end_line + 1:post_end] if l.strip()]
+    post_lines = [ln for ln in lines[end_line + 1:post_end] if ln.strip()]
 
     # Buduj regex
     draft_lines = []
-    draft_lines.append(f"# Auto-generated regex draft from LLM extraction")
+    draft_lines.append("# Auto-generated regex draft from LLM extraction")
     draft_lines.append(f"# Markers: title={markers.get('title', 'N/A')}")
     draft_lines.append(f"# Pre-article context (lines {pre_start+1}-{start_line}):")
 

--- a/backend/library/document_prepare.py
+++ b/backend/library/document_prepare.py
@@ -48,7 +48,7 @@ def prepare_markdown(document_id, doc, cache_dir, verbose: bool = False) -> str 
             return None
 
         s3_key = f"{doc.uuid}.html"
-        _log(f"[1/3] Sprawdzam HTML w S3...")
+        _log("[1/3] Sprawdzam HTML w S3...")
         if not s3_file_exist(s3_bucket, s3_key):
             _log("HTML nie znaleziony w S3")
             return None

--- a/backend/library/text_functions.py
+++ b/backend/library/text_functions.py
@@ -107,7 +107,7 @@ def split_text_into_chunks(text: str, max_chars: int) -> list[str]:
                 current_size = 0
             line_parts: list[str] = []
             line_size = 0
-            for line in [l.strip() for l in para.split('\n') if l.strip()]:
+            for line in [ln.strip() for ln in para.split('\n') if ln.strip()]:
                 if line_size + len(line) + 1 > max_chars and line_parts:
                     chunks.append('\n'.join(line_parts))
                     line_parts = [line]

--- a/backend/scripts/notion_changelog.py
+++ b/backend/scripts/notion_changelog.py
@@ -12,7 +12,6 @@ Usage:
 
 import argparse
 import io
-import logging
 import sys
 from datetime import datetime
 

--- a/backend/test_code/firecrawl.py
+++ b/backend/test_code/firecrawl.py
@@ -1,7 +1,4 @@
 from dotenv import load_dotenv
-import os
-from pprint import pprint
-from firecrawl import FirecrawlApp
 
 # dotenv.load_dotenv(".env", override=True)
 load_dotenv()

--- a/backend/test_code/gcloud_firestore.py
+++ b/backend/test_code/gcloud_firestore.py
@@ -41,13 +41,13 @@ def check_gcp_authentication(auto_login: bool = False) -> bool:
 
     try:
         credentials, project = default()
-        print(f"✅ Autoryzacja OK")
+        print("✅ Autoryzacja OK")
         print(f"   Project: {project or 'nie wykryto (użyje GCP_FIRESTORE_PROJECT_ID)'}")
         print(f"   Credentials type: {type(credentials).__name__}")
         print("="*70 + "\n")
         return True
     except DefaultCredentialsError as e:
-        print(f"❌ BRAK AUTORYZACJI!")
+        print("❌ BRAK AUTORYZACJI!")
         print(f"   Błąd: {str(e)}")
 
         if auto_login:
@@ -66,7 +66,7 @@ def check_gcp_authentication(auto_login: bool = False) -> bool:
             print("\n🔄 Sprawdzanie autoryzacji po logowaniu...")
             try:
                 credentials, project = default()
-                print(f"✅ Autoryzacja OK!")
+                print("✅ Autoryzacja OK!")
                 print(f"   Project: {project or 'nie wykryto (użyje GCP_FIRESTORE_PROJECT_ID)'}")
                 print(f"   Credentials type: {type(credentials).__name__}")
                 print("="*70 + "\n")
@@ -85,7 +85,7 @@ def check_gcp_authentication(auto_login: bool = False) -> bool:
             print("="*70 + "\n")
             return False
     except Exception as e:
-        print(f"⚠️  Nieoczekiwany błąd podczas sprawdzania autoryzacji:")
+        print("⚠️  Nieoczekiwany błąd podczas sprawdzania autoryzacji:")
         print(f"   {type(e).__name__}: {str(e)}")
         print("="*70 + "\n")
         return False
@@ -114,7 +114,7 @@ def auto_login_gcp() -> bool:
 
     for gcloud_cmd in gcloud_commands:
         try:
-            result = subprocess.run(  # nosec B603 — fixed gcloud command, list args, no shell
+            subprocess.run(  # nosec B603 — fixed gcloud command, list args, no shell
                 [gcloud_cmd, "auth", "application-default", "login"],
                 capture_output=False,
                 text=True,
@@ -308,7 +308,7 @@ def migrate_articles(table_name: str = 'lenie_dev_documents', timeout_seconds: i
 
         # Sprawdź czy dokument już istnieje
         doc_ref = db.collection('articles').document(document_id)
-        print(f"  → Sprawdzanie czy istnieje w Firestore (może trwać 5-30s)...")
+        print("  → Sprawdzanie czy istnieje w Firestore (może trwać 5-30s)...")
 
         try:
             check_start = time.time()
@@ -321,65 +321,65 @@ def migrate_articles(table_name: str = 'lenie_dev_documents', timeout_seconds: i
                 print(f"  ⚠️  UWAGA: Zapytanie trwało {check_time:.2f}s - połączenie może być wolne!")
 
             if doc_exists:
-                print(f"  ✓ Dokument już istnieje, pomijam")
+                print("  ✓ Dokument już istnieje, pomijam")
                 skipped_count += 1
                 continue
 
         except gcp_exceptions.DeadlineExceeded:
             print(f"  ❌ TIMEOUT po {timeout_seconds}s - pomijam dokument")
-            print(f"     Możliwe przyczyny: wolne połączenie, throttling, firewall")
+            print("     Możliwe przyczyny: wolne połączenie, throttling, firewall")
             skipped_count += 1
             continue
         except RetryError as e:
             # Sprawdź czy to błąd autoryzacji
             error_msg = str(e)
             if "Reauthentication is needed" in error_msg or "Getting metadata from plugin failed" in error_msg:
-                print(f"\n  ❌ BŁĄD AUTORYZACJI: Token wygasł podczas operacji")
-                print(f"     Próba automatycznego ponownego logowania...")
+                print("\n  ❌ BŁĄD AUTORYZACJI: Token wygasł podczas operacji")
+                print("     Próba automatycznego ponownego logowania...")
 
                 if not auto_login_gcp():
-                    print(f"\n     ❌ Nie udało się zalogować.")
-                    print(f"     📋 Spróbuj ręcznie: gcloud auth application-default login")
-                    print(f"     Przerywam migrację.")
+                    print("\n     ❌ Nie udało się zalogować.")
+                    print("     📋 Spróbuj ręcznie: gcloud auth application-default login")
+                    print("     Przerywam migrację.")
                     sys.exit(1)
 
-                print(f"\n     ✅ Zalogowano ponownie!")
-                print(f"     ℹ️  Dokumenty już zmigrowane zostaną pominięte.")
-                print(f"     🔄 Uruchom skrypt ponownie aby kontynuować migrację.")
-                print(f"\n     Przerywam migrację - uruchom skrypt ponownie.")
+                print("\n     ✅ Zalogowano ponownie!")
+                print("     ℹ️  Dokumenty już zmigrowane zostaną pominięte.")
+                print("     🔄 Uruchom skrypt ponownie aby kontynuować migrację.")
+                print("\n     Przerywam migrację - uruchom skrypt ponownie.")
                 sys.exit(0)
             else:
                 print(f"  ❌ BŁĄD RETRY: {error_msg}")
-                print(f"     Pomijam dokument")
+                print("     Pomijam dokument")
                 skipped_count += 1
                 continue
         except Exception as e:
             # Ogólne sprawdzenie autoryzacji w innych błędach
             error_msg = str(e)
             if "Reauthentication is needed" in error_msg or "Getting metadata from plugin failed" in error_msg:
-                print(f"\n  ❌ BŁĄD AUTORYZACJI: Token wygasł podczas operacji")
-                print(f"     Próba automatycznego ponownego logowania...")
+                print("\n  ❌ BŁĄD AUTORYZACJI: Token wygasł podczas operacji")
+                print("     Próba automatycznego ponownego logowania...")
 
                 if not auto_login_gcp():
-                    print(f"\n     ❌ Nie udało się zalogować.")
-                    print(f"     📋 Spróbuj ręcznie: gcloud auth application-default login")
-                    print(f"     Przerywam migrację.")
+                    print("\n     ❌ Nie udało się zalogować.")
+                    print("     📋 Spróbuj ręcznie: gcloud auth application-default login")
+                    print("     Przerywam migrację.")
                     sys.exit(1)
 
-                print(f"\n     ✅ Zalogowano ponownie!")
-                print(f"     ℹ️  Dokumenty już zmigrowane zostaną pominięte.")
-                print(f"     🔄 Uruchom skrypt ponownie aby kontynuować migrację.")
-                print(f"\n     Przerywam migrację - uruchom skrypt ponownie.")
+                print("\n     ✅ Zalogowano ponownie!")
+                print("     ℹ️  Dokumenty już zmigrowane zostaną pominięte.")
+                print("     🔄 Uruchom skrypt ponownie aby kontynuować migrację.")
+                print("\n     Przerywam migrację - uruchom skrypt ponownie.")
                 sys.exit(0)
             print(f"  ❌ BŁĄD: {type(e).__name__}: {str(e)}")
-            print(f"     Pomijam dokument")
+            print("     Pomijam dokument")
             skipped_count += 1
             continue
 
         # Konwertuj i dodaj do batch
-        print(f"  → Konwertowanie danych...")
+        print("  → Konwertowanie danych...")
         firestore_data = convert_dynamodb_to_firestore(item)
-        print(f"  → Dodawanie do batch...")
+        print("  → Dodawanie do batch...")
         batch.set(doc_ref, firestore_data)
         batch_count += 1
 
@@ -396,7 +396,7 @@ def migrate_articles(table_name: str = 'lenie_dev_documents', timeout_seconds: i
                 batch_count = 0
             except gcp_exceptions.DeadlineExceeded:
                 print(f"  ❌ TIMEOUT przy commit batch po {timeout_seconds * 2}s")
-                print(f"     Batch nie został zapisany - spróbuj ponownie lub zwiększ timeout")
+                print("     Batch nie został zapisany - spróbuj ponownie lub zwiększ timeout")
                 batch = db.batch()
                 batch_count = 0
             except Exception as e:
@@ -422,15 +422,15 @@ def migrate_articles(table_name: str = 'lenie_dev_documents', timeout_seconds: i
             print(f"❌ BŁĄD przy ostatnim commit: {type(e).__name__}: {str(e)}")
 
     total_time = time.time() - start_time
-    print(f"\n" + "="*70)
+    print("\n" + "="*70)
     print(f"✅ Migracja zakończona w {total_time:.2f}s ({total_time/60:.1f} min)")
-    print(f"="*70)
+    print("="*70)
     print(f"   Zmigrowano: {migrated_count} artykułów")
     print(f"   Pominięto: {skipped_count} artykułów")
     if migrated_count > 0:
         avg_time = total_time / (migrated_count + skipped_count)
         print(f"   Średni czas na dokument: {avg_time:.2f}s")
-    print(f"="*70)
+    print("="*70)
 
 
 def get_today_articles(db: Optional[firestore.Client] = None):
@@ -659,11 +659,11 @@ def migrate_uuid_to_storage_uuid(db: Optional[firestore.Client] = None, dry_run:
     if batch_count > 0 and not dry_run:
         batch.commit()
 
-    print(f"\n✅ Operacja zakończona!")
+    print("\n✅ Operacja zakończona!")
     print(f"   Sprawdzono: {total_count} artykułów")
     print(f"   {'Zostałoby zaktualizowanych' if dry_run else 'Zaktualizowano'}: {updated_count} artykułów")
     if dry_run:
-        print(f"\n⚠️  To był tryb TEST (dry_run=True). Aby faktycznie zmienić pola, uruchom z dry_run=False")
+        print("\n⚠️  To był tryb TEST (dry_run=True). Aby faktycznie zmienić pola, uruchom z dry_run=False")
 
     return updated_count
 
@@ -721,11 +721,11 @@ def clean_empty_fields(db: Optional[firestore.Client] = None, dry_run: bool = Tr
     if batch_count > 0 and not dry_run:
         batch.commit()
 
-    print(f"\n✅ Operacja zakończona!")
+    print("\n✅ Operacja zakończona!")
     print(f"   Sprawdzono: {total_count} artykułów")
     print(f"   {'Zostałoby zaktualizowanych' if dry_run else 'Zaktualizowano'}: {updated_count} artykułów")
     if dry_run:
-        print(f"\n⚠️  To był tryb TEST (dry_run=True). Aby faktycznie usunąć pola, uruchom z dry_run=False")
+        print("\n⚠️  To był tryb TEST (dry_run=True). Aby faktycznie usunąć pola, uruchom z dry_run=False")
 
     return updated_count
 

--- a/backend/test_code/google_calendar_to_obsidian.py
+++ b/backend/test_code/google_calendar_to_obsidian.py
@@ -18,14 +18,12 @@ Usage:
 Note:
     This script uses the reusable Google authentication module from backend/library/google_auth.py
 """
-import os
 import sys
 import argparse
 from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from library.google_auth import get_google_service

--- a/backend/test_code/obsidian_clean_jurnal.py
+++ b/backend/test_code/obsidian_clean_jurnal.py
@@ -329,9 +329,6 @@ def download_storytel_pages_with_playwright():
 
     print(f"\nFound {len(urls_found)} unique Storytel URLs")
 
-    # Initialize MarkItDown converter once before the loop
-    mdit = MarkItDown()
-
     # Use Playwright to download pages
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)

--- a/backend/test_code/ocr_mistral.py
+++ b/backend/test_code/ocr_mistral.py
@@ -186,7 +186,7 @@ def run_standard(args, pdf_files):
             print(f"BŁĄD: {e}")
             errors += 1
 
-    print(f"\n=== PODSUMOWANIE (standard) ===")
+    print("\n=== PODSUMOWANIE (standard) ===")
     print(f"Przetworzone: {processed}")
     print(f"Z cache:      {skipped}")
     print(f"Błędy:        {errors}")
@@ -285,8 +285,8 @@ def batch_submit(args, pdf_files):
     print(f"\n=== BATCH JOBS UTWORZONE: {len(all_jobs)} ===")
     for j in all_jobs:
         print(f"  Partia {j['batch_index']}: {j['job_id']} ({j['total_requests']} plików)")
-    print(f"\nSprawdź postęp:  python ocr_mistral.py --batch status")
-    print(f"Pobierz wyniki:  python ocr_mistral.py --batch download")
+    print("\nSprawdź postęp:  python ocr_mistral.py --batch status")
+    print("Pobierz wyniki:  python ocr_mistral.py --batch download")
 
     # Zapisz stan batch (obsługa wielu jobów)
     save_batch_state(args.output_dir, {
@@ -328,15 +328,15 @@ def batch_status(args):
             all_done = False
 
     if all_done:
-        print(f"\nWszystkie partie gotowe! Pobierz: python ocr_mistral.py --batch download")
+        print("\nWszystkie partie gotowe! Pobierz: python ocr_mistral.py --batch download")
     else:
-        print(f"\nCzekaj — przetwarzanie w toku...")
+        print("\nCzekaj — przetwarzanie w toku...")
 
 
 def _download_job_results(client, job, output_dir: Path, cache: dict) -> tuple[int, int]:
     """Pobierz wyniki jednego batch job. Zwraca (saved, errors)."""
     if not job.output_file:
-        print(f"  Brak pliku wyjściowego.")
+        print("  Brak pliku wyjściowego.")
         return 0, 0
 
     output = client.files.download(file_id=job.output_file)
@@ -430,7 +430,7 @@ def batch_download(args, pdf_files):
 
     save_cache(args.output_dir, cache)
 
-    print(f"\n=== PODSUMOWANIE (batch download) ===")
+    print("\n=== PODSUMOWANIE (batch download) ===")
     print(f"Zapisanych: {total_saved}")
     print(f"Błędów:     {total_errors}")
 
@@ -500,14 +500,14 @@ Przykłady:
         total_size = sum(f.stat().st_size for f in pdf_files)
         est_pages = len(pdf_files) * 2  # szacunek: ~2 strony/PDF
 
-        print(f"=== PLAN OCR ===")
+        print("=== PLAN OCR ===")
         print(f"Plików PDF:     {len(pdf_files)}")
         print(f"Rozmiar łączny: {total_size / 1024 / 1024:.1f} MB")
         print(f"Szac. stron:    ~{est_pages}")
         print(f"Z cache:        {cached}")
         print(f"Do przetworzenia: {len(pdf_files) - cached}")
-        print(f"")
-        print(f"Szacunkowy koszt:")
+        print("")
+        print("Szacunkowy koszt:")
         print(f"  Standard: ~${est_pages * 0.002:.2f} ($2/1000 stron)")
         print(f"  Batch:    ~${est_pages * 0.001:.2f} ($1/1000 stron)")
         print()


### PR DESCRIPTION
## Summary

Mechanical lint cleanup — `ruff check backend/` now passes with **zero errors** (was 66).

- Remove extraneous `f`-string prefixes (F541) — bulk of the findings
- Rename ambiguous variable `l` → `ln` (E741) in `article_extractor.py`, `text_functions.py`
- Drop unused assignments (F841) in `test_code/` scripts

## Verification
- `uvx ruff check backend/` — All checks passed
- `pytest tests/unit/ mcp_server/tests/unit/` — 756 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)