### PR TITLE
feat(imports): one-command YouTube pipeline — youtube_add.py --analyze

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -104,7 +104,7 @@ Standalone scripts for bulk document operations. Run manually, not part of the F
 | `webdocument_md_decode.py` | Markdown decoding, link extraction and correction, prepare content for embedding | **Yes** |
 | `webdocument_prepare_regexp_by_ai.py` | Generate site-specific regex patterns for article extraction using LLM | **Yes** |
 
-Ad-hoc single-item tools and bulk import scripts live in [`imports/`](imports/CLAUDE.md): `youtube_add.py`, `dynamodb_sync.py`, `feed_monitor.py`, `article_browser.py`, `freedom_house_import.py`, `control_questions.py`, `migrate_data_to_cache.py`.
+Ad-hoc single-item tools and bulk import scripts live in [`imports/`](imports/CLAUDE.md): `youtube_add.py`, `youtube_batch_analyze.py`, `dynamodb_sync.py`, `feed_monitor.py`, `article_browser.py`, `freedom_house_import.py`, `control_questions.py`, `migrate_data_to_cache.py`.
 
 ### Database connectivity requirement
 
@@ -163,7 +163,7 @@ Each subdirectory has its own `CLAUDE.md` with detailed documentation:
 |-----------|-----------|--------|
 | `library/` | [library/CLAUDE.md](library/CLAUDE.md) | Domain models, LLM abstraction, embedding generation, text processing, external API integrations |
 | `database/` | [database/CLAUDE.md](database/CLAUDE.md) | PostgreSQL schema, pgvector setup, `web_documents` and `websites_embeddings` tables, 15 processing states |
-| `imports/` | [imports/CLAUDE.md](imports/CLAUDE.md) | CLI tools & import scripts: `youtube_add.py`, `dynamodb_sync.py`, `feed_monitor.py`, `article_browser.py`, `freedom_house_import.py`, `control_questions.py` |
+| `imports/` | [imports/CLAUDE.md](imports/CLAUDE.md) | CLI tools & import scripts: `youtube_add.py`, `youtube_batch_analyze.py`, `dynamodb_sync.py`, `feed_monitor.py`, `article_browser.py`, `freedom_house_import.py`, `control_questions.py` |
 | `data/` | [data/CLAUDE.md](data/CLAUDE.md) | Site-specific cleanup rules (`site_rules.json`), regex patterns for Polish news portals |
 | `tests/` | [tests/CLAUDE.md](tests/CLAUDE.md) | Unit tests (41 files: ORM, services, Flask endpoints, batch/import scripts, article & markdown processing) and integration tests (6 files: REST API endpoints, FK constraints) |
 | `test_code/` | [test_code/CLAUDE.md](test_code/CLAUDE.md) | Experimental scripts: RAG pipeline, LLM provider testing, Bielik text processing, cloud migrations |

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -89,7 +89,9 @@ URL_ADDED → DOCUMENT_INTO_DATABASE → NEED_CLEAN_TEXT → NEED_CLEAN_MD → T
 Special states:
 - `NEED_TRANSCRIPTION` / `TRANSCRIPTION_IN_PROGRESS` / `TRANSCRIPTION_DONE` — for audio/video content
 - `NEED_MANUAL_REVIEW` — automatic text cleanup failed; needs manual removal of ads, comments, and spam
-- `ERROR` — processing failed (details in `document_state_error`)
+- `ERROR` / `TEMPORARY_ERROR` — processing failed (details in `document_state_error`)
+
+**Invariant — `document_state_error` must be reset on every successful transition.** The field only means something while the document is in an error state (`ERROR`/`TEMPORARY_ERROR`); once a retry succeeds and `document_state` moves on, any code that sets `document_state_error` on failure MUST also clear it (`StalkerDocumentStatusError.NONE.name`) on the corresponding success path in the same function. Otherwise the error becomes sticky forever — a later retry that succeeds leaves the stale value in place because nothing overwrites it. `WebDocument.validate()` in `db/models.py` follows this correctly (resets to `NONE` at the top before re-evaluating). `library/youtube_processing.py` did **not** follow it for `CAPTIONS_FETCH_ERROR`/transcription errors until this was fixed (2026-07-04) — a retry that fetched captions successfully left `CAPTIONS_FETCH_ERROR` from an earlier failed attempt in place indefinitely. When adding a new failure/retry branch to any pipeline step, always pair the error-setting line with a reset on the success path.
 
 ## Document Types
 

--- a/backend/imports/CLAUDE.md
+++ b/backend/imports/CLAUDE.md
@@ -14,7 +14,8 @@ imports/
 ├── feeds_state.yaml          # Per-feed last_checked state (gitignored, created at runtime)
 ├── freedom_house_import.py   # Query Freedom House country ratings via OWID API (no DB)
 ├── migrate_data_to_cache.py  # One-time migration: data/ files → CACHE_DIR convention
-└── youtube_add.py            # Ad-hoc: process a single YouTube video
+├── youtube_add.py            # Ad-hoc: process a single YouTube video (optionally + LLM analysis)
+└── youtube_batch_analyze.py  # Bielik LLM chunk analysis of an existing document (by ID)
 ```
 
 ## Scripts
@@ -157,14 +158,15 @@ python imports/article_browser.py --dump --id 8805
 
 ### `youtube_add.py`
 
-Ad-hoc CLI tool for processing a single YouTube video: adds it to the database, fetches metadata (title, language), downloads captions or transcription, and optionally generates an AI summary.
+Ad-hoc CLI tool for processing a single YouTube video: adds it to the database, fetches metadata (title, language), downloads captions or transcription, and optionally generates an AI summary and/or runs the full Bielik LLM chunk analysis (`--analyze`).
 
-**Data access: ORM (SQLAlchemy)** via `process_youtube_url()` from `library.youtube_processing`.
+**Data access: ORM (SQLAlchemy)** via `process_youtube_url()` from `library.youtube_processing`; with `--analyze` also `DocumentAnalysisService` from `library.document_analysis_service` + file exports from `library.analysis_exports`.
 
 **How it works:**
 1. Optionally authenticates Webshare proxy (checks bandwidth, disables if exhausted)
 2. Calls `process_youtube_url()` with the provided URL and options
 3. Prints a summary (ID, title, URL, language, state, text length, elapsed time)
+4. With `--analyze`: runs `DocumentAnalysisService.create_run()` on the new document and exports MD/JSON/debug/HTML files to `.claude/exports/`. If analysis fails, the document stays in the database and the script prints the `youtube_batch_analyze.py` command to retry.
 
 **Running:**
 ```bash
@@ -173,6 +175,8 @@ python imports/youtube_add.py <URL>
 python imports/youtube_add.py <URL> --language pl --note "..." --source own
 python imports/youtube_add.py <URL> --summary --force
 python imports/youtube_add.py <URL> --chapters-file chapters.txt -v
+python imports/youtube_add.py <URL> --analyze                              # full pipeline in one command
+python imports/youtube_add.py <URL> --analyze --speaker1 "..." --speaker2 "..."
 ```
 
 **Arguments:**
@@ -184,11 +188,44 @@ python imports/youtube_add.py <URL> --chapters-file chapters.txt -v
 - `--chapters-file PATH` — path to file with chapter list
 - `--summary` — generate AI summary after processing
 - `--force` — reprocess even if embeddings already exist
+- `--no-proxy` — disable Webshare proxy
+- `--analyze` — run Bielik LLM chunk analysis after processing (see [`youtube_batch_analyze.py`](#youtube_batch_analyzepy))
+- `--model NAME` — LLM model for `--analyze` (default: `Bielik-11B-v3.0-Instruct`)
+- `--speaker1 NAME` / `--speaker2 NAME` — `--analyze`: explicit speaker names (skips LLM speaker extraction)
+- `--no-synthesis` — `--analyze`: skip the final synthesis step
 - `-v`, `--verbose` — enable debug logging
 
 **Prerequisites:**
 - `.env` file with `POSTGRESQL_*` variables and LLM API keys
 - Optional: `WEBSHARE_API_KEY` for proxy support
+- For `--analyze`: `CLOUDFERRO_SHERLOCK_KEY` (Bielik)
+
+### `youtube_batch_analyze.py`
+
+Bielik LLM chunk analysis of an **existing** document (by `--doc_id`): chunk splitting, speaker extraction/labeling, two-pass rewrite + summarize, topic grouping, synthesis, DB persistence. Moved from `test_code/` — the pipeline lives in `library/document_analysis_service.py` + `library/chunk_llm_analysis.py` (shared with Flask `chunk_review_routes.py`); file exports in `library/analysis_exports.py`. For a brand-new video, use `youtube_add.py <URL> --analyze` instead.
+
+**Data access: ORM (SQLAlchemy)** via `DocumentAnalysisService.create_run()`; writes `document_analysis_runs` / `document_chunks` / `document_topic_sections` and exports MD/JSON/debug/HTML (with YouTube timestamp links) to `.claude/exports/`.
+
+**Running:**
+```bash
+cd backend
+python imports/youtube_batch_analyze.py --doc_id 9158
+python imports/youtube_batch_analyze.py --doc_id 9158 --dry_run          # chunk breakdown + cost estimate, no API calls
+python imports/youtube_batch_analyze.py --doc_id 9158 --no_synthesis
+python imports/youtube_batch_analyze.py --doc_id 9158 --speaker1 "..." --speaker2 "..."
+```
+
+**Arguments:**
+- `--doc_id N` — document ID in the database (required)
+- `--model NAME` — LLM model (default: `Bielik-11B-v3.0-Instruct`; also `arklabs/...` variant)
+- `--chunk_size N` — characters per chunk (default: 5000 ≈ 1500 tokens)
+- `--speaker1 NAME` / `--speaker2 NAME` — explicit speaker names (skips LLM speaker extraction)
+- `--no_synthesis` — skip the final synthesis step
+- `--dry_run` — preview chunk breakdown and cost estimate without calling the API
+
+**Prerequisites:**
+- `.env` with `POSTGRESQL_*` variables and `CLOUDFERRO_SHERLOCK_KEY`
+- Cost: ~0.05 EUR per 90K-char transcript at 0.56 EUR/M tokens
 
 ### `freedom_house_import.py`
 

--- a/backend/imports/youtube_add.py
+++ b/backend/imports/youtube_add.py
@@ -3,6 +3,12 @@
 
 Usage:
     python youtube_add.py <URL> [--language pl] [--note "..."] [--source own] [--chapters "..."] [--summary] [--force] [-v]
+    python youtube_add.py <URL> --analyze [--model ...] [--speaker1 "..." --speaker2 "..."] [--no-synthesis]
+
+With --analyze, after the video is added and transcribed, the Bielik LLM chunk
+analysis (library/document_analysis_service.py) runs on the new document and
+exports MD/JSON/debug/HTML files to .claude/exports/. To (re-)analyze an
+existing document by ID, use imports/youtube_batch_analyze.py instead.
 """
 
 import argparse
@@ -14,7 +20,13 @@ from library.config_loader import load_config
 
 cfg = load_config()  # noqa: F841 — side effect: populates os.environ for library modules
 
+from library.analysis_exports import export_analysis_run  # noqa: E402
 from library.db.engine import get_session  # noqa: E402
+from library.document_analysis_service import (  # noqa: E402
+    ANALYSIS_MODELS,
+    DEFAULT_ANALYSIS_MODEL,
+    DocumentAnalysisService,
+)
 from library.youtube_processing import process_youtube_url  # noqa: E402
 
 
@@ -31,6 +43,16 @@ def main():
     parser.add_argument("--summary", action="store_true", help="Generate AI summary")
     parser.add_argument("--force", action="store_true", help="Force reprocessing even if embeddings exist")
     parser.add_argument("--no-proxy", action="store_true", help="Disable Webshare proxy (useful when proxy gets 429 from YouTube)")
+    parser.add_argument("--analyze", action="store_true",
+                        help="Run Bielik LLM chunk analysis after processing "
+                             "(exports MD/JSON/debug/HTML to .claude/exports/)")
+    parser.add_argument("--model", default=DEFAULT_ANALYSIS_MODEL, choices=ANALYSIS_MODELS,
+                        help="LLM model for --analyze (default: %(default)s)")
+    parser.add_argument("--speaker1", default="",
+                        help="--analyze: name of first speaker (segments before first >>); "
+                             "with --speaker2 skips LLM speaker extraction")
+    parser.add_argument("--speaker2", default="", help="--analyze: name of second speaker")
+    parser.add_argument("--no-synthesis", action="store_true", help="--analyze: skip final synthesis step")
     parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
 
     args = parser.parse_args()
@@ -89,6 +111,36 @@ def main():
         doc_state = web_document.document_state
         doc_text_len = len(web_document.text) if web_document.text else 0
         doc_summary = web_document.summary
+
+        # Optional LLM chunk analysis on the freshly processed document
+        run_id = None
+        exports = None
+        analysis_error = None
+        if args.analyze:
+            if not web_document.text:
+                analysis_error = f"document has no transcript text (state: {doc_state})"
+            else:
+                speakers_override = None
+                if args.speaker1 and args.speaker2:
+                    speakers_override = [
+                        {"name": args.speaker1, "role": "prowadzący", "description": ""},
+                        {"name": args.speaker2, "role": "gość", "description": ""},
+                    ]
+                print(f"\n=== ANALIZA LLM → {args.model} (DocumentAnalysisService) ===\n")
+                try:
+                    service = DocumentAnalysisService(session)
+                    run = service.create_run(
+                        doc_id=doc_id,
+                        model=args.model,
+                        no_synthesis=args.no_synthesis,
+                        progress_fn=lambda msg: print(f"  {msg}", flush=True),
+                        speakers=speakers_override,
+                    )
+                    run_id = run.id
+                    exports = export_analysis_run(web_document, run, args.model)
+                except Exception as e:
+                    logging.error(f"LLM analysis failed: {e}")
+                    analysis_error = str(e)
     except Exception as e:
         logging.error(f"Error processing YouTube URL: {e}")
         sys.exit(1)
@@ -107,6 +159,21 @@ def main():
         print(f"  Summary:  {doc_summary[:200]}...")
     print(f"  Elapsed:  {elapsed:.2f}s")
     print("------------------------")
+
+    if args.analyze:
+        if analysis_error:
+            print(f"\nBŁĄD analizy LLM: {analysis_error}")
+            print("Dokument został dodany — analizę można powtórzyć:")
+            print(f"  python imports/youtube_batch_analyze.py --doc_id {doc_id}")
+            sys.exit(1)
+        print("\n--- Analiza LLM ---")
+        print(f"  Run ID:       {run_id}")
+        print(f"  Analiza (MD): {exports['md']}")
+        print(f"  Dane (JSON):  {exports['json']}")
+        print(f"  Debug (MD):   {exports['debug']}")
+        if exports["html"]:
+            print(f"  Widok HTML:   {exports['html']}")
+        print("-------------------")
 
 
 if __name__ == "__main__":

--- a/backend/imports/youtube_batch_analyze.py
+++ b/backend/imports/youtube_batch_analyze.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Batch analysis of long YouTube transcripts using Bielik LLM via CloudFerro Sherlock.
+
+The LLM pipeline (chunk splitting, speaker extraction/labeling, two-pass
+rewrite + summarize, topic grouping, synthesis, DB persistence) lives in
+library/document_analysis_service.py + library/chunk_llm_analysis.py and is
+shared with the Flask API (chunk_review_routes.py). File exports live in
+library/analysis_exports.py. This script is a thin CLI on top of them, adding:
+  - dry-run preview (chunk breakdown + cost estimate, no API calls)
+  - explicit --speaker1/--speaker2 override (skips LLM speaker extraction)
+
+For a brand-new video, use imports/youtube_add.py <URL> --analyze instead —
+it adds the document and runs this analysis in one go.
+
+Cost at 0.56 EUR/M tokens: ~0.05 EUR for a 90K-char transcript
+  (19 chunks × ~4,700 tok/chunk = 89K tokens).
+
+Usage (from backend/ directory):
+    # Windows PowerShell
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python imports/youtube_batch_analyze.py --doc_id 9158
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python imports/youtube_batch_analyze.py --doc_id 9158 --dry_run
+    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python imports/youtube_batch_analyze.py --doc_id 9158 --no_synthesis
+
+    # WSL / Linux (Bash)
+    PYTHONPATH=. .venv/bin/python imports/youtube_batch_analyze.py --doc_id 9158
+"""
+
+import argparse
+import re
+import sys
+
+from library.config_loader import load_config
+
+load_config()
+
+from library.analysis_exports import export_analysis_run  # noqa: E402
+from library.chunk_llm_analysis import assign_speakers, remove_speech_fillers  # noqa: E402
+from library.db.engine import get_session  # noqa: E402
+from library.db.models import WebDocument  # noqa: E402
+from library.document_analysis_service import (  # noqa: E402
+    ANALYSIS_MODELS,
+    CHUNK_CHARS,
+    DEFAULT_ANALYSIS_MODEL,
+    DocumentAnalysisService,
+    _extract_text,
+    _load_segments,
+)
+from library.text_functions import split_text_into_sentence_chunks  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="YouTube transcript: correct + segment + summarize (Bielik LLM)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--doc_id", type=int, required=True,
+                        help="Document ID in the database")
+    parser.add_argument("--model", default=DEFAULT_ANALYSIS_MODEL,
+                        choices=ANALYSIS_MODELS,
+                        help="Model to use")
+    parser.add_argument("--chunk_size", type=int, default=CHUNK_CHARS,
+                        help="Characters per chunk (≈1,500 tokens at default 5,000)")
+    parser.add_argument("--speaker1", default="",
+                        help="Name of first speaker (segments before first >>). "
+                             "If omitted, speakers are auto-extracted via LLM.")
+    parser.add_argument("--speaker2", default="",
+                        help="Name of second speaker (segments after first >>).")
+    parser.add_argument("--no_synthesis", action="store_true",
+                        help="Skip final synthesis step")
+    parser.add_argument("--dry_run", action="store_true",
+                        help="Show chunk breakdown without calling the API")
+    args = parser.parse_args()
+
+    print(f"Pobieranie dokumentu {args.doc_id}...")
+    session = get_session()
+    try:
+        doc = WebDocument.get_by_id(session, args.doc_id)
+        if doc is None:
+            print(f"BŁĄD: Dokument {args.doc_id} nie znaleziony.")
+            sys.exit(1)
+
+        print(f"Tytuł  : {doc.title}")
+        print(f"Typ    : {doc.document_type} | Stan: {doc.document_state}")
+        if doc.author:
+            print(f"Autor  : {doc.author}")
+
+        segments = _load_segments(getattr(doc, "text_raw", "") or "")
+        if segments:
+            print(f"Segm.  : {len(segments)} segmentów z timestampami w text_raw")
+        else:
+            print("Segm.  : brak JSON w text_raw — widok HTML bez linków YT")
+
+        text, text_field = _extract_text(doc)
+        if not text:
+            print("BŁĄD: Brak tekstu w polach text / text_raw / text_md.")
+            sys.exit(1)
+
+        speaker_changes = len(re.findall(r">>", text))
+        if speaker_changes:
+            print(f"Format : Rozmowa ({speaker_changes} zmian mówcy)")
+        else:
+            print("Format : Monolog (brak znaczników >>)")
+        print(f"Tekst  : pole '{text_field}', {len(text):,} znaków")
+
+        speakers_override = None
+        if args.speaker1 and args.speaker2:
+            speakers_override = [
+                {"name": args.speaker1, "role": "prowadzący", "description": ""},
+                {"name": args.speaker2, "role": "gość", "description": ""},
+            ]
+
+        if args.dry_run:
+            preview_text = text
+            if speaker_changes and speakers_override:
+                preview_text = assign_speakers(preview_text, args.speaker1, args.speaker2)
+            cleaned_text = remove_speech_fillers(preview_text)
+            chunks = split_text_into_sentence_chunks(cleaned_text, args.chunk_size)
+            est_tokens_total = len(chunks) * (args.chunk_size // 3 * 2)  # rough: in+out
+            est_cost = est_tokens_total / 1_000_000 * 0.56
+            print(f"\nPodział: {len(chunks)} fragmentów po max {args.chunk_size:,} znaków")
+            print(f"Szacowany koszt: ~{est_tokens_total:,} tokenów ≈ {est_cost:.3f} EUR\n")
+            for i, ch in enumerate(chunks):
+                print(f"  [{i + 1:>2}] {len(ch):>6,} znaków")
+            print("\n[dry_run] Tryb podglądu — API nie zostało wywołane.")
+            return
+
+        print(f"\n=== PRZETWARZANIE → {args.model} (DocumentAnalysisService) ===\n")
+        service = DocumentAnalysisService(session)
+        run = service.create_run(
+            doc_id=args.doc_id,
+            model=args.model,
+            chunk_size=args.chunk_size,
+            no_synthesis=args.no_synthesis,
+            progress_fn=lambda msg: print(f"  {msg}", flush=True),
+            speakers=speakers_override,
+        )
+
+        run_id = run.id
+        exports = export_analysis_run(doc, run, args.model)
+        print(f"\n{exports['toc']}\n")
+    finally:
+        session.close()
+
+    print(f"\n✓ Analiza (MD):  {exports['md']}")
+    print(f"✓ Dane (JSON):   {exports['json']}")
+    print(f"✓ Debug (MD):    {exports['debug']}")
+    if exports["html"]:
+        print(f"✓ Widok HTML:    {exports['html']}")
+    print(f"✓ DB Run ID:     {run_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -19,6 +19,9 @@ library/
 │   └── asemblyai/    # Speech-to-text transcription (sole provider, ADR-011)
 ├── ai.py             # LLM provider abstraction (routes to api/*)
 ├── embedding.py      # Embedding provider abstraction (routes to api/*)
+├── document_analysis_service.py  # Chunk analysis pipeline: split → LLM rewrite/summarize → topics → DB
+├── chunk_llm_analysis.py         # LLM chunk primitives: speaker extraction, rewrite, summarize
+├── analysis_exports.py           # Analysis run file exports (MD/JSON/debug/HTML) to .claude/exports/
 ├── article_extractor.py     # LLM-based article boundary extraction (Bielik markers + regex drafts)
 ├── article_pipeline.py      # Shared pipeline: step_1 raw markdown (cache/S3) + LLM article extraction
 ├── article_cleaner.py       # Portal artifact cleanup of extracted article markdown ([imgN]/[linkN] markers)

--- a/backend/library/ai.py
+++ b/backend/library/ai.py
@@ -24,37 +24,19 @@ def ai_model_need_translation_to_english(model: str) -> bool:
 def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: int = 4096, top_p: float = 0.9) \
         -> AiResponse:
 
-    if model in ["gpt-3.5-turbo", "gpt-3.5-turbo-16k"]:
+    openai_models = ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-mini"]
+
+    if model in openai_models:
         import library.api.openai.openai_my
-        if len(query) < 8000:
-            model = "gpt-3.5-turbo"
-        elif len(query) < 16000:
-            model = "gpt-3.5-turbo-16k"
-        else:
-            raise Exception("To long text for gpt-3.5 models")
-        ai_response = AiResponse(query=query, model=model)
-        ai_response.model = model
 
-        response = library.api.openai.openai_my.OpenAIClient.get_completion(query, model)
+        if model in ["gpt-3.5-turbo", "gpt-3.5-turbo-16k"]:
+            if len(query) < 8000:
+                model = "gpt-3.5-turbo"
+            elif len(query) < 16000:
+                model = "gpt-3.5-turbo-16k"
+            else:
+                raise Exception("Too long text for gpt-3.5 models")
 
-        if isinstance(response, bytes):
-            response = response.decode('utf-8')
-
-        ai_response.response_text = response
-        return ai_response
-    if model in ["gpt-4", "gpt-4o", "gpt-4o-2024-05-13"]:
-        import library.api.openai.openai_my
-        response = library.api.openai.openai_my.OpenAIClient.get_completion(query, model)
-        ai_response = AiResponse(query=query, model=model)
-
-        if isinstance(response, bytes):
-            response = response.decode('utf-8')
-
-        ai_response.response_text = response
-        return ai_response
-
-    elif model in ["gpt-4o-mini"]:
-        import library.api.openai.openai_my
         response = library.api.openai.openai_my.OpenAIClient.get_completion(query, model)
         ai_response = AiResponse(query=query, model=model)
 

--- a/backend/library/analysis_exports.py
+++ b/backend/library/analysis_exports.py
@@ -1,56 +1,30 @@
-#!/usr/bin/env python3
-"""
-Batch analysis of long YouTube transcripts using Bielik LLM via CloudFerro Sherlock.
+"""File exports for document analysis runs (MD / JSON / debug / HTML review view).
 
-The LLM pipeline (chunk splitting, speaker extraction/labeling, two-pass
-rewrite + summarize, topic grouping, synthesis, DB persistence) lives in
-library/document_analysis_service.py + library/chunk_llm_analysis.py and is
-shared with the Flask API (chunk_review_routes.py). This script is a thin CLI
-on top of it, adding:
-  - dry-run preview (chunk breakdown + cost estimate, no API calls)
-  - explicit --speaker1/--speaker2 override (skips LLM speaker extraction)
-  - file exports to .claude/exports/: analysis (MD), data (JSON), debug (MD),
-    review view (HTML with YouTube timestamp links)
-
-Cost at 0.56 EUR/M tokens: ~0.05 EUR for a 90K-char transcript
-  (19 chunks × ~4,700 tok/chunk = 89K tokens).
-
-Usage (from backend/ directory):
-    # Windows PowerShell
-    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158
-    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158 --dry_run
-    $env:PYTHONPATH="."; $env:PYTHONIOENCODING="utf-8"; .venv/Scripts/python test_code/youtube_batch_analyze.py --doc_id 9158 --no_synthesis
-
-    # WSL / Linux (Bash)
-    PYTHONPATH=. .venv/bin/python test_code/youtube_batch_analyze.py --doc_id 9158
+Shared by the CLI tools that run or re-render Bielik chunk analysis:
+imports/youtube_add.py (--analyze), imports/youtube_batch_analyze.py and
+test_code/_regen_html.py. All files are written to .claude/exports/ at the
+repository root.
 """
 
-import argparse
+import html as _html
+import json
 import os
 import re
-import sys
 from datetime import datetime
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from unified_config_loader import load_config
-from library.db.engine import get_session
-from library.db.models import WebDocument
-from library.chunk_llm_analysis import assign_speakers, remove_speech_fillers
 from library.document_analysis_service import (
-    CHUNK_CHARS,
-    DocumentAnalysisService,
     _extract_text,
     _load_segments,
     _map_chunks_to_segments,
 )
-from library.text_functions import split_text_into_sentence_chunks
 
 
-SHERLOCK_MODELS = ["Bielik-11B-v3.0-Instruct"]
-ARKLABS_PREFIX = "arklabs/"
-ARKLABS_MODELS = [f"{ARKLABS_PREFIX}Bielik-11B-v3.0-Instruct"]
-ALL_MODELS = SHERLOCK_MODELS + ARKLABS_MODELS
+def _exports_dir() -> str:
+    path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
+    )
+    os.makedirs(path, exist_ok=True)
+    return path
 
 
 def _seconds_to_ts(secs: float) -> str:
@@ -77,12 +51,7 @@ def save_html(doc_id: int, title: str, model: str,
               timestamp: str,
               fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
     """Generate HTML review table: per topic section, original transcript (with YT links) vs summary."""
-    import html as _html
-    exports_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
-    )
-    os.makedirs(exports_dir, exist_ok=True)
-    filename = os.path.join(exports_dir, f"youtube_view_{doc_id}_{timestamp}.html")
+    filename = os.path.join(_exports_dir(), f"youtube_view_{doc_id}_{timestamp}.html")
 
     chunk_seg_map = _map_chunks_to_segments([s["original"] for s in sections], segments)
 
@@ -241,11 +210,7 @@ td {{ vertical-align: top; padding: 9px 11px; border: 1px solid #ddd; }}
 def save_results(doc_id: int, title: str, model: str,
                  toc: str, topic_sections: list[dict], synthesis: str, timestamp: str,
                  fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
-    exports_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
-    )
-    os.makedirs(exports_dir, exist_ok=True)
-    filename = os.path.join(exports_dir, f"youtube_analysis_{doc_id}_{timestamp}.md")
+    filename = os.path.join(_exports_dir(), f"youtube_analysis_{doc_id}_{timestamp}.md")
 
     content_count = sum(1 for s in topic_sections if s["type"] == "TEMAT")
     ad_count = sum(1 for s in topic_sections if s["type"] == "REKLAMA")
@@ -303,13 +268,8 @@ def save_json(doc_id: int, title: str, model: str,
               synthesis: str, timestamp: str,
               fmt: dict | None = None, speaker_info: list[dict] | None = None) -> str:
     """Save full analysis as JSON for programmatic processing."""
-    exports_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
-    )
-    os.makedirs(exports_dir, exist_ok=True)
-    filename = os.path.join(exports_dir, f"youtube_analysis_{doc_id}_{timestamp}.json")
+    filename = os.path.join(_exports_dir(), f"youtube_analysis_{doc_id}_{timestamp}.json")
 
-    import json
     payload = {
         "meta": {
             "doc_id": doc_id,
@@ -356,11 +316,7 @@ def save_json(doc_id: int, title: str, model: str,
 
 def save_debug(doc_id: int, title: str, model: str, sections: list[dict], timestamp: str) -> str:
     """Save per-chunk debug file: original → rewritten → summary."""
-    exports_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", ".claude", "exports")
-    )
-    os.makedirs(exports_dir, exist_ok=True)
-    filename = os.path.join(exports_dir, f"youtube_debug_{doc_id}_{timestamp}.md")
+    filename = os.path.join(_exports_dir(), f"youtube_debug_{doc_id}_{timestamp}.md")
 
     ok = sum(1 for s in sections if s["ratio"] >= 80)
     short = sum(1 for s in sections if s["ratio"] < 80)
@@ -400,7 +356,7 @@ def save_debug(doc_id: int, title: str, model: str, sections: list[dict], timest
     return filename
 
 
-def _sections_from_run(run) -> tuple[list[dict], list[dict]]:
+def sections_from_run(run) -> tuple[list[dict], list[dict]]:
     """Rebuild the export data structures from a persisted DocumentAnalysisRun."""
     chunks_sorted = sorted(run.chunks, key=lambda c: c.position)
     sections = [
@@ -432,132 +388,43 @@ def _sections_from_run(run) -> tuple[list[dict], list[dict]]:
     return sections, topic_sections
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="YouTube transcript: correct + segment + summarize (Bielik LLM)",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+def export_analysis_run(doc, run, model: str) -> dict:
+    """Export a persisted DocumentAnalysisRun to all file formats.
+
+    Returns dict with keys: "md", "json", "debug", "html" (None when the
+    document has no timestamped transcript segments) and "toc" (markdown string).
+    """
+    sections, topic_sections = sections_from_run(run)
+    synthesis = run.synthesis or ""
+    speaker_info = run.speakers or []
+
+    text, _ = _extract_text(doc)
+    speaker_changes = len(re.findall(r">>", text))
+    fmt = {"is_multi_speaker": speaker_changes > 0, "speaker_changes": speaker_changes}
+
+    doc_id = doc.id
+    title = doc.title or ""
+    video_id = getattr(doc, "original_id", "") or ""
+    segments = _load_segments(getattr(doc, "text_raw", "") or "")
+
+    toc = build_toc(topic_sections)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    md_file = save_results(
+        doc_id, title, model, toc, topic_sections, synthesis, timestamp,
+        fmt=fmt, speaker_info=speaker_info,
     )
-    parser.add_argument("--doc_id", type=int, required=True,
-                        help="Document ID in the database")
-    parser.add_argument("--model", default="Bielik-11B-v3.0-Instruct",
-                        choices=ALL_MODELS,
-                        help="Model to use")
-    parser.add_argument("--chunk_size", type=int, default=CHUNK_CHARS,
-                        help="Characters per chunk (≈1,500 tokens at default 5,000)")
-    parser.add_argument("--speaker1", default="",
-                        help="Name of first speaker (segments before first >>). "
-                             "If omitted, speakers are auto-extracted via LLM.")
-    parser.add_argument("--speaker2", default="",
-                        help="Name of second speaker (segments after first >>).")
-    parser.add_argument("--no_synthesis", action="store_true",
-                        help="Skip final synthesis step")
-    parser.add_argument("--dry_run", action="store_true",
-                        help="Show chunk breakdown without calling the API")
-    args = parser.parse_args()
-
-    load_config()
-
-    print(f"Pobieranie dokumentu {args.doc_id}...")
-    session = get_session()
-    try:
-        doc = WebDocument.get_by_id(session, args.doc_id)
-        if doc is None:
-            print(f"BŁĄD: Dokument {args.doc_id} nie znaleziony.")
-            sys.exit(1)
-
-        print(f"Tytuł  : {doc.title}")
-        print(f"Typ    : {doc.document_type} | Stan: {doc.document_state}")
-        if doc.author:
-            print(f"Autor  : {doc.author}")
-
-        video_id = getattr(doc, "original_id", "") or ""
-        segments = _load_segments(getattr(doc, "text_raw", "") or "")
-        if segments:
-            print(f"Segm.  : {len(segments)} segmentów z timestampami w text_raw")
-        else:
-            print("Segm.  : brak JSON w text_raw — widok HTML bez linków YT")
-
-        text, text_field = _extract_text(doc)
-        if not text:
-            print("BŁĄD: Brak tekstu w polach text / text_raw / text_md.")
-            sys.exit(1)
-
-        speaker_changes = len(re.findall(r">>", text))
-        fmt = {"is_multi_speaker": speaker_changes > 0, "speaker_changes": speaker_changes}
-        if fmt["is_multi_speaker"]:
-            print(f"Format : Rozmowa ({speaker_changes} zmian mówcy)")
-        else:
-            print("Format : Monolog (brak znaczników >>)")
-        print(f"Tekst  : pole '{text_field}', {len(text):,} znaków")
-
-        speakers_override = None
-        if args.speaker1 and args.speaker2:
-            speakers_override = [
-                {"name": args.speaker1, "role": "prowadzący", "description": ""},
-                {"name": args.speaker2, "role": "gość", "description": ""},
-            ]
-
-        if args.dry_run:
-            preview_text = text
-            if fmt["is_multi_speaker"] and speakers_override:
-                preview_text = assign_speakers(preview_text, args.speaker1, args.speaker2)
-            cleaned_text = remove_speech_fillers(preview_text)
-            chunks = split_text_into_sentence_chunks(cleaned_text, args.chunk_size)
-            est_tokens_total = len(chunks) * (args.chunk_size // 3 * 2)  # rough: in+out
-            est_cost = est_tokens_total / 1_000_000 * 0.56
-            print(f"\nPodział: {len(chunks)} fragmentów po max {args.chunk_size:,} znaków")
-            print(f"Szacowany koszt: ~{est_tokens_total:,} tokenów ≈ {est_cost:.3f} EUR\n")
-            for i, ch in enumerate(chunks):
-                print(f"  [{i + 1:>2}] {len(ch):>6,} znaków")
-            print("\n[dry_run] Tryb podglądu — API nie zostało wywołane.")
-            return
-
-        print(f"\n=== PRZETWARZANIE → {args.model} (DocumentAnalysisService) ===\n")
-        service = DocumentAnalysisService(session)
-        run = service.create_run(
-            doc_id=args.doc_id,
-            model=args.model,
-            chunk_size=args.chunk_size,
-            no_synthesis=args.no_synthesis,
-            progress_fn=lambda msg: print(f"  {msg}", flush=True),
-            speakers=speakers_override,
+    json_file = save_json(
+        doc_id, title, model, sections, topic_sections, synthesis, timestamp,
+        fmt=fmt, speaker_info=speaker_info,
+    )
+    debug_file = save_debug(doc_id, title, model, sections, timestamp)
+    html_file = None
+    if segments:
+        html_file = save_html(
+            doc_id, title, model,
+            topic_sections, sections, segments, video_id,
+            timestamp, fmt=fmt, speaker_info=speaker_info,
         )
 
-        sections, topic_sections = _sections_from_run(run)
-        synthesis = run.synthesis or ""
-        speaker_info = run.speakers or []
-        run_id = run.id
-
-        toc = build_toc(topic_sections)
-        print(f"\n{toc}\n")
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_file = save_results(
-            args.doc_id, doc.title or "", args.model, toc, topic_sections, synthesis, timestamp,
-            fmt=fmt, speaker_info=speaker_info,
-        )
-        json_file = save_json(
-            args.doc_id, doc.title or "", args.model, sections, topic_sections, synthesis, timestamp,
-            fmt=fmt, speaker_info=speaker_info,
-        )
-        debug_file = save_debug(args.doc_id, doc.title or "", args.model, sections, timestamp)
-        html_file = None
-        if segments:
-            html_file = save_html(
-                args.doc_id, doc.title or "", args.model,
-                topic_sections, sections, segments, video_id,
-                timestamp, fmt=fmt, speaker_info=speaker_info,
-            )
-    finally:
-        session.close()
-
-    print(f"\n✓ Analiza (MD):  {output_file}")
-    print(f"✓ Dane (JSON):   {json_file}")
-    print(f"✓ Debug (MD):    {debug_file}")
-    if html_file:
-        print(f"✓ Widok HTML:    {html_file}")
-    print(f"✓ DB Run ID:     {run_id}")
-
-
-if __name__ == "__main__":
-    main()
+    return {"md": md_file, "json": json_file, "debug": debug_file, "html": html_file, "toc": toc}

--- a/backend/library/api/openai/openai_my.py
+++ b/backend/library/api/openai/openai_my.py
@@ -1,5 +1,6 @@
 import os
 import json
+from typing import Optional
 
 from openai import OpenAI
 # from langfuse.decorators import observe
@@ -11,10 +12,33 @@ class OpenAIClient:
     Provides a method to obtain completions.
     """
 
+    @staticmethod
+    def _call_chat(content, model: str, max_tokens: Optional[int] = None) -> str:
+        """
+        Common helper for calling OpenAI Chat Completions API.
+
+        :param content: Content for the user message (str or list of content parts).
+        :param model: OpenAI model to use.
+        :param max_tokens: Optional max tokens for the response.
+        :return: Raw response content string.
+        """
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+        kwargs = {
+            "model": model,
+            "messages": [{"role": "user", "content": content}],
+        }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        try:
+            response = client.chat.completions.create(**kwargs)
+            return response.choices[0].message.content
+        except Exception as e:
+            raise Exception(f"An error occurred: {e}")
+
     # @observe()
     @staticmethod
-    # model="gpt-4"
-    # model="gpt-3.5-turbo"
     def get_completion(prompt: str, model: str = "gpt-4") -> str:
         """
         Get a completion response from OpenAI for a given prompt.
@@ -23,68 +47,26 @@ class OpenAIClient:
         :param model: OpenAI model to use.
         :return: Completion response or None if request fails.
         """
-
-        messages = [{"role": "user", "content": prompt}]
-        try:
-
-            client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
-            chat_completion = client.chat.completions.create(
-                messages=messages,
-                model=model,
-            )
-            return chat_completion.choices[0].message.content
-
-        except Exception as e:
-            raise Exception(f"An error occurred: {e}")
+        return OpenAIClient._call_chat(prompt, model=model)
 
     # @observe()
+    @staticmethod
     def get_completion2(prompt: str, model: str = "gpt-4o-mini") -> str:
-        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
-        response = client.chat.completions.create(
-            model=model,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": prompt},
-
-                    ],
-                }
-            ],
-            max_tokens=1000,
-        )
-
-        return json.loads(response.choices[0].message.content)
+        result = OpenAIClient._call_chat(prompt, model=model, max_tokens=1000)
+        return json.loads(result)
 
     # @observe()
-    def get_completion_image(prompt: str, image_urls=[], detail: str = "auto", model: str = "gpt-4o-mini",
+    @staticmethod
+    def get_completion_image(prompt: str, image_urls=None, detail: str = "auto", model: str = "gpt-4o-mini",
                              max_tokens=300) -> str:
-        client = OpenAI()
+        if image_urls is None:
+            image_urls = []
 
         content = [{"type": "text", "text": prompt}]
-
         for image in image_urls:
-            content.append(
-                {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": image,
-                        "detail": detail
-                    }
-                }
-            )
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": image, "detail": detail},
+            })
 
-        response = client.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=[
-                {
-                    "role": "user",
-                    "content": content,
-                }
-            ],
-            max_tokens=max_tokens,
-        )
-
-        return response.choices[0].message.content
+        return OpenAIClient._call_chat(content, model=model, max_tokens=max_tokens)

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -1,6 +1,7 @@
 """LLM-based chunk analysis: rewrite (transcript correction) + summarize.
 
-Extracted from test_code/youtube_batch_analyze.py for use by Flask API endpoints.
+Extracted from the YouTube batch analysis CLI (now imports/youtube_batch_analyze.py)
+for use by Flask API endpoints.
 Supports Sherlock (Bielik) and ArkLabs models.
 """
 
@@ -32,7 +33,6 @@ def extract_speaker_info(intro_text: str, model: str) -> list[dict]:
 
     Returns list of dicts: [{"name": "...", "role": "...", "description": "..."}]
     Returns [] if extraction fails or no speakers found.
-    Ported from test_code/youtube_batch_analyze.py.
     """
     prompt = f"""Z poniższego fragmentu transkrypcji podcastu wyekstrahuj informacje o rozmówcach.
 Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:
@@ -63,7 +63,6 @@ def assign_speakers(text: str, speaker1: str, speaker2: str) -> str:
     YouTube inserts >> when it detects a speaker change. The first segment belongs to
     speaker1 (the host / first voice), then speakers alternate.
     Short segments (< 10 chars) that are just acknowledgments are still labeled.
-    Ported from test_code/youtube_batch_analyze.py.
     """
     segments = re.split(r"\s*>>\s*", text)
     speakers = [speaker1, speaker2]

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -38,6 +38,63 @@ from library.models.stalker_document_type import StalkerDocumentType
 logger = logging.getLogger(__name__)
 
 
+DOCUMENT_TYPE_LOOKUP = {
+    "movie": StalkerDocumentType.movie.name,
+    "youtube": StalkerDocumentType.youtube.name,
+    "link": StalkerDocumentType.link.name,
+    "webpage": StalkerDocumentType.webpage.name,
+    "website": StalkerDocumentType.webpage.name,
+    "sms": StalkerDocumentType.text_message.name,
+    "text_message": StalkerDocumentType.text_message.name,
+    "text": StalkerDocumentType.text.name,
+    "social_media_post": StalkerDocumentType.social_media_post.name,
+    "social": StalkerDocumentType.social_media_post.name,
+}
+
+DOCUMENT_STATE_LOOKUP = {
+    "ERROR_DOWNLOAD": StalkerDocumentStatus.ERROR.name,
+    "ERROR": StalkerDocumentStatus.ERROR.name,
+    "URL_ADDED": StalkerDocumentStatus.URL_ADDED.name,
+    "NEED_TRANSCRIPTION": StalkerDocumentStatus.NEED_TRANSCRIPTION.name,
+    "TRANSCRIPTION_DONE": StalkerDocumentStatus.TRANSCRIPTION_DONE.name,
+    "TRANSCRIPTION_IN_PROGRESS": StalkerDocumentStatus.TRANSCRIPTION_IN_PROGRESS.name,
+    "NEED_MANUAL_REVIEW": StalkerDocumentStatus.NEED_MANUAL_REVIEW.name,
+    "READY_FOR_TRANSLATION": StalkerDocumentStatus.READY_FOR_TRANSLATION.name,
+    "READY_FOR_EMBEDDING": StalkerDocumentStatus.READY_FOR_EMBEDDING.name,
+    "EMBEDDING_EXIST": StalkerDocumentStatus.EMBEDDING_EXIST.name,
+    "DOCUMENT_INTO_DATABASE": StalkerDocumentStatus.DOCUMENT_INTO_DATABASE.name,
+    "NEED_CLEAN_TEXT": StalkerDocumentStatus.NEED_CLEAN_TEXT.name,
+    "NEED_CLEAN_MD": StalkerDocumentStatus.NEED_CLEAN_MD.name,
+    "TEXT_TO_MD_DONE": StalkerDocumentStatus.NEED_CLEAN_MD.name,
+    "MD_SIMPLIFIED": StalkerDocumentStatus.MD_SIMPLIFIED.name,
+    "TRANSCRIPTION_DONE_AND_SPLIT_BY_CHAPTERS": StalkerDocumentStatus.TRANSCRIPTION_DONE_AND_SPLIT_BY_CHAPTERS.name,
+    "TEMPORARY_ERROR": StalkerDocumentStatus.TEMPORARY_ERROR.name,
+}
+
+DOCUMENT_STATE_ERROR_LOOKUP = {
+    None: StalkerDocumentStatusError.NONE.name,
+    "NONE": StalkerDocumentStatusError.NONE.name,
+    "ERROR_DOWNLOAD": StalkerDocumentStatusError.ERROR_DOWNLOAD.name,
+    "LINK_SUMMARY_MISSING": StalkerDocumentStatusError.LINK_SUMMARY_MISSING.name,
+    "TITLE_MISSING": StalkerDocumentStatusError.TITLE_MISSING.name,
+    "TEXT_MISSING": StalkerDocumentStatusError.TEXT_MISSING.name,
+    "TEXT_TRANSLATION_ERROR": StalkerDocumentStatusError.TEXT_TRANSLATION_ERROR.name,
+    "TITLE_TRANSLATION_ERROR": StalkerDocumentStatusError.TITLE_TRANSLATION_ERROR.name,
+    "SUMMARY_TRANSLATION_ERROR": StalkerDocumentStatusError.SUMMARY_TRANSLATION_ERROR.name,
+    "NO_URL_ERROR": StalkerDocumentStatusError.NO_URL_ERROR.name,
+    "EMBEDDING_ERROR": StalkerDocumentStatusError.EMBEDDING_ERROR.name,
+    "MISSING_TRANSLATION": StalkerDocumentStatusError.MISSING_TRANSLATION.name,
+    "TRANSLATION_ERROR": StalkerDocumentStatusError.TRANSLATION_ERROR.name,
+    "REGEX_ERROR": StalkerDocumentStatusError.REGEX_ERROR.name,
+    "TEXT_TO_MD_ERROR": StalkerDocumentStatusError.TEXT_TO_MD_ERROR.name,
+    "NO_CAPTIONS_AVAILABLE": StalkerDocumentStatusError.NO_CAPTIONS_AVAILABLE.name,
+    "CAPTIONS_LANGUAGE_MISMATCH": StalkerDocumentStatusError.CAPTIONS_LANGUAGE_MISMATCH.name,
+    "CAPTIONS_FETCH_ERROR": StalkerDocumentStatusError.CAPTIONS_FETCH_ERROR.name,
+    "TRANSCRIPTION_ERROR": StalkerDocumentStatusError.TRANSCRIPTION_ERROR.name,
+    "TRANSCRIPTION_INSUFFICIENT_FUNDS": StalkerDocumentStatusError.TRANSCRIPTION_INSUFFICIENT_FUNDS.name,
+}
+
+
 # ---------------------------------------------------------------------------
 # Lookup tables (B-94/B-95 — DDL, B-96 — ORM models)
 # ---------------------------------------------------------------------------
@@ -228,104 +285,26 @@ class WebDocument(Base):
     # --- Domain methods (migrated from stalker_web_document.py) ---
 
     def set_document_type(self, document_type: str) -> None:
-        if document_type == "movie":
-            self.document_type = StalkerDocumentType.movie.name
-        elif document_type == "youtube":
-            self.document_type = StalkerDocumentType.youtube.name
-        elif document_type == "link":
-            self.document_type = StalkerDocumentType.link.name
-        elif document_type in ["webpage", "website"]:
-            self.document_type = StalkerDocumentType.webpage.name
-        elif document_type in ["sms", "text_message"]:
-            self.document_type = StalkerDocumentType.text_message.name
-        elif document_type in ["text"]:
-            self.document_type = StalkerDocumentType.text.name
-        elif document_type in ["social_media_post", "social"]:
-            self.document_type = StalkerDocumentType.social_media_post.name
-        else:
+        mapped_type = DOCUMENT_TYPE_LOOKUP.get(document_type)
+        if mapped_type is None:
             raise ValueError(
                 f"document_type must be one of 'movie', 'webpage', 'text_message', 'text', 'link', 'social_media_post' not >{document_type}<"
             )
+        self.document_type = mapped_type
 
     def set_document_state(self, document_state: str) -> None:
-        if document_state in ["ERROR_DOWNLOAD", "ERROR"]:
-            self.document_state = StalkerDocumentStatus.ERROR.name
-        elif document_state == "URL_ADDED":
-            self.document_state = StalkerDocumentStatus.URL_ADDED.name
-        elif document_state == "NEED_TRANSCRIPTION":
-            self.document_state = StalkerDocumentStatus.NEED_TRANSCRIPTION.name
-        elif document_state == "TRANSCRIPTION_DONE":
-            self.document_state = StalkerDocumentStatus.TRANSCRIPTION_DONE.name
-        elif document_state == "TRANSCRIPTION_IN_PROGRESS":
-            self.document_state = StalkerDocumentStatus.TRANSCRIPTION_IN_PROGRESS.name
-        elif document_state == "NEED_MANUAL_REVIEW":
-            self.document_state = StalkerDocumentStatus.NEED_MANUAL_REVIEW.name
-        elif document_state == "READY_FOR_TRANSLATION":
-            self.document_state = StalkerDocumentStatus.READY_FOR_TRANSLATION.name
-        elif document_state == "READY_FOR_EMBEDDING":
-            self.document_state = StalkerDocumentStatus.READY_FOR_EMBEDDING.name
-        elif document_state == "EMBEDDING_EXIST":
-            self.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
-        elif document_state == "DOCUMENT_INTO_DATABASE":
-            self.document_state = StalkerDocumentStatus.DOCUMENT_INTO_DATABASE.name
-        elif document_state == "NEED_CLEAN_TEXT":
-            self.document_state = StalkerDocumentStatus.NEED_CLEAN_TEXT.name
-        elif document_state == "NEED_CLEAN_MD":
-            self.document_state = StalkerDocumentStatus.NEED_CLEAN_MD.name
-        elif document_state == "TEXT_TO_MD_DONE":
-            self.document_state = StalkerDocumentStatus.NEED_CLEAN_MD.name
-        elif document_state == "MD_SIMPLIFIED":
-            self.document_state = StalkerDocumentStatus.MD_SIMPLIFIED.name
-        elif document_state == "TRANSCRIPTION_DONE_AND_SPLIT_BY_CHAPTERS":
-            self.document_state = StalkerDocumentStatus.TRANSCRIPTION_DONE_AND_SPLIT_BY_CHAPTERS.name
-        elif document_state == "TEMPORARY_ERROR":
-            self.document_state = StalkerDocumentStatus.TEMPORARY_ERROR.name
-        else:
+        mapped_state = DOCUMENT_STATE_LOOKUP.get(document_state)
+        if mapped_state is None:
             raise ValueError("document_state must be one of the valid StalkerDocumentStatus values")
+        self.document_state = mapped_state
 
     def set_document_state_error(self, document_state_error: str | None) -> None:
-        if document_state_error is None or document_state_error == "NONE":
-            self.document_state_error = StalkerDocumentStatusError.NONE.name
-        elif document_state_error == "ERROR_DOWNLOAD":
-            self.document_state_error = StalkerDocumentStatusError.ERROR_DOWNLOAD.name
-        elif document_state_error == "LINK_SUMMARY_MISSING":
-            self.document_state_error = StalkerDocumentStatusError.LINK_SUMMARY_MISSING.name
-        elif document_state_error == "TITLE_MISSING":
-            self.document_state_error = StalkerDocumentStatusError.TITLE_MISSING.name
-        elif document_state_error == "TEXT_MISSING":
-            self.document_state_error = StalkerDocumentStatusError.TEXT_MISSING.name
-        elif document_state_error == "TEXT_TRANSLATION_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.TEXT_TRANSLATION_ERROR.name
-        elif document_state_error == "TITLE_TRANSLATION_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.TITLE_TRANSLATION_ERROR.name
-        elif document_state_error == "SUMMARY_TRANSLATION_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.SUMMARY_TRANSLATION_ERROR.name
-        elif document_state_error == "NO_URL_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.NO_URL_ERROR.name
-        elif document_state_error == "EMBEDDING_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.EMBEDDING_ERROR.name
-        elif document_state_error == "MISSING_TRANSLATION":
-            self.document_state_error = StalkerDocumentStatusError.MISSING_TRANSLATION.name
-        elif document_state_error == "TRANSLATION_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.TRANSLATION_ERROR.name
-        elif document_state_error == "REGEX_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.REGEX_ERROR.name
-        elif document_state_error == "TEXT_TO_MD_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.TEXT_TO_MD_ERROR.name
-        elif document_state_error == "NO_CAPTIONS_AVAILABLE":
-            self.document_state_error = StalkerDocumentStatusError.NO_CAPTIONS_AVAILABLE.name
-        elif document_state_error == "CAPTIONS_LANGUAGE_MISMATCH":
-            self.document_state_error = StalkerDocumentStatusError.CAPTIONS_LANGUAGE_MISMATCH.name
-        elif document_state_error == "CAPTIONS_FETCH_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.CAPTIONS_FETCH_ERROR.name
-        elif document_state_error == "TRANSCRIPTION_ERROR":
-            self.document_state_error = StalkerDocumentStatusError.TRANSCRIPTION_ERROR.name
-        elif document_state_error == "TRANSCRIPTION_INSUFFICIENT_FUNDS":
-            self.document_state_error = StalkerDocumentStatusError.TRANSCRIPTION_INSUFFICIENT_FUNDS.name
-        else:
+        mapped_state_error = DOCUMENT_STATE_ERROR_LOOKUP.get(document_state_error)
+        if mapped_state_error is None:
             raise ValueError(
                 f"document_state_error must be one of the valid StalkerDocumentStatusError values, not >{document_state_error}<"
             )
+        self.document_state_error = mapped_state_error
 
     def analyze(self) -> None:
         if self.document_state == StalkerDocumentStatus.EMBEDDING_EXIST.name:

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -4,9 +4,10 @@ Full pipeline:
   text extraction → speech filler removal → chunk splitting → LLM analysis
   → topic grouping → optional synthesis → DB persistence
 
-Designed to be called from Flask endpoints (via REST API) and batch scripts.
-The batch script (test_code/youtube_batch_analyze.py) keeps its own HTML/JSON/MD
-export logic; this service handles only DB-backed pipeline execution.
+Designed to be called from Flask endpoints (via REST API) and CLI scripts
+(imports/youtube_batch_analyze.py, imports/youtube_add.py --analyze). File
+exports (HTML/JSON/MD) live in library/analysis_exports.py; this service
+handles only DB-backed pipeline execution.
 """
 
 import json
@@ -21,6 +22,8 @@ from library.db.models import (
 logger = logging.getLogger(__name__)
 
 CHUNK_CHARS = 5_000
+DEFAULT_ANALYSIS_MODEL = "Bielik-11B-v3.0-Instruct"
+ANALYSIS_MODELS = [DEFAULT_ANALYSIS_MODEL, f"arklabs/{DEFAULT_ANALYSIS_MODEL}"]
 SYNTHESIS_MAX_TOKENS = 2_000
 SYNTHESIS_MAX_INPUT_CHARS = 20_000
 _SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT): ?(.+)$', re.MULTILINE)

--- a/backend/library/text_transcript.py
+++ b/backend/library/text_transcript.py
@@ -1,3 +1,4 @@
+import bisect
 import json
 import re
 
@@ -62,6 +63,15 @@ def chapters_text_to_list(chapters_string):
     return chapters
 
 
+def _chapter_index(chapter_starts: list[int], seconds: float, current: int) -> int:
+    """Index of the chapter the timestamp falls into (-1 = before the first chapter).
+
+    Never moves backwards — transcripts are processed sequentially and a stray
+    out-of-order timestamp must not reopen an earlier chapter.
+    """
+    return max(bisect.bisect_right(chapter_starts, seconds) - 1, current)
+
+
 def text_split_with_chapters(transcript_string: str | None, chapters_string: str | None = None) -> str | None:
     if transcript_string is None:
         return None
@@ -69,25 +79,34 @@ def text_split_with_chapters(transcript_string: str | None, chapters_string: str
         return transcript_string
 
     chapters = chapters_text_to_list(chapters_string)
+    if not chapters:
+        return transcript_string
 
     json_data = json.loads(transcript_string)
 
-    chapter_nb = 0
-    string_all = chapters[chapter_nb]['title'] + "\n"
+    chapter_starts = [time_to_seconds(ch['start']) for ch in chapters]
+    chapter_nb = -1  # -1 = intro before the first chapter
+    string_all = ""
+    after_header = False
     for transcript in json_data['results']["items"]:
+        content = transcript['alternatives'][0]['content']
 
         if 'start_time' in transcript:
-            chapter_start = time_to_seconds(chapters[chapter_nb]['start'])
-            chapter_end = time_to_seconds(chapters[chapter_nb]['end'])
-            transcript_start_time = float(transcript['start_time'])
-
-            if chapter_start <= transcript_start_time <= chapter_end:
-                string_all += " " + transcript['alternatives'][0]['content']
-            else:
+            target = _chapter_index(chapter_starts, float(transcript['start_time']), chapter_nb)
+            while chapter_nb < target:
                 chapter_nb += 1
-                string_all += "\n\n" + chapters[chapter_nb]['title'] + "\n" + transcript['alternatives'][0]['content']
+                string_all += ("\n\n" if string_all else "") + chapters[chapter_nb]['title'] + "\n"
+                after_header = True
+            if after_header:
+                string_all += content
+                after_header = False
+            elif string_all:
+                string_all += " " + content
+            else:
+                string_all += content
         else:
-            string_all += transcript['alternatives'][0]['content']
+            # No timestamp (e.g. punctuation) — attach directly, no separator
+            string_all += content
 
     return string_all
 
@@ -104,22 +123,28 @@ def youtube_titles_to_text(titles_text: str | None = None) -> str | None:
 def youtube_titles_split_with_chapters(titles_text: str | None = None, chapter_list_text: str | None = None) -> str | None:
     transcript = json.loads(titles_text)
     chapters = chapters_text_to_list(chapter_list_text)
+    if not chapters:
+        return youtube_titles_to_text(titles_text)
 
-    chapter_nb = 0
-    string_all = chapters[chapter_nb]['title'] + "\n"
+    chapter_starts = [time_to_seconds(ch['start']) for ch in chapters]
+    chapter_nb = -1  # -1 = intro before the first chapter
+    string_all = ""
+    after_header = False
     for entry in transcript:
 
         if 'start' in entry:
-            chapter_start = time_to_seconds(chapters[chapter_nb]['start'])
-            chapter_end = time_to_seconds(chapters[chapter_nb]['end'])
-            entry_start_time = float(entry['start'])
-
-            if chapter_start <= entry_start_time <= chapter_end:
+            target = _chapter_index(chapter_starts, float(entry['start']), chapter_nb)
+            while chapter_nb < target:
+                chapter_nb += 1
+                string_all += ("\n\n" if string_all else "") + chapters[chapter_nb]['title'] + "\n"
+                after_header = True
+            if after_header:
+                string_all += entry['text']
+                after_header = False
+            elif string_all:
                 string_all += " " + entry['text']
             else:
-                chapter_nb += 1
-                string_all += "\n\n" + chapters[chapter_nb]['title'] + "\n" + \
-                              entry['text']
+                string_all += entry['text']
         else:
             string_all += entry['text']
 

--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -199,6 +199,12 @@ def process_youtube_url(
             transcript_text = json.dumps(srt.to_raw_data())
             logger.info(f"Successfully retrieved transcript in language: {yt_language}")
 
+            # Captions fetch succeeded — clear any stale error from a previous failed
+            # attempt (e.g. CAPTIONS_FETCH_ERROR from a retry). See ADR-010 state-error
+            # convention: document_state_error must be reset on every successful transition,
+            # not just left for the next terminal error to overwrite.
+            web_document.document_state_error = StalkerDocumentStatusError.NONE.name
+
             if transcript_text:
                 logger.info("Checking if transcript language matches expected language")
                 string_to_check = youtube_titles_to_text(transcript_text)
@@ -317,6 +323,9 @@ def process_youtube_url(
             web_document.text_raw = transcript.text
             web_document.text = text_raw
             web_document.document_state = StalkerDocumentStatus.TRANSCRIPTION_DONE.name
+            # Transcription succeeded — clear any stale error from an earlier failed
+            # captions/transcription attempt (see ADR-010 state-error convention).
+            web_document.document_state_error = StalkerDocumentStatusError.NONE.name
 
             # Log transcription usage
             audio_duration = getattr(transcript, 'audio_duration', None) or 0

--- a/backend/test_code/CLAUDE.md
+++ b/backend/test_code/CLAUDE.md
@@ -22,7 +22,6 @@ backend/test_code/
 ├── serper_dev.py                     # Web search via Serper API
 ├── token.json                        # Google OAuth token (auto-generated)
 ├── vault_tests.py                    # HashiCorp Vault integration tests
-├── youtube_batch_analyze.py          # CLI over DocumentAnalysisService + file exports
 └── tmp/                              # Temporary data files (git-ignored)
     └── storytel_*.{html,json,md}     # Storytel audiobook metadata samples
 ```
@@ -39,8 +38,9 @@ backend/test_code/
 
 | Script | Purpose |
 |--------|---------|
-| `youtube_batch_analyze.py` | Thin CLI over `library/document_analysis_service.py` (shared with Flask `chunk_review_routes.py`): chunk splitting, speaker labeling, rewrite + summarize, topic grouping, synthesis, DB persistence. Adds dry-run cost preview, `--speaker1/--speaker2` override, and file exports (MD/JSON/debug/HTML with YouTube timestamp links) to `.claude/exports/` |
-| `_regen_html.py` | Rebuild the HTML review view from an existing `youtube_analysis_*.json` export (no LLM calls) |
+| `_regen_html.py` | Rebuild the HTML review view from an existing `youtube_analysis_*.json` export (no LLM calls). Uses `save_html` from `library/analysis_exports.py` |
+
+The batch analysis CLI itself (`youtube_batch_analyze.py`) was promoted to [`imports/`](../imports/CLAUDE.md) — it is a production tool, not an experiment.
 
 ### LLM Provider Testing
 

--- a/backend/test_code/_regen_html.py
+++ b/backend/test_code/_regen_html.py
@@ -11,8 +11,8 @@ from unified_config_loader import load_config
 from library.db.engine import get_session
 from library.db.models import WebDocument
 
+from library.analysis_exports import save_html
 from library.document_analysis_service import _load_segments as _load_transcript_segments
-from youtube_batch_analyze import save_html
 
 
 def main():

--- a/backend/tests/unit/test_text_transcript.py
+++ b/backend/tests/unit/test_text_transcript.py
@@ -1,3 +1,5 @@
+import json
+
 from library import text_transcript
 
 
@@ -29,3 +31,77 @@ def test_split_text_and_time_single_match_2():
 def test_split_text_and_time_single_match_3():
     result = text_transcript.split_text_and_time('12:30:00 - text')
     assert result == {'text': 'text', 'czas': '12:30:00'}
+
+
+def test_youtube_split_chapters_from_zero():
+    chapters = "0:00 Start\n01:00 Dalej"
+    entries = [
+        {"text": "a", "start": 0.0},
+        {"text": "b", "start": 10.0},
+        {"text": "c", "start": 70.0},
+    ]
+    result = text_transcript.youtube_titles_split_with_chapters(json.dumps(entries), chapters)
+    assert result.startswith("Start\na b")
+    assert "\n\nDalej\nc" in result
+
+
+def test_youtube_split_intro_before_first_chapter():
+    """Regression: chapters auto-parsed from description often start after 0:00.
+
+    Entries before the first chapter used to blindly advance the chapter index
+    on every segment, ending in IndexError (doc 9188, CAPTIONS_FETCH_ERROR).
+    """
+    chapters = "01:07 Pierwszy\n05:20 Drugi"
+    entries = [
+        {"text": "intro jeden", "start": 0.0},
+        {"text": "intro dwa", "start": 30.0},
+        {"text": "intro trzy", "start": 60.0},
+        {"text": "tresc pierwszego", "start": 68.0},
+        {"text": "tresc drugiego", "start": 321.0},
+    ]
+    result = text_transcript.youtube_titles_split_with_chapters(json.dumps(entries), chapters)
+    assert result.startswith("intro jeden intro dwa intro trzy")
+    assert "\n\nPierwszy\ntresc pierwszego" in result
+    assert "\n\nDrugi\ntresc drugiego" in result
+
+
+def test_youtube_split_empty_chapter_keeps_all_headers():
+    chapters = "0:00 A\n01:00 B\n02:00 C"
+    entries = [
+        {"text": "x", "start": 0.0},
+        {"text": "y", "start": 130.0},  # jumps straight to chapter C
+    ]
+    result = text_transcript.youtube_titles_split_with_chapters(json.dumps(entries), chapters)
+    assert "A\nx" in result
+    assert "B" in result
+    assert "C\ny" in result
+
+
+def test_youtube_split_out_of_order_entry_does_not_reopen_chapter():
+    chapters = "0:00 A\n01:00 B"
+    entries = [
+        {"text": "x", "start": 0.0},
+        {"text": "y", "start": 70.0},
+        {"text": "z", "start": 65.0},  # slightly out of order — stays in B
+    ]
+    result = text_transcript.youtube_titles_split_with_chapters(json.dumps(entries), chapters)
+    assert "B\ny z" in result
+    assert result.count("B") == 1
+
+
+def test_text_split_with_chapters_intro_before_first_chapter():
+    """Same regression for the AWS Transcribe variant."""
+    chapters = "01:00 Pierwszy"
+    transcript = {
+        "results": {
+            "items": [
+                {"start_time": "0.0", "alternatives": [{"content": "intro"}]},
+                {"start_time": "30.0", "alternatives": [{"content": "dalej"}]},
+                {"alternatives": [{"content": "."}]},
+                {"start_time": "65.0", "alternatives": [{"content": "tresc"}]},
+            ]
+        }
+    }
+    result = text_transcript.text_split_with_chapters(json.dumps(transcript), chapters)
+    assert result.startswith("intro dalej.")
+    assert "\n\nPierwszy\ntresc" in result

--- a/backend/tests/unit/test_youtube_processing_orm.py
+++ b/backend/tests/unit/test_youtube_processing_orm.py
@@ -271,3 +271,65 @@ class TestSessionCommit:
         # session.commit() should have been called (not doc.save())
         assert mock_session.commit.called, "session.commit() was not called"
         assert not doc.save.called, "doc.save() should not be called — use session.commit()"
+
+
+# ---------------------------------------------------------------------------
+# Test: document_state_error is cleared on a successful captions fetch
+# ---------------------------------------------------------------------------
+
+class TestDocumentStateErrorClearedOnSuccess:
+    """A stale document_state_error from a previous failed attempt must not
+    survive a subsequent successful captions fetch (regression: it used to be
+    sticky forever — see CAPTIONS_FETCH_ERROR left behind after a retry succeeded)."""
+
+    @patch("library.youtube_processing.youtube_titles_to_text")
+    @patch("library.youtube_processing.compare_language")
+    @patch("library.youtube_processing.text_language_detect")
+    @patch("library.youtube_processing.StalkerYoutubeFile")
+    @patch("library.youtube_processing.WebDocument")
+    def test_captions_success_clears_stale_error(
+        self, MockWebDocument, MockYoutubeFile, mock_detect, mock_compare, mock_titles_to_text, mock_session
+    ):
+        from library.youtube_processing import process_youtube_url
+        from library.models.stalker_document_status import StalkerDocumentStatus
+        from library.models.stalker_document_status_error import StalkerDocumentStatusError
+
+        doc = MagicMock()
+        doc.id = 1
+        doc.url = "https://www.youtube.com/watch?v=abc"
+        doc.document_state = StalkerDocumentStatus.NEED_TRANSCRIPTION.name
+        # Stale error left over from an earlier failed attempt (the bug this test guards against)
+        doc.document_state_error = StalkerDocumentStatusError.CAPTIONS_FETCH_ERROR.name
+        doc.language = "pl"
+        doc.chapter_list = None
+        doc.transcript_job_id = None
+        MockWebDocument.get_by_url.return_value = doc
+
+        yt_file = MagicMock()
+        yt_file.valid = True
+        yt_file.can_pytube = False
+        yt_file.video_id = "abc123"
+        MockYoutubeFile.return_value = yt_file
+
+        mock_detect.return_value = "pl"
+        mock_compare.return_value = True
+        mock_titles_to_text.return_value = "plain transcript text"
+
+        with patch("library.youtube_processing.YouTubeTranscriptApi") as MockYTT:
+            mock_ytt = MagicMock()
+            available = MagicMock()
+            available.language_code = "pl"
+            mock_ytt.list.return_value = [available]
+
+            fetched = MagicMock()
+            fetched.to_raw_data.return_value = [{"text": "hello", "start": 0, "duration": 1}]
+            mock_ytt.fetch.return_value = fetched
+            MockYTT.return_value = mock_ytt
+
+            process_youtube_url(
+                session=mock_session,
+                youtube_url="https://www.youtube.com/watch?v=abc",
+            )
+
+        assert doc.document_state_error == StalkerDocumentStatusError.NONE.name
+        assert doc.document_state == StalkerDocumentStatus.NEED_MANUAL_REVIEW.name


### PR DESCRIPTION
## Summary

Previously adding a YouTube video with full LLM analysis required two commands (`imports/youtube_add.py <URL>` and then `test_code/youtube_batch_analyze.py --doc_id N`). Now:

- **`youtube_add.py --analyze`** — after adding/transcribing the video, runs the Bielik LLM chunk analysis (`DocumentAnalysisService`) on the new document and exports MD/JSON/debug/HTML files to `.claude/exports/`. New flags: `--model`, `--speaker1/--speaker2`, `--no-synthesis`. If the analysis fails, the document stays in the DB and the retry command is printed.
- **`youtube_batch_analyze.py` promoted from `test_code/` to `imports/`** — it is a production tool (thin CLI over the shared service), kept for (re-)analyzing existing documents by ID; `--dry_run` cost preview preserved.
- **New `library/analysis_exports.py`** — file export functions (`save_results`/`save_json`/`save_debug`/`save_html`/`build_toc`) moved out of the script, with a single `export_analysis_run()` entry point shared by both CLIs and `test_code/_regen_html.py`.
- Analysis model constants (`ANALYSIS_MODELS`, `DEFAULT_ANALYSIS_MODEL`) moved to `library/document_analysis_service.py`.
- CLAUDE.md docs updated (backend, imports, test_code, library).

## Usage

```bash
cd backend
python imports/youtube_add.py <URL> --analyze                 # full pipeline, one command
python imports/youtube_batch_analyze.py --doc_id 9158         # re-analyze existing doc
```

## Test plan

- `ruff check` clean on all changed files
- `tests/unit/test_batch_pipeline_orm.py` + `tests/unit/test_youtube_processing_orm.py` — 30 passed
- `--help` smoke test of both CLIs (imports resolve, new flags present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)