### PR TITLE
feat(chunks): article analysis mode, SZUM type, cleanup loop, run management (v0.3.14.0)

### DIFF
--- a/.claude/commands/obsidian-note.md
+++ b/.claude/commands/obsidian-note.md
@@ -48,10 +48,10 @@ else:
     run = runs[0]
     chunks = session.query(DocumentChunk).filter_by(run_id=run.id).order_by(DocumentChunk.position).all()
     temat = [c for c in chunks if c.type == 'TEMAT']
-    reklama = [c for c in chunks if c.type == 'REKLAMA']
+    reklama = [c for c in chunks if c.type != 'TEMAT']  # REKLAMA + SZUM
     approved = [c for c in temat if c.status == 'approved']
     print(f'RUN_ID={run.id}|MODEL={run.model}|CREATED={run.created_at.strftime(chr(37)+\"Y-\"+chr(37)+\"m-\"+chr(37)+\"d\")}')
-    print(f'TEMAT={len(temat)}|REKLAMA={len(reklama)}|APPROVED={len(approved)}')
+    print(f'TEMAT={len(temat)}|REKLAMA_SZUM={len(reklama)}|APPROVED={len(approved)}')
     print('---CHUNKS---')
     for c in temat:
         summary = (c.summary or '(brak)').replace(chr(10), ' ')[:250]
@@ -99,7 +99,7 @@ The `--dump` JSON adds one extra field to `--meta`: `text` (full article content
 **Nieopracowane** (empty `obsidian_note_paths` AND status != `skipped`) — these need work:
 - position number, status badge (approved/pending/needs_reanalysis), topic, summary
 
-Count of REKLAMA chunks (filtered out automatically).
+Count of REKLAMA/SZUM chunks (filtered out automatically — SZUM is extraction junk like portal navigation).
 Warning if any TEMAT chunks have status `needs_reanalysis` or `pending` (analysis incomplete).
 
 **Default proposal:** suggest working on unprocessed chunks only. If the user says "wszystkie" or "lista", show all.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Project Lenie is a personal AI assistant for collecting, managing, and searching data using LLMs. Named after the protagonist from Peter Watts' novel "Starfish," it helps users collect links/references, download and store webpage content, transcribe YouTube videos, and assess information reliability.
 
-**Current version**: 0.3.13.0 | **Status**: Active development | **License**: [BSL 1.1](LICENSE) (converts to Apache 2.0 on 2030-03-12)
+**Current version**: 0.3.14.0 | **Status**: Active development | **License**: [BSL 1.1](LICENSE) (converts to Apache 2.0 on 2030-03-12)
 
 ## Common Commands
 
@@ -110,7 +110,7 @@ See [`shared_python/unified-config-loader/README.md`](shared_python/unified-conf
 Shared TypeScript type definitions used by both frontend applications. Contains domain types (`WebDocument`, `ApiType`, `SearchResult`, `ListItem`), constants (`DEFAULT_API_URLS`), and factory values (`emptyDocument`). No build step — Vite transpiles directly via esbuild. Both frontends reference it through `@lenie/shared` alias (tsconfig `paths` + Vite `resolve.alias`). See `docs/shared-types.md` for details.
 
 ### Frontend (`web_interface_react/`)
-React 18 SPA (Vite) for document management and AI processing. 7 pages: document list with filtering, vector similarity search, and per-type editors (link, webpage, youtube, movie) with AI tools (split for embedding, clean text). Formik for form state, axios for API calls, React Router v6. Supports two backend modes: AWS Serverless (Lambda) and Docker (Flask). Includes infrastructure controls (start/stop RDS, VPN, SQS queue status). Domain types imported from `shared/` via `@lenie/shared` alias.
+React 18 SPA (Vite) for document management and AI processing. Pages: document list with filtering, vector similarity search, chunk review (`/chunks/:id`), and per-type editors (link, webpage, youtube, movie) with AI tools (split for embedding, clean text). Formik for form state, axios for API calls, React Router v6. Single backend mode: Docker (Flask) — the AWS Serverless mode was removed entirely 2026-07-04 (Lambdas decommissioned 2026-07-02). Domain types imported from `shared/` via `@lenie/shared` alias.
 
 See `web_interface_react/CLAUDE.md` for details.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -36,7 +36,7 @@ backend/
 
 ## Main Application (`server.py`)
 
-Flask + Flask-CORS application exposing 20 REST API endpoints. **Version**: 0.3.13.0.
+Flask + Flask-CORS application exposing 20 REST API endpoints. **Version**: 0.3.14.0.
 
 ### API Endpoints
 

--- a/backend/alembic/versions/f6a7b8c9d0e1_add_mode_status_scope_to_analysis_runs.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_mode_status_scope_to_analysis_runs.py
@@ -1,0 +1,39 @@
+"""add mode, status and scope to document_analysis_runs
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same columns may already have been added by the Docker
+    # init script 15-add-analysis-run-workflow-columns.sql on a fresh database.
+    op.execute(
+        "ALTER TABLE document_analysis_runs "
+        "ADD COLUMN IF NOT EXISTS mode VARCHAR(20) NOT NULL DEFAULT 'transcript'"
+    )
+    op.execute(
+        "ALTER TABLE document_analysis_runs "
+        "ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'created'"
+    )
+    op.execute(
+        "ALTER TABLE document_analysis_runs "
+        "ADD COLUMN IF NOT EXISTS scope VARCHAR(200)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document_analysis_runs", "scope")
+    op.drop_column("document_analysis_runs", "status")
+    op.drop_column("document_analysis_runs", "mode")

--- a/backend/database/init/13-create-analysis-tables.sql
+++ b/backend/database/init/13-create-analysis-tables.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS public.document_chunks (
     run_id            INTEGER NOT NULL REFERENCES public.document_analysis_runs(id) ON DELETE CASCADE,
     document_id       INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
     position          SMALLINT NOT NULL,
-    type              VARCHAR(20) NOT NULL,        -- TEMAT | REKLAMA
+    type              VARCHAR(20) NOT NULL,        -- TEMAT | REKLAMA | SZUM
     topic             VARCHAR(500),
     original_text     TEXT NOT NULL,
     corrected_text    TEXT,
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS public.document_topic_sections (
     run_id          INTEGER NOT NULL REFERENCES public.document_analysis_runs(id) ON DELETE CASCADE,
     document_id     INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
     position        SMALLINT NOT NULL,
-    type            VARCHAR(20) NOT NULL,          -- TEMAT | REKLAMA
+    type            VARCHAR(20) NOT NULL,          -- TEMAT | REKLAMA | SZUM
     title           VARCHAR(500),
     summary         TEXT,
     chunk_positions INTEGER[] NOT NULL,            -- np. {1,2,3} — pozycje chunków z tego runu

--- a/backend/database/init/15-add-analysis-run-workflow-columns.sql
+++ b/backend/database/init/15-add-analysis-run-workflow-columns.sql
@@ -1,0 +1,17 @@
+-- Migration: add workflow columns to document_analysis_runs
+-- mode:   analysis pipeline variant — 'transcript' (YouTube STT) | 'article' (clean markdown/text)
+-- status: review workflow state — 'created' | 'in_review' | 'reviewed'
+-- scope:  human-readable analysed range (e.g. chapter title); NULL = whole document
+
+\c "lenie-ai";
+
+ALTER TABLE public.document_analysis_runs
+    ADD COLUMN IF NOT EXISTS mode VARCHAR(20) NOT NULL DEFAULT 'transcript';
+
+ALTER TABLE public.document_analysis_runs
+    ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'created';
+
+ALTER TABLE public.document_analysis_runs
+    ADD COLUMN IF NOT EXISTS scope VARCHAR(200);
+
+SELECT 'Columns mode, status, scope added to document_analysis_runs' AS status;

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -15,7 +15,7 @@ REWRITE_MAX_TOKENS = 2_500
 REWRITE_MIN_RATIO = 0.80
 SUMMARY_MAX_TOKENS = 400
 
-SECTION_HEADER_RE = re.compile(r"^### (REKLAMA|TEMAT): ?(.+)$", re.MULTILINE)
+SECTION_HEADER_RE = re.compile(r"^### (REKLAMA|TEMAT|SZUM): ?(.+)$", re.MULTILINE)
 
 _ARKLABS_PREFIX = "arklabs/"
 
@@ -251,15 +251,18 @@ def analyze_article_chunk(original_text: str, model: str,
 
 Sklasyfikuj poniższy fragment i jeśli to TEMAT — napisz streszczenie.
 
-W PIERWSZEJ LINII wpisz etykietę (tylko jedną z dwóch opcji):
-   ### REKLAMA: <opis>       (treść reklamowa, sponsorska lub nawigacyjny szum strony)
+W PIERWSZEJ LINII wpisz etykietę (tylko jedną z trzech opcji):
    ### TEMAT: <temat>        (merytoryczna treść dokumentu)
+   ### REKLAMA: <opis>       (treść reklamowa lub sponsorska)
+   ### SZUM: <opis>          (szum techniczny strony: nawigacja portalu, menu, stopka,
+                              cookie/zgody, listy linków "przeczytaj też", przyciski udostępniania)
 W miejsce <temat>/<opis> wpisz KONKRETNY temat tego fragmentu w 3-5 słowach —
 nie przepisuj dosłownie tekstu "<temat>" ani nazwy etykiety.
+Jeśli fragment miesza szum z treścią merytoryczną — wybierz TEMAT.
 
 Jeśli TEMAT: w kolejnych liniach napisz streszczenie w 2-3 zdaniach po polsku,
 skupiając się na głównych tezach i wnioskach.
-Jeśli REKLAMA: nie dodawaj nic więcej.
+Jeśli REKLAMA lub SZUM: nie dodawaj nic więcej.
 
 --- TEKST ---
 {original_text}

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -239,6 +239,44 @@ Jeśli REKLAMA: nie dodawaj nic więcej.
     }
 
 
+def analyze_article_chunk(original_text: str, model: str,
+                          position: int = 1, total: int = 1) -> dict:
+    """Analyze a chunk of a clean article/document — no verbatim rewrite.
+
+    Article text is already clean (no STT artifacts), so a single LLM call
+    classifies the chunk and summarizes it. Returns the same dict shape as
+    analyze_chunk(), with corrected_text=None and rewrite_ratio=None.
+    """
+    prompt = f"""Fragment {position}/{total} artykułu lub dokumentu.
+
+Sklasyfikuj poniższy fragment i jeśli to TEMAT — napisz streszczenie.
+
+W PIERWSZEJ LINII wpisz etykietę (tylko jedną z dwóch opcji):
+   ### REKLAMA: krótki_opis          (treść reklamowa, sponsorska lub nawigacyjny szum strony)
+   ### TEMAT: opis_3_4_słowa         (merytoryczna treść dokumentu)
+
+Jeśli TEMAT: w kolejnych liniach napisz streszczenie w 2-3 zdaniach po polsku,
+skupiając się na głównych tezach i wnioskach.
+Jeśli REKLAMA: nie dodawaj nic więcej.
+
+--- TEKST ---
+{original_text}
+--- KONIEC ---"""
+
+    logger.info("article analysis chunk %d/%d, len=%d", position, total, len(original_text))
+    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    logger.info("article analysis done: %d tokens", tokens)
+
+    section_type, topic, summary_text = parse_rewritten_chunk(raw)
+    return {
+        "type": section_type,
+        "topic": topic,
+        "corrected_text": None,
+        "summary": summary_text.strip() if section_type == "TEMAT" and summary_text.strip() else None,
+        "rewrite_ratio": None,
+    }
+
+
 def analyze_chunk(original_text: str, model: str,
                   position: int = 1, total: int = 1,
                   speakers: list[dict] | None = None,

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -252,8 +252,10 @@ def analyze_article_chunk(original_text: str, model: str,
 Sklasyfikuj poniższy fragment i jeśli to TEMAT — napisz streszczenie.
 
 W PIERWSZEJ LINII wpisz etykietę (tylko jedną z dwóch opcji):
-   ### REKLAMA: krótki_opis          (treść reklamowa, sponsorska lub nawigacyjny szum strony)
-   ### TEMAT: opis_3_4_słowa         (merytoryczna treść dokumentu)
+   ### REKLAMA: <opis>       (treść reklamowa, sponsorska lub nawigacyjny szum strony)
+   ### TEMAT: <temat>        (merytoryczna treść dokumentu)
+W miejsce <temat>/<opis> wpisz KONKRETNY temat tego fragmentu w 3-5 słowach —
+nie przepisuj dosłownie tekstu "<temat>" ani nazwy etykiety.
 
 Jeśli TEMAT: w kolejnych liniach napisz streszczenie w 2-3 zdaniach po polsku,
 skupiając się na głównych tezach i wnioskach.
@@ -268,6 +270,8 @@ Jeśli REKLAMA: nie dodawaj nic więcej.
     logger.info("article analysis done: %d tokens", tokens)
 
     section_type, topic, summary_text = parse_rewritten_chunk(raw)
+    # Bielik tends to prefix the summary with a literal "Streszczenie:" label
+    summary_text = re.sub(r'^\s*Streszczenie:?\s*', '', summary_text, flags=re.IGNORECASE)
     return {
         "type": section_type,
         "topic": topic,

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -86,6 +86,7 @@ def analyze_document_chunks(doc_id: int):
         chunk_size   — max chars per chunk (default: 5000)
         no_synthesis — skip final synthesis step (default: false)
         mode         — "transcript" (default) or "article"
+        split_only   — split into chunks without any LLM analysis (default: false)
 
     Returns immediately with {job_id}. Poll GET /analysis_job/<job_id> for status.
     """
@@ -96,6 +97,7 @@ def analyze_document_chunks(doc_id: int):
     chunk_size = int(data.get("chunk_size", 5000))
     no_synthesis = bool(data.get("no_synthesis", False))
     mode = data.get("mode", "transcript")
+    split_only = bool(data.get("split_only", False))
     if mode not in ANALYSIS_MODES:
         return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
 
@@ -130,6 +132,7 @@ def analyze_document_chunks(doc_id: int):
                 no_synthesis=no_synthesis,
                 progress_fn=_progress,
                 mode=mode,
+                split_only=split_only,
             )
             ad_count = sum(1 for c in run.chunks if c.type == "REKLAMA")
             _analysis_jobs[job_id].update({

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -283,6 +283,72 @@ def update_run(run_id: int):
 
 
 # ---------------------------------------------------------------------------
+# API: POST /analysis_run/<run_id>/apply_cleanup
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/apply_cleanup", methods=["POST"])
+def apply_run_cleanup(run_id: int):
+    """Overwrite the document's source text with the run's TEMAT chunks only.
+
+    Article-mode runs are a full partition of the source text, so joining the
+    TEMAT chunks (which already carry manual line removals) yields the cleaned
+    document: REKLAMA/SZUM chunks and removed lines disappear from the source.
+    After this, a fresh analysis run ("zaproponuj nowy podział") starts clean.
+
+    Transcript runs are rejected: their chunk texts were transformed before
+    splitting (speaker labels, filler removal), so the join is not the source.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+    if run.mode != "article":
+        return jsonify({"status": "error",
+                        "message": "apply_cleanup works only for article-mode runs"}), 400
+
+    chunks = session.scalars(
+        select(DocumentChunk)
+        .where(DocumentChunk.run_id == run_id)
+        .order_by(DocumentChunk.position)
+    ).all()
+    temat = [c for c in chunks if c.type == "TEMAT"]
+    cleaned = "\n\n".join(c.original_text for c in temat).strip()
+    if not cleaned:
+        return jsonify({"status": "error", "message": "Run has no TEMAT chunks"}), 400
+
+    doc = session.get(WebDocument, run.document_id)
+    if doc is None:
+        abort(404, f"Document {run.document_id} not found")
+
+    # Write back to the same field an article-mode analysis would read
+    from library.document_analysis_service import _extract_text
+    _, field = _extract_text(doc, prefer_md=True)
+    if field not in ("text", "text_md"):
+        return jsonify({"status": "error",
+                        "message": f"Cannot apply cleanup to source field: {field or 'none'}"}), 400
+
+    length_before = len(getattr(doc, field) or "")
+    setattr(doc, field, cleaned)
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("apply_cleanup DB save failed for run %d", run_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    logger.info("apply_cleanup run %d: %s %d -> %d chars (%d TEMAT / %d chunks)",
+                run_id, field, length_before, len(cleaned), len(temat), len(chunks))
+    return jsonify({
+        "status": "success",
+        "field": field,
+        "length_before": length_before,
+        "length_after": len(cleaned),
+        "temat_chunks": len(temat),
+        "dropped_chunks": len(chunks) - len(temat),
+    })
+
+
+# ---------------------------------------------------------------------------
 # API: POST /analysis_run/<run_id>/extract_speakers
 # ---------------------------------------------------------------------------
 
@@ -372,6 +438,24 @@ def update_chunk(chunk_id: int):
         chunk.original_text = val
         changed = True
 
+    doc_lines_removed = 0
+    removed_lines = data.get("remove_lines_from_document") or []
+    if removed_lines:
+        # Propagate cleanup to the source document: drop ALL whole-line exact
+        # matches (junk lines like player controls repeat per embedded video)
+        targets = {ln.strip() for ln in removed_lines if isinstance(ln, str) and ln.strip()}
+        if targets:
+            doc = session.get(WebDocument, chunk.document_id)
+            if doc is not None:
+                for field in ("text", "text_md"):
+                    value = getattr(doc, field, None)
+                    if not value:
+                        continue
+                    kept = [ln for ln in value.split("\n") if ln.strip() not in targets]
+                    doc_lines_removed += value.count("\n") + 1 - len(kept)
+                    setattr(doc, field, "\n".join(kept))
+                changed = True
+
     if "split_at_seg" in data:
         chunk.split_at_seg = data["split_at_seg"]
         changed = True
@@ -399,7 +483,11 @@ def update_chunk(chunk_id: int):
             logger.exception("Failed to update chunk %d", chunk_id)
             return jsonify({"status": "error", "message": "DB error"}), 500
 
-    return jsonify({"status": "success", "chunk": _chunk_to_dict(chunk)})
+    return jsonify({
+        "status": "success",
+        "chunk": _chunk_to_dict(chunk),
+        "document_lines_removed": doc_lines_removed,
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -524,6 +612,77 @@ def execute_split(chunk_id: int):
         session.rollback()
         logger.exception("Failed to execute split on chunk %d", chunk_id)
         return jsonify({"status": "error", "message": "DB error during split"}), 500
+
+
+# ---------------------------------------------------------------------------
+# API: POST /chunk/<chunk_id>/merge_with_next
+# ---------------------------------------------------------------------------
+
+@bp.route("/chunk/<int:chunk_id>/merge_with_next", methods=["POST"])
+def merge_with_next(chunk_id: int):
+    """Merge a chunk with the following one (inverse of execute_split).
+
+    Concatenates texts, unions obsidian_note_paths, keeps the TEMAT type when
+    either side is TEMAT, and marks the merged chunk needs_reanalysis so the
+    topic/summary get refreshed. Positions after the removed chunk shift by -1.
+    """
+    session = get_scoped_session()
+    chunk = session.get(DocumentChunk, chunk_id)
+    if chunk is None:
+        abort(404, f"Chunk {chunk_id} not found")
+
+    next_chunk = session.scalar(
+        select(DocumentChunk).where(
+            DocumentChunk.run_id == chunk.run_id,
+            DocumentChunk.position == chunk.position + 1,
+        )
+    )
+    if next_chunk is None:
+        return jsonify({"status": "error", "message": "Chunk has no successor to merge with"}), 400
+
+    try:
+        chunk.original_text = f"{chunk.original_text}\n\n{next_chunk.original_text}".strip()
+        if chunk.corrected_text and next_chunk.corrected_text:
+            chunk.corrected_text = f"{chunk.corrected_text}\n\n{next_chunk.corrected_text}".strip()
+        else:
+            chunk.corrected_text = None
+        chunk.seg_end = next_chunk.seg_end
+        if next_chunk.type == "TEMAT":
+            chunk.type = "TEMAT"
+        chunk.topic = None
+        chunk.summary = None
+        chunk.rewrite_ratio = None
+        chunk.status = "needs_reanalysis"
+        merged_paths = list(chunk.obsidian_note_paths or [])
+        for p in next_chunk.obsidian_note_paths or []:
+            if p not in merged_paths:
+                merged_paths.append(p)
+        chunk.obsidian_note_paths = merged_paths
+        chunk.updated_at = datetime.utcnow()
+
+        removed_pos = next_chunk.position
+        session.delete(next_chunk)
+        session.flush()
+
+        # Shift following positions down via temp range (unique constraint on run_id+position)
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == chunk.run_id, DocumentChunk.position > removed_pos)
+            .values(position=DocumentChunk.position + 10000)
+        )
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == chunk.run_id, DocumentChunk.position > 10000)
+            .values(position=DocumentChunk.position - 10001)
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("Failed to merge chunk %d with next", chunk_id)
+        return jsonify({"status": "error", "message": "DB error during merge"}), 500
+
+    logger.info("Merged chunk %d with its successor (pos %d)", chunk_id, removed_pos)
+    return jsonify({"status": "success", "chunk": _chunk_to_dict(chunk)})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -18,7 +18,7 @@ import uuid
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request, abort
-from sqlalchemy import select, update as sa_update
+from sqlalchemy import func, select, update as sa_update
 
 from library.db.engine import get_scoped_session
 from library.db.models import (
@@ -33,8 +33,9 @@ bp = Blueprint("chunk_review", __name__)
 # Keyed by job_id (short UUID). Lives as long as the server process.
 _analysis_jobs: dict[str, dict] = {}
 
-ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split"}
+ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split", "skipped"}
 ALLOWED_TYPES = {"TEMAT", "REKLAMA"}
+ALLOWED_RUN_STATUSES = {"created", "in_review", "reviewed"}
 
 
 def _parse_segments(text_raw: str | None) -> list[dict]:
@@ -83,19 +84,26 @@ def analyze_document_chunks(doc_id: int):
         model        — LLM model name (default: Bielik-11B-v3.0-Instruct)
         chunk_size   — max chars per chunk (default: 5000)
         no_synthesis — skip final synthesis step (default: false)
+        mode         — "transcript" (default) or "article"
 
     Returns immediately with {job_id}. Poll GET /analysis_job/<job_id> for status.
     """
+    from library.document_analysis_service import ANALYSIS_MODES
+
     data = request.get_json(silent=True) or {}
     model = data.get("model", "Bielik-11B-v3.0-Instruct")
     chunk_size = int(data.get("chunk_size", 5000))
     no_synthesis = bool(data.get("no_synthesis", False))
+    mode = data.get("mode", "transcript")
+    if mode not in ANALYSIS_MODES:
+        return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
 
     job_id = uuid.uuid4().hex[:8]
     _analysis_jobs[job_id] = {
         "status": "running",
         "doc_id": doc_id,
         "model": model,
+        "mode": mode,
         "run_id": None,
         "chunk_count": None,
         "ad_count": None,
@@ -120,6 +128,7 @@ def analyze_document_chunks(doc_id: int):
                 chunk_size=chunk_size,
                 no_synthesis=no_synthesis,
                 progress_fn=_progress,
+                mode=mode,
             )
             ad_count = sum(1 for c in run.chunks if c.type == "REKLAMA")
             _analysis_jobs[job_id].update({
@@ -173,6 +182,9 @@ def list_runs():
                 "id": r.id,
                 "model": r.model,
                 "chunk_size": r.chunk_size,
+                "mode": r.mode,
+                "status": r.status,
+                "scope": r.scope,
                 "created_at": r.created_at.isoformat(),
                 "chunk_count": len(r.chunks),
             }
@@ -207,6 +219,9 @@ def get_run_chunks(run_id: int):
             "id": run.id,
             "model": run.model,
             "chunk_size": run.chunk_size,
+            "mode": run.mode,
+            "status": run.status,
+            "scope": run.scope,
             "synthesis": run.synthesis,
             "speakers": run.speakers or [],
             "created_at": run.created_at.isoformat(),
@@ -215,6 +230,7 @@ def get_run_chunks(run_id: int):
             "id": doc.id if doc else None,
             "title": doc.title if doc else "",
             "original_id": doc.original_id if doc else "",
+            "document_type": doc.document_type if doc else "",
         },
         "segments": segments,
         "chunks": [_chunk_to_dict(c) for c in run.chunks],
@@ -229,6 +245,39 @@ def get_run_chunks(run_id: int):
             }
             for ts in topic_sections
         ],
+    })
+
+
+# ---------------------------------------------------------------------------
+# API: PATCH /analysis_run/<run_id>
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>", methods=["PATCH", "OPTIONS"])
+def update_run(run_id: int):
+    """Update run workflow fields. Body (JSON): {"status": "created"|"in_review"|"reviewed"}."""
+    if request.method == "OPTIONS":
+        return jsonify({"status": "ok"}), 200
+
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    data = request.get_json() or {}
+    if "status" in data:
+        if data["status"] not in ALLOWED_RUN_STATUSES:
+            return jsonify({"status": "error", "message": f"Invalid run status: {data['status']}"}), 400
+        run.status = data["status"]
+        try:
+            session.commit()
+        except Exception:
+            session.rollback()
+            logger.exception("Failed to update run %d", run_id)
+            return jsonify({"status": "error", "message": "DB error"}), 500
+
+    return jsonify({
+        "status": "success",
+        "run": {"id": run.id, "mode": run.mode, "status": run.status, "scope": run.scope},
     })
 
 
@@ -498,7 +547,19 @@ def reanalyze_chunk(chunk_id: int):
     speakers = run.speakers or []
 
     try:
-        if mode == "semantic" and chunk.corrected_text and chunk.corrected_text.strip():
+        if run.mode == "article":
+            # Article runs have no rewrite step — always re-run classify+summarize
+            text_to_analyze = chunk.original_text or ""
+            if not text_to_analyze.strip():
+                return jsonify({"status": "error", "message": "Chunk has no original_text to analyze"}), 400
+            total = session.scalar(
+                select(func.count()).select_from(DocumentChunk)
+                .where(DocumentChunk.run_id == chunk.run_id)
+            ) or 1
+            from library.chunk_llm_analysis import analyze_article_chunk
+            result = analyze_article_chunk(text_to_analyze, model,
+                                           position=chunk.position, total=total)
+        elif mode == "semantic" and chunk.corrected_text and chunk.corrected_text.strip():
             from library.chunk_llm_analysis import analyze_chunk_semantic
             result = analyze_chunk_semantic(chunk.corrected_text, model, speakers=speakers)
         else:

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -364,6 +364,14 @@ def update_chunk(chunk_id: int):
         chunk.topic = data["topic"] or None
         changed = True
 
+    if "original_text" in data:
+        # Manual cleanup: UI line-removal mode sends the whole edited text
+        val = data["original_text"]
+        if not isinstance(val, str) or not val.strip():
+            return jsonify({"status": "error", "message": "original_text must be a non-empty string"}), 400
+        chunk.original_text = val
+        changed = True
+
     if "split_at_seg" in data:
         chunk.split_at_seg = data["split_at_seg"]
         changed = True

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -56,6 +56,7 @@ def _chunk_to_dict(c: DocumentChunk) -> dict:
         "position": c.position,
         "type": c.type,
         "topic": c.topic,
+        "original_text": c.original_text,
         "corrected_text": c.corrected_text,
         "summary": c.summary,
         "seg_start": c.seg_start,

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -34,7 +34,7 @@ bp = Blueprint("chunk_review", __name__)
 _analysis_jobs: dict[str, dict] = {}
 
 ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split", "skipped"}
-ALLOWED_TYPES = {"TEMAT", "REKLAMA"}
+ALLOWED_TYPES = {"TEMAT", "REKLAMA", "SZUM"}
 ALLOWED_RUN_STATUSES = {"created", "in_review", "reviewed"}
 
 
@@ -404,8 +404,8 @@ def execute_split(chunk_id: int):
 
     Body (JSON):
         split_at_seg      — absolute segment index (required)
-        split_first_type  — type for part before split: TEMAT | REKLAMA
-        split_second_type — type for part after split:  TEMAT | REKLAMA
+        split_first_type  — type for part before split: TEMAT | REKLAMA | SZUM
+        split_second_type — type for part after split:  TEMAT | REKLAMA | SZUM
 
     Effect:
         - Deletes the original chunk
@@ -477,7 +477,7 @@ def execute_split(chunk_id: int):
 
         # Chunk A — content before the split point
         text_a = _text_from_segs(seg_start, split_at)
-        status_a = "approved" if first_type == "REKLAMA" else "pending"
+        status_a = "approved" if first_type in ("REKLAMA", "SZUM") else "pending"
         chunk_a = DocumentChunk(
             run_id=run_id, document_id=doc_id, position=orig_pos,
             type=first_type, topic=None,
@@ -624,6 +624,7 @@ body{font-family:Arial,sans-serif;background:#f5f5f5;color:#222;font-size:14px}
 .badge:hover{opacity:.8}
 .badge.TEMAT{background:#dbeafe;color:#1d4ed8}
 .badge.REKLAMA{background:#fef3c7;color:#92400e}
+.badge.SZUM{background:#e5e7eb;color:#4b5563}
 .badge.pending{background:#e2e8f0;color:#475569}
 .badge.approved{background:#dcfce7;color:#15803d}
 .badge.needs_reanalysis{background:#fee2e2;color:#b91c1c}
@@ -896,12 +897,14 @@ function renderSplitPanel(chunkId) {
         <select id="split-first-type-${chunkId}">
           <option value="REKLAMA" ${st.firstType==="REKLAMA"?"selected":""}>REKLAMA</option>
           <option value="TEMAT" ${st.firstType==="TEMAT"?"selected":""}>TEMAT</option>
+          <option value="SZUM" ${st.firstType==="SZUM"?"selected":""}>SZUM</option>
         </select>
       </label>
       <label>Część 2 (po):
         <select id="split-second-type-${chunkId}">
           <option value="TEMAT" ${st.secondType==="TEMAT"?"selected":""}>TEMAT</option>
           <option value="REKLAMA" ${st.secondType==="REKLAMA"?"selected":""}>REKLAMA</option>
+          <option value="SZUM" ${st.secondType==="SZUM"?"selected":""}>SZUM</option>
         </select>
       </label>
       <button class="btn-confirm" onclick="confirmSplit(${chunkId})">Wykonaj podział</button>
@@ -929,8 +932,8 @@ function rerenderChunkTranscript(chunkId) {
 
 function updateProgress() {
   if (!_data) return;
-  const temat = _data.chunks.filter(c => c.type !== "REKLAMA");
-  const reklama = _data.chunks.filter(c => c.type === "REKLAMA");
+  const temat = _data.chunks.filter(c => c.type === "TEMAT");
+  const reklama = _data.chunks.filter(c => c.type !== "TEMAT");
   const approved = temat.filter(c => c.status === "approved").length;
   const pct = temat.length ? Math.round(approved / temat.length * 100) : 0;
   const adsPart = reklama.length
@@ -955,7 +958,9 @@ function cycleStatus(chunkId) {
 function toggleType(chunkId) {
   const chunk = _data.chunks.find(c => c.id === chunkId);
   if (!chunk) return;
-  saveChunk(chunkId, {type: chunk.type === "TEMAT" ? "REKLAMA" : "TEMAT"});
+  const order = ["TEMAT", "REKLAMA", "SZUM"];
+  const next = order[(order.indexOf(chunk.type) + 1) % order.length];
+  saveChunk(chunkId, {type: next});
 }
 
 function saveTopic(chunkId) {
@@ -1123,7 +1128,7 @@ async function extractSpeakers() {
 function updateAdsButton() {
   const btn = document.getElementById("btn-ads");
   if (!btn || !_data) return;
-  const count = _data.chunks.filter(c => c.type === "REKLAMA").length;
+  const count = _data.chunks.filter(c => c.type !== "TEMAT").length;
   if (_hideAds) {
     btn.textContent = `Pokaż reklamy (${count})`;
     btn.className = "show-mode";
@@ -1151,7 +1156,7 @@ function applyChunkFilter() {
   document.querySelectorAll(".chunk").forEach(el => {
     const chunkId = parseInt(el.id.replace("chunk-", ""));
     const chunk = _data.chunks.find(c => c.id === chunkId);
-    if (chunk) el.style.display = (_hideAds && chunk.type === "REKLAMA") ? "none" : "";
+    if (chunk) el.style.display = (_hideAds && chunk.type !== "TEMAT") ? "none" : "";
   });
 }
 

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -496,10 +496,12 @@ def update_chunk(chunk_id: int):
 
 @bp.route("/chunk/<int:chunk_id>/execute_split", methods=["POST"])
 def execute_split(chunk_id: int):
-    """Split a chunk into two at the given segment index.
+    """Split a chunk into two.
 
-    Body (JSON):
-        split_at_seg      — absolute segment index (required)
+    Body (JSON) — exactly one split point:
+        split_at_seg      — absolute transcript segment index (transcript chunks)
+        split_at_line     — line index in original_text; the line starts part B
+                            (article chunks without segments)
         split_first_type  — type for part before split: TEMAT | REKLAMA | SZUM
         split_second_type — type for part after split:  TEMAT | REKLAMA | SZUM
 
@@ -518,36 +520,65 @@ def execute_split(chunk_id: int):
 
     # Allow split data from body OR from what's already stored on the chunk
     split_at = data.get("split_at_seg", chunk.split_at_seg)
+    split_at_line = data.get("split_at_line")
     first_type = data.get("split_first_type", chunk.split_first_type)
     second_type = data.get("split_second_type", chunk.split_second_type)
 
-    if split_at is None:
-        return jsonify({"status": "error", "message": "split_at_seg required"}), 400
     if first_type not in ALLOWED_TYPES:
         return jsonify({"status": "error", "message": f"Invalid split_first_type: {first_type}"}), 400
     if second_type not in ALLOWED_TYPES:
         return jsonify({"status": "error", "message": f"Invalid split_second_type: {second_type}"}), 400
 
-    seg_start = chunk.seg_start or 0
-    seg_end = chunk.seg_end
+    if split_at_line is not None:
+        # Line-based split (article chunks — no transcript segments)
+        lines = (chunk.original_text or "").split("\n")
+        try:
+            split_at_line = int(split_at_line)
+        except (TypeError, ValueError):
+            return jsonify({"status": "error", "message": "split_at_line must be an integer"}), 400
+        if not 0 < split_at_line < len(lines):
+            return jsonify({"status": "error",
+                            "message": f"split_at_line {split_at_line} out of range (1..{len(lines) - 1})"}), 400
+        text_a = "\n".join(lines[:split_at_line]).strip()
+        text_b = "\n".join(lines[split_at_line:]).strip()
+        if not text_a or not text_b:
+            return jsonify({"status": "error", "message": "Both parts must contain text"}), 400
+        seg_a = (None, None)
+        seg_b = (None, None)
+        # Fresh TEMAT parts need new topic/summary; junk is auto-approved
+        status_a = "needs_reanalysis" if first_type == "TEMAT" else "approved"
+        status_b = "needs_reanalysis" if second_type == "TEMAT" else "approved"
+    else:
+        if split_at is None:
+            return jsonify({"status": "error", "message": "split_at_seg or split_at_line required"}), 400
 
-    if not (seg_start <= split_at < (seg_end or split_at + 1)):
-        return jsonify({"status": "error",
-                        "message": f"split_at_seg {split_at} out of range [{seg_start}, {seg_end})"}), 400
+        seg_start = chunk.seg_start or 0
+        seg_end = chunk.seg_end
 
-    # Reconstruct text from raw transcript segments
-    doc = session.get(WebDocument, chunk.document_id)
-    segments = _parse_segments(doc.text_raw if doc else None)
+        if not (seg_start <= split_at < (seg_end or split_at + 1)):
+            return jsonify({"status": "error",
+                            "message": f"split_at_seg {split_at} out of range [{seg_start}, {seg_end})"}), 400
 
-    def _text_from_segs(start: int, end: int | None) -> str:
-        parts = []
-        for seg in (segments[start:end] if segments else []):
-            t = (seg.get("text") or "").strip()
-            if t.startswith(">>"):
-                t = t[2:].strip()
-            if t:
-                parts.append(t)
-        return " ".join(parts)
+        # Reconstruct text from raw transcript segments
+        doc = session.get(WebDocument, chunk.document_id)
+        segments = _parse_segments(doc.text_raw if doc else None)
+
+        def _text_from_segs(start: int, end: int | None) -> str:
+            parts = []
+            for seg in (segments[start:end] if segments else []):
+                t = (seg.get("text") or "").strip()
+                if t.startswith(">>"):
+                    t = t[2:].strip()
+                if t:
+                    parts.append(t)
+            return " ".join(parts)
+
+        text_a = _text_from_segs(seg_start, split_at)
+        text_b = _text_from_segs(split_at, seg_end)
+        seg_a = (seg_start, split_at)
+        seg_b = (split_at, seg_end)
+        status_a = "approved" if first_type in ("REKLAMA", "SZUM") else "pending"
+        status_b = "needs_reanalysis" if second_type == "TEMAT" else "approved"
 
     orig_pos = chunk.position
     run_id = chunk.run_id
@@ -571,27 +602,21 @@ def execute_split(chunk_id: int):
         session.delete(chunk)
         session.flush()
 
-        # Chunk A — content before the split point
-        text_a = _text_from_segs(seg_start, split_at)
-        status_a = "approved" if first_type in ("REKLAMA", "SZUM") else "pending"
         chunk_a = DocumentChunk(
             run_id=run_id, document_id=doc_id, position=orig_pos,
             type=first_type, topic=None,
             original_text=text_a or "(brak tekstu)",
             corrected_text=None, summary=None,
-            seg_start=seg_start, seg_end=split_at,
+            seg_start=seg_a[0], seg_end=seg_a[1],
             rewrite_ratio=None, status=status_a,
         )
 
-        # Chunk B — content after the split point
-        text_b = _text_from_segs(split_at, seg_end)
-        status_b = "needs_reanalysis" if second_type == "TEMAT" else "approved"
         chunk_b = DocumentChunk(
             run_id=run_id, document_id=doc_id, position=orig_pos + 1,
             type=second_type, topic=None,
             original_text=text_b or "(brak tekstu)",
             corrected_text=None, summary=None,
-            seg_start=split_at, seg_end=seg_end,
+            seg_start=seg_b[0], seg_end=seg_b[1],
             rewrite_ratio=None, status=status_b,
         )
 
@@ -599,8 +624,9 @@ def execute_split(chunk_id: int):
         session.add(chunk_b)
         session.commit()
 
-        logger.info("Split chunk %d at seg %d → chunks at pos %d and %d",
-                    chunk_id, split_at, orig_pos, orig_pos + 1)
+        split_point = f"line {split_at_line}" if split_at_line is not None else f"seg {split_at}"
+        logger.info("Split chunk %d at %s → chunks at pos %d and %d",
+                    chunk_id, split_point, orig_pos, orig_pos + 1)
 
         return jsonify({
             "status": "success",

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -283,6 +283,35 @@ def update_run(run_id: int):
 
 
 # ---------------------------------------------------------------------------
+# API: DELETE /analysis_run/<run_id>
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>", methods=["DELETE"])
+def delete_run(run_id: int):
+    """Delete an analysis run with all its chunks and topic sections.
+
+    Document-level obsidian_note_paths stay intact; only the chunk-level
+    note links stored on this run's chunks are lost.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    chunk_count = len(run.chunks)
+    try:
+        session.delete(run)  # ORM cascade removes chunks and topic_sections
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("Failed to delete run %d", run_id)
+        return jsonify({"status": "error", "message": "DB error"}), 500
+
+    logger.info("Deleted analysis run %d (%d chunks)", run_id, chunk_count)
+    return jsonify({"status": "success", "deleted_run_id": run_id, "chunk_count": chunk_count})
+
+
+# ---------------------------------------------------------------------------
 # API: POST /analysis_run/<run_id>/apply_cleanup
 # ---------------------------------------------------------------------------
 

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -551,6 +551,16 @@ class DocumentAnalysisRun(Base):
     chunk_size: Mapped[int] = mapped_column(Integer, nullable=False, server_default=sa_text("5000"))
     synthesis: Mapped[str | None] = mapped_column(Text)
     speakers: Mapped[list] = mapped_column(JSONB, nullable=False, server_default=sa_text("'[]'"))
+    # mode: transcript (YouTube STT — rewrite + speakers) | article (clean markdown — no rewrite)
+    mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=sa_text("'transcript'"),
+    )
+    # status: created | in_review | reviewed
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=sa_text("'created'"),
+    )
+    # scope: human-readable analysed range (e.g. chapter title); NULL = whole document
+    scope: Mapped[str | None] = mapped_column(String(200))
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(),
     )

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -592,7 +592,7 @@ class DocumentChunk(Base):
         ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
     )
     position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
-    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA
+    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA | SZUM
     topic: Mapped[str | None] = mapped_column(String(500))
     original_text: Mapped[str] = mapped_column(Text, nullable=False)
     corrected_text: Mapped[str | None] = mapped_column(Text)
@@ -635,7 +635,7 @@ class DocumentTopicSection(Base):
         ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
     )
     position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
-    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA
+    type: Mapped[str] = mapped_column(String(20), nullable=False)         # TEMAT | REKLAMA | SZUM
     title: Mapped[str | None] = mapped_column(String(500))
     summary: Mapped[str | None] = mapped_column(Text)
     chunk_positions: Mapped[list[int]] = mapped_column(ARRAY(Integer), nullable=False)

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -92,13 +92,16 @@ def _sentence_head(text: str, max_chars: int = 300) -> str:
     return seg
 
 
-def _extract_text(doc: WebDocument) -> tuple[str, str]:
+def _extract_text(doc: WebDocument, prefer_md: bool = False) -> tuple[str, str]:
     """Return (text, field_name) from best available field.
 
     Priority: text → text_md → text_raw (JSON transcript → plain text).
+    With prefer_md=True (article mode) text_md wins over text, so the
+    markdown-header splitter sees the document structure.
     Returns ("", "") when no usable text found.
     """
-    for field in ("text", "text_md"):
+    fields = ("text_md", "text") if prefer_md else ("text", "text_md")
+    for field in fields:
         val = getattr(doc, field, None)
         if val and len(val) > 100:
             return val, field
@@ -249,8 +252,8 @@ class DocumentAnalysisService:
         if doc is None:
             raise ValueError(f"Document {doc_id} not found")
 
-        # 2. Extract text
-        text, text_field = _extract_text(doc)
+        # 2. Extract text (article mode prefers text_md — headers drive the split)
+        text, text_field = _extract_text(doc, prefer_md=not is_transcript)
         if not text:
             raise ValueError(f"Document {doc_id} has no usable text (checked: text, text_md, text_raw)")
 

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -210,6 +210,7 @@ class DocumentAnalysisService:
         progress_fn: Callable[[str], None] | None = None,
         speakers: list[dict] | None = None,
         mode: str = "transcript",
+        split_only: bool = False,
     ) -> DocumentAnalysisRun:
         """Create a new analysis run for an existing document and persist to DB.
 
@@ -223,6 +224,9 @@ class DocumentAnalysisService:
                           when given, skips LLM speaker extraction (transcript mode only).
             mode:         "transcript" (STT: speakers, fillers, verbatim rewrite) or
                           "article" (clean text: header-based split, classify+summarize).
+            split_only:   Split into chunks WITHOUT any LLM calls — chunks land as
+                          TEMAT/pending with no topic/summary, so the user can first
+                          clean lines, merge or re-split, then analyze on demand.
 
         Returns:
             Persisted DocumentAnalysisRun with .chunks and .topic_sections populated.
@@ -270,7 +274,7 @@ class DocumentAnalysisService:
             #    unless the caller already provided them
             if speakers is None:
                 speakers = []
-                if is_multi_speaker:
+                if is_multi_speaker and not split_only:
                     intro_text = text[800:2400].strip()
                     try:
                         speakers = extract_speaker_info(intro_text, model)
@@ -305,10 +309,27 @@ class DocumentAnalysisService:
             if segments else [(None, None)] * len(chunk_texts)
         )
 
-        # 9. Analyze each chunk via LLM (with boundary context from adjacent chunks)
+        # 9. Analyze each chunk via LLM (with boundary context from adjacent chunks).
+        #    split_only: no LLM at all — chunks await manual cleanup + on-demand analysis.
         sections: list[dict] = []
         total = len(chunk_texts)
-        for i, chunk_text in enumerate(chunk_texts):
+        if split_only:
+            log(f"split_only: {total} chunks without LLM analysis")
+            sections = [
+                {
+                    "type": "TEMAT",
+                    "topic": None,
+                    "original": chunk_text,
+                    "text": None,
+                    "ratio": None,
+                    "summary": None,
+                }
+                for chunk_text in chunk_texts
+            ]
+            chunk_texts_iter: list[str] = []
+        else:
+            chunk_texts_iter = chunk_texts
+        for i, chunk_text in enumerate(chunk_texts_iter):
             log(f"chunk {i + 1}/{total} ({len(chunk_text):,} chars)...")
             try:
                 if is_transcript:
@@ -333,8 +354,8 @@ class DocumentAnalysisService:
                 "summary": result["summary"],
             })
 
-        # 10. Group chunks into logical topic sections
-        topic_groups = _merge_topics(sections, model, mode=mode)
+        # 10. Group chunks into logical topic sections (skip LLM grouping for split_only)
+        topic_groups = [] if split_only else _merge_topics(sections, model, mode=mode)
         if topic_groups:
             topic_sections_data = []
             for group in topic_groups:
@@ -351,6 +372,9 @@ class DocumentAnalysisService:
                     "chunk_indices": [i + 1 for i in valid],
                     "summary": merged_summary.strip(),
                 })
+        elif split_only:
+            # No LLM ran — sections would carry no information yet
+            topic_sections_data = []
         else:
             # Fallback: each chunk is its own section
             topic_sections_data = [
@@ -366,7 +390,7 @@ class DocumentAnalysisService:
 
         # 11. Optional synthesis
         synthesis = ""
-        if not no_synthesis:
+        if not no_synthesis and not split_only:
             log("generating synthesis...")
             synthesis = _synthesize(sections, doc.title or f"Dokument {doc_id}", model, mode=mode)
 

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 CHUNK_CHARS = 5_000
 DEFAULT_ANALYSIS_MODEL = "Bielik-11B-v3.0-Instruct"
 ANALYSIS_MODELS = [DEFAULT_ANALYSIS_MODEL, f"arklabs/{DEFAULT_ANALYSIS_MODEL}"]
+# mode: transcript (YouTube STT — speakers, fillers, verbatim rewrite)
+#       article    (clean markdown/text — header-based split, classify+summarize only)
+ANALYSIS_MODES = ("transcript", "article")
 SYNTHESIS_MAX_TOKENS = 2_000
 SYNTHESIS_MAX_INPUT_CHARS = 20_000
 _SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT): ?(.+)$', re.MULTILINE)
@@ -108,7 +111,7 @@ def _extract_text(doc: WebDocument) -> tuple[str, str]:
     return "", ""
 
 
-def _merge_topics(sections: list[dict], model: str) -> list[dict]:
+def _merge_topics(sections: list[dict], model: str, mode: str = "transcript") -> list[dict]:
     """Ask LLM to group adjacent chunks into logical topic sections.
 
     Returns list of {title, type, chunks: [1-based indices]}.
@@ -120,8 +123,9 @@ def _merge_topics(sections: list[dict], model: str) -> list[dict]:
         f"{i + 1}. [{s['type']}] {s['topic']}"
         for i, s in enumerate(sections)
     )
+    source_desc = "transkrypcji podcastu" if mode == "transcript" else "dokumentu"
     prompt = (
-        f"Poniżej lista {len(sections)} fragmentów transkrypcji podcastu z ich tematami.\n"
+        f"Poniżej lista {len(sections)} fragmentów {source_desc} z ich tematami.\n"
         "Pogrupuj SĄSIADUJĄCE fragmenty w logiczne sekcje tematyczne (zwykle 5-10 sekcji).\n"
         "Fragmenty reklamowe (REKLAMA) możesz pominąć lub zgrupować razem pod jedną sekcją REKLAMA.\n\n"
         "Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:\n"
@@ -147,7 +151,7 @@ def _merge_topics(sections: list[dict], model: str) -> list[dict]:
     return []
 
 
-def _synthesize(sections: list[dict], title: str, model: str) -> str:
+def _synthesize(sections: list[dict], title: str, model: str, mode: str = "transcript") -> str:
     """Generate overall synthesis from all TEMAT chunk summaries.
 
     Returns "" if no summaries available or LLM call fails.
@@ -165,8 +169,9 @@ def _synthesize(sections: list[dict], title: str, model: str) -> str:
         logger.warning("synthesis input too long (%d chars), skipping", len(summaries))
         return ""
 
+    source_desc = "podcastu YouTube" if mode == "transcript" else "dokumentu"
     prompt = (
-        f'Poniżej są streszczenia kolejnych sekcji merytorycznych podcastu YouTube pt.: „{title}".\n\n'
+        f'Poniżej są streszczenia kolejnych sekcji merytorycznych {source_desc} pt.: „{title}".\n\n'
         "Na ich podstawie przygotuj:\n"
         "1. GŁÓWNE WNIOSKI: 5-7 najważniejszych wniosków (lista punktowana).\n"
         "2. SYNTEZA: Spójne streszczenie całości (6-8 zdań).\n\n"
@@ -200,6 +205,7 @@ class DocumentAnalysisService:
         no_synthesis: bool = False,
         progress_fn: Callable[[str], None] | None = None,
         speakers: list[dict] | None = None,
+        mode: str = "transcript",
     ) -> DocumentAnalysisRun:
         """Create a new analysis run for an existing document and persist to DB.
 
@@ -210,19 +216,26 @@ class DocumentAnalysisService:
             no_synthesis: Skip the final synthesis step.
             progress_fn:  Optional callback for progress messages (used by batch scripts).
             speakers:     Optional speaker list [{"name", "role", "description"}] —
-                          when given, skips LLM speaker extraction.
+                          when given, skips LLM speaker extraction (transcript mode only).
+            mode:         "transcript" (STT: speakers, fillers, verbatim rewrite) or
+                          "article" (clean text: header-based split, classify+summarize).
 
         Returns:
             Persisted DocumentAnalysisRun with .chunks and .topic_sections populated.
 
         Raises:
-            ValueError:   Document not found or has no text content.
+            ValueError:   Document not found, no text content, or invalid mode.
             RuntimeError: LLM call failed or DB commit failed.
         """
         from library.chunk_llm_analysis import (
-            analyze_chunk, assign_speakers, extract_speaker_info, remove_speech_fillers,
+            analyze_article_chunk, analyze_chunk, assign_speakers,
+            extract_speaker_info, remove_speech_fillers,
         )
-        from library.text_functions import split_text_into_sentence_chunks
+        from library.text_functions import split_markdown_into_chunks, split_text_into_sentence_chunks
+
+        if mode not in ANALYSIS_MODES:
+            raise ValueError(f"Invalid mode: {mode!r} (expected one of {ANALYSIS_MODES})")
+        is_transcript = mode == "transcript"
 
         def log(msg: str) -> None:
             logger.info(msg)
@@ -241,40 +254,48 @@ class DocumentAnalysisService:
         if not text:
             raise ValueError(f"Document {doc_id} has no usable text (checked: text, text_md, text_raw)")
 
-        log(f"doc={doc_id} field={text_field} len={len(text):,}")
+        log(f"doc={doc_id} mode={mode} field={text_field} len={len(text):,}")
 
-        # 3. Detect format (multi-speaker = has >> speaker markers)
-        speaker_changes = len(re.findall(r'>>', text))
-        is_multi_speaker = speaker_changes > 0
-        log(f"format={'multi-speaker' if is_multi_speaker else 'monologue'} ({speaker_changes} >>)")
+        if is_transcript:
+            # 3. Detect format (multi-speaker = has >> speaker markers)
+            speaker_changes = len(re.findall(r'>>', text))
+            is_multi_speaker = speaker_changes > 0
+            log(f"format={'multi-speaker' if is_multi_speaker else 'monologue'} ({speaker_changes} >>)")
 
-        # 4. Extract speakers from intro text (only for multi-speaker conversations),
-        #    unless the caller already provided them
-        if speakers is None:
-            speakers = []
-            if is_multi_speaker:
-                intro_text = text[800:2400].strip()
-                try:
-                    speakers = extract_speaker_info(intro_text, model)
-                    log(f"speakers={[sp['name'] for sp in speakers]}")
-                except Exception:
-                    logger.exception("speaker extraction failed, continuing without speakers")
+            # 4. Extract speakers from intro text (only for multi-speaker conversations),
+            #    unless the caller already provided them
+            if speakers is None:
+                speakers = []
+                if is_multi_speaker:
+                    intro_text = text[800:2400].strip()
+                    try:
+                        speakers = extract_speaker_info(intro_text, model)
+                        log(f"speakers={[sp['name'] for sp in speakers]}")
+                    except Exception:
+                        logger.exception("speaker extraction failed, continuing without speakers")
 
-        # 5. Label speaker turns from >> markers (must happen before splitting,
-        #    so the rewrite prompt sees the [Name]: labels it is asked to preserve)
-        if is_multi_speaker and len(speakers) >= 2:
-            text = assign_speakers(text, speakers[0]["name"], speakers[1]["name"])
-            log(f"labeled speaker turns: [{speakers[0]['name']}] / [{speakers[1]['name']}]")
+            # 5. Label speaker turns from >> markers (must happen before splitting,
+            #    so the rewrite prompt sees the [Name]: labels it is asked to preserve)
+            if is_multi_speaker and len(speakers) >= 2:
+                text = assign_speakers(text, speakers[0]["name"], speakers[1]["name"])
+                log(f"labeled speaker turns: [{speakers[0]['name']}] / [{speakers[1]['name']}]")
 
-        # 6. Remove speech fillers before splitting (cheaper than asking LLM)
-        text = remove_speech_fillers(text)
+            # 6. Remove speech fillers before splitting (cheaper than asking LLM)
+            text = remove_speech_fillers(text)
 
-        # 7. Split into chunks at sentence boundaries
-        chunk_texts = split_text_into_sentence_chunks(text, chunk_size)
+            # 7. Split into chunks at sentence boundaries
+            chunk_texts = split_text_into_sentence_chunks(text, chunk_size)
+
+            # 8. Map chunks to transcript segments (for timestamp links)
+            segments = _load_segments(getattr(doc, "text_raw", None) or "")
+        else:
+            # Article mode: text is already clean — no speakers, no fillers,
+            # split at markdown headers, no transcript segments to map.
+            speakers = speakers or []
+            chunk_texts = split_markdown_into_chunks(text, chunk_size)
+            segments = []
         log(f"split={len(chunk_texts)} chunks, max {chunk_size:,} chars")
 
-        # 8. Map chunks to transcript segments (for timestamp links)
-        segments = _load_segments(getattr(doc, "text_raw", None) or "")
         seg_map = (
             _map_chunks_to_segments(chunk_texts, segments)
             if segments else [(None, None)] * len(chunk_texts)
@@ -286,13 +307,16 @@ class DocumentAnalysisService:
         for i, chunk_text in enumerate(chunk_texts):
             log(f"chunk {i + 1}/{total} ({len(chunk_text):,} chars)...")
             try:
-                result = analyze_chunk(
-                    chunk_text, model,
-                    position=i + 1, total=total,
-                    speakers=speakers or None,
-                    prev_context=_sentence_tail(chunk_texts[i - 1]) if i > 0 else "",
-                    next_context=_sentence_head(chunk_texts[i + 1]) if i < total - 1 else "",
-                )
+                if is_transcript:
+                    result = analyze_chunk(
+                        chunk_text, model,
+                        position=i + 1, total=total,
+                        speakers=speakers or None,
+                        prev_context=_sentence_tail(chunk_texts[i - 1]) if i > 0 else "",
+                        next_context=_sentence_head(chunk_texts[i + 1]) if i < total - 1 else "",
+                    )
+                else:
+                    result = analyze_article_chunk(chunk_text, model, position=i + 1, total=total)
             except Exception as exc:
                 raise RuntimeError(f"LLM call failed for chunk {i + 1}/{total}: {exc}") from exc
 
@@ -306,7 +330,7 @@ class DocumentAnalysisService:
             })
 
         # 10. Group chunks into logical topic sections
-        topic_groups = _merge_topics(sections, model)
+        topic_groups = _merge_topics(sections, model, mode=mode)
         if topic_groups:
             topic_sections_data = []
             for group in topic_groups:
@@ -340,7 +364,7 @@ class DocumentAnalysisService:
         synthesis = ""
         if not no_synthesis:
             log("generating synthesis...")
-            synthesis = _synthesize(sections, doc.title or f"Dokument {doc_id}", model)
+            synthesis = _synthesize(sections, doc.title or f"Dokument {doc_id}", model, mode=mode)
 
         # 12. Persist to DB
         run = DocumentAnalysisRun(
@@ -349,6 +373,8 @@ class DocumentAnalysisService:
             chunk_size=chunk_size,
             synthesis=synthesis or None,
             speakers=speakers,
+            mode=mode,
+            status="created",
         )
         session.add(run)
         session.flush()  # get run.id before adding children

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -29,7 +29,7 @@ ANALYSIS_MODELS = [DEFAULT_ANALYSIS_MODEL, f"arklabs/{DEFAULT_ANALYSIS_MODEL}"]
 ANALYSIS_MODES = ("transcript", "article")
 SYNTHESIS_MAX_TOKENS = 2_000
 SYNTHESIS_MAX_INPUT_CHARS = 20_000
-_SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT): ?(.+)$', re.MULTILINE)
+_SECTION_HEADER_RE = re.compile(r'^### (REKLAMA|TEMAT|SZUM): ?(.+)$', re.MULTILINE)
 
 
 # ---------------------------------------------------------------------------
@@ -130,10 +130,11 @@ def _merge_topics(sections: list[dict], model: str, mode: str = "transcript") ->
     prompt = (
         f"Poniżej lista {len(sections)} fragmentów {source_desc} z ich tematami.\n"
         "Pogrupuj SĄSIADUJĄCE fragmenty w logiczne sekcje tematyczne (zwykle 5-10 sekcji).\n"
-        "Fragmenty reklamowe (REKLAMA) możesz pominąć lub zgrupować razem pod jedną sekcją REKLAMA.\n\n"
+        "Fragmenty reklamowe (REKLAMA) i szum techniczny (SZUM) możesz pominąć lub zgrupować\n"
+        "razem pod jedną sekcją odpowiednio REKLAMA lub SZUM.\n\n"
         "Zwróć TYLKO tablicę JSON bez żadnego dodatkowego tekstu, w formacie:\n"
         '[{"title": "Tytuł sekcji tematycznej", "type": "TEMAT", "chunks": [1, 2]}]\n'
-        'Gdzie "chunks" to numery fragmentów (numeracja od 1), "type" to "TEMAT" lub "REKLAMA".\n\n'
+        'Gdzie "chunks" to numery fragmentów (numeracja od 1), "type" to "TEMAT", "REKLAMA" lub "SZUM".\n\n'
         f"Fragmenty:\n{chunk_list}"
     )
     try:

--- a/backend/library/text_functions.py
+++ b/backend/library/text_functions.py
@@ -131,6 +131,61 @@ def split_text_into_chunks(text: str, max_chars: int) -> list[str]:
     return chunks
 
 
+_MD_HEADER_RE = re.compile(r'^#{1,6} ', re.MULTILINE)
+
+
+def split_markdown_into_chunks(text: str, max_chars: int) -> list[str]:
+    """Split markdown text into chunks, preferring section boundaries (headers).
+
+    Strategy:
+      1. Cut the text into sections at markdown headers (#..######) — a header
+         always starts a new section and stays with the content that follows it.
+      2. Pack consecutive sections into chunks of up to max_chars.
+      3. A single section larger than max_chars is split at paragraph boundaries
+         (falling back to line/sentence splits via split_text_into_chunks).
+      4. Text without any headers degrades to plain paragraph splitting.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    boundaries = [m.start() for m in _MD_HEADER_RE.finditer(text)]
+    if not boundaries:
+        return split_text_into_chunks(text, max_chars)
+
+    # Preamble before the first header is its own section
+    starts = boundaries if boundaries[0] == 0 else [0] + boundaries
+    sections = [
+        text[start:end].strip()
+        for start, end in zip(starts, starts[1:] + [len(text)])
+    ]
+    sections = [s for s in sections if s]
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_size = 0
+
+    for section in sections:
+        if len(section) > max_chars:
+            if current:
+                chunks.append('\n\n'.join(current))
+                current = []
+                current_size = 0
+            chunks.extend(split_text_into_chunks(section, max_chars))
+        elif current_size + len(section) + 2 > max_chars and current:
+            chunks.append('\n\n'.join(current))
+            current = [section]
+            current_size = len(section)
+        else:
+            current.append(section)
+            current_size += len(section) + 2
+
+    if current:
+        chunks.append('\n\n'.join(current))
+
+    return chunks
+
+
 def split_text_for_embedding(text, paragraph_titles=[], max_words_in_line=300, max_characters_in_line=1000):
     sentences2 = []
     paragraphs = text.split("\n\n")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lenie-server"
-version = "0.3.13.0"
+version = "0.3.14.0"
 description = "Personal AI assistant for collecting, managing, and searching data using LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/server.py
+++ b/backend/server.py
@@ -21,8 +21,8 @@ cfg = load_config()
 
 secrets_backend = cfg.require("SECRETS_BACKEND", "env")
 
-APP_VERSION = "0.3.13.0"
-BUILD_TIME = "2026.01.23 04:04"
+APP_VERSION = "0.3.14.0"
+BUILD_TIME = "2026.07.04 08:00"
 
 logging.info(f"APP VERSION={APP_VERSION} (build time:{BUILD_TIME})")
 

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -146,6 +146,23 @@ class TestArticleMode:
         assert article_env["speakers"] == 0
         assert article_env["fillers"] == 0
 
+    def test_split_only_makes_no_llm_calls(self, session, article_env):
+        service = DocumentAnalysisService(session)
+        run = service.create_run(
+            doc_id=42, model="test-model", mode="article", chunk_size=300, split_only=True,
+        )
+
+        assert article_env["article"] == 0
+        assert article_env["transcript"] == 0
+        assert run.synthesis is None
+        chunks = [o for o in session.added if isinstance(o, DocumentChunk)]
+        assert len(chunks) >= 2
+        assert all(c.type == "TEMAT" and c.status == "pending" for c in chunks)
+        assert all(c.topic is None and c.summary is None and c.corrected_text is None for c in chunks)
+        from library.db.models import DocumentTopicSection
+        sections = [o for o in session.added if isinstance(o, DocumentTopicSection)]
+        assert sections == []
+
     def test_default_mode_is_transcript(self, session, article_env, monkeypatch):
         """Without mode argument the transcript pipeline runs (fillers get called)."""
         # Un-fail the transcript primitives — record calls instead

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -79,6 +79,35 @@ def article_env(monkeypatch, session):
     return calls
 
 
+class TestSzumType:
+    def test_parse_szum_header(self):
+        from library.chunk_llm_analysis import parse_rewritten_chunk
+        t, topic, rest = parse_rewritten_chunk("### SZUM: nawigacja portalu WP\n")
+        assert t == "SZUM"
+        assert topic == "nawigacja portalu WP"
+        assert rest == ""
+
+    def test_article_chunk_szum_has_no_summary(self, monkeypatch):
+        monkeypatch.setattr(
+            llm, "call_model",
+            lambda prompt, model, max_tokens: ("### SZUM: menu i stopka strony\ncokolwiek", 10),
+        )
+        result = llm.analyze_article_chunk("Wróć na POLSKA ŚWIAT...", "m")
+        assert result["type"] == "SZUM"
+        assert result["topic"] == "menu i stopka strony"
+        assert result["summary"] is None
+        assert result["corrected_text"] is None
+
+    def test_article_chunk_temat_strips_streszczenie_prefix(self, monkeypatch):
+        monkeypatch.setattr(
+            llm, "call_model",
+            lambda prompt, model, max_tokens: ("### TEMAT: konflikt USA-Iran\nStreszczenie: Analiza sytuacji.", 10),
+        )
+        result = llm.analyze_article_chunk("Treść merytoryczna.", "m")
+        assert result["type"] == "TEMAT"
+        assert result["summary"] == "Analiza sytuacji."
+
+
 class TestArticleMode:
     def test_invalid_mode_raises(self, session):
         service = DocumentAnalysisService(session)

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -1,0 +1,135 @@
+"""Unit tests for DocumentAnalysisService.create_run in article mode.
+
+LLM calls and DB access are mocked — verifies pipeline routing only:
+article mode must skip speaker/filler processing, use the markdown splitter,
+call analyze_article_chunk and persist mode/status on the run.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import library.chunk_llm_analysis as llm
+import library.document_analysis_service as das
+from library.db.models import DocumentChunk
+from library.document_analysis_service import ANALYSIS_MODES, DocumentAnalysisService
+
+
+ARTICLE_TEXT = (
+    "# Rozdział pierwszy\n\n" + "Zdanie merytoryczne. " * 20
+    + "\n\n# Rozdział drugi\n\n" + "Kolejne zdanie. " * 20
+)
+
+
+class FakeDoc:
+    id = 42
+    title = "Testowy artykuł"
+    text = ARTICLE_TEXT
+    text_md = None
+    text_raw = None
+
+
+@pytest.fixture
+def session():
+    s = MagicMock()
+    s.added = []
+    s.add.side_effect = s.added.append
+    return s
+
+
+@pytest.fixture
+def article_env(monkeypatch, session):
+    """Patch document lookup, LLM primitives and topic grouping/synthesis."""
+    monkeypatch.setattr(
+        das.WebDocument, "get_by_id", staticmethod(lambda _s, _id: FakeDoc()),
+    )
+
+    calls = {"article": 0, "transcript": 0, "speakers": 0, "fillers": 0}
+
+    def fake_article(text, model, position=1, total=1):
+        calls["article"] += 1
+        return {
+            "type": "TEMAT",
+            "topic": f"temat {position}",
+            "corrected_text": None,
+            "summary": f"streszczenie {position}",
+            "rewrite_ratio": None,
+        }
+
+    def fail_transcript(*_a, **_kw):
+        calls["transcript"] += 1
+        raise AssertionError("transcript-mode LLM primitive called in article mode")
+
+    def fail_speakers(*_a, **_kw):
+        calls["speakers"] += 1
+        raise AssertionError("speaker extraction called in article mode")
+
+    def fail_fillers(text):
+        calls["fillers"] += 1
+        raise AssertionError("remove_speech_fillers called in article mode")
+
+    monkeypatch.setattr(llm, "analyze_article_chunk", fake_article)
+    monkeypatch.setattr(llm, "analyze_chunk", fail_transcript)
+    monkeypatch.setattr(llm, "extract_speaker_info", fail_speakers)
+    monkeypatch.setattr(llm, "remove_speech_fillers", fail_fillers)
+    monkeypatch.setattr(das, "_merge_topics", lambda sections, model, mode="transcript": [])
+    monkeypatch.setattr(
+        das, "_synthesize", lambda sections, title, model, mode="transcript": "synteza",
+    )
+    return calls
+
+
+class TestArticleMode:
+    def test_invalid_mode_raises(self, session):
+        service = DocumentAnalysisService(session)
+        with pytest.raises(ValueError, match="Invalid mode"):
+            service.create_run(doc_id=42, model="m", mode="ksiazka")
+
+    def test_modes_constant(self):
+        assert ANALYSIS_MODES == ("transcript", "article")
+
+    def test_article_run_persists_mode_and_status(self, session, article_env):
+        service = DocumentAnalysisService(session)
+        run = service.create_run(doc_id=42, model="test-model", mode="article")
+
+        assert run.mode == "article"
+        assert run.status == "created"
+        assert run.speakers == []
+        session.commit.assert_called_once()
+
+    def test_article_chunks_have_no_corrected_text(self, session, article_env):
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=42, model="test-model", mode="article", chunk_size=300)
+
+        chunks = [o for o in session.added if isinstance(o, DocumentChunk)]
+        assert len(chunks) >= 2
+        assert all(c.corrected_text is None for c in chunks)
+        assert all(c.rewrite_ratio is None for c in chunks)
+        assert all(c.seg_start is None and c.seg_end is None for c in chunks)
+        assert [c.position for c in chunks] == list(range(1, len(chunks) + 1))
+
+    def test_article_mode_skips_transcript_pipeline(self, session, article_env):
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=42, model="test-model", mode="article", chunk_size=300)
+
+        assert article_env["article"] >= 2
+        assert article_env["transcript"] == 0
+        assert article_env["speakers"] == 0
+        assert article_env["fillers"] == 0
+
+    def test_default_mode_is_transcript(self, session, article_env, monkeypatch):
+        """Without mode argument the transcript pipeline runs (fillers get called)."""
+        # Un-fail the transcript primitives — record calls instead
+        monkeypatch.setattr(llm, "remove_speech_fillers", lambda t: t)
+        monkeypatch.setattr(
+            llm, "analyze_chunk",
+            lambda *a, **kw: {
+                "type": "TEMAT", "topic": "t", "corrected_text": "x",
+                "summary": "s", "rewrite_ratio": 100,
+            },
+        )
+        service = DocumentAnalysisService(session)
+        run = service.create_run(doc_id=42, model="test-model")
+
+        assert run.mode == "transcript"
+        assert article_env["article"] == 0

--- a/backend/tests/unit/test_split_markdown_into_chunks.py
+++ b/backend/tests/unit/test_split_markdown_into_chunks.py
@@ -1,0 +1,66 @@
+"""Unit tests for library.text_functions.split_markdown_into_chunks."""
+
+from library.text_functions import split_markdown_into_chunks
+
+
+class TestSplitMarkdownIntoChunks:
+    def test_empty_text_returns_empty_list(self):
+        assert split_markdown_into_chunks("", 1000) == []
+        assert split_markdown_into_chunks("   \n\n  ", 1000) == []
+
+    def test_short_text_single_chunk(self):
+        text = "# Tytuł\n\nKrótki akapit."
+        assert split_markdown_into_chunks(text, 1000) == [text]
+
+    def test_splits_at_headers_when_over_limit(self):
+        sec1 = "# Rozdział 1\n\n" + "a" * 60
+        sec2 = "# Rozdział 2\n\n" + "b" * 60
+        chunks = split_markdown_into_chunks(f"{sec1}\n\n{sec2}", 100)
+        assert chunks == [sec1, sec2]
+
+    def test_packs_small_sections_together(self):
+        sec1 = "## A\n\nkrótki"
+        sec2 = "## B\n\nkrótki"
+        sec3 = "## C\n\nkrótki"
+        chunks = split_markdown_into_chunks(f"{sec1}\n\n{sec2}\n\n{sec3}", 1000)
+        assert len(chunks) == 1
+        assert sec1 in chunks[0] and sec3 in chunks[0]
+
+    def test_header_starts_new_chunk_not_middle(self):
+        """A header never lands at the end of a chunk without its content."""
+        sec1 = "# Pierwszy\n\n" + "x" * 80
+        sec2 = "# Drugi\n\n" + "y" * 80
+        chunks = split_markdown_into_chunks(f"{sec1}\n\n{sec2}", 120)
+        assert chunks[0].startswith("# Pierwszy")
+        assert chunks[1].startswith("# Drugi")
+
+    def test_preamble_before_first_header_is_kept(self):
+        text = "Wstęp bez nagłówka.\n\n# Rozdział\n\nTreść."
+        chunks = split_markdown_into_chunks(text, 1000)
+        assert len(chunks) == 1
+        assert chunks[0].startswith("Wstęp")
+
+    def test_oversized_section_split_by_paragraphs(self):
+        paras = "\n\n".join("p" * 50 for _ in range(5))
+        text = f"# Duży rozdział\n\n{paras}"
+        chunks = split_markdown_into_chunks(text, 120)
+        assert len(chunks) > 1
+        assert all(len(c) <= 120 for c in chunks)
+
+    def test_no_headers_falls_back_to_paragraphs(self):
+        text = "\n\n".join(f"Akapit {i} " + "z" * 40 for i in range(4))
+        chunks = split_markdown_into_chunks(text, 100)
+        assert len(chunks) > 1
+        assert "".join(chunks).count("Akapit") == 4
+
+    def test_all_header_levels_recognized(self):
+        text = "###### Głęboki\n\n" + "a" * 60 + "\n\n## Płytki\n\n" + "b" * 60
+        chunks = split_markdown_into_chunks(text, 80)
+        assert len(chunks) == 2
+        assert chunks[1].startswith("## Płytki")
+
+    def test_hash_inside_line_is_not_a_header(self):
+        """'#' not at line start (e.g. C# or anchors) must not create a boundary."""
+        text = "Język C# oraz F# to platforma .NET. " * 3
+        chunks = split_markdown_into_chunks(text, 1000)
+        assert len(chunks) == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "lenie-server"
-version = "0.3.13.0"
+version = "0.3.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/docs/shared-types.md
+++ b/docs/shared-types.md
@@ -25,7 +25,7 @@ shared/
 
 | Export | Kind | Description |
 |--------|------|-------------|
-| `ApiType` | type | `"AWS Serverless" \| "Docker"` — backend deployment mode |
+| `ApiType` | type | `"Docker"` — backend deployment mode ("AWS Serverless" removed 2026-07-04) |
 | `DEFAULT_API_URLS` | const | Default backend URLs per API type |
 
 ### `documents.ts`

--- a/shared/types/api.ts
+++ b/shared/types/api.ts
@@ -1,6 +1,9 @@
-export type ApiType = "AWS Serverless" | "Docker";
+// "AWS Serverless" removed 2026-07-04 — the document-serving Lambdas
+// (app-server-db/app-server-internet) were decommissioned 2026-07-02 and no
+// frontend can browse documents through the AWS API anymore.
+// Restoration notes: docs/aws-serverless-restoration.md
+export type ApiType = "Docker";
 
 export const DEFAULT_API_URLS: Record<ApiType, string> = {
-  "AWS Serverless": "https://api.dev.lenie-ai.eu",
   Docker: "http://192.168.200.7:5055",
 };

--- a/web_interface_app2/src/services/storage.ts
+++ b/web_interface_app2/src/services/storage.ts
@@ -9,7 +9,7 @@ const KEYS = {
   apiUrl: `${PREFIX}apiUrl`,
 } as const;
 
-export const DEFAULT_API_URL = DEFAULT_API_URLS["AWS Serverless"];
+export const DEFAULT_API_URL = DEFAULT_API_URLS["Docker"];
 
 export function loadAuth(): AuthState | null {
   const storedKey = localStorage.getItem(KEYS.apiKey);

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -2,7 +2,7 @@
 
 React 18 single-page application for managing documents and running AI operations (text correction, embedding, similarity search). Built with **Vite** and **TypeScript**.
 
-**App version**: 0.3.13.0 | **Package version**: 0.3.13.0
+**App version**: 0.3.14.0 | **Package version**: 0.3.14.0
 
 ## Directory Structure
 
@@ -92,7 +92,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 
 ### Global State (`authorizationContext.tsx`)
 
-- **API config** (persisted to localStorage): `apiUrl`, `apiKey`, `apiType` (AWS Serverless / Docker)
+- **API config** (persisted to localStorage): `apiUrl`, `apiKey`, `apiType` (always "Docker" since 2026-07-04)
 - *(Infrastructure status state removed 2026-07-02 — the RDS/OpenVPN/SQS widgets went away along with the AWS resources they monitored)*
 - **Document filters**: `selectedDocumentType`, `selectedDocumentState`, `searchInDocument`, `searchType`
 
@@ -100,7 +100,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 
 | Key | Value |
 |-----|-------|
-| `lenie_apiType` | "AWS Serverless" or "Docker" |
+| `lenie_apiType` | "Docker" (stale "AWS Serverless" values are ignored on load) |
 | `lenie_apiUrl` | API URL (single URL for both app and infra endpoints) |
 | `lenie_apiKey` | API authentication key |
 
@@ -118,7 +118,7 @@ AuthorizationProvider (init from localStorage) → BrowserRouter → App → Req
 - **HTTP client**: axios
 - **Auth header**: `x-api-key: {apiKey}` on all requests
 - **Content-Type**: `application/x-www-form-urlencoded`
-- **API type**: Docker (Flask backend, localhost:5000 or NAS) — the only selectable option. The "AWS Serverless" option was removed from the connect screen 2026-07-02: its document-serving Lambdas (`app-server-db`/`app-server-internet`) were decommissioned, leaving only `/url_add` in the AWS API (used by the Chrome extension, not this frontend). The `ApiType` union in `@lenie/shared` still includes "AWS Serverless" because `web_interface_app2` references it. Restoration: [docs/aws-serverless-restoration.md](../docs/aws-serverless-restoration.md).
+- **API type**: Docker (Flask backend, localhost:5000 or NAS) — the only mode. The "AWS Serverless" option was removed from the connect screen 2026-07-02 and purged entirely 2026-07-04 (`ApiType` union, `DEFAULT_API_URLS`, storage fallback, `authorizationContext` default, `useSearch` AWS branch, app2 default URL): its document-serving Lambdas (`app-server-db`/`app-server-internet`) were decommissioned, leaving only `/url_add` in the AWS API (used by the Chrome extension, not this frontend). Restoration: [docs/aws-serverless-restoration.md](../docs/aws-serverless-restoration.md).
 
 ### Default URLs
 

--- a/web_interface_react/package.json
+++ b/web_interface_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenie-ai",
-  "version": "0.3.13.0",
+  "version": "0.3.14.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/web_interface_react/src/modules/shared/constants/variables.ts
+++ b/web_interface_react/src/modules/shared/constants/variables.ts
@@ -1,1 +1,1 @@
-export const lenie_version = "0.3.13.0";
+export const lenie_version = "0.3.14.0";

--- a/web_interface_react/src/modules/shared/context/authorizationContext.tsx
+++ b/web_interface_react/src/modules/shared/context/authorizationContext.tsx
@@ -7,7 +7,7 @@ export const AuthorizationContext = createContext<AuthorizationState>({
   setApiKey: () => {},
   apiUrl: "",
   setApiUrl: () => {},
-  apiType: "AWS Serverless",
+  apiType: "Docker",
   setApiType: () => {},
   searchInDocument: "",
   setSearchInDocument: () => {},

--- a/web_interface_react/src/modules/shared/hooks/useSearch.ts
+++ b/web_interface_react/src/modules/shared/hooks/useSearch.ts
@@ -7,7 +7,7 @@ export const useSearch = ({ callback }: { callback: () => void }) => {
   const [message, setMessage] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
-  const { apiKey, apiUrl, apiType } = React.useContext(AuthorizationContext);
+  const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
   const [results, setResults] = React.useState<any[] | null>(null);
   const [searchSimilar, setSearchSimilar] = React.useState('');
 
@@ -19,94 +19,13 @@ export const useSearch = ({ callback }: { callback: () => void }) => {
 
   const handleSearchSimilar = async (search?: string, searchLimit?: string, translate?: boolean) => {
     setIsLoading(true);
-    console.log("api Type:" + apiType)
     console.log("searching: " + search)
     console.log("searching limit: " + searchLimit)
     console.log("translate: " + translate);
 
-    let responseEmbedding: any = NaN;
-    let embedds: any = NaN;
-
-    if (apiType === "AWS Serverless") {
-      console.log("AWS serverless version")
-
-      try {
-        setResults([])
-        responseEmbedding = await axios.post(`${apiUrl}/ai_embedding_get`, {
-          text: search,
-          model: "amazon.titan-embed-text-v1",
-          translate: translate
-        }, {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'x-api-key': `${apiKey}`,
-          },
-        });
-        console.log(responseEmbedding.data.message);
-        console.log(responseEmbedding.data);
-        if (responseEmbedding.data.websites != null) {
-          setData(responseEmbedding.data.websites);
-        }
-        embedds = responseEmbedding.data.embedds
-        console.log("end of handleSearchSimilar");
-        setIsLoading(false);
-        setIsError(false);
-      } catch (error: any) {
-        console.error("There was an error on handleGetList!", error);
-        let message = error.message;
-        if (
-            error.response &&
-            error.response.status &&
-            error.response.status === 400
-        ) {
-          message += " Check your API key first";
-        }
-        setIsLoading(false);
-        setIsError(true);
-        setMessage(`There was an error on handleSearchSimilar. ${message}`);
-      }
-
-      try {
-        const response = await axios.post(`${apiUrl}/website_similar`, {
-          embedds: embedds,
-          model: "amazon.titan-embed-text-v1",
-          search: search,
-          limit: searchLimit,
-        }, {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'x-api-key': `${apiKey}`,
-          },
-        });
-        console.log(response.data.message);
-        console.log(response.data);
-        if (response.data.websites != null) {
-          setData(response.data.websites);
-          setResults(response.data.websites)
-        }
-        console.log("end of handleSearchSimilar2");
-        setIsLoading(false);
-        setIsError(false);
-      } catch (error: any) {
-        console.error("There was an error on handleGetList2!", error);
-        let message = error.message;
-        if (
-            error.response &&
-            error.response.status &&
-            error.response.status === 400
-        ) {
-          message += " Check your API key first";
-        }
-        setIsLoading(false);
-        setIsError(true);
-        setMessage(`There was an error on handleSearchSimilar2. ${message}`);
-      }
-
-
-  }
-
-    if (apiType === "Docker") {
-      console.log("Docker version")
+    // AWS Serverless two-step flow (ai_embedding_get + website_similar) removed
+    // 2026-07-04 — the AWS document API is decommissioned.
+    {
       try {
         const response = await axios.post(`${apiUrl}/website_similar`, {
           model: "amazon.titan-embed-text-v1",

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams, NavLink } from "react-router-dom";
+import { useParams, useLocation, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -12,6 +12,7 @@ interface Segment {
 interface Chunk {
   id: number;
   position: number;
+  original_text: string | null;
   corrected_text: string | null;
   summary: string | null;
   topic: string | null;
@@ -32,7 +33,16 @@ interface AnalysisRun {
   model: string;
   created_at: string;
   chunk_count: number;
+  mode: string;
+  status: string;
+  scope: string | null;
 }
+
+const RUN_STATUS_LABELS: Record<string, string> = {
+  created: "nowa",
+  in_review: "w przeglądzie",
+  reviewed: "zamknięta",
+};
 
 interface SplitState {
   segIdx: number;
@@ -170,6 +180,8 @@ const SegmentsView: React.FC<{
 
 const Chunks = () => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const initialDocType = (location.state as { docType?: string } | null)?.docType ?? "";
   const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
 
   const [runs, setRuns]             = React.useState<AnalysisRun[]>([]);
@@ -177,6 +189,8 @@ const Chunks = () => {
   const [chunks, setChunks]         = React.useState<Chunk[]>([]);
   const [segments, setSegments]     = React.useState<Segment[]>([]);
   const [videoId, setVideoId]       = React.useState("");
+  const [docType, setDocType]       = React.useState(initialDocType);
+  const [runMode, setRunMode]       = React.useState("transcript");
   const [speakers, setSpeakers]     = React.useState<Speaker[]>([]);
 
   const [loading, setLoading]       = React.useState(false);
@@ -184,6 +198,7 @@ const Chunks = () => {
   const [jobStatus, setJobStatus]   = React.useState<string | null>(null);
   const [jobId, setJobId]           = React.useState<string | null>(null);
   const [newModel, setNewModel]     = React.useState(MODELS[0]);
+  const [newMode, setNewMode]       = React.useState("transcript");
   const [chunkSize, setChunkSize]   = React.useState(5000);
   const [hideAds, setHideAds]       = React.useState(false);
 
@@ -226,6 +241,8 @@ const Chunks = () => {
       setChunks(loaded);
       setSegments(data.segments ?? []);
       setVideoId(data.document?.original_id ?? "");
+      setDocType(data.document?.document_type ?? "");
+      setRunMode(data.run?.mode ?? "transcript");
       setSpeakers(data.run?.speakers ?? []);
       const edits: Record<number, string> = {};
       const correctedDefaults: Record<number, boolean> = {};
@@ -246,6 +263,10 @@ const Chunks = () => {
 
   React.useEffect(() => { fetchRuns(); }, [fetchRuns]);
   React.useEffect(() => { if (selectedRun !== null) fetchChunks(selectedRun); }, [selectedRun, fetchChunks]);
+  // Clean documents (articles, webpages) default to article mode for new analyses
+  React.useEffect(() => {
+    if (docType && docType !== "youtube" && docType !== "movie") setNewMode("article");
+  }, [docType]);
 
   // ── Job polling ──
 
@@ -280,7 +301,7 @@ const Chunks = () => {
     try {
       const r = await fetch(`${apiUrl}/document/${id}/analyze_chunks`, {
         method: "POST", headers,
-        body: JSON.stringify({ model: newModel, chunk_size: chunkSize }),
+        body: JSON.stringify({ model: newModel, chunk_size: chunkSize, mode: newMode }),
       });
       const data = await r.json();
       if (data.job_id) { setJobId(data.job_id); setJobStatus("running"); pollJob(data.job_id); }
@@ -428,7 +449,7 @@ const Chunks = () => {
     <div>
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 6, flexWrap: "wrap" }}>
         <h2 style={{ margin: 0 }}>Przegląd chunków — dokument #{id}</h2>
-        <NavLink to={`/youtube/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>← Edytuj dokument</NavLink>
+        <NavLink to={`/${docType || "youtube"}/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>← Edytuj dokument</NavLink>
       </div>
 
       {/* Nowa analiza */}
@@ -437,6 +458,11 @@ const Chunks = () => {
         <div style={{ display: "flex", gap: 10, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
           <select value={newModel} onChange={e => setNewModel(e.target.value)} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
             {MODELS.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+          <select value={newMode} onChange={e => setNewMode(e.target.value)} style={{ padding: "4px 8px", fontSize: "0.88em" }}
+            title="transkrypcja: mówcy + korekta STT; artykuł: czysty tekst, podział po nagłówkach, bez korekty">
+            <option value="transcript">transkrypcja (YouTube)</option>
+            <option value="article">artykuł (czysty tekst)</option>
           </select>
           <label style={{ fontSize: "0.85em" }}>
             Chunk:&nbsp;
@@ -457,6 +483,8 @@ const Chunks = () => {
             {runs.map(r => (
               <option key={r.id} value={r.id}>
                 #{r.id} — {r.model} ({r.chunk_count} chunków, {new Date(r.created_at).toLocaleString("pl")})
+                {" "}[{r.mode === "article" ? "artykuł" : "transkrypcja"}
+                {r.scope ? `, ${r.scope}` : ""}, {RUN_STATUS_LABELS[r.status] ?? r.status}]
               </option>
             ))}
           </select>
@@ -500,8 +528,8 @@ const Chunks = () => {
         </div>
       )}
 
-      {/* Pasek rozmówców */}
-      {selectedRun !== null && (
+      {/* Pasek rozmówców (tylko transkrypcje — artykuły nie mają mówców) */}
+      {selectedRun !== null && runMode !== "article" && (
         <div style={{ marginBottom: 12, padding: "8px 14px", background: "#1e3a5f", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <strong style={{ color: "#fff", fontSize: "0.85em" }}>Rozmówcy:</strong>
           {speakers.length > 0 ? (
@@ -610,11 +638,11 @@ const Chunks = () => {
               </button>
             </div>
 
-            {/* Treść */}
+            {/* Treść: poprawiony tekst → segmenty transkrypcji → surowy tekst (artykuły) */}
             <div style={{ padding: "12px 14px", fontSize: "0.88em", lineHeight: 1.6 }}>
               {isCorrectedView && hasCorrected ? (
                 <div style={{ whiteSpace: "pre-wrap", color: "#1e293b" }}>{chunk.corrected_text}</div>
-              ) : (
+              ) : chunkSegs.length > 0 ? (
                 <SegmentsView
                   segs={chunkSegs}
                   videoId={videoId}
@@ -623,6 +651,10 @@ const Chunks = () => {
                   splitState={splitSt}
                   onMarkSplit={markSplit}
                 />
+              ) : (
+                <div style={{ whiteSpace: "pre-wrap", color: "#1e293b" }}>
+                  {chunk.original_text ?? <em style={{ color: "#94a3b8" }}>brak tekstu</em>}
+                </div>
               )}
             </div>
 

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -187,6 +187,65 @@ const SegmentsView: React.FC<{
   );
 };
 
+// ── Plain-text view with line removal (article chunks) ──────────────────────
+
+const PlainTextLines: React.FC<{
+  text: string;
+  markedLines: Set<number>;
+  saving: boolean;
+  onToggleLine: (idx: number) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}> = ({ text, markedLines, saving, onToggleLine, onSave, onCancel }) => {
+  if (!text) return <em style={{ color: "#94a3b8" }}>brak tekstu</em>;
+  const lines = text.split("\n");
+  return (
+    <div>
+      {lines.map((line, i) => {
+        const marked = markedLines.has(i);
+        return (
+          <div
+            key={i}
+            style={{
+              position: "relative", paddingRight: 30, borderRadius: 2, minHeight: "1.4em",
+              ...(marked ? { background: "#fee2e2", textDecoration: "line-through", color: "#991b1b" } : {}),
+            }}
+          >
+            <span style={{ whiteSpace: "pre-wrap" }}>{line || " "}</span>
+            <button
+              onClick={() => onToggleLine(i)}
+              title={marked ? "Przywróć linię" : "Usuń linię"}
+              style={{
+                position: "absolute", right: 2, top: 1,
+                background: "none", border: "1px solid #e2e8f0", borderRadius: 3,
+                fontSize: "0.78em", cursor: "pointer", padding: "0 5px",
+                color: marked ? "#991b1b" : "#94a3b8",
+              }}
+            >
+              {marked ? "↺" : "✕"}
+            </button>
+          </div>
+        );
+      })}
+      {markedLines.size > 0 && (
+        <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
+          <button onClick={onSave} disabled={saving}
+            style={{ padding: "3px 12px", background: "#b91c1c", color: "#fff", border: "none", borderRadius: 3, cursor: "pointer", fontWeight: "bold", fontSize: "0.85em" }}>
+            {saving ? "Zapisuję…" : `Usuń ${markedLines.size} ${markedLines.size === 1 ? "linię" : "linie/linii"} i zapisz`}
+          </button>
+          <button onClick={onCancel}
+            style={{ padding: "3px 10px", background: "#e2e8f0", color: "#475569", border: "none", borderRadius: 3, cursor: "pointer", fontSize: "0.85em" }}>
+            Anuluj
+          </button>
+          <span style={{ fontSize: "0.8em", color: "#94a3b8" }}>
+            Po zapisie warto ponownie uruchomić analizę chunka (▶ Pełna), by odświeżyć temat i streszczenie.
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
 // ── Main component ───────────────────────────────────────────────────────────
 
 const Chunks = () => {
@@ -221,6 +280,8 @@ const Chunks = () => {
   const [reanalyzingAll, setReanalyzingAll] = React.useState(false);
   const [approvingAll, setApprovingAll] = React.useState(false);
   const [splitStates, setSplitStates]     = React.useState<Record<number, SplitState>>({});
+  const [lineEdits, setLineEdits]         = React.useState<Record<number, Set<number>>>({});
+  const [savingLines, setSavingLines]     = React.useState<Record<number, boolean>>({});
   const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
   const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
   const [hiddenChunks, setHiddenChunks] = React.useState<Set<number>>(new Set());
@@ -264,6 +325,7 @@ const Chunks = () => {
       setTopicEdits(edits);
       setShowCorrected(correctedDefaults);
       setSplitStates({});
+      setLineEdits({});
       setHiddenChunks(new Set());
     } catch {
       setError("Błąd ładowania chunków");
@@ -395,6 +457,36 @@ const Chunks = () => {
     } finally {
       setApprovingAll(false);
     }
+  };
+
+  // ── Line removal (article chunks) ──
+
+  const toggleLineMark = (chunkId: number, idx: number) => {
+    setLineEdits(prev => {
+      const cur = new Set(prev[chunkId] ?? []);
+      if (cur.has(idx)) {
+        cur.delete(idx);
+      } else {
+        cur.add(idx);
+      }
+      return { ...prev, [chunkId]: cur };
+    });
+  };
+
+  const clearLineMarks = (chunkId: number) => {
+    setLineEdits(prev => { const n = { ...prev }; delete n[chunkId]; return n; });
+  };
+
+  const saveLineRemovals = async (chunk: Chunk) => {
+    const marked = lineEdits[chunk.id];
+    if (!marked || marked.size === 0) return;
+    const lines = (chunk.original_text ?? "").split("\n");
+    const newText = lines.filter((_, i) => !marked.has(i)).join("\n");
+    if (!newText.trim()) { setError("Nie można usunąć wszystkich linii"); return; }
+    setSavingLines(prev => ({ ...prev, [chunk.id]: true }));
+    const res = await patchChunk(chunk.id, { original_text: newText });
+    setSavingLines(prev => ({ ...prev, [chunk.id]: false }));
+    if (res?.status === "success") clearLineMarks(chunk.id);
   };
 
   // ── Split ──
@@ -662,9 +754,14 @@ const Chunks = () => {
                   onMarkSplit={markSplit}
                 />
               ) : (
-                <div style={{ whiteSpace: "pre-wrap", color: "#1e293b" }}>
-                  {chunk.original_text ?? <em style={{ color: "#94a3b8" }}>brak tekstu</em>}
-                </div>
+                <PlainTextLines
+                  text={chunk.original_text ?? ""}
+                  markedLines={lineEdits[chunk.id] ?? new Set()}
+                  saving={savingLines[chunk.id] ?? false}
+                  onToggleLine={idx => toggleLineMark(chunk.id, idx)}
+                  onSave={() => saveLineRemovals(chunk)}
+                  onCancel={() => clearLineMarks(chunk.id)}
+                />
               )}
             </div>
 

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -44,11 +44,13 @@ const RUN_STATUS_LABELS: Record<string, string> = {
   reviewed: "zamknięta",
 };
 
+type ChunkType = "TEMAT" | "REKLAMA" | "SZUM";
+
 interface SplitState {
   segIdx: number;
   ts: string;
-  firstType: "TEMAT" | "REKLAMA";
-  secondType: "TEMAT" | "REKLAMA";
+  firstType: ChunkType;
+  secondType: ChunkType;
 }
 
 interface SegGroup {
@@ -68,6 +70,15 @@ const MODELS = [
 ];
 
 const STATUS_CYCLE = ["pending", "approved", "needs_reanalysis"] as const;
+const TYPE_CYCLE: ChunkType[] = ["TEMAT", "REKLAMA", "SZUM"];
+
+function typeColor(type: string | null): React.CSSProperties {
+  switch (type) {
+    case "REKLAMA": return { background: "#fee2e2", color: "#991b1b" };
+    case "SZUM":    return { background: "#e5e7eb", color: "#4b5563" };
+    default:        return { background: "#dbeafe", color: "#1d4ed8" };
+  }
+}
 
 function secs2ts(s: number): string {
   s = Math.floor(s);
@@ -343,7 +354,8 @@ const Chunks = () => {
   };
 
   const toggleType = (chunk: Chunk) => {
-    patchChunk(chunk.id, { type: chunk.type === "TEMAT" ? "REKLAMA" : "TEMAT" });
+    const idx = TYPE_CYCLE.indexOf(chunk.type as ChunkType);
+    patchChunk(chunk.id, { type: TYPE_CYCLE[(idx + 1) % TYPE_CYCLE.length] });
   };
 
   // ── Re-analysis ──
@@ -375,7 +387,7 @@ const Chunks = () => {
   };
 
   const approveAll = async () => {
-    const toApprove = chunks.filter(c => c.type !== "REKLAMA" && c.status !== "approved");
+    const toApprove = chunks.filter(c => c.type === "TEMAT" && c.status !== "approved");
     if (!toApprove.length) return;
     setApprovingAll(true);
     try {
@@ -432,15 +444,15 @@ const Chunks = () => {
 
   // ── Progress ──
 
-  const tematChunks = chunks.filter(c => c.type !== "REKLAMA");
+  const tematChunks = chunks.filter(c => c.type === "TEMAT");
   const approvedCount = tematChunks.filter(c => c.status === "approved").length;
   const unapprovedTematCount = tematChunks.filter(c => c.status !== "approved").length;
   const pct = tematChunks.length ? Math.round(approvedCount / tematChunks.length * 100) : 0;
-  const reklamaCount = chunks.filter(c => c.type === "REKLAMA").length;
-  const visibleReklamaCount = chunks.filter(c => c.type === "REKLAMA" && !hiddenChunks.has(c.id)).length;
+  const reklamaCount = chunks.filter(c => c.type !== "TEMAT").length;
+  const visibleReklamaCount = chunks.filter(c => c.type !== "TEMAT" && !hiddenChunks.has(c.id)).length;
   const needsReanalysisCount = chunks.filter(c => c.status === "needs_reanalysis").length;
   const visibleChunks = chunks.filter(c =>
-    !hiddenChunks.has(c.id) && (!hideAds || c.type !== "REKLAMA")
+    !hiddenChunks.has(c.id) && (!hideAds || c.type === "TEMAT")
   );
 
   // ── Render ───────────────────────────────────────────────────────────────
@@ -496,7 +508,7 @@ const Chunks = () => {
         <div style={{ marginBottom: 12, padding: "8px 14px", background: "#0f172a", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <span style={{ color: "#94a3b8", fontSize: "0.82em" }}>
             TEMAT: {approvedCount}/{tematChunks.length} zatwierdzonych ({pct}%)
-            {reklamaCount > 0 && ` • ${reklamaCount} reklam${hideAds ? " (ukryte)" : ""}`}
+            {reklamaCount > 0 && ` • ${reklamaCount} reklam/szum${hideAds ? " (ukryte)" : ""}`}
           </span>
           <div style={{ flex: 1, minWidth: 80, background: "#334155", borderRadius: 4, height: 8 }}>
             <div style={{ width: `${pct}%`, height: 8, background: "#22c55e", borderRadius: 4, transition: "width .3s" }} />
@@ -516,7 +528,7 @@ const Chunks = () => {
           {reklamaCount > 0 && (visibleReklamaCount > 0 || hideAds) && (
             <button className="button" onClick={() => setHideAds(h => !h)}
               style={{ fontSize: "0.8em", padding: "3px 10px", background: hideAds ? "#475569" : "#b91c1c", color: "#fff", border: "none" }}>
-              {hideAds ? `Pokaż reklamy (${reklamaCount})` : `Ukryj reklamy (${visibleReklamaCount})`}
+              {hideAds ? `Pokaż reklamy i szum (${reklamaCount})` : `Ukryj reklamy i szum (${visibleReklamaCount})`}
             </button>
           )}
           {hiddenChunks.size > 0 && (
@@ -559,7 +571,6 @@ const Chunks = () => {
       {visibleChunks.map((chunk, i) => {
         const hasCorrected = !!chunk.corrected_text;
         const isCorrectedView = showCorrected[chunk.id] ?? hasCorrected;
-        const isReklama = chunk.type === "REKLAMA";
         const isReanalyzing = reanalyzing[chunk.id] ?? false;
         const splitSt = splitStates[chunk.id];
         const chunkSegs = segments.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segments.length);
@@ -577,8 +588,7 @@ const Chunks = () => {
                 title="Kliknij aby zmienić typ"
                 style={{
                   cursor: "pointer", padding: "1px 8px", borderRadius: 4, fontWeight: 600,
-                  background: isReklama ? "#fee2e2" : "#dbeafe",
-                  color: isReklama ? "#991b1b" : "#1d4ed8",
+                  ...typeColor(chunk.type),
                 }}
               >
                 {chunk.type ?? "?"}
@@ -665,18 +675,20 @@ const Chunks = () => {
                 <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 8, flexWrap: "wrap" }}>
                   <label>Część 1 (przed):&nbsp;
                     <select value={splitSt.firstType}
-                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], firstType: e.target.value as "TEMAT" | "REKLAMA" } }))}
+                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], firstType: e.target.value as ChunkType } }))}
                       style={{ padding: "2px 6px", borderRadius: 3 }}>
                       <option value="REKLAMA">REKLAMA</option>
                       <option value="TEMAT">TEMAT</option>
+                      <option value="SZUM">SZUM</option>
                     </select>
                   </label>
                   <label>Część 2 (po):&nbsp;
                     <select value={splitSt.secondType}
-                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], secondType: e.target.value as "TEMAT" | "REKLAMA" } }))}
+                      onChange={e => setSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], secondType: e.target.value as ChunkType } }))}
                       style={{ padding: "2px 6px", borderRadius: 3 }}>
                       <option value="TEMAT">TEMAT</option>
                       <option value="REKLAMA">REKLAMA</option>
+                      <option value="SZUM">SZUM</option>
                     </select>
                   </label>
                   <button onClick={() => confirmSplit(chunk.id)} disabled={confirmingSplit[chunk.id]}

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -53,6 +53,12 @@ interface SplitState {
   secondType: ChunkType;
 }
 
+interface LineSplitState {
+  lineIdx: number;
+  firstType: ChunkType;
+  secondType: ChunkType;
+}
+
 interface SegGroup {
   absIdx: number;
   start: number;
@@ -192,39 +198,53 @@ const SegmentsView: React.FC<{
 const PlainTextLines: React.FC<{
   text: string;
   markedLines: Set<number>;
+  splitLineIdx: number | null;
   saving: boolean;
   onToggleLine: (idx: number) => void;
+  onMarkSplit: (idx: number) => void;
   onSave: (removeFromDocument: boolean) => void;
   onCancel: () => void;
-}> = ({ text, markedLines, saving, onToggleLine, onSave, onCancel }) => {
+}> = ({ text, markedLines, splitLineIdx, saving, onToggleLine, onMarkSplit, onSave, onCancel }) => {
   const [removeFromDoc, setRemoveFromDoc] = React.useState(true);
   if (!text) return <em style={{ color: "#94a3b8" }}>brak tekstu</em>;
   const lines = text.split("\n");
+  const lineBtnStyle: React.CSSProperties = {
+    background: "none", border: "1px solid #e2e8f0", borderRadius: 3,
+    fontSize: "0.78em", cursor: "pointer", padding: "0 4px", lineHeight: "1.3em",
+  };
   return (
     <div>
       {lines.map((line, i) => {
         const marked = markedLines.has(i);
+        const isSplitMark = splitLineIdx === i;
         return (
           <div
             key={i}
             style={{
-              position: "relative", paddingRight: 30, borderRadius: 2, minHeight: "1.4em",
+              position: "relative", paddingLeft: 56, borderRadius: 2, minHeight: "1.4em",
               ...(marked ? { background: "#fee2e2", textDecoration: "line-through", color: "#991b1b" } : {}),
+              ...(isSplitMark ? { background: "#fff7ed", borderLeft: "3px solid #f97316" } : {}),
             }}
           >
+            <span style={{ position: "absolute", left: 0, top: 1, display: "flex", gap: 3 }}>
+              <button
+                onClick={() => onToggleLine(i)}
+                title={marked ? "Przywróć linię" : "Usuń linię"}
+                style={{ ...lineBtnStyle, color: marked ? "#991b1b" : "#94a3b8" }}
+              >
+                {marked ? "↺" : "✕"}
+              </button>
+              {i > 0 && (
+                <button
+                  onClick={() => onMarkSplit(i)}
+                  title="Podziel tutaj — ta linia zacznie nowy chunk"
+                  style={{ ...lineBtnStyle, color: isSplitMark ? "#92400e" : "#94a3b8", fontWeight: isSplitMark ? "bold" : "normal" }}
+                >
+                  ✂
+                </button>
+              )}
+            </span>
             <span style={{ whiteSpace: "pre-wrap" }}>{line || " "}</span>
-            <button
-              onClick={() => onToggleLine(i)}
-              title={marked ? "Przywróć linię" : "Usuń linię"}
-              style={{
-                position: "absolute", right: 2, top: 1,
-                background: "none", border: "1px solid #e2e8f0", borderRadius: 3,
-                fontSize: "0.78em", cursor: "pointer", padding: "0 5px",
-                color: marked ? "#991b1b" : "#94a3b8",
-              }}
-            >
-              {marked ? "↺" : "✕"}
-            </button>
           </div>
         );
       })}
@@ -290,6 +310,8 @@ const Chunks = () => {
   const [splitStates, setSplitStates]     = React.useState<Record<number, SplitState>>({});
   const [lineEdits, setLineEdits]         = React.useState<Record<number, Set<number>>>({});
   const [savingLines, setSavingLines]     = React.useState<Record<number, boolean>>({});
+  const [lineSplitStates, setLineSplitStates] = React.useState<Record<number, LineSplitState>>({});
+  const [confirmingLineSplit, setConfirmingLineSplit] = React.useState<Record<number, boolean>>({});
   const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
   const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
   const [hiddenChunks, setHiddenChunks] = React.useState<Set<number>>(new Set());
@@ -335,6 +357,7 @@ const Chunks = () => {
       setShowCorrected(correctedDefaults);
       setSplitStates({});
       setLineEdits({});
+      setLineSplitStates({});
       setHiddenChunks(new Set());
     } catch {
       setError("Błąd ładowania chunków");
@@ -505,6 +528,41 @@ const Chunks = () => {
         setInfo(`Usunięto ${res.document_lines_removed} linii z dokumentu źródłowego`);
       }
     }
+  };
+
+  const markLineSplit = (chunkId: number, lineIdx: number) => {
+    setLineSplitStates(prev => {
+      if (prev[chunkId]?.lineIdx === lineIdx) {
+        const n = { ...prev }; delete n[chunkId]; return n;  // click again = unmark
+      }
+      return { ...prev, [chunkId]: { lineIdx, firstType: "TEMAT", secondType: "TEMAT" } };
+    });
+  };
+
+  const cancelLineSplit = (chunkId: number) => {
+    setLineSplitStates(prev => { const n = { ...prev }; delete n[chunkId]; return n; });
+  };
+
+  const confirmLineSplit = async (chunkId: number) => {
+    const st = lineSplitStates[chunkId];
+    if (!st) return;
+    setConfirmingLineSplit(prev => ({ ...prev, [chunkId]: true }));
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunkId}/execute_split`, {
+        method: "POST", headers,
+        body: JSON.stringify({
+          split_at_line: st.lineIdx,
+          split_first_type: st.firstType,
+          split_second_type: st.secondType,
+        }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        cancelLineSplit(chunkId);
+        if (selectedRun !== null) await fetchChunks(selectedRun);
+      } else { setError("Błąd podziału: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy podziale"); }
+    finally { setConfirmingLineSplit(prev => ({ ...prev, [chunkId]: false })); }
   };
 
   const mergeWithNext = async (chunk: Chunk) => {
@@ -729,6 +787,7 @@ const Chunks = () => {
         const isCorrectedView = showCorrected[chunk.id] ?? hasCorrected;
         const isReanalyzing = reanalyzing[chunk.id] ?? false;
         const splitSt = splitStates[chunk.id];
+        const lineSplitSt = lineSplitStates[chunk.id];
         const chunkSegs = segments.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segments.length);
 
         return (
@@ -830,8 +889,10 @@ const Chunks = () => {
                 <PlainTextLines
                   text={chunk.original_text ?? ""}
                   markedLines={lineEdits[chunk.id] ?? new Set()}
+                  splitLineIdx={lineSplitStates[chunk.id]?.lineIdx ?? null}
                   saving={savingLines[chunk.id] ?? false}
                   onToggleLine={idx => toggleLineMark(chunk.id, idx)}
+                  onMarkSplit={idx => markLineSplit(chunk.id, idx)}
                   onSave={removeFromDoc => saveLineRemovals(chunk, removeFromDoc)}
                   onCancel={() => clearLineMarks(chunk.id)}
                 />
@@ -871,6 +932,42 @@ const Chunks = () => {
                   </button>
                 </div>
                 <div style={{ color: "#92400e", fontSize: "0.8em", marginTop: 4 }}>Kliknij ✂ przy innym akapicie aby zmienić punkt podziału.</div>
+              </div>
+            )}
+
+            {/* Panel podziału liniowego (chunki artykułowe) */}
+            {lineSplitSt && (
+              <div style={{ margin: "0 14px 14px", padding: "10px 12px", background: "#fff7ed", border: "1px solid #fed7aa", borderRadius: 5, fontSize: "0.84em" }}>
+                <strong style={{ color: "#92400e" }}>✂ Punkt podziału: linia {lineSplitSt.lineIdx + 1} (zaczyna nowy chunk)</strong>
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 8, flexWrap: "wrap" }}>
+                  <label>Część 1 (przed):&nbsp;
+                    <select value={lineSplitSt.firstType}
+                      onChange={e => setLineSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], firstType: e.target.value as ChunkType } }))}
+                      style={{ padding: "2px 6px", borderRadius: 3 }}>
+                      <option value="TEMAT">TEMAT</option>
+                      <option value="REKLAMA">REKLAMA</option>
+                      <option value="SZUM">SZUM</option>
+                    </select>
+                  </label>
+                  <label>Część 2 (po):&nbsp;
+                    <select value={lineSplitSt.secondType}
+                      onChange={e => setLineSplitStates(prev => ({ ...prev, [chunk.id]: { ...prev[chunk.id], secondType: e.target.value as ChunkType } }))}
+                      style={{ padding: "2px 6px", borderRadius: 3 }}>
+                      <option value="TEMAT">TEMAT</option>
+                      <option value="REKLAMA">REKLAMA</option>
+                      <option value="SZUM">SZUM</option>
+                    </select>
+                  </label>
+                  <button onClick={() => confirmLineSplit(chunk.id)} disabled={confirmingLineSplit[chunk.id]}
+                    style={{ padding: "3px 12px", background: "#f97316", color: "#fff", border: "none", borderRadius: 3, cursor: "pointer", fontWeight: "bold", fontSize: "0.82em" }}>
+                    {confirmingLineSplit[chunk.id] ? "Dzielę…" : "Wykonaj podział"}
+                  </button>
+                  <button onClick={() => cancelLineSplit(chunk.id)}
+                    style={{ padding: "3px 10px", background: "#e2e8f0", color: "#475569", border: "none", borderRadius: 3, cursor: "pointer", fontSize: "0.82em" }}>
+                    Anuluj
+                  </button>
+                </div>
+                <div style={{ color: "#92400e", fontSize: "0.8em", marginTop: 4 }}>Kliknij ✂ przy innej linii aby zmienić punkt podziału. Części TEMAT dostaną status needs_reanalysis.</div>
               </div>
             )}
 

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -194,9 +194,10 @@ const PlainTextLines: React.FC<{
   markedLines: Set<number>;
   saving: boolean;
   onToggleLine: (idx: number) => void;
-  onSave: () => void;
+  onSave: (removeFromDocument: boolean) => void;
   onCancel: () => void;
 }> = ({ text, markedLines, saving, onToggleLine, onSave, onCancel }) => {
+  const [removeFromDoc, setRemoveFromDoc] = React.useState(true);
   if (!text) return <em style={{ color: "#94a3b8" }}>brak tekstu</em>;
   const lines = text.split("\n");
   return (
@@ -228,8 +229,8 @@ const PlainTextLines: React.FC<{
         );
       })}
       {markedLines.size > 0 && (
-        <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center" }}>
-          <button onClick={onSave} disabled={saving}
+        <div style={{ marginTop: 10, display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <button onClick={() => onSave(removeFromDoc)} disabled={saving}
             style={{ padding: "3px 12px", background: "#b91c1c", color: "#fff", border: "none", borderRadius: 3, cursor: "pointer", fontWeight: "bold", fontSize: "0.85em" }}>
             {saving ? "Zapisuję…" : `Usuń ${markedLines.size} ${markedLines.size === 1 ? "linię" : "linie/linii"} i zapisz`}
           </button>
@@ -237,6 +238,11 @@ const PlainTextLines: React.FC<{
             style={{ padding: "3px 10px", background: "#e2e8f0", color: "#475569", border: "none", borderRadius: 3, cursor: "pointer", fontSize: "0.85em" }}>
             Anuluj
           </button>
+          <label style={{ fontSize: "0.8em", color: "#475569", display: "flex", alignItems: "center", gap: 4 }}
+            title="Usuwa wszystkie wystąpienia tych linii z pól text/text_md dokumentu — kolejne analizy startują z czystego tekstu">
+            <input type="checkbox" checked={removeFromDoc} onChange={e => setRemoveFromDoc(e.target.checked)} />
+            usuń też z dokumentu źródłowego (wszystkie wystąpienia)
+          </label>
           <span style={{ fontSize: "0.8em", color: "#94a3b8" }}>
             Po zapisie warto ponownie uruchomić analizę chunka (▶ Pełna), by odświeżyć temat i streszczenie.
           </span>
@@ -265,6 +271,8 @@ const Chunks = () => {
 
   const [loading, setLoading]       = React.useState(false);
   const [error, setError]           = React.useState("");
+  const [info, setInfo]             = React.useState("");
+  const [applyingCleanup, setApplyingCleanup] = React.useState(false);
   const [jobStatus, setJobStatus]   = React.useState<string | null>(null);
   const [jobId, setJobId]           = React.useState<string | null>(null);
   const [newModel, setNewModel]     = React.useState(MODELS[0]);
@@ -306,6 +314,7 @@ const Chunks = () => {
   const fetchChunks = React.useCallback(async (runId: number) => {
     setLoading(true);
     setError("");
+    setInfo("");
     try {
       const r = await fetch(`${apiUrl}/analysis_run/${runId}/chunks`, { headers });
       const data = await r.json();
@@ -368,13 +377,13 @@ const Chunks = () => {
 
   // ── Analysis ──
 
-  const startAnalysis = async () => {
+  const startAnalysis = async (modeOverride?: string) => {
     if (!id) return;
     setError(""); setJobStatus("starting");
     try {
       const r = await fetch(`${apiUrl}/document/${id}/analyze_chunks`, {
         method: "POST", headers,
-        body: JSON.stringify({ model: newModel, chunk_size: chunkSize, mode: newMode }),
+        body: JSON.stringify({ model: newModel, chunk_size: chunkSize, mode: modeOverride ?? newMode }),
       });
       const data = await r.json();
       if (data.job_id) { setJobId(data.job_id); setJobStatus("running"); pollJob(data.job_id); }
@@ -477,16 +486,58 @@ const Chunks = () => {
     setLineEdits(prev => { const n = { ...prev }; delete n[chunkId]; return n; });
   };
 
-  const saveLineRemovals = async (chunk: Chunk) => {
+  const saveLineRemovals = async (chunk: Chunk, removeFromDocument: boolean) => {
     const marked = lineEdits[chunk.id];
     if (!marked || marked.size === 0) return;
     const lines = (chunk.original_text ?? "").split("\n");
     const newText = lines.filter((_, i) => !marked.has(i)).join("\n");
     if (!newText.trim()) { setError("Nie można usunąć wszystkich linii"); return; }
+    const removedLines = lines.filter((_, i) => marked.has(i)).map(l => l.trim()).filter(Boolean);
     setSavingLines(prev => ({ ...prev, [chunk.id]: true }));
-    const res = await patchChunk(chunk.id, { original_text: newText });
+    const res = await patchChunk(chunk.id, {
+      original_text: newText,
+      ...(removeFromDocument && removedLines.length ? { remove_lines_from_document: removedLines } : {}),
+    });
     setSavingLines(prev => ({ ...prev, [chunk.id]: false }));
-    if (res?.status === "success") clearLineMarks(chunk.id);
+    if (res?.status === "success") {
+      clearLineMarks(chunk.id);
+      if (res.document_lines_removed > 0) {
+        setInfo(`Usunięto ${res.document_lines_removed} linii z dokumentu źródłowego`);
+      }
+    }
+  };
+
+  const mergeWithNext = async (chunk: Chunk) => {
+    if (!window.confirm(`Scalić chunk #${chunk.position} z #${chunk.position + 1}? Scalony chunk będzie wymagał ponownej analizy.`)) return;
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunk.id}/merge_with_next`, { method: "POST", headers });
+      const data = await r.json();
+      if (data.status === "success") {
+        if (selectedRun !== null) await fetchChunks(selectedRun);
+      } else { setError("Błąd scalania: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy scalaniu"); }
+  };
+
+  const applyCleanupAndResplit = async () => {
+    if (selectedRun === null) return;
+    if (!window.confirm(
+      "Nadpisać tekst źródłowy dokumentu treścią chunków TEMAT (REKLAMA/SZUM i usunięte linie znikną),\n"
+      + "a następnie uruchomić nową analizę z propozycją nowego podziału?"
+    )) return;
+    setApplyingCleanup(true);
+    setError("");
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/apply_cleanup`, { method: "POST", headers });
+      const data = await r.json();
+      if (data.status !== "success") {
+        setError("Błąd czyszczenia dokumentu: " + (data.message ?? ""));
+        return;
+      }
+      setInfo(`Dokument wyczyszczony (${data.field}: ${data.length_before} → ${data.length_after} znaków, `
+        + `odrzucono ${data.dropped_chunks} chunków). Startuję nową analizę…`);
+      await startAnalysis("article");
+    } catch { setError("Błąd połączenia przy czyszczeniu dokumentu"); }
+    finally { setApplyingCleanup(false); }
   };
 
   // ── Split ──
@@ -543,6 +594,7 @@ const Chunks = () => {
   const reklamaCount = chunks.filter(c => c.type !== "TEMAT").length;
   const visibleReklamaCount = chunks.filter(c => c.type !== "TEMAT" && !hiddenChunks.has(c.id)).length;
   const needsReanalysisCount = chunks.filter(c => c.status === "needs_reanalysis").length;
+  const maxPosition = chunks.reduce((m, c) => Math.max(m, c.position), 0);
   const visibleChunks = chunks.filter(c =>
     !hiddenChunks.has(c.id) && (!hideAds || c.type === "TEMAT")
   );
@@ -573,7 +625,7 @@ const Chunks = () => {
             <input type="number" value={chunkSize} onChange={e => setChunkSize(Number(e.target.value))}
               style={{ width: 75, padding: "3px 6px", fontSize: "0.88em" }} min={500} max={20000} step={500} />
           </label>
-          <button className="button" onClick={startAnalysis} disabled={!!jobId}>
+          <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}>
             {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
           </button>
         </div>
@@ -657,7 +709,19 @@ const Chunks = () => {
       )}
 
       {error && <p style={{ color: "#dc2626", marginBottom: 12 }}>{error}</p>}
+      {info && <p style={{ color: "#15803d", marginBottom: 12 }}>{info}</p>}
       {loading && <div className="loader" style={{ marginBottom: 12 }} />}
+
+      {/* Czyszczenie dokumentu z runa artykułowego */}
+      {runMode === "article" && chunks.length > 0 && (
+        <div style={{ marginBottom: 12 }}>
+          <button className="button" onClick={applyCleanupAndResplit} disabled={applyingCleanup || !!jobId}
+            title="Nadpisuje tekst źródłowy dokumentu treścią chunków TEMAT (REKLAMA/SZUM i usunięte linie znikają), po czym uruchamia nową analizę"
+            style={{ fontSize: "0.85em", background: "#7c3aed", color: "#fff", border: "none", padding: "4px 12px" }}>
+            {applyingCleanup ? "Czyszczę dokument…" : "Wyczyść dokument i zaproponuj nowy podział"}
+          </button>
+        </div>
+      )}
 
       {/* Chunki */}
       {visibleChunks.map((chunk, i) => {
@@ -731,6 +795,15 @@ const Chunks = () => {
                   {isCorrectedView ? "Surowy" : "Poprawiony"}
                 </button>
               )}
+              {chunk.position < maxPosition && (
+                <button
+                  onClick={() => mergeWithNext(chunk)}
+                  title={`Scal z chunkiem #${chunk.position + 1}`}
+                  style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b" }}
+                >
+                  ⇣ Scal
+                </button>
+              )}
               <button
                 onClick={() => setHiddenChunks(prev => new Set([...prev, chunk.id]))}
                 title="Ukryj ten chunk"
@@ -759,7 +832,7 @@ const Chunks = () => {
                   markedLines={lineEdits[chunk.id] ?? new Set()}
                   saving={savingLines[chunk.id] ?? false}
                   onToggleLine={idx => toggleLineMark(chunk.id, idx)}
-                  onSave={() => saveLineRemovals(chunk)}
+                  onSave={removeFromDoc => saveLineRemovals(chunk, removeFromDoc)}
                   onCancel={() => clearLineMarks(chunk.id)}
                 />
               )}

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -297,6 +297,7 @@ const Chunks = () => {
   const [jobId, setJobId]           = React.useState<string | null>(null);
   const [newModel, setNewModel]     = React.useState(MODELS[0]);
   const [newMode, setNewMode]       = React.useState("transcript");
+  const [splitOnly, setSplitOnly]   = React.useState(false);
   const [chunkSize, setChunkSize]   = React.useState(5000);
   const [hideAds, setHideAds]       = React.useState(false);
 
@@ -400,13 +401,17 @@ const Chunks = () => {
 
   // ── Analysis ──
 
-  const startAnalysis = async (modeOverride?: string) => {
+  const startAnalysis = async (modeOverride?: string, splitOnlyOverride?: boolean) => {
     if (!id) return;
     setError(""); setJobStatus("starting");
     try {
       const r = await fetch(`${apiUrl}/document/${id}/analyze_chunks`, {
         method: "POST", headers,
-        body: JSON.stringify({ model: newModel, chunk_size: chunkSize, mode: modeOverride ?? newMode }),
+        body: JSON.stringify({
+          model: newModel, chunk_size: chunkSize,
+          mode: modeOverride ?? newMode,
+          split_only: splitOnlyOverride ?? splitOnly,
+        }),
       });
       const data = await r.json();
       if (data.job_id) { setJobId(data.job_id); setJobStatus("running"); pollJob(data.job_id); }
@@ -470,11 +475,17 @@ const Chunks = () => {
     finally { setReanalyzing(prev => ({ ...prev, [chunkId]: false })); }
   };
 
+  // Chunks that still need an LLM pass: flagged for re-analysis OR fresh from
+  // a split-only run (pending TEMAT without a summary)
+  const chunksToAnalyze = chunks.filter(c =>
+    c.status === "needs_reanalysis"
+    || (c.type === "TEMAT" && c.status === "pending" && !c.summary)
+  );
+
   const reanalyzeAll = async () => {
-    const pending = chunks.filter(c => c.status === "needs_reanalysis");
-    if (!pending.length) return;
+    if (!chunksToAnalyze.length) return;
     setReanalyzingAll(true);
-    for (const chunk of pending) {
+    for (const chunk of chunksToAnalyze) {
       await reanalyzeChunk(chunk.id, chunk.corrected_text ? "semantic" : "full");
     }
     setReanalyzingAll(false);
@@ -600,7 +611,8 @@ const Chunks = () => {
     if (selectedRun === null || applyingCleanup || jobId) return;
     if (!window.confirm(
       "Nadpisać tekst źródłowy dokumentu treścią chunków TEMAT (REKLAMA/SZUM i usunięte linie znikną),\n"
-      + "a następnie uruchomić nową analizę z propozycją nowego podziału?"
+      + "a następnie zaproponować NOWY PODZIAŁ (bez analizy LLM)?\n"
+      + "Analizę uruchomisz przyciskiem 'Analizuj chunki' po przejrzeniu podziału."
     )) return;
     setApplyingCleanup(true);
     setError("");
@@ -612,8 +624,8 @@ const Chunks = () => {
         return;
       }
       setInfo(`Dokument wyczyszczony (${data.field}: ${data.length_before} → ${data.length_after} znaków, `
-        + `odrzucono ${data.dropped_chunks} chunków). Startuję nową analizę…`);
-      await startAnalysis("article");
+        + `odrzucono ${data.dropped_chunks} chunków). Startuję nowy podział (bez analizy LLM)…`);
+      await startAnalysis("article", true);
     } catch { setError("Błąd połączenia przy czyszczeniu dokumentu"); }
     finally { setApplyingCleanup(false); }
   };
@@ -671,7 +683,6 @@ const Chunks = () => {
   const pct = tematChunks.length ? Math.round(approvedCount / tematChunks.length * 100) : 0;
   const reklamaCount = chunks.filter(c => c.type !== "TEMAT").length;
   const visibleReklamaCount = chunks.filter(c => c.type !== "TEMAT" && !hiddenChunks.has(c.id)).length;
-  const needsReanalysisCount = chunks.filter(c => c.status === "needs_reanalysis").length;
   const maxPosition = chunks.reduce((m, c) => Math.max(m, c.position), 0);
   const visibleChunks = chunks.filter(c =>
     !hiddenChunks.has(c.id) && (!hideAds || c.type === "TEMAT")
@@ -702,6 +713,11 @@ const Chunks = () => {
             Chunk:&nbsp;
             <input type="number" value={chunkSize} onChange={e => setChunkSize(Number(e.target.value))}
               style={{ width: 75, padding: "3px 6px", fontSize: "0.88em" }} min={500} max={20000} step={500} />
+          </label>
+          <label style={{ fontSize: "0.85em", display: "flex", alignItems: "center", gap: 4 }}
+            title="Podziel na chunki bez wywołań LLM — najpierw doczyścisz/scalisz chunki, potem klikniesz Analizuj">
+            <input type="checkbox" checked={splitOnly} onChange={e => setSplitOnly(e.target.checked)} />
+            tylko podział (bez analizy LLM)
           </label>
           <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}>
             {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
@@ -745,10 +761,10 @@ const Chunks = () => {
               {approvingAll ? "Zatwierdzam…" : `Zatwierdź wszystkie (${unapprovedTematCount})`}
             </button>
           )}
-          {needsReanalysisCount > 0 && (
+          {chunksToAnalyze.length > 0 && (
             <button className="button" onClick={reanalyzeAll} disabled={reanalyzingAll}
               style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0369a1", color: "#fff", border: "none" }}>
-              {reanalyzingAll ? "Analizuję…" : `Analizuj wszystkie (${needsReanalysisCount})`}
+              {reanalyzingAll ? "Analizuję…" : `Analizuj chunki (${chunksToAnalyze.length})`}
             </button>
           )}
           {reklamaCount > 0 && (visibleReklamaCount > 0 || hideAds) && (

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -576,8 +576,28 @@ const Chunks = () => {
     } catch { setError("Błąd połączenia przy scalaniu"); }
   };
 
-  const applyCleanupAndResplit = async () => {
+  const deleteRun = async () => {
     if (selectedRun === null) return;
+    if (!window.confirm(
+      `Usunąć run #${selectedRun} wraz ze wszystkimi chunkami i sekcjami?\n`
+      + "Powiązania chunków z notatkami Obsidian z tego runu zostaną utracone "
+      + "(ścieżki na dokumencie pozostają)."
+    )) return;
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}`, { method: "DELETE", headers });
+      const data = await r.json();
+      if (data.status === "success") {
+        setInfo(`Run #${data.deleted_run_id} usunięty (${data.chunk_count} chunków)`);
+        setChunks([]);
+        setSelectedRun(null);
+        setRuns([]);
+        await fetchRuns();
+      } else { setError("Błąd usuwania runa: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy usuwaniu runa"); }
+  };
+
+  const applyCleanupAndResplit = async () => {
+    if (selectedRun === null || applyingCleanup || jobId) return;
     if (!window.confirm(
       "Nadpisać tekst źródłowy dokumentu treścią chunków TEMAT (REKLAMA/SZUM i usunięte linie znikną),\n"
       + "a następnie uruchomić nową analizę z propozycją nowego podziału?"
@@ -691,7 +711,7 @@ const Chunks = () => {
 
       {/* Wybór runu */}
       {runs.length > 0 && (
-        <div style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 12, display: "flex", alignItems: "center", gap: 8 }}>
           <label style={{ fontSize: "0.85em", fontWeight: 600 }}>Analiza: </label>
           <select value={selectedRun ?? ""} onChange={e => setSelectedRun(Number(e.target.value))} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
             {runs.map(r => (
@@ -702,6 +722,10 @@ const Chunks = () => {
               </option>
             ))}
           </select>
+          <button onClick={deleteRun} title="Usuń wybrany run (chunki i sekcje)"
+            style={{ padding: "3px 9px", border: "1px solid #fca5a5", borderRadius: 4, background: "#fff", color: "#b91c1c", cursor: "pointer", fontSize: "0.82em" }}>
+            🗑 Usuń run
+          </button>
         </div>
       )}
 

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -143,11 +143,12 @@ const List = () => {
               >
                 Edit
               </NavLink>
-              {(item.document_type === "youtube" || item.document_type === "movie") && (
+              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && (
                 <NavLink
                   className={"button"}
                   style={{ margin: "0 0 0 6px" }}
                   to={`/chunks/${item.id}`}
+                  state={{ docType: item.document_type }}
                 >
                   Chunki
                 </NavLink>

--- a/web_interface_react/src/modules/shared/pages/webpage.tsx
+++ b/web_interface_react/src/modules/shared/pages/webpage.tsx
@@ -3,7 +3,7 @@ import { useFormik } from "formik";
 import { useManageLLM } from "../hooks/useManageLLM";
 import SharedInputs from "../components/SharedInputs/sharedInputs";
 import InputsForAllExceptLink from "../components/SharedInputs/InputsForAllExceptLink";
-import { useParams } from "react-router-dom";
+import { useParams, NavLink } from "react-router-dom";
 import FormButtons from "../components/FormButtons/formButtons";
 import { AuthorizationContext } from '../context/authorizationContext';
 
@@ -59,7 +59,19 @@ const Webpage = () => {
 
   return (
     <div>
-      <h2 style={{ marginBottom: "10px" }}>Webpage</h2>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: "10px" }}>
+        <h2 style={{ margin: 0 }}>Webpage</h2>
+        {id && (
+          <NavLink
+            className={"button"}
+            to={`/chunks/${id}`}
+            state={{ docType: "webpage" }}
+            style={{ fontSize: "0.85em" }}
+          >
+            Analiza chunków
+          </NavLink>
+        )}
+      </div>
       <form onSubmit={formik.handleSubmit} style={{ maxWidth: "800px" }}>
         <SharedInputs
           formik={formik}

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -12,7 +12,9 @@ export function loadConnectionConfig(): {
   apiUrl: string;
   apiKey: string | undefined;
 } {
-  const apiType = (localStorage.getItem(KEYS.apiType) as ApiType) || "AWS Serverless";
+  // "Docker" is the only backend mode since the AWS API decommission —
+  // ignore any stale "AWS Serverless" value left in localStorage
+  const apiType: ApiType = "Docker";
   const storedKey = localStorage.getItem(KEYS.apiKey);
   return {
     apiType,


### PR DESCRIPTION
## Co zawiera

### Tryb artykułowy analizy chunków (Etapy 1-2 planu rozbudowy)
- `document_analysis_runs` z kolumnami `mode` (transcript|article), `status` (created|in_review|reviewed) i `scope` (migracja Alembic `f6a7b8c9d0e1` + idempotentny init SQL 15)
- `create_run(mode='article')`: podział po nagłówkach markdown (`split_markdown_into_chunks`), bez mówców/fillerów/rewrite — pojedynczy call LLM (klasyfikacja+streszczenie) na chunk, `corrected_text` zostaje NULL
- `create_run(split_only=True)`: podział bez ŻADNYCH wywołań LLM — najpierw czyszczenie/scalanie, potem analiza na żądanie ("Analizuj chunki (n)")
- UI `/chunks/:id` obsługuje artykuły: selektor trybu, render tekstu zamiast segmentów, ukryty pasek rozmówców, przycisk "Chunki" także dla webpage/text

### Typ SZUM
Trzeci typ chunka obok TEMAT/REKLAMA: szum ekstrakcji (nawigacja portalu, stopki, cookie, kontrolki playera). Odróżniony od REKLAMA celowo — REKLAMA mówi o jakości źródła, SZUM o jakości pipeline'u czyszczenia i posłuży jako dane treningowe do poprawy usuwania śmieci.

### Pętla czyszczenia dokumentu
- Usuwanie linii z tekstu chunka (kontrolki po lewej stronie linii) z opcjonalną propagacją do `text`/`text_md` dokumentu (wszystkie wystąpienia)
- `POST /chunk/<id>/merge_with_next` (przycisk "⇣ Scal") i `split_at_line` w `execute_split` (✂ przy linii) — scalanie i dzielenie chunków artykułowych
- `POST /analysis_run/<id>/apply_cleanup` + przycisk "Wyczyść dokument i zaproponuj nowy podział": nadpisuje źródło sklejką chunków TEMAT (REKLAMA/SZUM i usunięte linie znikają), po czym tworzy run split_only
- `DELETE /analysis_run/<id>` (przycisk 🗑) + guard przed podwójnym uruchomieniem czyszczenia

### Usunięcie AWS Serverless + wersja 0.3.14.0
Wycięte pozostałości po zdekomisjonowanym API AWS: fallback w storage, default kontekstu, martwa gałąź w useSearch, domyślny URL app2. `ApiType` = tylko "Docker". Wersja podbita we wszystkich miejscach.

### Wcześniejsze commity na branchu
Pipeline YouTube `youtube_add.py --analyze`, poprawka IndexError przy rozdziałach, czyszczenie `document_state_error` przy retry, refaktory (lookup maps, wspólny `_call_chat`).

## Testy i weryfikacja
- 20 nowych testów jednostkowych (splitter markdown, tryb article, split_only, SZUM); regresja 89 testów ORM/serwisów przechodzi; ruff i tsc czyste
- Smoke test na żywo z Bielikiem (doc 9179): run artykułowy ~20 s, poprawki promptu po teście
- Pełna pętla przetestowana ręcznie przez użytkownika na NAS: split → SZUM → wyczyść dokument → czysty podział (2×TEMAT, zero szumu)
- Migracja zaaplikowana i zweryfikowana na bazie NAS; całość wdrożona na NAS

## Znany dług (nie w tym PR)
- app2 nie przechodzi tsc (TS1261: importy `Pages/` vs katalog `pages/`) — pre-existing
- Sekcje tematyczne/synteza nie są odtwarzane po "Analizuj chunki" (dopisane do planu, Etap 4)

Plan wieloetapowy: `.claude/exports/plan-chunks-rozbudowa.md` (Etapy 3-6 w kolejnych sesjach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)