### PR TITLE
fix(chunks): tail-merge splitter tolerance + live split-count preview

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -157,6 +157,49 @@ def analyze_document_chunks(doc_id: int):
     return jsonify({"status": "started", "job_id": job_id, "doc_id": doc_id})
 
 
+@bp.route("/document/<int:doc_id>/split_preview", methods=["GET"])
+def split_preview(doc_id: int):
+    """Preview how a document would split into chunks — no LLM calls, no DB writes.
+
+    Query params: mode (article|transcript, default article), chunk_size (default 5000).
+    Transcript sizes are approximate (speaker labeling happens only in a real run).
+    """
+    from library.document_analysis_service import ANALYSIS_MODES, _extract_text
+    from library.text_functions import split_markdown_into_chunks, split_text_into_sentence_chunks
+
+    mode = request.args.get("mode", "article")
+    chunk_size = request.args.get("chunk_size", 5000, type=int)
+    if mode not in ANALYSIS_MODES:
+        return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
+    if not 500 <= chunk_size <= 50000:
+        return jsonify({"status": "error", "message": f"chunk_size out of range: {chunk_size}"}), 400
+
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    text, field = _extract_text(doc, prefer_md=(mode == "article"))
+    if not text:
+        return jsonify({"status": "error", "message": "Document has no usable text"}), 400
+
+    if mode == "article":
+        parts = split_markdown_into_chunks(text, chunk_size)
+    else:
+        from library.chunk_llm_analysis import remove_speech_fillers
+        parts = split_text_into_sentence_chunks(remove_speech_fillers(text), chunk_size)
+
+    return jsonify({
+        "status": "success",
+        "mode": mode,
+        "chunk_size": chunk_size,
+        "source_field": field,
+        "text_length": len(text),
+        "chunk_count": len(parts),
+        "chunk_sizes": [len(p) for p in parts],
+    })
+
+
 @bp.route("/analysis_job/<job_id>", methods=["GET"])
 def get_analysis_job(job_id: str):
     """Poll status of an async analysis job started by POST /document/<id>/analyze_chunks."""

--- a/backend/library/text_functions.py
+++ b/backend/library/text_functions.py
@@ -47,6 +47,18 @@ def remove_matching_lines(input_text):
 
 _SENT_BOUNDARY = re.compile(r'(?<=[.!?…])\s+')
 
+# A trailing chunk smaller than this fraction of max_chars gets merged into the
+# previous one (accepting a slight overflow) — avoids orphan tails like a
+# 320-char chunk when a 5,106-char document meets a 5,000-char limit.
+_TAIL_MERGE_RATIO = 0.15
+
+
+def _merge_small_tail(chunks: list[str], max_chars: int, separator: str) -> list[str]:
+    if len(chunks) >= 2 and len(chunks[-1]) < max_chars * _TAIL_MERGE_RATIO:
+        tail = chunks.pop()
+        chunks[-1] = f"{chunks[-1]}{separator}{tail}"
+    return chunks
+
 
 def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
     """Split text at sentence boundaries, accumulating up to max_chars per chunk.
@@ -85,7 +97,7 @@ def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
     if current:
         chunks.append(' '.join(current))
 
-    return chunks
+    return _merge_small_tail(chunks, max_chars, ' ')
 
 
 def split_text_into_chunks(text: str, max_chars: int) -> list[str]:
@@ -128,7 +140,7 @@ def split_text_into_chunks(text: str, max_chars: int) -> list[str]:
     if current_parts:
         chunks.append('\n\n'.join(current_parts))
 
-    return chunks
+    return _merge_small_tail(chunks, max_chars, '\n\n')
 
 
 _MD_HEADER_RE = re.compile(r'^#{1,6} ', re.MULTILINE)
@@ -183,7 +195,7 @@ def split_markdown_into_chunks(text: str, max_chars: int) -> list[str]:
     if current:
         chunks.append('\n\n'.join(current))
 
-    return chunks
+    return _merge_small_tail(chunks, max_chars, '\n\n')
 
 
 def split_text_for_embedding(text, paragraph_titles=[], max_words_in_line=300, max_characters_in_line=1000):

--- a/backend/tests/unit/test_split_markdown_into_chunks.py
+++ b/backend/tests/unit/test_split_markdown_into_chunks.py
@@ -64,3 +64,28 @@ class TestSplitMarkdownIntoChunks:
         text = "Język C# oraz F# to platforma .NET. " * 3
         chunks = split_markdown_into_chunks(text, 1000)
         assert len(chunks) == 1
+
+
+class TestTailMerge:
+    def test_small_tail_merged_into_previous(self):
+        """A document just over the limit must not leave an orphan tail chunk."""
+        # 3 paragraphs: 480+480+60 = ~1024 chars with a 1000 limit
+        text = "\n\n".join(["a" * 480, "b" * 480, "c" * 60])
+        chunks = split_markdown_into_chunks(text, 1000)
+        assert len(chunks) == 1
+        assert chunks[0].endswith("c" * 60)
+
+    def test_large_tail_stays_separate(self):
+        # tail of 400 chars (40% of limit) must remain its own chunk
+        text = "\n\n".join(["a" * 480, "b" * 480, "c" * 400])
+        chunks = split_markdown_into_chunks(text, 1000)
+        assert len(chunks) == 2
+        assert chunks[1] == "c" * 400
+
+    def test_sentence_splitter_merges_small_tail(self):
+        from library.text_functions import split_text_into_sentence_chunks
+        sentences = ("Zdanie ma tutaj dokladnie piecdziesiat znakow tu. " * 20).strip()
+        # ~1000 chars of sentences + one short trailing sentence, limit 1000
+        text = sentences + " Kropka."
+        chunks = split_text_into_sentence_chunks(text, 1000)
+        assert len(chunks) == 1 or len(chunks[-1]) >= 150

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -299,6 +299,8 @@ const Chunks = () => {
   const [newMode, setNewMode]       = React.useState("transcript");
   const [splitOnly, setSplitOnly]   = React.useState(false);
   const [chunkSize, setChunkSize]   = React.useState(5000);
+  const [splitPreview, setSplitPreview] = React.useState<{ count: number; sizes: number[]; length: number } | null>(null);
+  const [previewNonce, setPreviewNonce] = React.useState(0);
   const [hideAds, setHideAds]       = React.useState(false);
 
   const [showCorrected, setShowCorrected] = React.useState<Record<number, boolean>>({});
@@ -373,6 +375,26 @@ const Chunks = () => {
   React.useEffect(() => {
     if (docType && docType !== "youtube" && docType !== "movie") setNewMode("article");
   }, [docType]);
+
+  // Live preview: how many chunks would a new split produce (no LLM, debounced)
+  React.useEffect(() => {
+    if (!id) return;
+    const t = setTimeout(async () => {
+      try {
+        const r = await fetch(
+          `${apiUrl}/document/${id}/split_preview?mode=${newMode}&chunk_size=${chunkSize}`,
+          { headers: { "x-api-key": apiKey ?? "" } },
+        );
+        const data = await r.json();
+        if (data.status === "success") {
+          setSplitPreview({ count: data.chunk_count, sizes: data.chunk_sizes, length: data.text_length });
+        } else {
+          setSplitPreview(null);
+        }
+      } catch { setSplitPreview(null); }
+    }, 400);
+    return () => clearTimeout(t);
+  }, [id, newMode, chunkSize, apiUrl, apiKey, previewNonce]);
 
   // ── Job polling ──
 
@@ -537,6 +559,7 @@ const Chunks = () => {
       clearLineMarks(chunk.id);
       if (res.document_lines_removed > 0) {
         setInfo(`Usunięto ${res.document_lines_removed} linii z dokumentu źródłowego`);
+        setPreviewNonce(n => n + 1);
       }
     }
   };
@@ -625,6 +648,7 @@ const Chunks = () => {
       }
       setInfo(`Dokument wyczyszczony (${data.field}: ${data.length_before} → ${data.length_after} znaków, `
         + `odrzucono ${data.dropped_chunks} chunków). Startuję nowy podział (bez analizy LLM)…`);
+      setPreviewNonce(n => n + 1);
       await startAnalysis("article", true);
     } catch { setError("Błąd połączenia przy czyszczeniu dokumentu"); }
     finally { setApplyingCleanup(false); }
@@ -719,6 +743,14 @@ const Chunks = () => {
             <input type="checkbox" checked={splitOnly} onChange={e => setSplitOnly(e.target.checked)} />
             tylko podział (bez analizy LLM)
           </label>
+          {splitPreview && (
+            <span style={{ fontSize: "0.82em", color: "#475569" }}
+              title={`Rozmiary chunków: ${splitPreview.sizes.join(", ")} znaków`}>
+              → podział da <strong>{splitPreview.count}</strong> {splitPreview.count === 1 ? "chunk" : "chunki(-ów)"}
+              {" "}({splitPreview.length.toLocaleString("pl")} zn
+              {splitPreview.count > 1 && `: ${splitPreview.sizes.slice(0, 6).join(" + ")}${splitPreview.sizes.length > 6 ? " + …" : ""}`})
+            </span>
+          )}
           <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}>
             {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
           </button>


### PR DESCRIPTION
## Co zawiera

Follow-up do PR #194 — naprawa zaobserwowana przez użytkownika na doc 9179: dokument tuż nad limitem chunka (5106 zn / limit 5000) zawsze zostawiał sierocy ogonek (320 zn) po każdym podziale, wymuszając ręczne scalanie za każdym razem.

- `_merge_small_tail`: ostatni chunk mniejszy niż 15% limitu jest doklejany do poprzedniego (z lekkim przekroczeniem limitu) — zastosowane we wszystkich 3 splitterach (markdown, akapitowy, zdaniowy)
- `GET /document/<id>/split_preview?mode&chunk_size` — liczy podział bez wywołań LLM i bez zapisu do bazy
- UI: panel "Nowa analiza" pokazuje na żywo (debounce 400 ms) ile chunków i jakiej wielkości da podział, odświeżane po propagacji usuniętych linii i po apply_cleanup

## Weryfikacja
- 3 nowe testy tolerancji ogonka + pełna regresja (62 testy) przechodzą, ruff i tsc czyste
- Zweryfikowane na żywo na NAS: doc 9179 przy chunk_size=5000 → 1 chunk (5106 zn) zamiast 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)