### PR TITLE
feat(chunks): embeddings from approved chunks, text_extracted/text_md in sync, removed-lines tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ All application variables (database, LLM, API keys, etc.) are defined in [`scrip
 PostgreSQL 18 with pgvector extension for vector similarity search. Schema defined in `backend/database/init/` (see `backend/database/CLAUDE.md` for full details).
 
 Two tables:
-- **`web_documents`** (29 columns) — documents with content, metadata, processing state, and multilingual fields
+- **`web_documents`** (30 columns) — documents with content, metadata, processing state, and multilingual fields
 - **`websites_embeddings`** — vector embeddings (dimensionless column, per-model HNSW partial indexes) with cosine similarity search
 
 Document processing states: `URL_ADDED` → `DOCUMENT_INTO_DATABASE` → ... → `EMBEDDING_EXIST` (15 states total, see `backend/library/models/stalker_document_status.py`).

--- a/backend/alembic/versions/a7b8c9d0e1f2_add_chunk_id_to_websites_embeddings.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_chunk_id_to_websites_embeddings.py
@@ -1,0 +1,33 @@
+"""add chunk_id to websites_embeddings
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same column may already have been added by the Docker
+    # init script 16-add-chunk-id-to-embeddings.sql on a fresh database.
+    op.execute(
+        "ALTER TABLE websites_embeddings "
+        "ADD COLUMN IF NOT EXISTS chunk_id INTEGER REFERENCES document_chunks(id) ON DELETE SET NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_websites_embeddings_chunk_id ON websites_embeddings(chunk_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_websites_embeddings_chunk_id")
+    op.drop_column("websites_embeddings", "chunk_id")

--- a/backend/alembic/versions/b8c9d0e1f2a3_add_text_extracted_to_web_documents.py
+++ b/backend/alembic/versions/b8c9d0e1f2a3_add_text_extracted_to_web_documents.py
@@ -1,0 +1,28 @@
+"""add text_extracted to web_documents
+
+Revision ID: b8c9d0e1f2a3
+Revises: a7b8c9d0e1f2
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8c9d0e1f2a3"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same column may already have been added by the Docker
+    # init script 17-add-text-extracted-to-web-documents.sql on a fresh database.
+    op.execute(
+        "ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS text_extracted TEXT"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("web_documents", "text_extracted")

--- a/backend/alembic/versions/c9d0e1f2a3b4_create_document_removed_lines.py
+++ b/backend/alembic/versions/c9d0e1f2a3b4_create_document_removed_lines.py
@@ -1,0 +1,44 @@
+"""create document_removed_lines
+
+Revision ID: c9d0e1f2a3b4
+Revises: b8c9d0e1f2a3
+Create Date: 2026-07-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, None] = "b8c9d0e1f2a3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same table may already have been created by the Docker
+    # init script 18-create-document-removed-lines.sql on a fresh database.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS document_removed_lines (
+            id          SERIAL PRIMARY KEY,
+            document_id INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            run_id      INTEGER REFERENCES document_analysis_runs(id) ON DELETE SET NULL,
+            chunk_id    INTEGER REFERENCES document_chunks(id) ON DELETE SET NULL,
+            source      VARCHAR(20) NOT NULL,
+            line_text   TEXT NOT NULL,
+            created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_removed_lines_document_id ON document_removed_lines(document_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_removed_lines_source ON document_removed_lines(source)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS document_removed_lines")

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -40,6 +40,7 @@ Main document storage. Each row represents a collected web resource (article, vi
 | `text_raw` | `text` | Raw extracted text before cleanup |
 | `text_english` | `text` | English translation of text |
 | `text_md` | `text` | Markdown version of text |
+| `text_extracted` | `text` | Raw LLM article extraction output (pre `clean_article_text()`), diagnostic only — not exposed via API |
 | `summary` | `text` | AI-generated summary |
 | `summary_english` | `text` | English translation of summary |
 | `language` | `varchar(10)` | Detected language code |

--- a/backend/database/init/16-add-chunk-id-to-embeddings.sql
+++ b/backend/database/init/16-add-chunk-id-to-embeddings.sql
@@ -1,0 +1,12 @@
+-- Migration: link embeddings to the chunk they were generated from
+-- chunk_id: FK -> document_chunks.id, NULL for embeddings not generated from a chunk
+-- (e.g. link title+summary, or whole-document embeddings from webdocument_md_decode.py)
+
+\c "lenie-ai";
+
+ALTER TABLE public.websites_embeddings
+    ADD COLUMN IF NOT EXISTS chunk_id INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_websites_embeddings_chunk_id ON public.websites_embeddings(chunk_id);
+
+SELECT 'Column chunk_id added to websites_embeddings' AS status;

--- a/backend/database/init/17-add-text-extracted-to-web-documents.sql
+++ b/backend/database/init/17-add-text-extracted-to-web-documents.sql
@@ -1,0 +1,11 @@
+-- Migration: store raw LLM article extraction output (pre clean_article_text)
+-- text_extracted: markdown returned by the LLM article boundary extraction, BEFORE
+-- article_cleaner.clean_article_text(). Diagnostic column for cleaner regression
+-- checks — intentionally NOT exposed via the API. text_md holds the cleaned version.
+
+\c "lenie-ai";
+
+ALTER TABLE public.web_documents
+    ADD COLUMN IF NOT EXISTS text_extracted TEXT;
+
+SELECT 'Column text_extracted added to web_documents' AS status;

--- a/backend/database/init/18-create-document-removed-lines.sql
+++ b/backend/database/init/18-create-document-removed-lines.sql
@@ -1,0 +1,24 @@
+-- Migration: store lines/blocks removed during manual chunk-review cleanup
+-- Training data for improving article_cleaner.py / site_rules.json: what the
+-- automatic cleaner missed and a human had to remove.
+-- source: manual (line removed in chunk-review UI) | szum_chunk (whole
+--         SZUM/REKLAMA chunk dropped by apply_cleanup)
+-- run_id/chunk_id are SET NULL on delete so rows survive run cleanup and stay
+-- usable for aggregate queries (portal derived via join on web_documents.url).
+
+\c "lenie-ai";
+
+CREATE TABLE IF NOT EXISTS public.document_removed_lines (
+    id          SERIAL PRIMARY KEY,
+    document_id INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    run_id      INTEGER REFERENCES public.document_analysis_runs(id) ON DELETE SET NULL,
+    chunk_id    INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL,
+    source      VARCHAR(20) NOT NULL,
+    line_text   TEXT NOT NULL,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_removed_lines_document_id ON public.document_removed_lines(document_id);
+CREATE INDEX IF NOT EXISTS idx_removed_lines_source      ON public.document_removed_lines(source);
+
+SELECT 'Table document_removed_lines created' AS status;

--- a/backend/imports/CLAUDE.md
+++ b/backend/imports/CLAUDE.md
@@ -35,7 +35,7 @@ Incremental sync of documents from AWS DynamoDB and S3 webpage content to the lo
 4. For `webpage` type items with `uuid`: fetches `{uuid}.txt` and `{uuid}.html` from S3 into memory
 5. Inserts new documents via `DocumentService.import_document(skip_if_exists=True)`
 6. After insert, saves S3 content to cache as `{CACHE_DIR}/markdown/{doc.id}/{doc.id}.html` (same convention as `document_prepare.py`, so downstream tools can reuse cached files without re-downloading from S3)
-7. For webpages: converts HTML to markdown (`_step_1_all.md`) and runs LLM article extraction (CloudFerro primary, ARK Labs fallback) unless `--skip-llm`
+7. For webpages: converts HTML to markdown (`_step_1_all.md`) and runs LLM article extraction (CloudFerro primary, ARK Labs fallback) unless `--skip-llm`. On successful extraction, persists `text_extracted` (raw LLM output, pre-clean) and `text_md` (after `article_cleaner.clean_article_text()`) on the document — `--skip-llm` and failed extraction leave both fields untouched
 8. Sets `document_state` to `DOCUMENT_INTO_DATABASE` (with S3 content) or `URL_ADDED` (without)
 
 **DynamoDB → PostgreSQL field mapping:**

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -187,9 +187,11 @@ def process_article_content(doc_id: int, cache_base_dir: str,
                              session, skip_llm: bool = False) -> tuple[bool, bool]:
     """Convert HTML to markdown and optionally run LLM article extraction.
 
-    Saves files to cache only — no DB writes.
+    On successful LLM extraction persists text_extracted (pre-clean) and
+    text_md (post clean_article_text) on the document; otherwise no DB writes.
     Returns (markdown_ok, llm_ok).
     """
+    from library.article_cleaner import clean_article_text
     from library.article_pipeline import extract_article
 
     doc_cache_dir = os.path.join(cache_base_dir, str(doc_id))
@@ -218,6 +220,15 @@ def process_article_content(doc_id: int, cache_base_dir: str,
 
     if article:
         print(f"  Process: LLM OK ({len(article)} chars)")
+        cleaned = clean_article_text(article, doc.url)
+        doc.text_extracted = article
+        doc.text_md = cleaned["text"]
+        try:
+            session.commit()
+            print(f"  Process: saved text_extracted/text_md ({len(cleaned['text'])} chars cleaned)")
+        except Exception:
+            session.rollback()
+            print(f"  WARNING: failed to save text_extracted/text_md for doc {doc_id}")
         return True, True
 
     print("  Process: LLM failed — no article markers extracted")

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -46,6 +46,21 @@ from library.models.stalker_document_status import StalkerDocumentStatus
 cfg = load_config()
 
 
+def check_markdown_deps_installed() -> None:
+    """Fail fast with an actionable message if the optional 'markdown' dependency
+    group isn't installed. Needed to convert webpage HTML to markdown
+    (process_article_content) — without it the script would crash mid-run,
+    after DynamoDB items are already fetched and the document row inserted.
+    """
+    try:
+        import html2markdown  # noqa: F401
+    except ImportError:
+        print("ERROR: Missing optional dependency 'html2markdown' — required to convert "
+              "webpage HTML into markdown (process_article_content).")
+        print("Install it with: cd backend && uv sync --extra markdown")
+        sys.exit(1)
+
+
 def get_ssm_parameter(name: str, region: str = None) -> str:
     """Fetch a single SSM Parameter Store value."""
     region = region or cfg.require("AWS_REGION", "us-east-1")
@@ -311,6 +326,11 @@ def main():
     # Resolve cache dir default from config
     if args.data_dir is None:
         args.data_dir = os.path.join(cfg.get("CACHE_DIR") or "tmp", "markdown")
+
+    # Fail fast if the markdown conversion dependency is missing — better to
+    # find out before AWS calls / DB writes than mid-run on the first webpage item.
+    if not args.skip_s3 and not args.dry_run:
+        check_markdown_deps_installed()
 
     # Auto-detect last successful sync date. The DB connection doubles as a
     # fail-fast check before AWS calls; skipped for --dry-run with explicit

--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -45,7 +45,7 @@ library/
 - **`db/engine.py`** — SQLAlchemy engine and session factories: `get_session()`, `get_scoped_session()`.
 - **`stalker_web_documents_db_postgresql.py`** — `WebsitesDBPostgreSQL`: query layer using SQLAlchemy session. Requires `session` parameter. Methods: `get_list()` (paginated/filtered), `get_similar()` (pgvector cosine search), `get_next_to_correct()`, `get_count()`, `embedding_add()`, `embedding_delete()`.
 
-**Database tables:** `public.web_documents` (29 columns), `public.websites_embeddings` (vector similarity).
+**Database tables:** `public.web_documents` (30 columns), `public.websites_embeddings` (vector similarity).
 
 ### Models (`models/`)
 

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -22,7 +22,8 @@ from sqlalchemy import func, select, update as sa_update
 
 from library.db.engine import get_scoped_session
 from library.db.models import (
-    DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument, WebsiteEmbedding,
+    DocumentAnalysisRun, DocumentChunk, DocumentRemovedLine, DocumentTopicSection,
+    WebDocument, WebsiteEmbedding,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,43 @@ _embedding_jobs: dict[str, dict] = {}
 ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split", "skipped"}
 ALLOWED_TYPES = {"TEMAT", "REKLAMA", "SZUM"}
 ALLOWED_RUN_STATUSES = {"created", "in_review", "reviewed"}
+
+
+def _removed_lines_diff(old_text: str, new_text: str) -> list[str]:
+    """Return non-empty lines (stripped) present in old_text but absent from new_text.
+
+    Whole-line set difference, order preserved from old_text. A line still
+    present elsewhere in new_text is not reported even if one of its
+    occurrences was removed — good enough for cleaner-rule mining.
+    """
+    new_lines = {ln.strip() for ln in new_text.split("\n")}
+    seen: set[str] = set()
+    removed: list[str] = []
+    for ln in old_text.split("\n"):
+        stripped = ln.strip()
+        if stripped and stripped not in new_lines and stripped not in seen:
+            seen.add(stripped)
+            removed.append(stripped)
+    return removed
+
+
+def _log_removed_lines(session, *, document_id: int, run_id: int | None,
+                       chunk_id: int | None, lines: list[str], source: str) -> int:
+    """Queue DocumentRemovedLine rows on the session (no commit). Returns row count.
+
+    Removed lines feed cleaner-rule mining (article_cleaner.py / site_rules.json):
+    aggregate what the automatic cleanup missed and humans had to remove.
+    """
+    count = 0
+    for line in lines:
+        if not line or not line.strip():
+            continue
+        session.add(DocumentRemovedLine(
+            document_id=document_id, run_id=run_id, chunk_id=chunk_id,
+            source=source, line_text=line.strip(),
+        ))
+        count += 1
+    return count
 
 
 def _parse_segments(text_raw: str | None) -> list[dict]:
@@ -419,6 +457,23 @@ def apply_run_cleanup(run_id: int):
 
     length_before = len(getattr(doc, field) or "")
     setattr(doc, field, cleaned)
+
+    # Log dropped SZUM/REKLAMA chunks as cleaner-training data. Deduped by
+    # chunk_id so a repeated apply_cleanup does not double-log.
+    dropped = [c for c in chunks if c.type != "TEMAT"]
+    if dropped:
+        already_logged = set(session.scalars(
+            select(DocumentRemovedLine.chunk_id)
+            .where(DocumentRemovedLine.run_id == run_id,
+                   DocumentRemovedLine.source == "szum_chunk")
+        ).all())
+        for c in dropped:
+            if c.id not in already_logged:
+                _log_removed_lines(
+                    session, document_id=run.document_id, run_id=run_id,
+                    chunk_id=c.id, lines=[c.original_text], source="szum_chunk",
+                )
+
     try:
         session.commit()
     except Exception:
@@ -583,11 +638,13 @@ def update_chunk(chunk_id: int):
         chunk.topic = data["topic"] or None
         changed = True
 
+    manually_removed: list[str] = []
     if "original_text" in data:
         # Manual cleanup: UI line-removal mode sends the whole edited text
         val = data["original_text"]
         if not isinstance(val, str) or not val.strip():
             return jsonify({"status": "error", "message": "original_text must be a non-empty string"}), 400
+        manually_removed = _removed_lines_diff(chunk.original_text, val)
         chunk.original_text = val
         changed = True
 
@@ -608,6 +665,16 @@ def update_chunk(chunk_id: int):
                     doc_lines_removed += value.count("\n") + 1 - len(kept)
                     setattr(doc, field, "\n".join(kept))
                 changed = True
+            # Lines propagated to the document but not caught by the chunk-text
+            # diff (e.g. still present elsewhere in the chunk) — log those too
+            already = set(manually_removed)
+            manually_removed += [t for t in sorted(targets) if t not in already]
+
+    if manually_removed:
+        _log_removed_lines(
+            session, document_id=chunk.document_id, run_id=chunk.run_id,
+            chunk_id=chunk.id, lines=manually_removed, source="manual",
+        )
 
     if "split_at_seg" in data:
         chunk.split_at_seg = data["split_at_seg"]

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -22,7 +22,7 @@ from sqlalchemy import func, select, update as sa_update
 
 from library.db.engine import get_scoped_session
 from library.db.models import (
-    DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument,
+    DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument, WebsiteEmbedding,
 )
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,10 @@ bp = Blueprint("chunk_review", __name__)
 # In-memory job registry for async analysis runs.
 # Keyed by job_id (short UUID). Lives as long as the server process.
 _analysis_jobs: dict[str, dict] = {}
+
+# In-memory job registry for async embedding-generation runs (separate from
+# _analysis_jobs — different job shape, polled via /embedding_job/<job_id>).
+_embedding_jobs: dict[str, dict] = {}
 
 ALLOWED_STATUSES = {"pending", "approved", "needs_reanalysis", "split_requested", "split", "skipped"}
 ALLOWED_TYPES = {"TEMAT", "REKLAMA", "SZUM"}
@@ -50,7 +54,7 @@ def _parse_segments(text_raw: str | None) -> list[dict]:
     return []
 
 
-def _chunk_to_dict(c: DocumentChunk) -> dict:
+def _chunk_to_dict(c: DocumentChunk, has_embeddings: bool | None = None) -> dict:
     return {
         "id": c.id,
         "position": c.position,
@@ -66,6 +70,8 @@ def _chunk_to_dict(c: DocumentChunk) -> dict:
         "split_at_seg": c.split_at_seg,
         "split_first_type": c.split_first_type,
         "split_second_type": c.split_second_type,
+        "obsidian_note_paths": c.obsidian_note_paths or [],
+        "has_embeddings": bool(has_embeddings) if has_embeddings is not None else None,
     }
 
 
@@ -260,6 +266,15 @@ def get_run_chunks(run_id: int):
         .order_by(DocumentTopicSection.position)
     ).all()
 
+    chunk_ids = [c.id for c in run.chunks]
+    embedded_chunk_ids: set[int] = set()
+    if chunk_ids:
+        embedded_chunk_ids = set(session.scalars(
+            select(WebsiteEmbedding.chunk_id)
+            .where(WebsiteEmbedding.chunk_id.in_(chunk_ids))
+            .distinct()
+        ).all())
+
     return jsonify({
         "status": "success",
         "run": {
@@ -280,7 +295,7 @@ def get_run_chunks(run_id: int):
             "document_type": doc.document_type if doc else "",
         },
         "segments": segments,
-        "chunks": [_chunk_to_dict(c) for c in run.chunks],
+        "chunks": [_chunk_to_dict(c, has_embeddings=c.id in embedded_chunk_ids) for c in run.chunks],
         "topic_sections": [
             {
                 "id": ts.id,
@@ -421,6 +436,69 @@ def apply_run_cleanup(run_id: int):
         "temat_chunks": len(temat),
         "dropped_chunks": len(chunks) - len(temat),
     })
+
+
+# ---------------------------------------------------------------------------
+# API: POST /analysis_run/<run_id>/generate_embeddings
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/generate_embeddings", methods=["POST"])
+def generate_embeddings(run_id: int):
+    """Start an async job generating embeddings from this run's approved TEMAT chunks.
+
+    Returns immediately with {job_id}. Poll GET /embedding_job/<job_id> for status.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    job_id = uuid.uuid4().hex[:8]
+    _embedding_jobs[job_id] = {
+        "status": "running",
+        "run_id": run_id,
+        "result": None,
+        "error": None,
+        "progress": "Startowanie...",
+    }
+
+    def _run_embeddings() -> None:
+        from library.db.engine import get_session
+        from library.document_analysis_service import generate_embeddings_from_run
+
+        job_session = get_session()
+        try:
+            def _progress(msg: str) -> None:
+                _embedding_jobs[job_id]["progress"] = msg
+
+            result = generate_embeddings_from_run(job_session, run_id, progress_fn=_progress)
+            _embedding_jobs[job_id].update({
+                "status": "done",
+                "result": result,
+                "progress": f"Gotowe: {result['embeddings_created']} embeddingów "
+                            f"z {result['chunks_considered']} chunków",
+            })
+        except ValueError as exc:
+            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        except Exception as exc:
+            logger.exception("background embedding generation failed for run %d", run_id)
+            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        finally:
+            job_session.close()
+
+    t = threading.Thread(target=_run_embeddings, daemon=True, name=f"embeddings-{job_id}")
+    t.start()
+
+    return jsonify({"status": "started", "job_id": job_id, "run_id": run_id})
+
+
+@bp.route("/embedding_job/<job_id>", methods=["GET"])
+def get_embedding_job(job_id: str):
+    """Poll status of an async embedding job started by POST /analysis_run/<id>/generate_embeddings."""
+    job = _embedding_jobs.get(job_id)
+    if job is None:
+        return jsonify({"status": "error", "message": "Job not found"}), 404
+    return jsonify({"status": "success", "job": job})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -429,6 +429,9 @@ class WebsiteEmbedding(Base):
     model: Mapped[str] = mapped_column(
         String(100), ForeignKey("embedding_models.name"), nullable=False,
     )
+    chunk_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_chunks.id", ondelete="SET NULL"), nullable=True,
+    )
     created_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime, server_default=sa_text("CURRENT_TIMESTAMP"),
     )
@@ -436,6 +439,7 @@ class WebsiteEmbedding(Base):
     # Relationships
     document: Mapped["WebDocument"] = relationship(back_populates="embeddings")
     model_ref: Mapped["EmbeddingModel"] = relationship(foreign_keys=[model])
+    chunk: Mapped["DocumentChunk | None"] = relationship(foreign_keys=[chunk_id])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -658,3 +658,38 @@ class DocumentTopicSection(Base):
 
     def __repr__(self) -> str:
         return f"DocumentTopicSection(id={self.id!r}, run_id={self.run_id!r}, position={self.position!r})"
+
+
+class DocumentRemovedLine(Base):
+    """Line/block removed from a document during manual chunk review cleanup.
+
+    Training data for improving article_cleaner.py / site_rules.json: what the
+    automatic cleaner missed and a human had to remove. Rows survive run/chunk
+    deletion (FKs SET NULL) so aggregate queries (e.g. most-removed lines per
+    portal, via join on web_documents.url) keep working over time.
+    """
+
+    __tablename__ = "document_removed_lines"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="SET NULL"),
+    )
+    chunk_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_chunks.id", ondelete="SET NULL"),
+    )
+    # source: manual (line removed in chunk-review UI) | szum_chunk (whole
+    # SZUM/REKLAMA chunk dropped by apply_cleanup)
+    source: Mapped[str] = mapped_column(String(20), nullable=False)
+    line_text: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return f"DocumentRemovedLine(id={self.id!r}, document_id={self.document_id!r}, source={self.source!r})"

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -197,6 +197,9 @@ class WebDocument(Base):
     )
     project: Mapped[str | None] = mapped_column(String(100))
     text_md: Mapped[str | None] = mapped_column(Text)
+    # Raw LLM article extraction output (pre clean_article_text) — diagnostic only,
+    # intentionally NOT exposed via dict()/API (used for article_cleaner regression checks).
+    text_extracted: Mapped[str | None] = mapped_column(Text)
     transcript_needed: Mapped[bool | None] = mapped_column(Boolean, server_default=sa_text("false"))
 
     # Review & Obsidian tracking (Story 33.4, ADR-014)

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -443,3 +443,102 @@ class DocumentAnalysisService:
 
         log(f"saved run_id={run.id} chunks={len(sections)} topic_sections={len(topic_sections_data)}")
         return run
+
+
+def generate_embeddings_from_run(
+    session, run_id: int, progress_fn: Callable[[str], None] | None = None,
+) -> dict:
+    """Generate embeddings from a run's approved TEMAT chunks.
+
+    For each chunk with type == "TEMAT" and status == "approved": takes
+    corrected_text (transcript mode) or original_text (article mode), splits it
+    into embedding-sized pieces (md_split_for_emb, same splitter used by
+    webdocument_md_decode.py), strips markdown syntax, and stores one
+    WebsiteEmbedding row per piece with chunk_id set. REKLAMA/SZUM chunks and
+    non-approved TEMAT chunks are skipped.
+
+    Re-running deletes this run's previously chunk-linked embeddings first, so
+    it is safe to call again after a chunk is re-approved or edited.
+    """
+    from sqlalchemy import delete, select
+
+    from library.config_loader import load_config
+    from library.db.models import WebsiteEmbedding
+    from library.lenie_markdown import md_remove_markdown, md_split_for_emb
+    from library.models.stalker_document_status import StalkerDocumentStatus
+    from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
+    import library.embedding as embedding
+
+    def log(msg: str) -> None:
+        logger.info("[embeddings run=%d] %s", run_id, msg)
+        if progress_fn:
+            progress_fn(msg)
+
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        raise ValueError(f"Run {run_id} not found")
+
+    doc = session.get(WebDocument, run.document_id)
+    if doc is None:
+        raise ValueError(f"Document {run.document_id} not found")
+
+    model = load_config().require("EMBEDDING_MODEL")
+    websites = WebsitesDBPostgreSQL(session)
+
+    all_chunks = session.scalars(
+        select(DocumentChunk).where(DocumentChunk.run_id == run_id)
+    ).all()
+    eligible = [c for c in all_chunks if c.type == "TEMAT" and c.status == "approved"]
+
+    chunk_ids = [c.id for c in all_chunks]
+    if chunk_ids:
+        session.execute(delete(WebsiteEmbedding).where(WebsiteEmbedding.chunk_id.in_(chunk_ids)))
+        session.commit()
+
+    if not doc.language:
+        doc.language = "pl"
+
+    created = 0
+    skipped_empty = 0
+    for i, chunk in enumerate(eligible, 1):
+        log(f"chunk {i}/{len(eligible)} (position {chunk.position})...")
+        text = (chunk.corrected_text or chunk.original_text or "").strip()
+        if not text:
+            skipped_empty += 1
+            continue
+        for part in md_split_for_emb(text):
+            cleaned = md_remove_markdown(part).strip()
+            if not cleaned:
+                continue
+            result = embedding.get_embedding(model=model, text=cleaned)
+            if result.status != "success" or not result.embedding:
+                logger.warning(
+                    "Embedding generation failed for chunk %d (run %d): %s",
+                    chunk.id, run_id, result.status,
+                )
+                continue
+            websites.embedding_add(
+                website_id=doc.id,
+                embedding=result.embedding,
+                language=doc.language,
+                text=cleaned,
+                text_original=cleaned,
+                model=model,
+                chunk_id=chunk.id,
+            )
+            created += 1
+
+    if created:
+        doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
+
+    session.commit()
+    log(f"done: {created} embeddings created from {len(eligible)} chunks")
+
+    return {
+        "run_id": run_id,
+        "document_id": doc.id,
+        "model": model,
+        "chunks_considered": len(eligible),
+        "chunks_skipped_empty": skipped_empty,
+        "embeddings_created": created,
+    }

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -5,7 +5,7 @@ from typing import Any
 from sqlalchemy import Float, and_, column, delete, func, literal, or_, select, union
 from sqlalchemy.orm import Session
 
-from library.db.models import WebDocument, WebsiteEmbedding
+from library.db.models import DocumentChunk, WebDocument, WebsiteEmbedding
 from library.models.stalker_document_status import StalkerDocumentStatus
 from library.models.stalker_document_status_error import StalkerDocumentStatusError
 from library.models.stalker_document_type import StalkerDocumentType
@@ -201,8 +201,11 @@ class WebsitesDBPostgreSQL:
                 WebDocument.title,
                 WebDocument.document_type,
                 WebDocument.project,
+                WebsiteEmbedding.chunk_id,
+                DocumentChunk.obsidian_note_paths,
             )
             .outerjoin(WebDocument, WebsiteEmbedding.website_id == WebDocument.id)
+            .outerjoin(DocumentChunk, WebsiteEmbedding.chunk_id == DocumentChunk.id)
             .where(WebsiteEmbedding.model == model)
             .where(
                 literal(1) - func.cast(
@@ -232,6 +235,8 @@ class WebsitesDBPostgreSQL:
                 "title": r.title,
                 "document_type": r.document_type,
                 "project": r.project,
+                "chunk_id": r.chunk_id,
+                "obsidian_note_paths": r.obsidian_note_paths or [],
             }
             for r in rows
         ]
@@ -240,7 +245,7 @@ class WebsitesDBPostgreSQL:
     # Embedding CRUD
     # ------------------------------------------------------------------
 
-    def embedding_add(self, website_id, embedding, language, text, text_original, model) -> None:
+    def embedding_add(self, website_id, embedding, language, text, text_original, model, chunk_id=None) -> None:
         emb = WebsiteEmbedding(
             website_id=website_id,
             language=language,
@@ -248,6 +253,7 @@ class WebsitesDBPostgreSQL:
             text_original=text_original,
             embedding=embedding,
             model=model,
+            chunk_id=chunk_id,
         )
         self.session.add(emb)
 

--- a/backend/library/text_transcript.py
+++ b/backend/library/text_transcript.py
@@ -72,27 +72,22 @@ def _chapter_index(chapter_starts: list[int], seconds: float, current: int) -> i
     return max(bisect.bisect_right(chapter_starts, seconds) - 1, current)
 
 
-def text_split_with_chapters(transcript_string: str | None, chapters_string: str | None = None) -> str | None:
-    if transcript_string is None:
-        return None
-    if chapters_string is None:
-        return transcript_string
-
-    chapters = chapters_text_to_list(chapters_string)
-    if not chapters:
-        return transcript_string
-
-    json_data = json.loads(transcript_string)
-
+def _append_with_chapters(
+    entries: list[dict],
+    chapters: list[dict],
+    content_key: str,
+    start_time_key: str,
+) -> str:
     chapter_starts = [time_to_seconds(ch['start']) for ch in chapters]
     chapter_nb = -1  # -1 = intro before the first chapter
     string_all = ""
     after_header = False
-    for transcript in json_data['results']["items"]:
-        content = transcript['alternatives'][0]['content']
 
-        if 'start_time' in transcript:
-            target = _chapter_index(chapter_starts, float(transcript['start_time']), chapter_nb)
+    for entry in entries:
+        content = entry[content_key]
+
+        if start_time_key in entry:
+            target = _chapter_index(chapter_starts, float(entry[start_time_key]), chapter_nb)
             while chapter_nb < target:
                 chapter_nb += 1
                 string_all += ("\n\n" if string_all else "") + chapters[chapter_nb]['title'] + "\n"
@@ -111,6 +106,28 @@ def text_split_with_chapters(transcript_string: str | None, chapters_string: str
     return string_all
 
 
+def text_split_with_chapters(transcript_string: str | None, chapters_string: str | None = None) -> str | None:
+    if transcript_string is None:
+        return None
+    if chapters_string is None:
+        return transcript_string
+
+    chapters = chapters_text_to_list(chapters_string)
+    if not chapters:
+        return transcript_string
+
+    json_data = json.loads(transcript_string)
+
+    entries = []
+    for transcript in json_data['results']["items"]:
+        normalized = {'content': transcript['alternatives'][0]['content']}
+        if 'start_time' in transcript:
+            normalized['start_time'] = transcript['start_time']
+        entries.append(normalized)
+
+    return _append_with_chapters(entries, chapters, content_key='content', start_time_key='start_time')
+
+
 def youtube_titles_to_text(titles_text: str | None = None) -> str | None:
     transcript = json.loads(titles_text)
     string_all = ""
@@ -126,26 +143,11 @@ def youtube_titles_split_with_chapters(titles_text: str | None = None, chapter_l
     if not chapters:
         return youtube_titles_to_text(titles_text)
 
-    chapter_starts = [time_to_seconds(ch['start']) for ch in chapters]
-    chapter_nb = -1  # -1 = intro before the first chapter
-    string_all = ""
-    after_header = False
+    entries = []
     for entry in transcript:
-
+        normalized = {'content': entry['text']}
         if 'start' in entry:
-            target = _chapter_index(chapter_starts, float(entry['start']), chapter_nb)
-            while chapter_nb < target:
-                chapter_nb += 1
-                string_all += ("\n\n" if string_all else "") + chapters[chapter_nb]['title'] + "\n"
-                after_header = True
-            if after_header:
-                string_all += entry['text']
-                after_header = False
-            elif string_all:
-                string_all += " " + entry['text']
-            else:
-                string_all += entry['text']
-        else:
-            string_all += entry['text']
+            normalized['start_time'] = entry['start']
+        entries.append(normalized)
 
-    return string_all
+    return _append_with_chapters(entries, chapters, content_key='content', start_time_key='start_time')

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -38,6 +38,7 @@ Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. The
 | `test_similarity_search_orm.py` | `get_similar()` pgvector ORM path |
 | `test_sql_parameterization.py` | SQL parameterization (no string interpolation) |
 | `test_import_log_tracker.py` | `ImportLog` model + `ImportLogTracker` context manager |
+| `test_removed_lines.py` | `DocumentRemovedLine` model + `_removed_lines_diff`/`_log_removed_lines` helpers (cleaner-training data) |
 | `test_alembic_setup.py` | Alembic configuration, Flask session teardown |
 
 ### Services & Flask Endpoints (mocked sessions)

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -30,7 +30,7 @@ Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. The
 | File | Covers |
 |------|--------|
 | `test_db_engine.py` | Engine singleton, session factories, `Base` |
-| `test_db_models.py` | `WebDocument` columns (29), STI subclasses (7), `dict()` output (33 keys), lookup models |
+| `test_db_models.py` | `WebDocument` columns (30), STI subclasses (7), `dict()` output (33 keys), lookup models |
 | `test_orm_crud.py` | `WebDocument` CRUD, `dict()` compatibility |
 | `test_repository_queries.py` | `WebsitesDBPostgreSQL` repository queries |
 | `test_get_list_query.py` | `get_list()` ORM query construction |

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -159,12 +159,12 @@ class TestWebDocumentColumns:
         "chapter_list", "document_state", "document_state_error",
         "text_raw", "transcript_job_id", "ai_summary_needed",
         "author", "note", "uuid", "project", "text_md",
-        "transcript_needed", "reviewed_at", "obsidian_note_paths",
-        "video_description",
+        "text_extracted", "transcript_needed", "reviewed_at",
+        "obsidian_note_paths", "video_description",
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebDocument)) == 29
+        assert len(_column_names(WebDocument)) == 30
 
     def test_all_column_names(self):
         assert _column_names(WebDocument) == self.EXPECTED_COLUMNS
@@ -240,8 +240,8 @@ class TestWebDocumentColumnTypes:
     def test_text_fields_are_text_type(self):
         text_columns = [
             "summary", "tags", "text", "title", "text_raw",
-            "text_md", "chapter_list", "source", "original_id",
-            "transcript_job_id", "author", "note",
+            "text_md", "text_extracted", "chapter_list", "source",
+            "original_id", "transcript_job_id", "author", "note",
         ]
         for name in text_columns:
             col = _get_column(WebDocument, name)

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -572,17 +572,17 @@ class TestDict:
 
 
 # ---------------------------------------------------------------------------
-# 5.11: WebsiteEmbedding has all 8 columns
+# 5.11: WebsiteEmbedding has all 9 columns
 # ---------------------------------------------------------------------------
 
 class TestWebsiteEmbeddingColumns:
     EXPECTED_COLUMNS = {
         "id", "website_id", "language", "text",
-        "text_original", "embedding", "model", "created_at",
+        "text_original", "embedding", "model", "created_at", "chunk_id",
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebsiteEmbedding)) == 8
+        assert len(_column_names(WebsiteEmbedding)) == 9
 
     def test_all_column_names(self):
         assert _column_names(WebsiteEmbedding) == self.EXPECTED_COLUMNS

--- a/backend/tests/unit/test_dynamodb_sync_orm.py
+++ b/backend/tests/unit/test_dynamodb_sync_orm.py
@@ -182,3 +182,36 @@ class TestSyncItemToPostgres:
 
         assert result == ("added", None)
         MockDocService.return_value.import_document.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for check_markdown_deps_installed (preflight dependency check)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMarkdownDepsInstalled:
+    """The 'markdown' optional dependency group (html2markdown) is needed to
+    convert webpage HTML into markdown. Missing it should fail fast with an
+    actionable message, not crash mid-run after AWS calls/DB writes.
+    """
+
+    def test_passes_when_dependency_importable(self):
+        from imports.dynamodb_sync import check_markdown_deps_installed
+
+        # html2markdown is installed in this environment — should not raise/exit.
+        check_markdown_deps_installed()
+
+    def test_exits_with_actionable_message_when_missing(self, monkeypatch, capsys):
+        from imports.dynamodb_sync import check_markdown_deps_installed
+
+        # A None entry in sys.modules makes `import html2markdown` raise ImportError,
+        # simulating the missing-dependency case without uninstalling the package.
+        monkeypatch.setitem(sys.modules, "html2markdown", None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            check_markdown_deps_installed()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "html2markdown" in captured.out
+        assert "uv sync --extra markdown" in captured.out

--- a/backend/tests/unit/test_dynamodb_sync_orm.py
+++ b/backend/tests/unit/test_dynamodb_sync_orm.py
@@ -215,3 +215,104 @@ class TestCheckMarkdownDepsInstalled:
         captured = capsys.readouterr()
         assert "html2markdown" in captured.out
         assert "uv sync --extra markdown" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Tests for process_article_content (text_extracted / text_md persistence)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessArticleContent:
+    """process_article_content persists text_extracted (pre-clean) and text_md
+    (post clean_article_text) ONLY when LLM extraction succeeded — --skip-llm
+    and failed extraction must leave both fields untouched.
+    """
+
+    def _run(self, monkeypatch, extract_result, skip_llm=False, commit_raises=False):
+        """Run process_article_content with mocked pipeline; return (result, doc, session, cleaner_calls)."""
+        from imports import dynamodb_sync
+
+        doc = MagicMock()
+        doc.url = "https://example.com/article"
+
+        session = MagicMock(spec=["commit", "rollback"])
+        if commit_raises:
+            session.commit.side_effect = RuntimeError("db down")
+
+        monkeypatch.setattr(dynamodb_sync.os.path, "isfile", lambda p: True)
+        monkeypatch.setattr(
+            dynamodb_sync, "WebDocument",
+            MagicMock(get_by_id=MagicMock(return_value=doc)),
+        )
+        monkeypatch.setattr(
+            "library.article_pipeline.extract_article",
+            lambda *args, **kwargs: extract_result,
+        )
+
+        cleaner_calls = []
+
+        def fake_clean(text, url=""):
+            cleaner_calls.append((text, url))
+            return {"text": f"CLEANED::{text}", "links": [], "images": []}
+
+        monkeypatch.setattr("library.article_cleaner.clean_article_text", fake_clean)
+
+        result = dynamodb_sync.process_article_content(
+            doc_id=42, cache_base_dir="/cache", session=session, skip_llm=skip_llm,
+        )
+        return result, doc, session, cleaner_calls
+
+    def test_success_saves_text_extracted_and_text_md(self, monkeypatch):
+        result, doc, session, cleaner_calls = self._run(
+            monkeypatch, extract_result=("raw markdown", "extracted article"),
+        )
+
+        assert result == (True, True)
+        assert doc.text_extracted == "extracted article"
+        assert doc.text_md == "CLEANED::extracted article"
+        assert cleaner_calls == [("extracted article", doc.url)]
+        session.commit.assert_called_once()
+        session.rollback.assert_not_called()
+
+    def test_skip_llm_does_not_touch_text_fields(self, monkeypatch):
+        result, doc, session, cleaner_calls = self._run(
+            monkeypatch, extract_result=("raw markdown", None), skip_llm=True,
+        )
+
+        assert result == (True, False)
+        assert not isinstance(doc.text_extracted, str)
+        assert not isinstance(doc.text_md, str)
+        assert cleaner_calls == []
+        session.commit.assert_not_called()
+
+    def test_failed_extraction_does_not_touch_text_fields(self, monkeypatch):
+        result, doc, session, cleaner_calls = self._run(
+            monkeypatch, extract_result=("raw markdown", None),
+        )
+
+        assert result == (True, False)
+        assert not isinstance(doc.text_extracted, str)
+        assert not isinstance(doc.text_md, str)
+        assert cleaner_calls == []
+        session.commit.assert_not_called()
+
+    def test_markdown_failure_returns_false_false(self, monkeypatch):
+        result, doc, session, cleaner_calls = self._run(
+            monkeypatch, extract_result=(None, None),
+        )
+
+        assert result == (False, False)
+        assert cleaner_calls == []
+        session.commit.assert_not_called()
+
+    def test_commit_failure_rolls_back_and_warns(self, monkeypatch, capsys):
+        result, doc, session, cleaner_calls = self._run(
+            monkeypatch, extract_result=("raw markdown", "extracted article"),
+            commit_raises=True,
+        )
+
+        # Extraction itself succeeded — only persistence failed.
+        assert result == (True, True)
+        session.rollback.assert_called_once()
+        captured = capsys.readouterr()
+        assert "WARNING: failed to save text_extracted/text_md" in captured.out

--- a/backend/tests/unit/test_generate_embeddings_from_run.py
+++ b/backend/tests/unit/test_generate_embeddings_from_run.py
@@ -1,0 +1,157 @@
+"""Unit tests for document_analysis_service.generate_embeddings_from_run.
+
+DB session, embedding provider and the repository layer are mocked — verifies
+selection logic (TEMAT + approved only), text preference (corrected_text over
+original_text), chunk_id propagation, and idempotent re-run (old chunk-linked
+embeddings deleted first).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import library.document_analysis_service as das
+from library.db.models import DocumentAnalysisRun, DocumentChunk, WebDocument
+from library.document_analysis_service import generate_embeddings_from_run
+from library.models.embedding_result import EmbeddingResult
+
+
+def _chunk(id_, type_, status, corrected_text=None, original_text="tekst oryginalny"):
+    c = MagicMock(spec=DocumentChunk)
+    c.id = id_
+    c.type = type_
+    c.status = status
+    c.corrected_text = corrected_text
+    c.original_text = original_text
+    c.position = id_
+    return c
+
+
+@pytest.fixture
+def fake_run():
+    run = MagicMock(spec=DocumentAnalysisRun)
+    run.id = 5
+    run.document_id = 42
+    return run
+
+
+@pytest.fixture
+def fake_doc():
+    doc = MagicMock(spec=WebDocument)
+    doc.id = 42
+    doc.language = "pl"
+    return doc
+
+
+@pytest.fixture
+def session(fake_run, fake_doc):
+    s = MagicMock()
+
+    def _get(model, id_):
+        if model is DocumentAnalysisRun:
+            return fake_run
+        if model is WebDocument:
+            return fake_doc
+        return None
+
+    s.get.side_effect = _get
+    return s
+
+
+@pytest.fixture
+def embedding_env(monkeypatch):
+    """Patch config, embedding provider and the repository add() call."""
+    monkeypatch.setattr(das, "logger", das.logger)  # no-op, keeps import explicit
+
+    class FakeConfig:
+        def require(self, key):
+            assert key == "EMBEDDING_MODEL"
+            return "test-embedding-model"
+
+    monkeypatch.setattr("library.config_loader.load_config", lambda: FakeConfig())
+
+    calls = {"embedding_add": []}
+
+    class FakeWebsitesDB:
+        def __init__(self, session):
+            pass
+
+        def embedding_add(self, **kwargs):
+            calls["embedding_add"].append(kwargs)
+
+    monkeypatch.setattr(
+        "library.stalker_web_documents_db_postgresql.WebsitesDBPostgreSQL", FakeWebsitesDB,
+    )
+    monkeypatch.setattr(
+        "library.embedding.get_embedding",
+        lambda model, text: EmbeddingResult(text=text, embedding=[0.1, 0.2], status="success"),
+    )
+    return calls
+
+
+class TestGenerateEmbeddingsFromRun:
+    def test_run_not_found_raises(self, session):
+        session.get.side_effect = lambda model, id_: None
+        with pytest.raises(ValueError, match="Run 5 not found"):
+            generate_embeddings_from_run(session, 5)
+
+    def test_only_approved_temat_chunks_are_embedded(self, session, embedding_env):
+        chunks = [
+            _chunk(1, "TEMAT", "approved", original_text="Merytoryczna treść o gospodarce. " * 30),
+            _chunk(2, "TEMAT", "pending", original_text="Nie powinno się embedować."),
+            _chunk(3, "REKLAMA", "approved", original_text="Reklama, pomijana mimo approved."),
+            _chunk(4, "SZUM", "approved", original_text="Szum, pomijany mimo approved."),
+        ]
+        session.scalars.return_value.all.return_value = chunks
+
+        result = generate_embeddings_from_run(session, 5)
+
+        assert result["chunks_considered"] == 1
+        assert len(embedding_env["embedding_add"]) >= 1
+        assert all(kw["chunk_id"] == 1 for kw in embedding_env["embedding_add"])
+
+    def test_prefers_corrected_text_over_original(self, session, embedding_env):
+        chunks = [_chunk(1, "TEMAT", "approved", corrected_text="Wersja poprawiona.", original_text="Wersja surowa.")]
+        session.scalars.return_value.all.return_value = chunks
+
+        generate_embeddings_from_run(session, 5)
+
+        assert embedding_env["embedding_add"][0]["text"] == "Wersja poprawiona."
+
+    def test_empty_text_chunk_is_skipped(self, session, embedding_env):
+        chunks = [_chunk(1, "TEMAT", "approved", original_text="   ")]
+        session.scalars.return_value.all.return_value = chunks
+
+        result = generate_embeddings_from_run(session, 5)
+
+        assert result["chunks_skipped_empty"] == 1
+        assert result["embeddings_created"] == 0
+
+    def test_deletes_existing_chunk_linked_embeddings_before_recreating(self, session, embedding_env):
+        chunks = [_chunk(1, "TEMAT", "approved", original_text="Treść.")]
+        session.scalars.return_value.all.return_value = chunks
+
+        generate_embeddings_from_run(session, 5)
+
+        assert session.execute.called  # delete() statement issued before re-adding
+
+    def test_marks_document_embedding_exist_when_embeddings_created(self, session, embedding_env, fake_doc):
+        chunks = [_chunk(1, "TEMAT", "approved", original_text="Treść merytoryczna wystarczająco długa.")]
+        session.scalars.return_value.all.return_value = chunks
+
+        generate_embeddings_from_run(session, 5)
+
+        assert fake_doc.document_state == "EMBEDDING_EXIST"
+
+    def test_failed_embedding_provider_is_skipped_not_raised(self, session, embedding_env, monkeypatch):
+        monkeypatch.setattr(
+            "library.embedding.get_embedding",
+            lambda model, text: EmbeddingResult(text=text, embedding=[], status="error"),
+        )
+        chunks = [_chunk(1, "TEMAT", "approved", original_text="Treść.")]
+        session.scalars.return_value.all.return_value = chunks
+
+        result = generate_embeddings_from_run(session, 5)
+
+        assert result["embeddings_created"] == 0
+        assert embedding_env["embedding_add"] == []

--- a/backend/tests/unit/test_removed_lines.py
+++ b/backend/tests/unit/test_removed_lines.py
@@ -1,0 +1,152 @@
+"""Unit tests for removed-lines tracking (document_removed_lines).
+
+Lines removed during manual chunk-review cleanup are persisted as training
+data for improving article_cleaner.py / site_rules.json. Covers the ORM model
+and the pure helpers in chunk_review_routes.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+sa = pytest.importorskip("sqlalchemy")
+pytest.importorskip("flask")
+
+from sqlalchemy import inspect  # noqa: E402
+
+from library.chunk_review_routes import _log_removed_lines, _removed_lines_diff  # noqa: E402
+from library.db.models import DocumentRemovedLine  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# ORM model
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentRemovedLineModel:
+    EXPECTED_COLUMNS = {
+        "id", "document_id", "run_id", "chunk_id", "source", "line_text", "created_at",
+    }
+
+    def test_tablename(self):
+        assert DocumentRemovedLine.__tablename__ == "document_removed_lines"
+
+    def test_columns(self):
+        mapper = inspect(DocumentRemovedLine).mapper
+        assert {col.key for col in mapper.columns} == self.EXPECTED_COLUMNS
+
+    def test_document_fk_cascade(self):
+        col = inspect(DocumentRemovedLine).mapper.columns["document_id"]
+        fk = next(iter(col.foreign_keys))
+        assert fk.column.table.name == "web_documents"
+        assert fk.ondelete == "CASCADE"
+        assert col.nullable is False
+
+    def test_run_and_chunk_fks_set_null(self):
+        """Rows must survive run/chunk deletion — FKs are SET NULL, nullable."""
+        mapper = inspect(DocumentRemovedLine).mapper
+        for name, table in (("run_id", "document_analysis_runs"),
+                            ("chunk_id", "document_chunks")):
+            col = mapper.columns[name]
+            fk = next(iter(col.foreign_keys))
+            assert fk.column.table.name == table
+            assert fk.ondelete == "SET NULL"
+            assert col.nullable is True
+
+
+# ---------------------------------------------------------------------------
+# _removed_lines_diff
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedLinesDiff:
+    def test_removed_lines_reported_in_order(self):
+        old = "keep one\nAD BANNER\nkeep two\nSubscribe now\nkeep three"
+        new = "keep one\nkeep two\nkeep three"
+        assert _removed_lines_diff(old, new) == ["AD BANNER", "Subscribe now"]
+
+    def test_no_removal_returns_empty(self):
+        text = "line a\nline b"
+        assert _removed_lines_diff(text, text) == []
+
+    def test_whitespace_only_lines_ignored(self):
+        old = "keep\n   \n\t\nnoise"
+        new = "keep"
+        assert _removed_lines_diff(old, new) == ["noise"]
+
+    def test_comparison_is_stripped(self):
+        old = "  keep  \n  noise  "
+        new = "keep"
+        assert _removed_lines_diff(old, new) == ["noise"]
+
+    def test_duplicate_removed_line_reported_once(self):
+        old = "Udostępnij\nkeep\nUdostępnij"
+        new = "keep"
+        assert _removed_lines_diff(old, new) == ["Udostępnij"]
+
+    def test_line_still_present_elsewhere_not_reported(self):
+        # One of two occurrences removed — line still in new text, so not reported
+        old = "Udostępnij\nkeep\nUdostępnij"
+        new = "keep\nUdostępnij"
+        assert _removed_lines_diff(old, new) == []
+
+    def test_added_lines_do_not_matter(self):
+        old = "keep"
+        new = "keep\nbrand new line"
+        assert _removed_lines_diff(old, new) == []
+
+
+# ---------------------------------------------------------------------------
+# _log_removed_lines
+# ---------------------------------------------------------------------------
+
+
+class TestLogRemovedLines:
+    def _added_rows(self, session):
+        return [call.args[0] for call in session.add.call_args_list]
+
+    def test_adds_one_row_per_line(self):
+        session = MagicMock(spec=["add"])
+        count = _log_removed_lines(
+            session, document_id=9202, run_id=17, chunk_id=101,
+            lines=["Skróć artykuł", "Udostępnij"], source="manual",
+        )
+
+        assert count == 2
+        rows = self._added_rows(session)
+        assert [r.line_text for r in rows] == ["Skróć artykuł", "Udostępnij"]
+        for r in rows:
+            assert isinstance(r, DocumentRemovedLine)
+            assert (r.document_id, r.run_id, r.chunk_id, r.source) == (9202, 17, 101, "manual")
+
+    def test_skips_empty_and_whitespace_lines(self):
+        session = MagicMock(spec=["add"])
+        count = _log_removed_lines(
+            session, document_id=1, run_id=None, chunk_id=None,
+            lines=["", "   ", "real line"], source="manual",
+        )
+
+        assert count == 1
+        assert self._added_rows(session)[0].line_text == "real line"
+
+    def test_strips_stored_text_and_allows_null_run_chunk(self):
+        session = MagicMock(spec=["add"])
+        _log_removed_lines(
+            session, document_id=1, run_id=None, chunk_id=None,
+            lines=["  block text  "], source="szum_chunk",
+        )
+
+        row = self._added_rows(session)[0]
+        assert row.line_text == "block text"
+        assert row.run_id is None
+        assert row.chunk_id is None
+        assert row.source == "szum_chunk"
+
+    def test_does_not_commit(self):
+        """Caller owns the transaction — helper must only queue adds."""
+        session = MagicMock(spec=["add", "commit"])
+        _log_removed_lines(
+            session, document_id=1, run_id=2, chunk_id=3,
+            lines=["x"], source="manual",
+        )
+        session.commit.assert_not_called()

--- a/backend/tests/unit/test_similarity_search_orm.py
+++ b/backend/tests/unit/test_similarity_search_orm.py
@@ -14,12 +14,12 @@ sa = pytest.importorskip("sqlalchemy")
 EXPECTED_KEYS = {
     "website_id", "text", "similarity", "id", "url", "language",
     "text_original", "websites_text_length", "embeddings_text_length",
-    "title", "document_type", "project",
+    "title", "document_type", "project", "chunk_id", "obsidian_note_paths",
 }
 
 
 def _make_row(**overrides):
-    """Create a mock result row with all 12 expected attributes."""
+    """Create a mock result row with all 14 expected attributes."""
     defaults = {
         "website_id": 1,
         "text": "chunk text",
@@ -33,6 +33,8 @@ def _make_row(**overrides):
         "title": "Test Doc",
         "document_type": "webpage",
         "project": "lenie",
+        "chunk_id": None,
+        "obsidian_note_paths": None,
     }
     defaults.update(overrides)
     row = MagicMock()

--- a/backend/web_documents_do_the_needful_new.py
+++ b/backend/web_documents_do_the_needful_new.py
@@ -340,9 +340,71 @@ def step4_mark_transcribed_ready(session, websites):
         session.commit()
 
 
+def _find_run_with_approved_chunks(session, document_id):
+    """Return the most recent DocumentAnalysisRun for this document that has at
+    least one approved TEMAT chunk, or None if there isn't one.
+    """
+    from sqlalchemy import select
+
+    from library.db.models import DocumentAnalysisRun, DocumentChunk
+
+    return session.scalar(
+        select(DocumentAnalysisRun)
+        .join(DocumentChunk, DocumentChunk.run_id == DocumentAnalysisRun.id)
+        .where(
+            DocumentAnalysisRun.document_id == document_id,
+            DocumentChunk.type == "TEMAT",
+            DocumentChunk.status == "approved",
+        )
+        .order_by(DocumentAnalysisRun.created_at.desc())
+        .limit(1)
+    )
+
+
+def _embed_document_from_markdown(session, websites, doc, model):
+    """Fallback embedding for youtube/webpage docs without an approved-chunk run.
+
+    Whole-document embedding: splits text_md (or text) into embedding-sized
+    pieces the same way webdocument_md_decode.py does (md_split_for_emb +
+    md_remove_markdown), no chunk_id (not tied to a chunk analysis run).
+    """
+    from library.lenie_markdown import md_remove_markdown, md_split_for_emb
+    import library.embedding as embedding
+
+    source = doc.text_md or doc.text
+    if not source:
+        print(f"WARNING: document {doc.id} has no text_md/text, skipping")
+        return False
+
+    if not doc.language:
+        doc.language = "pl"
+
+    created = 0
+    for part in md_split_for_emb(source):
+        cleaned = md_remove_markdown(part).strip()
+        if not cleaned:
+            continue
+        result = embedding.get_embedding(model=model, text=cleaned)
+        if result.status != "success" or not result.embedding:
+            print(f"WARNING: embedding failed for document {doc.id}: {result.status}")
+            continue
+        websites.embedding_add(doc.id, result.embedding, doc.language, cleaned, cleaned, model)
+        created += 1
+
+    return created > 0
+
+
 def step5_create_embeddings(session, websites):
-    """Step 5: create embeddings for link documents that are ready."""
+    """Step 5: create embeddings for documents that are ready.
+
+    link              — title + summary (single embedding).
+    youtube / webpage — embeds from the document's approved-chunk analysis run
+                        (via generate_embeddings_from_run) when one exists;
+                        otherwise falls back to a whole-document embedding
+                        split from text_md/text (no chunk_id).
+    """
     from library.db.models import WebDocument
+    from library.document_analysis_service import generate_embeddings_from_run
     from library.models.stalker_document_status import StalkerDocumentStatus
     from library.models.stalker_document_type import StalkerDocumentType
     from library.search_service import SearchService
@@ -361,24 +423,39 @@ def step5_create_embeddings(session, websites):
         print(f"Working on ID:{doc.id} ({website_nb} from {embedding_needed_len} {progress}%)"
               f" {doc.document_type} url: {doc.url}")
 
-        # Build text for embedding (same logic as StalkerWebDocumentDB.embedding_add)
         if doc.document_type == StalkerDocumentType.link.name:
             text = doc.title or ""
             if doc.summary:
                 text = (text + " " + doc.summary).strip() if text else doc.summary
+
+            if not text:
+                print(f"WARNING: document {doc.id} has no title or summary, skipping")
+                continue
+
+            websites.embedding_delete(doc.id, model)
+            result = search_service.get_embedding(text)
+            websites.embedding_add(doc.id, result.embedding, doc.language, text, text, model)
+            doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
+            session.commit()
+
+        elif doc.document_type in (StalkerDocumentType.youtube.name, StalkerDocumentType.webpage.name):
+            run = _find_run_with_approved_chunks(session, doc.id)
+            if run is not None:
+                result = generate_embeddings_from_run(session, run.id)
+                print(f"  embedded {result['embeddings_created']} pieces from run #{run.id} "
+                      f"({result['chunks_considered']} approved chunks)")
+            else:
+                websites.embedding_delete(doc.id, model)
+                session.commit()
+                if _embed_document_from_markdown(session, websites, doc, model):
+                    doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
+                    session.commit()
+                else:
+                    session.rollback()
+
         else:
             print(f"WARNING: embedding_add not yet implemented for document type: {doc.document_type}, skipping")
             continue
-
-        if not text:
-            print(f"WARNING: document {doc.id} has no title or summary, skipping")
-            continue
-
-        websites.embedding_delete(doc.id, model)
-        result = search_service.get_embedding(text)
-        websites.embedding_add(doc.id, result.embedding, doc.language, text, text, model)
-        doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
-        session.commit()
 
 
 def main():

--- a/shared/types/documents.ts
+++ b/shared/types/documents.ts
@@ -48,6 +48,8 @@ export interface SearchResult {
   similarity: number;
   website_id: number;
   url: string;
+  chunk_id: number | null;
+  obsidian_note_paths: string[];
 }
 
 export interface ListItem {

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -21,6 +21,8 @@ interface Chunk {
   status: string;
   seg_start: number | null;
   seg_end: number | null;
+  obsidian_note_paths?: string[];
+  has_embeddings?: boolean | null;
 }
 
 interface Speaker {
@@ -318,6 +320,9 @@ const Chunks = () => {
   const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
   const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
   const [hiddenChunks, setHiddenChunks] = React.useState<Set<number>>(new Set());
+  const [filterUnprocessed, setFilterUnprocessed] = React.useState(false);
+  const [embedJobId, setEmbedJobId] = React.useState<string | null>(null);
+  const [embedJobStatus, setEmbedJobStatus] = React.useState<string | null>(null);
 
   const headers = { "x-api-key": apiKey ?? "", "Content-Type": "application/json" };
 
@@ -699,6 +704,44 @@ const Chunks = () => {
     finally { setExtractingSpeakers(false); }
   };
 
+  // ── Embeddings ──
+
+  const pollEmbeddingJob = React.useCallback((jid: string) => {
+    const interval = setInterval(async () => {
+      try {
+        const r = await fetch(`${apiUrl}/embedding_job/${jid}`, { headers });
+        const data = await r.json();
+        setEmbedJobStatus(data.job?.status ?? data.status);
+        if (data.job?.status === "done") {
+          clearInterval(interval);
+          setEmbedJobId(null);
+          const res = data.job.result ?? {};
+          setInfo(`Embeddingi: ${res.embeddings_created ?? 0} utworzonych z ${res.chunks_considered ?? 0} zatwierdzonych chunków`);
+          if (selectedRun !== null) await fetchChunks(selectedRun);
+        } else if (data.job?.status === "failed") {
+          clearInterval(interval);
+          setEmbedJobId(null);
+          setError("Generowanie embeddingów nie powiodło się: " + (data.job.error ?? ""));
+        }
+      } catch {
+        clearInterval(interval);
+        setEmbedJobId(null);
+      }
+    }, 3000);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, apiKey, selectedRun, fetchChunks]);
+
+  const generateEmbeddings = async () => {
+    if (selectedRun === null || embedJobId) return;
+    setError(""); setEmbedJobStatus("starting");
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/generate_embeddings`, { method: "POST", headers });
+      const data = await r.json();
+      if (data.job_id) { setEmbedJobId(data.job_id); setEmbedJobStatus("running"); pollEmbeddingJob(data.job_id); }
+      else { setError("Nie udało się uruchomić generowania embeddingów"); setEmbedJobStatus(null); }
+    } catch { setError("Błąd połączenia przy generowaniu embeddingów"); setEmbedJobStatus(null); }
+  };
+
   // ── Progress ──
 
   const tematChunks = chunks.filter(c => c.type === "TEMAT");
@@ -710,6 +753,7 @@ const Chunks = () => {
   const maxPosition = chunks.reduce((m, c) => Math.max(m, c.position), 0);
   const visibleChunks = chunks.filter(c =>
     !hiddenChunks.has(c.id) && (!hideAds || c.type === "TEMAT")
+    && (!filterUnprocessed || (c.type === "TEMAT" && (c.obsidian_note_paths?.length ?? 0) === 0))
   );
 
   // ── Render ───────────────────────────────────────────────────────────────
@@ -811,6 +855,18 @@ const Chunks = () => {
               Pokaż ukryte ({hiddenChunks.size})
             </button>
           )}
+          <label style={{ fontSize: "0.8em", color: "#94a3b8", display: "flex", alignItems: "center", gap: 4 }}
+            title="Pokaż tylko chunki TEMAT bez notatki Obsidian">
+            <input type="checkbox" checked={filterUnprocessed} onChange={e => setFilterUnprocessed(e.target.checked)} />
+            tylko nieopracowane
+          </label>
+          {approvedCount > 0 && (
+            <button className="button" onClick={generateEmbeddings} disabled={!!embedJobId}
+              title="Generuje embeddingi z zatwierdzonych chunków TEMAT (do wyszukiwania semantycznego)"
+              style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0891b2", color: "#fff", border: "none" }}>
+              {embedJobId ? `Embeddingi… (${embedJobStatus})` : "Generuj embeddingi"}
+            </button>
+          )}
         </div>
       )}
 
@@ -891,6 +947,17 @@ const Chunks = () => {
               </span>
 
               {chunk.speaker && <span style={{ color: "#64748b" }}>🎙 {chunk.speaker}</span>}
+
+              {!!chunk.obsidian_note_paths?.length && (
+                <span title={chunk.obsidian_note_paths.join("\n")} style={{ color: "#7c3aed" }}>
+                  📝 {chunk.obsidian_note_paths.length}
+                </span>
+              )}
+              {chunk.has_embeddings != null && (
+                <span title={chunk.has_embeddings ? "Ma embeddingi" : "Brak embeddingów"}>
+                  {chunk.has_embeddings ? "🟢" : "⚪"}
+                </span>
+              )}
 
               {/* Edycja tematu */}
               <input

--- a/web_interface_react/src/utils.tsx
+++ b/web_interface_react/src/utils.tsx
@@ -5,10 +5,13 @@ interface ListItemSearchSimilarProps {
     text: string;
     website_id: number;
     url: string;
+    chunk_id?: number | null;
+    obsidian_note_paths?: string[];
   };
 }
 
 const ListItemSearchSimilar = ({ item }: ListItemSearchSimilarProps) => {
+    const notes = item.obsidian_note_paths ?? [];
     return (
         <li>
             {item.similarity} {item.id} - {item.text}
@@ -17,6 +20,15 @@ const ListItemSearchSimilar = ({ item }: ListItemSearchSimilarProps) => {
             <a href={item.url} target="_blank" rel="noopener noreferrer">
                 {item.url}
             </a>
+            {item.chunk_id != null && (
+                <>
+                    {" "}
+                    <a href={`/chunks/${item.website_id}`}>chunk #{item.chunk_id}</a>
+                </>
+            )}
+            {notes.length > 0 && (
+                <span title={notes.join("\n")}> 📝 {notes.length}</span>
+            )}
         </li>
     )
 }


### PR DESCRIPTION
## Summary

Continuation of the chunks pipeline work (Stage 3 of the chunks expansion plan) plus ingestion-quality improvements:

- **Embeddings from approved chunks + note visibility** (`a680269`): async embedding generation from approved TEMAT chunks of an analysis run (`POST /analysis_run/<id>/generate_embeddings` + job polling), chunk-level Obsidian note paths surfaced in the review UI.
- **Transcript refactor** (`163c5a1`): chapter-splitting loop deduplicated into `_append_with_chapters`.
- **Fail-fast preflight for imports** (`357b968`): `dynamodb_sync.py` exits with an actionable message when the `markdown` extra (html2markdown) is missing, instead of crashing mid-run.
- **`text_extracted` + `text_md` persisted during sync** (`35303a4`): new `web_documents.text_extracted` column stores the raw LLM article extraction (pre-clean, diagnostic only, not exposed via API); `process_article_content()` now runs `clean_article_text()` and saves both fields, so the chunks pipeline gets clean markdown right after sync instead of raw page text with nav/ads. Alembic `b8c9d0e1f2a3` + init SQL 17.
- **Removed-lines tracking** (`225349a`): new `document_removed_lines` table persists lines removed during manual chunk review (source: `manual` | `szum_chunk`; rows survive run deletion via SET NULL FKs) — training data for improving `article_cleaner.py` / `site_rules.json`. Alembic `c9d0e1f2a3b4` + init SQL 18.

## Testing

- Full backend unit suite: **762 passed** (includes new `TestProcessArticleContent` and `test_removed_lines.py`)
- `ruff check backend/` clean
- Both Alembic migrations applied and verified on the NAS database

🤖 Generated with [Claude Code](https://claude.com/claude-code)