### PR TITLE
feat(reader): per-user reading progress + quote-anchored fragment notes (Etap 7, iter. 1)

### DIFF
--- a/backend/alembic/versions/d0e1f2a3b4c5_create_reader_user_tables.py
+++ b/backend/alembic/versions/d0e1f2a3b4c5_create_reader_user_tables.py
@@ -1,0 +1,76 @@
+"""create reader user tables (users, reading progress, document notes)
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same tables may already have been created by the Docker
+    # init script 19-create-reader-user-tables.sql on a fresh database.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id           SERIAL PRIMARY KEY,
+            username     VARCHAR(50) NOT NULL UNIQUE,
+            display_name VARCHAR(100),
+            created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_reading_progress (
+            id                    SERIAL PRIMARY KEY,
+            user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            document_id           INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            current_chapter       INTEGER NOT NULL,
+            current_chapter_title VARCHAR(500),
+            read_chapters         INTEGER[] NOT NULL DEFAULT '{}',
+            updated_at            TIMESTAMP NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_reading_progress_user_document UNIQUE (user_id, document_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_document_notes (
+            id               SERIAL PRIMARY KEY,
+            user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            document_id      INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            chapter_position INTEGER,
+            anchor_quote     TEXT NOT NULL,
+            anchor_prefix    VARCHAR(100),
+            anchor_suffix    VARCHAR(100),
+            run_id           INTEGER REFERENCES document_analysis_runs(id) ON DELETE SET NULL,
+            chunk_id         INTEGER REFERENCES document_chunks(id) ON DELETE SET NULL,
+            note_text        TEXT NOT NULL,
+            stance           VARCHAR(10),
+            created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at       TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_notes_document_id ON user_document_notes(document_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_notes_user_id ON user_document_notes(user_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS user_document_notes")
+    op.execute("DROP TABLE IF EXISTS user_reading_progress")
+    op.execute("DROP TABLE IF EXISTS users")

--- a/backend/database/init/19-create-reader-user-tables.sql
+++ b/backend/database/init/19-create-reader-user-tables.sql
@@ -1,0 +1,50 @@
+-- Migration: reader users, per-user reading progress and per-fragment notes (Etap 7)
+-- users: lightweight identity (household trust model) — x-api-key stays the app-level
+--        auth, x-user-id header only says WHO is reading.
+-- user_reading_progress: current chapter + read chapters per (user, document);
+--        chapter positions are 1-based and match GET /document/<id>/chapters.
+-- user_document_notes: note anchored by exact quote + surrounding context
+--        (W3C TextQuoteSelector style) at the DOCUMENT level, so it survives
+--        run deletion; run_id/chunk_id are convenience links (SET NULL).
+-- stance: agree | disagree | neutral | NULL — "czy się zgadzam" reaction.
+
+\c "lenie-ai";
+
+CREATE TABLE IF NOT EXISTS public.users (
+    id           SERIAL PRIMARY KEY,
+    username     VARCHAR(50) NOT NULL UNIQUE,
+    display_name VARCHAR(100),
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_reading_progress (
+    id                    SERIAL PRIMARY KEY,
+    user_id               INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    document_id           INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    current_chapter       INTEGER NOT NULL,
+    current_chapter_title VARCHAR(500),
+    read_chapters         INTEGER[] NOT NULL DEFAULT '{}',
+    updated_at            TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_reading_progress_user_document UNIQUE (user_id, document_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.user_document_notes (
+    id               SERIAL PRIMARY KEY,
+    user_id          INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    document_id      INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    chapter_position INTEGER,
+    anchor_quote     TEXT NOT NULL,
+    anchor_prefix    VARCHAR(100),
+    anchor_suffix    VARCHAR(100),
+    run_id           INTEGER REFERENCES public.document_analysis_runs(id) ON DELETE SET NULL,
+    chunk_id         INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL,
+    note_text        TEXT NOT NULL,
+    stance           VARCHAR(10),
+    created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_notes_document_id ON public.user_document_notes(document_id);
+CREATE INDEX IF NOT EXISTS idx_user_notes_user_id     ON public.user_document_notes(user_id);
+
+SELECT 'Reader user tables created' AS status;

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     SmallInteger,
     String,
     Text,
+    UniqueConstraint,
     func,
     select,
     text as sa_text,
@@ -693,3 +694,110 @@ class DocumentRemovedLine(Base):
 
     def __repr__(self) -> str:
         return f"DocumentRemovedLine(id={self.id!r}, document_id={self.document_id!r}, source={self.source!r})"
+
+
+class User(Base):
+    """Reader identity (household trust model).
+
+    x-api-key stays the app-level auth; the x-user-id header only says WHO is
+    reading — no passwords. Owns reading progress and document notes.
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    display_name: Mapped[str | None] = mapped_column(String(100))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return f"User(id={self.id!r}, username={self.username!r})"
+
+
+class UserReadingProgress(Base):
+    """Per-(user, document) reading position for the /read/:id reader.
+
+    Chapter positions are 1-based and match GET /document/<id>/chapters
+    (computed on the fly from text_md — independent of analysis runs).
+    Renormalizing a book may shift positions; current_chapter_title is a
+    snapshot that lets the UI notice the mismatch.
+    """
+
+    __tablename__ = "user_reading_progress"
+    __table_args__ = (
+        UniqueConstraint("user_id", "document_id", name="uq_reading_progress_user_document"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    current_chapter: Mapped[int] = mapped_column(Integer, nullable=False)
+    current_chapter_title: Mapped[str | None] = mapped_column(String(500))
+    read_chapters: Mapped[list[int]] = mapped_column(
+        ARRAY(Integer), nullable=False, server_default=sa_text("'{}'"),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return (
+            f"UserReadingProgress(user_id={self.user_id!r}, document_id={self.document_id!r}, "
+            f"current_chapter={self.current_chapter!r})"
+        )
+
+
+class UserDocumentNote(Base):
+    """User note/reaction anchored to a document fragment.
+
+    Anchored by exact quote + surrounding context (W3C TextQuoteSelector
+    style) at the DOCUMENT level so the note survives analysis-run deletion;
+    run_id/chunk_id are convenience links only (SET NULL). chapter_position
+    is a hint where to re-anchor. stance: agree | disagree | neutral | NULL.
+    """
+
+    __tablename__ = "user_document_notes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    chapter_position: Mapped[int | None] = mapped_column(Integer)
+    anchor_quote: Mapped[str] = mapped_column(Text, nullable=False)
+    anchor_prefix: Mapped[str | None] = mapped_column(String(100))
+    anchor_suffix: Mapped[str | None] = mapped_column(String(100))
+    run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="SET NULL"),
+    )
+    chunk_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_chunks.id", ondelete="SET NULL"),
+    )
+    note_text: Mapped[str] = mapped_column(Text, nullable=False)
+    stance: Mapped[str | None] = mapped_column(String(10))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return (
+            f"UserDocumentNote(id={self.id!r}, user_id={self.user_id!r}, "
+            f"document_id={self.document_id!r}, chapter_position={self.chapter_position!r})"
+        )

--- a/backend/library/reader_routes.py
+++ b/backend/library/reader_routes.py
@@ -1,0 +1,325 @@
+"""Flask blueprint: reader users, per-user reading progress and fragment notes (Etap 7).
+
+Endpoints (all require x-api-key via the global before_request; the ones
+marked [user] additionally require an x-user-id header of an existing user):
+  GET    /users                                — list users
+  POST   /users                                — create user {username, display_name?}
+  GET    /document/<doc_id>/reading_progress   — [user] progress for this document
+  PUT    /document/<doc_id>/reading_progress   — [user] upsert current chapter / read chapters
+  GET    /document/<doc_id>/notes              — [user] notes (optional ?chapter=N filter)
+  POST   /document/<doc_id>/notes              — [user] add a note anchored by quote
+  PATCH  /note/<note_id>                       — [user] edit own note (note_text / stance)
+  DELETE /note/<note_id>                       — [user] delete own note
+
+Notes are anchored by exact quote + context (W3C TextQuoteSelector style) at
+the document level, so they survive analysis-run deletion; re-anchoring in the
+chapter text is the frontend's job (exact match, then whitespace-normalized).
+"""
+
+import logging
+from datetime import datetime
+
+from flask import Blueprint, abort, jsonify, request
+from sqlalchemy import select
+
+from library.db.engine import get_scoped_session
+from library.db.models import User, UserDocumentNote, UserReadingProgress, WebDocument
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("reader", __name__)
+
+ALLOWED_STANCES = {"agree", "disagree", "neutral"}
+
+
+def _require_user(session) -> User:
+    """Resolve the x-user-id header to a User row or abort."""
+    raw = request.headers.get("x-user-id")
+    if not raw:
+        abort(400, "x-user-id header is missing")
+    try:
+        user_id = int(raw)
+    except ValueError:
+        abort(400, "x-user-id header must be an integer")
+    user = session.get(User, user_id)
+    if user is None:
+        abort(404, f"User {user_id} not found")
+    return user
+
+
+def _get_document_or_404(session, doc_id: int) -> WebDocument:
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+    return doc
+
+
+def _note_to_dict(note: UserDocumentNote) -> dict:
+    return {
+        "id": note.id,
+        "user_id": note.user_id,
+        "document_id": note.document_id,
+        "chapter_position": note.chapter_position,
+        "anchor_quote": note.anchor_quote,
+        "anchor_prefix": note.anchor_prefix,
+        "anchor_suffix": note.anchor_suffix,
+        "run_id": note.run_id,
+        "chunk_id": note.chunk_id,
+        "note_text": note.note_text,
+        "stance": note.stance,
+        "created_at": note.created_at.isoformat() if note.created_at else None,
+        "updated_at": note.updated_at.isoformat() if note.updated_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/users", methods=["GET"])
+def list_users():
+    session = get_scoped_session()
+    users = session.execute(select(User).order_by(User.id)).scalars().all()
+    return jsonify({
+        "status": "success",
+        "users": [
+            {"id": u.id, "username": u.username, "display_name": u.display_name}
+            for u in users
+        ],
+    })
+
+
+@bp.route("/users", methods=["POST"])
+def create_user():
+    data = request.get_json(silent=True) or {}
+    username = (data.get("username") or "").strip()
+    if not username:
+        return jsonify({"status": "error", "message": "username is required"}), 400
+    if len(username) > 50:
+        return jsonify({"status": "error", "message": "username too long (max 50)"}), 400
+
+    session = get_scoped_session()
+    existing = session.execute(
+        select(User).where(User.username == username)
+    ).scalar_one_or_none()
+    if existing is not None:
+        return jsonify({"status": "error", "message": f"username '{username}' already exists"}), 409
+
+    user = User(username=username, display_name=(data.get("display_name") or "").strip() or None)
+    session.add(user)
+    session.commit()
+    return jsonify({
+        "status": "success",
+        "user": {"id": user.id, "username": user.username, "display_name": user.display_name},
+    }), 201
+
+
+# ---------------------------------------------------------------------------
+# Reading progress
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/document/<int:doc_id>/reading_progress", methods=["GET"])
+def get_reading_progress(doc_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    progress = session.execute(
+        select(UserReadingProgress).where(
+            UserReadingProgress.user_id == user.id,
+            UserReadingProgress.document_id == doc_id,
+        )
+    ).scalar_one_or_none()
+
+    if progress is None:
+        return jsonify({
+            "status": "success",
+            "doc_id": doc_id,
+            "user_id": user.id,
+            "current_chapter": None,
+            "current_chapter_title": None,
+            "read_chapters": [],
+        })
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "current_chapter": progress.current_chapter,
+        "current_chapter_title": progress.current_chapter_title,
+        "read_chapters": sorted(progress.read_chapters or []),
+        "updated_at": progress.updated_at.isoformat() if progress.updated_at else None,
+    })
+
+
+@bp.route("/document/<int:doc_id>/reading_progress", methods=["PUT"])
+def put_reading_progress(doc_id: int):
+    """Upsert reading progress.
+
+    Body: current_chapter (int >= 1, required), current_chapter_title (optional
+    snapshot from the client — avoids re-slicing the whole book server-side),
+    mark_read / unmark_read (optional lists of chapter positions).
+    """
+    data = request.get_json(silent=True) or {}
+    current_chapter = data.get("current_chapter")
+    if not isinstance(current_chapter, int) or current_chapter < 1:
+        return jsonify({"status": "error", "message": "current_chapter must be a positive integer"}), 400
+    for key in ("mark_read", "unmark_read"):
+        value = data.get(key, [])
+        if not isinstance(value, list) or not all(isinstance(p, int) and p >= 1 for p in value):
+            return jsonify({"status": "error", "message": f"{key} must be a list of positive integers"}), 400
+
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    progress = session.execute(
+        select(UserReadingProgress).where(
+            UserReadingProgress.user_id == user.id,
+            UserReadingProgress.document_id == doc_id,
+        )
+    ).scalar_one_or_none()
+    if progress is None:
+        progress = UserReadingProgress(
+            user_id=user.id, document_id=doc_id,
+            current_chapter=current_chapter, read_chapters=[],
+        )
+        session.add(progress)
+
+    progress.current_chapter = current_chapter
+    title = data.get("current_chapter_title")
+    if title is not None:
+        progress.current_chapter_title = str(title)[:500] or None
+
+    read = set(progress.read_chapters or [])
+    read.update(data.get("mark_read", []))
+    read.difference_update(data.get("unmark_read", []))
+    progress.read_chapters = sorted(read)
+
+    progress.updated_at = datetime.now()
+    session.commit()
+
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "current_chapter": progress.current_chapter,
+        "current_chapter_title": progress.current_chapter_title,
+        "read_chapters": progress.read_chapters,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/document/<int:doc_id>/notes", methods=["GET"])
+def list_notes(doc_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    query = select(UserDocumentNote).where(
+        UserDocumentNote.user_id == user.id,
+        UserDocumentNote.document_id == doc_id,
+    )
+    chapter = request.args.get("chapter", type=int)
+    if chapter is not None:
+        query = query.where(UserDocumentNote.chapter_position == chapter)
+    notes = session.execute(
+        query.order_by(UserDocumentNote.chapter_position, UserDocumentNote.id)
+    ).scalars().all()
+
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "notes": [_note_to_dict(n) for n in notes],
+    })
+
+
+@bp.route("/document/<int:doc_id>/notes", methods=["POST"])
+def create_note(doc_id: int):
+    data = request.get_json(silent=True) or {}
+    anchor_quote = (data.get("anchor_quote") or "").strip()
+    note_text = (data.get("note_text") or "").strip()
+    if not anchor_quote:
+        return jsonify({"status": "error", "message": "anchor_quote is required"}), 400
+    if not note_text:
+        return jsonify({"status": "error", "message": "note_text is required"}), 400
+    stance = data.get("stance")
+    if stance is not None and stance not in ALLOWED_STANCES:
+        return jsonify({
+            "status": "error",
+            "message": f"stance must be one of {sorted(ALLOWED_STANCES)}",
+        }), 400
+
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    note = UserDocumentNote(
+        user_id=user.id,
+        document_id=doc_id,
+        chapter_position=data.get("chapter_position"),
+        anchor_quote=anchor_quote,
+        # prefix keeps its END (nearest the quote), suffix keeps its beginning
+        anchor_prefix=str(data.get("anchor_prefix") or "")[-100:] or None,
+        anchor_suffix=str(data.get("anchor_suffix") or "")[:100] or None,
+        run_id=data.get("run_id"),
+        chunk_id=data.get("chunk_id"),
+        note_text=note_text,
+        stance=stance,
+    )
+    session.add(note)
+    session.commit()
+    return jsonify({"status": "success", "note": _note_to_dict(note)}), 201
+
+
+@bp.route("/note/<int:note_id>", methods=["PATCH"])
+def update_note(note_id: int):
+    data = request.get_json(silent=True) or {}
+    session = get_scoped_session()
+    user = _require_user(session)
+
+    note = session.get(UserDocumentNote, note_id)
+    if note is None:
+        abort(404, f"Note {note_id} not found")
+    if note.user_id != user.id:
+        abort(403, "Note belongs to another user")
+
+    if "note_text" in data:
+        note_text = (data.get("note_text") or "").strip()
+        if not note_text:
+            return jsonify({"status": "error", "message": "note_text cannot be empty"}), 400
+        note.note_text = note_text
+    if "stance" in data:
+        stance = data.get("stance")
+        if stance is not None and stance not in ALLOWED_STANCES:
+            return jsonify({
+                "status": "error",
+                "message": f"stance must be one of {sorted(ALLOWED_STANCES)}",
+            }), 400
+        note.stance = stance
+
+    note.updated_at = datetime.now()
+    session.commit()
+    return jsonify({"status": "success", "note": _note_to_dict(note)})
+
+
+@bp.route("/note/<int:note_id>", methods=["DELETE"])
+def delete_note(note_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+
+    note = session.get(UserDocumentNote, note_id)
+    if note is None:
+        abort(404, f"Note {note_id} not found")
+    if note.user_id != user.id:
+        abort(403, "Note belongs to another user")
+
+    session.delete(note)
+    session.commit()
+    return jsonify({"status": "success", "deleted_note_id": note_id})

--- a/backend/server.py
+++ b/backend/server.py
@@ -14,6 +14,7 @@ from library.models.stalker_document_status import StalkerDocumentStatus
 from library.models.stalker_document_type import StalkerDocumentType
 from library.models.stalker_document_status_error import StalkerDocumentStatusError
 from library.chunk_review_routes import bp as chunk_review_bp
+from library.reader_routes import bp as reader_bp
 
 logging.basicConfig(level=logging.INFO)
 
@@ -79,6 +80,7 @@ logging.info("Flask - enabling CORS for all routes")
 CORS(app)  # This will enable CORS for all routes
 
 app.register_blueprint(chunk_review_bp)
+app.register_blueprint(reader_bp)
 
 
 @app.teardown_appcontext

--- a/backend/tests/unit/test_reader_routes.py
+++ b/backend/tests/unit/test_reader_routes.py
@@ -1,0 +1,318 @@
+"""Unit tests for Etap 7 (reader): users, reading progress and fragment notes.
+
+Covers library/reader_routes.py with a mocked scoped session (no DB): user
+CRUD + x-user-id resolution, reading-progress upsert semantics and note
+anchoring/ownership rules.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+flask = pytest.importorskip("flask")
+
+from library import reader_routes as rr  # noqa: E402
+from library.db.models import User, UserDocumentNote, UserReadingProgress, WebDocument  # noqa: E402
+
+
+READER_USER = User(username="krzysztof", display_name="Krzysztof")
+READER_USER.id = 1
+
+OTHER_USER = User(username="gosc")
+OTHER_USER.id = 2
+
+DOC_ID = 9204
+
+
+def _make_note(**overrides) -> UserDocumentNote:
+    note = UserDocumentNote(
+        user_id=READER_USER.id,
+        document_id=DOC_ID,
+        chapter_position=4,
+        anchor_quote="cytowany fragment",
+        anchor_prefix="poprzedzający tekst",
+        anchor_suffix="następujący tekst",
+        note_text="moja reakcja",
+        stance="agree",
+    )
+    note.id = 501
+    for key, value in overrides.items():
+        setattr(note, key, value)
+    return note
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    session = MagicMock()
+    doc = MagicMock(spec=WebDocument)
+    doc.id = DOC_ID
+
+    store = {"users": {1: READER_USER, 2: OTHER_USER}, "notes": {}, "doc": doc}
+
+    def fake_get(model, pk):
+        if model is User:
+            return store["users"].get(pk)
+        if model is WebDocument:
+            return store["doc"] if pk == DOC_ID else None
+        if model is UserDocumentNote:
+            return store["notes"].get(pk)
+        return None
+
+    session.get.side_effect = fake_get
+    # new objects get an id on add (stand-in for commit-time sequence values)
+    session.add.side_effect = lambda obj: setattr(obj, "id", getattr(obj, "id", None) or 900)
+    session.store = store
+    monkeypatch.setattr(rr, "get_scoped_session", lambda: session)
+    return session
+
+
+@pytest.fixture
+def client(fake_session):
+    app = flask.Flask(__name__)
+    app.register_blueprint(rr.bp)
+    return app.test_client()
+
+
+USER_HDR = {"x-user-id": "1"}
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+class TestUsers:
+    def test_list_users(self, client, fake_session):
+        fake_session.execute.return_value.scalars.return_value.all.return_value = [
+            READER_USER, OTHER_USER,
+        ]
+        resp = client.get("/users")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert [u["username"] for u in data["users"]] == ["krzysztof", "gosc"]
+
+    def test_create_user(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.post("/users", json={"username": "nowy", "display_name": " Nowy "})
+        data = resp.get_json()
+
+        assert resp.status_code == 201
+        assert data["user"]["username"] == "nowy"
+        assert data["user"]["display_name"] == "Nowy"
+        fake_session.commit.assert_called_once()
+
+    def test_create_user_duplicate_409(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = READER_USER
+        resp = client.post("/users", json={"username": "krzysztof"})
+        assert resp.status_code == 409
+
+    def test_create_user_empty_username_400(self, client):
+        resp = client.post("/users", json={"username": "  "})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# x-user-id resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRequireUser:
+    def test_missing_header_400(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
+        assert resp.status_code == 400
+
+    def test_non_integer_header_400(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "abc"})
+        assert resp.status_code == 400
+
+    def test_unknown_user_404(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "99"})
+        assert resp.status_code == 404
+
+    def test_unknown_document_404(self, client, fake_session):
+        resp = client.get("/document/12345/reading_progress", headers=USER_HDR)
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reading progress
+# ---------------------------------------------------------------------------
+
+
+class TestReadingProgress:
+    def test_get_without_row_returns_nulls(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["current_chapter"] is None
+        assert data["read_chapters"] == []
+
+    def test_get_existing_row(self, client, fake_session):
+        progress = UserReadingProgress(
+            user_id=1, document_id=DOC_ID, current_chapter=7,
+            current_chapter_title="Bank centralny", read_chapters=[3, 1, 2],
+        )
+        fake_session.execute.return_value.scalar_one_or_none.return_value = progress
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert data["current_chapter"] == 7
+        assert data["current_chapter_title"] == "Bank centralny"
+        assert data["read_chapters"] == [1, 2, 3]
+
+    def test_put_creates_row(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 5, "current_chapter_title": "Rozdział 5", "mark_read": [4]},
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["current_chapter"] == 5
+        assert data["read_chapters"] == [4]
+        fake_session.add.assert_called_once()
+        fake_session.commit.assert_called_once()
+
+    def test_put_updates_existing_row_and_read_set(self, client, fake_session):
+        progress = UserReadingProgress(
+            user_id=1, document_id=DOC_ID, current_chapter=3, read_chapters=[1, 2, 3],
+        )
+        fake_session.execute.return_value.scalar_one_or_none.return_value = progress
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 6, "mark_read": [5, 5], "unmark_read": [2]},
+        )
+        data = resp.get_json()
+
+        assert data["current_chapter"] == 6
+        assert data["read_chapters"] == [1, 3, 5]
+        fake_session.add.assert_not_called()
+
+    def test_put_invalid_current_chapter_400(self, client):
+        for bad in (None, 0, -1, "3"):
+            resp = client.put(
+                f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+                json={"current_chapter": bad},
+            )
+            assert resp.status_code == 400
+
+    def test_put_invalid_mark_read_400(self, client):
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 1, "mark_read": [0]},
+        )
+        assert resp.status_code == 400
+
+    def test_put_truncates_title_to_500(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 1, "current_chapter_title": "x" * 600},
+        )
+        assert len(resp.get_json()["current_chapter_title"]) == 500
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+class TestNotes:
+    def test_create_note(self, client, fake_session):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={
+                "anchor_quote": "fragment książki",
+                "note_text": "zgadzam się z autorem",
+                "anchor_prefix": "p" * 150,
+                "anchor_suffix": "s" * 150,
+                "chapter_position": 4,
+                "stance": "agree",
+            },
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 201
+        note = data["note"]
+        assert note["anchor_quote"] == "fragment książki"
+        assert len(note["anchor_prefix"]) == 100
+        assert len(note["anchor_suffix"]) == 100
+        assert note["chapter_position"] == 4
+        assert note["stance"] == "agree"
+        fake_session.commit.assert_called_once()
+
+    def test_create_note_requires_quote_and_text(self, client):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "", "note_text": "coś"},
+        )
+        assert resp.status_code == 400
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "coś", "note_text": " "},
+        )
+        assert resp.status_code == 400
+
+    def test_create_note_invalid_stance_400(self, client):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "q", "note_text": "n", "stance": "meh"},
+        )
+        assert resp.status_code == 400
+
+    def test_list_notes(self, client, fake_session):
+        fake_session.execute.return_value.scalars.return_value.all.return_value = [_make_note()]
+        resp = client.get(f"/document/{DOC_ID}/notes", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert len(data["notes"]) == 1
+        assert data["notes"][0]["note_text"] == "moja reakcja"
+
+    def test_patch_note_updates_text_and_stance(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(
+            f"/note/{note.id}", headers=USER_HDR,
+            json={"note_text": "zmienione", "stance": "disagree"},
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["note"]["note_text"] == "zmienione"
+        assert data["note"]["stance"] == "disagree"
+
+    def test_patch_note_empty_text_400(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": ""})
+        assert resp.status_code == 400
+
+    def test_patch_foreign_note_403(self, client, fake_session):
+        note = _make_note(user_id=OTHER_USER.id)
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": "x"})
+        assert resp.status_code == 403
+
+    def test_delete_note(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+
+        assert resp.status_code == 200
+        fake_session.delete.assert_called_once_with(note)
+
+    def test_delete_foreign_note_403(self, client, fake_session):
+        note = _make_note(user_id=OTHER_USER.id)
+        fake_session.store["notes"][note.id] = note
+        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+        assert resp.status_code == 403
+
+    def test_delete_missing_note_404(self, client):
+        resp = client.delete("/note/777", headers=USER_HDR)
+        assert resp.status_code == 404

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -22,6 +22,33 @@ interface ChapterContent {
   next: number | null;
 }
 
+interface ReaderUser {
+  id: number;
+  username: string;
+  display_name: string | null;
+}
+
+interface UserNote {
+  id: number;
+  chapter_position: number | null;
+  anchor_quote: string;
+  anchor_prefix: string | null;
+  anchor_suffix: string | null;
+  note_text: string;
+  stance: string | null;
+}
+
+interface PendingNote {
+  quote: string;
+  prefix: string;
+  suffix: string;
+  x: number;
+  y: number;
+}
+
+const USER_STORAGE_KEY = "lenie_userId";
+const STANCE_ICON: Record<string, string> = { agree: "👍", disagree: "👎", neutral: "➖" };
+
 // ── Minimal markdown rendering (headings, paragraphs, hr; images skipped) ────
 
 const IMAGE_LINE = /^!\[[^\]]*\]\([^)]*\)$/;
@@ -36,7 +63,47 @@ function renderInline(text: string): React.ReactNode[] {
   });
 }
 
-function renderMarkdown(text: string): React.ReactNode[] {
+const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
+
+/** Render a paragraph's text with <mark> around anchored note quotes.
+ *  Exact match → inline highlight; whitespace-normalized match → whole
+ *  paragraph tinted (quote spans line breaks or renderer differences). */
+function renderParagraphWithNotes(
+  text: string,
+  notes: UserNote[],
+): { nodes: React.ReactNode[]; paragraphTint: UserNote | null } {
+  const matches = notes
+    .map(n => ({ note: n, idx: text.indexOf(n.anchor_quote) }))
+    .filter(m => m.idx >= 0)
+    .sort((a, b) => a.idx - b.idx);
+
+  if (matches.length === 0) {
+    const tint = notes.find(n => normalizeWs(text).includes(normalizeWs(n.anchor_quote))) ?? null;
+    return { nodes: renderInline(text), paragraphTint: tint };
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  matches.forEach((m, i) => {
+    if (m.idx < cursor) return; // overlapping quote — skip
+    if (m.idx > cursor) nodes.push(...renderInline(text.slice(cursor, m.idx)));
+    const quoted = text.slice(m.idx, m.idx + m.note.anchor_quote.length);
+    nodes.push(
+      <mark
+        key={`note-${m.note.id}-${i}`}
+        title={`${STANCE_ICON[m.note.stance ?? ""] ?? "📝"} ${m.note.note_text}`}
+        style={{ background: "#fef08a", padding: "0 1px", cursor: "help" }}
+      >
+        {renderInline(quoted)}
+      </mark>
+    );
+    cursor = m.idx + m.note.anchor_quote.length;
+  });
+  if (cursor < text.length) nodes.push(...renderInline(text.slice(cursor)));
+  return { nodes, paragraphTint: null };
+}
+
+function renderMarkdown(text: string, notes: UserNote[]): React.ReactNode[] {
   const blocks = text.split(/\n\s*\n/);
   const out: React.ReactNode[] = [];
   blocks.forEach((block, i) => {
@@ -55,11 +122,17 @@ function renderMarkdown(text: string): React.ReactNode[] {
     }
     // footnote / caption lines (superscript digits or "Wykres N.") — smaller font
     const isNote = /^([¹²³⁴⁵⁶⁷⁸⁹⁰]+|\d{1,3} )\S*\s*(http|www|[A-ZŻŹĆĄŚĘŁÓŃ])/.test(trimmed) && trimmed.length < 400;
+    const paraText = trimmed.replace(/\n/g, " ");
+    const { nodes, paragraphTint } = renderParagraphWithNotes(paraText, notes);
     out.push(
       <p key={i} style={isNote
         ? { fontSize: "0.8em", color: "#64748b", margin: "6px 0" }
-        : { lineHeight: 1.65, margin: "14px 0", textAlign: "justify" }}>
-        {renderInline(trimmed.replace(/\n/g, " "))}
+        : {
+            lineHeight: 1.65, margin: "14px 0", textAlign: "justify",
+            ...(paragraphTint ? { background: "#fefce8", borderLeft: "3px solid #eab308", paddingLeft: 8 } : {}),
+          }}
+        title={paragraphTint ? `📝 ${paragraphTint.note_text}` : undefined}>
+        {nodes}
       </p>
     );
   });
@@ -79,8 +152,55 @@ const Read: React.FC = () => {
   const [error, setError] = React.useState<string | null>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
+  // ── User identity ──
+  const [users, setUsers] = React.useState<ReaderUser[]>([]);
+  const [userId, setUserId] = React.useState<number | null>(() => {
+    const v = localStorage.getItem(USER_STORAGE_KEY);
+    return v ? Number(v) : null;
+  });
+  const [newUsername, setNewUsername] = React.useState("");
+
+  // ── Reading progress ──
+  const [readChapters, setReadChapters] = React.useState<number[]>([]);
+  const [progressLoaded, setProgressLoaded] = React.useState(false);
+  const initialRedirectDone = React.useRef(false);
+
+  // ── Notes ──
+  const [notes, setNotes] = React.useState<UserNote[]>([]);
+  const [pendingNote, setPendingNote] = React.useState<PendingNote | null>(null);
+  const [noteText, setNoteText] = React.useState("");
+  const [noteStance, setNoteStance] = React.useState<string | null>(null);
+  const [editingNoteId, setEditingNoteId] = React.useState<number | null>(null);
+  const [editingText, setEditingText] = React.useState("");
+
   const position = Number(searchParams.get("chapter") ?? 1);
-  const headers = React.useMemo(() => ({ "x-api-key": apiKey ?? "" }), [apiKey]);
+  const headers = React.useMemo(() => {
+    const h: Record<string, string> = { "x-api-key": apiKey ?? "" };
+    if (userId) h["x-user-id"] = String(userId);
+    return h;
+  }, [apiKey, userId]);
+  const jsonHeaders = React.useMemo(
+    () => ({ ...headers, "Content-Type": "application/json" }), [headers]);
+
+  const selectUser = (uid: number | null) => {
+    setUserId(uid);
+    setProgressLoaded(false);
+    initialRedirectDone.current = false;
+    if (uid) localStorage.setItem(USER_STORAGE_KEY, String(uid));
+    else localStorage.removeItem(USER_STORAGE_KEY);
+  };
+
+  // ── Data loading ──
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/users`, { headers: { "x-api-key": apiKey ?? "" } });
+        const data = await r.json();
+        if (data.status === "success") setUsers(data.users ?? []);
+      } catch { /* users are optional — reader works without identity */ }
+    })();
+  }, [apiUrl, apiKey]);
 
   React.useEffect(() => {
     (async () => {
@@ -93,12 +213,48 @@ const Read: React.FC = () => {
         setError(String(e));
       }
     })();
-  }, [apiUrl, id, headers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, apiKey]);
+
+  // progress: fetch once per (user, doc); redirect to last position when URL has no ?chapter
+  React.useEffect(() => {
+    if (!userId) { setProgressLoaded(true); setReadChapters([]); return; }
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/document/${id}/reading_progress`, { headers });
+        const data = await r.json();
+        if (data.status === "success") {
+          setReadChapters(data.read_chapters ?? []);
+          if (!initialRedirectDone.current && !searchParams.get("chapter") && data.current_chapter) {
+            setSearchParams({ chapter: String(data.current_chapter) }, { replace: true });
+          }
+        }
+      } catch { /* progress is best-effort */ }
+      initialRedirectDone.current = true;
+      setProgressLoaded(true);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, userId]);
 
   React.useEffect(() => {
+    if (!userId) { setNotes([]); return; }
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/document/${id}/notes`, { headers });
+        const data = await r.json();
+        if (data.status === "success") setNotes(data.notes ?? []);
+      } catch { /* notes are best-effort */ }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, userId]);
+
+  // chapter content — waits for the progress redirect so we don't flash chapter 1
+  React.useEffect(() => {
+    if (!progressLoaded) return;
     (async () => {
       setLoading(true);
       setError(null);
+      setPendingNote(null);
       try {
         const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}`, { headers });
         const data = await r.json();
@@ -112,11 +268,139 @@ const Read: React.FC = () => {
         setLoading(false);
       }
     })();
-  }, [apiUrl, id, position, headers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, position, progressLoaded, apiKey]);
+
+  // persist current chapter as reading position
+  React.useEffect(() => {
+    if (!userId || !content || !progressLoaded) return;
+    fetch(`${apiUrl}/document/${id}/reading_progress`, {
+      method: "PUT", headers: jsonHeaders,
+      body: JSON.stringify({ current_chapter: content.position, current_chapter_title: content.title }),
+    }).catch(() => undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content?.position, userId]);
+
+  // ── Actions ──
 
   const goTo = (pos: number | null) => {
     if (pos) setSearchParams({ chapter: String(pos) });
   };
+
+  const toggleRead = (pos: number, read: boolean) => {
+    if (!userId) return;
+    setReadChapters(prev => read ? [...prev, pos].sort((a, b) => a - b) : prev.filter(p => p !== pos));
+    fetch(`${apiUrl}/document/${id}/reading_progress`, {
+      method: "PUT", headers: jsonHeaders,
+      body: JSON.stringify({
+        current_chapter: position,
+        [read ? "mark_read" : "unmark_read"]: [pos],
+      }),
+    }).catch(() => undefined);
+  };
+
+  const goNext = () => {
+    if (!content?.next) return;
+    if (userId && !readChapters.includes(content.position)) toggleRead(content.position, true);
+    goTo(content.next);
+  };
+
+  const addUser = async () => {
+    const username = newUsername.trim();
+    if (!username) return;
+    const r = await fetch(`${apiUrl}/users`, {
+      method: "POST", headers: { "x-api-key": apiKey ?? "", "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setUsers(prev => [...prev, data.user]);
+      selectUser(data.user.id);
+      setNewUsername("");
+    } else {
+      alert(data.message ?? "Nie udało się dodać użytkownika");
+    }
+  };
+
+  const onTextSelected = () => {
+    if (!userId) return;
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed) return;
+    const quote = normalizeWs(sel.toString());
+    if (quote.length < 3 || quote.length > 2000) return;
+
+    let prefix = "";
+    let suffix = "";
+    const anchorEl = sel.anchorNode instanceof Element ? sel.anchorNode : sel.anchorNode?.parentElement;
+    const para = anchorEl?.closest("p");
+    const paraText = para?.textContent ?? "";
+    const idx = paraText.indexOf(quote);
+    if (idx >= 0) {
+      prefix = paraText.slice(Math.max(0, idx - 50), idx);
+      suffix = paraText.slice(idx + quote.length, idx + quote.length + 50);
+    }
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    setPendingNote({ quote, prefix, suffix, x: rect.left + window.scrollX, y: rect.bottom + window.scrollY + 6 });
+    setNoteText("");
+    setNoteStance(null);
+  };
+
+  const saveNote = async () => {
+    if (!pendingNote || !noteText.trim()) return;
+    const r = await fetch(`${apiUrl}/document/${id}/notes`, {
+      method: "POST", headers: jsonHeaders,
+      body: JSON.stringify({
+        anchor_quote: pendingNote.quote,
+        anchor_prefix: pendingNote.prefix,
+        anchor_suffix: pendingNote.suffix,
+        chapter_position: position,
+        note_text: noteText.trim(),
+        stance: noteStance,
+      }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => [...prev, data.note]);
+      setPendingNote(null);
+    } else {
+      alert(data.message ?? "Nie udało się zapisać notatki");
+    }
+  };
+
+  const deleteNote = async (noteId: number) => {
+    if (!window.confirm("Usunąć notatkę?")) return;
+    const r = await fetch(`${apiUrl}/note/${noteId}`, { method: "DELETE", headers });
+    const data = await r.json();
+    if (data.status === "success") setNotes(prev => prev.filter(n => n.id !== noteId));
+  };
+
+  const saveEditedNote = async (noteId: number) => {
+    const text = editingText.trim();
+    if (!text) return;
+    const r = await fetch(`${apiUrl}/note/${noteId}`, {
+      method: "PATCH", headers: jsonHeaders,
+      body: JSON.stringify({ note_text: text }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => prev.map(n => (n.id === noteId ? data.note : n)));
+      setEditingNoteId(null);
+    }
+  };
+
+  // ── Derived ──
+
+  const chapterNotes = React.useMemo(
+    () => notes.filter(n => n.chapter_position === position), [notes, position]);
+
+  const anchoredNoteIds = React.useMemo(() => {
+    if (!content) return new Set<number>();
+    const normText = normalizeWs(content.text);
+    return new Set(
+      chapterNotes.filter(n => normText.includes(normalizeWs(n.anchor_quote))).map(n => n.id));
+  }, [content, chapterNotes]);
+
+  // ── Render ──
 
   const navButtons = content && (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 12, margin: "18px 0" }}>
@@ -127,10 +411,62 @@ const Read: React.FC = () => {
       <span style={{ fontSize: "0.85em", color: "#64748b", alignSelf: "center" }}>
         {content.position} / {content.chapter_total}
       </span>
-      <button onClick={() => goTo(content.next)} disabled={!content.next}
+      <button onClick={goNext} disabled={!content.next}
         style={{ padding: "6px 14px", cursor: content.next ? "pointer" : "default" }}>
         Następny →
       </button>
+    </div>
+  );
+
+  const userPicker = (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.85em" }}>
+      <span style={{ color: "#64748b" }}>Czytasz jako:</span>
+      <select value={userId ?? ""} onChange={e => selectUser(e.target.value ? Number(e.target.value) : null)}>
+        <option value="">— wybierz —</option>
+        {users.map(u => (
+          <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
+        ))}
+      </select>
+      <input
+        value={newUsername} onChange={e => setNewUsername(e.target.value)}
+        onKeyDown={e => e.key === "Enter" && addUser()}
+        placeholder="nowy użytkownik…" style={{ width: 130 }}
+      />
+      <button onClick={addUser} disabled={!newUsername.trim()}>＋</button>
+    </div>
+  );
+
+  const renderNoteRow = (n: UserNote, showUnanchored: boolean) => (
+    <div key={n.id} style={{
+      padding: "6px 10px", borderBottom: "1px solid #e2e8f0", fontSize: "0.8em", lineHeight: 1.4,
+    }}>
+      <div style={{ color: "#64748b", cursor: n.chapter_position ? "pointer" : undefined }}
+        onClick={() => n.chapter_position && goTo(n.chapter_position)}>
+        {STANCE_ICON[n.stance ?? ""] ?? "📝"} rozdz. {n.chapter_position ?? "?"}
+        {showUnanchored && n.chapter_position === position && !anchoredNoteIds.has(n.id) &&
+          <span style={{ color: "#b45309" }}> ⚠ nie odnaleziono w tekście</span>}
+      </div>
+      <div style={{ fontStyle: "italic", color: "#94a3b8", margin: "2px 0" }}>
+        „{n.anchor_quote.length > 90 ? `${n.anchor_quote.slice(0, 90)}…` : n.anchor_quote}"
+      </div>
+      {editingNoteId === n.id ? (
+        <div>
+          <textarea value={editingText} onChange={e => setEditingText(e.target.value)}
+            style={{ width: "100%", minHeight: 50 }} />
+          <button onClick={() => saveEditedNote(n.id)}>Zapisz</button>{" "}
+          <button onClick={() => setEditingNoteId(null)}>Anuluj</button>
+        </div>
+      ) : (
+        <div>
+          {n.note_text}{" "}
+          <span style={{ whiteSpace: "nowrap" }}>
+            <button title="Edytuj" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => { setEditingNoteId(n.id); setEditingText(n.note_text); }}>✏</button>
+            <button title="Usuń" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => deleteNote(n.id)}>🗑</button>
+          </span>
+        </div>
+      )}
     </div>
   );
 
@@ -140,40 +476,107 @@ const Read: React.FC = () => {
         <h2 style={{ margin: 0 }}>Czytelnik — dokument #{id}</h2>
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
+        <div style={{ marginLeft: "auto" }}>{userPicker}</div>
       </div>
 
       {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
+      {!userId && (
+        <p style={{ fontSize: "0.85em", color: "#64748b", margin: "4px 0 10px" }}>
+          Wybierz użytkownika, aby zapisywać postęp czytania i dodawać notatki do fragmentów.
+        </p>
+      )}
 
       <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
-        {/* TOC sidebar */}
-        <nav style={{
-          flex: "0 0 280px", position: "sticky", top: 12, maxHeight: "85vh", overflowY: "auto",
-          background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
-        }}>
-          <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>Spis treści ({chapters.length})</strong>
-          {chapters.map(ch => (
-            <div key={ch.position}
-              onClick={() => goTo(ch.position)}
-              style={{
-                padding: "5px 14px", fontSize: "0.83em", cursor: "pointer", lineHeight: 1.3,
-                background: ch.position === position ? "#e0f2fe" : undefined,
-                fontWeight: ch.position === position ? 600 : undefined,
-              }}>
-              {ch.position}. {ch.title}
+        {/* TOC sidebar + notes */}
+        <div style={{ flex: "0 0 300px", position: "sticky", top: 12, maxHeight: "85vh", overflowY: "auto" }}>
+          <nav style={{
+            background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
+          }}>
+            <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>Spis treści ({chapters.length})</strong>
+            {chapters.map(ch => {
+              const isRead = readChapters.includes(ch.position);
+              return (
+                <div key={ch.position}
+                  style={{
+                    display: "flex", alignItems: "baseline", gap: 6,
+                    padding: "5px 8px 5px 14px", fontSize: "0.83em", lineHeight: 1.3,
+                    background: ch.position === position ? "#e0f2fe" : undefined,
+                    fontWeight: ch.position === position ? 600 : undefined,
+                  }}>
+                  <span onClick={() => goTo(ch.position)}
+                    style={{ cursor: "pointer", flex: 1, color: isRead ? "#94a3b8" : undefined }}>
+                    {ch.position === position ? "▶ " : ""}{ch.position}. {ch.title}
+                  </span>
+                  {userId && (
+                    <span
+                      title={isRead ? "Oznacz jako nieprzeczytany" : "Oznacz jako przeczytany"}
+                      onClick={() => toggleRead(ch.position, !isRead)}
+                      style={{ cursor: "pointer", color: isRead ? "#16a34a" : "#cbd5e1" }}>
+                      ✓
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </nav>
+
+          {userId && notes.length > 0 && (
+            <div style={{
+              background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+              marginTop: 12, padding: "10px 0",
+            }}>
+              <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>📝 Moje notatki ({notes.length})</strong>
+              {notes.map(n => renderNoteRow(n, true))}
             </div>
-          ))}
-        </nav>
+          )}
+        </div>
 
         {/* Chapter content */}
         <div ref={contentRef} style={{ flex: 1, maxWidth: 760 }}>
           {navButtons}
           {loading && <p style={{ color: "#64748b" }}>Ładowanie…</p>}
           {!loading && content && (
-            <article style={{ fontSize: "1.02em" }}>{renderMarkdown(content.text)}</article>
+            <article style={{ fontSize: "1.02em" }} onMouseUp={onTextSelected}>
+              {renderMarkdown(content.text, chapterNotes)}
+            </article>
           )}
           {navButtons}
         </div>
       </div>
+
+      {/* Note popover */}
+      {pendingNote && (
+        <div style={{
+          position: "absolute", left: pendingNote.x, top: pendingNote.y, zIndex: 50,
+          background: "#fff", border: "1px solid #cbd5e1", borderRadius: 8, padding: 10,
+          boxShadow: "0 4px 12px rgba(0,0,0,0.15)", width: 340,
+        }}>
+          <div style={{ fontSize: "0.75em", color: "#94a3b8", fontStyle: "italic", marginBottom: 6 }}>
+            „{pendingNote.quote.length > 120 ? `${pendingNote.quote.slice(0, 120)}…` : pendingNote.quote}"
+          </div>
+          <textarea
+            autoFocus value={noteText} onChange={e => setNoteText(e.target.value)}
+            placeholder="Twoja notatka — co myślisz o tym fragmencie?"
+            style={{ width: "100%", minHeight: 60, fontSize: "0.85em" }}
+          />
+          <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
+            {(["agree", "disagree", "neutral"] as const).map(s => (
+              <button key={s} onClick={() => setNoteStance(noteStance === s ? null : s)}
+                title={{ agree: "Zgadzam się", disagree: "Nie zgadzam się", neutral: "Neutralnie" }[s]}
+                style={{
+                  border: noteStance === s ? "2px solid #0369a1" : "1px solid #cbd5e1",
+                  borderRadius: 6, background: "#fff", cursor: "pointer", padding: "2px 8px",
+                }}>
+                {STANCE_ICON[s]}
+              </button>
+            ))}
+            <span style={{ marginLeft: "auto" }}>
+              <button onClick={saveNote} disabled={!noteText.trim()} style={{ marginRight: 6 }}>Zapisz</button>
+              <button onClick={() => setPendingNote(null)}>Anuluj</button>
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Iteration 1 of Stage 7 (reader: per-user reading progress + fragment notes):

- **DB**: new tables `users`, `user_reading_progress` (unique user+doc, `read_chapters INT[]`), `user_document_notes` (W3C TextQuoteSelector-style anchor: `anchor_quote` + prefix/suffix, stance, `run_id`/`chunk_id` with `SET NULL` so notes survive run deletion) — Alembic migration `d0e1f2a3b4c5` + init SQL + ORM models.
- **Backend**: new blueprint `library/reader_routes.py` — `GET/POST /users`, `GET/PUT /document/<id>/reading_progress` (with `mark_read`/`unmark_read`), `GET/POST /document/<id>/notes`, `PATCH/DELETE /note/<id>` (owner check → 403). User identity via `x-user-id` header alongside the global `x-api-key` (interim solution — personal API keys are planned as Stage 8).
- **UI (`read.tsx`)**: user picker (persisted in `localStorage`), automatic return to the last-read chapter, ✓ per chapter in the TOC (toggle + auto-mark on "Next"), text selection → note popover (stance 👍/👎/➖), inline `<mark>` highlights with tooltip (whitespace-normalized paragraph tint as fallback), "My notes" panel with edit/delete. No new dependencies.

## Testing

- `test_reader_routes.py` (25 tests) — unit suite 838 passed; ruff/tsc/Vitest/build clean.
- Deployed to NAS: Alembic migration applied, REST smoke test passed.
- Live UI inspection on NAS (Chrome automation): user selection → redirect to last chapter, ✓ toggling + auto-read (PUT 200), selection → note saved with immediate highlight + tooltip, notes panel OK; state restored after the test.

## Known issue (minor, deferred to iteration 2)

A note whose anchor quote lands in a chapter **heading** is not highlighted — `renderMarkdown()` applies note highlighting only to paragraph blocks, and the notes panel shows no ⚠ because the quote does occur in the raw chapter text. Real-world notes (prose selections) are unaffected.

## Next (planned)

Iteration 2: user notes surfaced in `/chunks/:id`; then Stage 8 (api_keys: service accounts + personal keys replacing `x-user-id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)