### PR TITLE
feat: reader progress/notes, chunk fragment notes, API keys, mobile reader UX

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -46,9 +46,10 @@ Flask + Flask-CORS application exposing 20 REST API endpoints. **Version**: 0.3.
 | **AI Operations** | `/ai_get_embedding`, `/website_similar` |
 | **Content Processing** | `/website_download_text_content`, `/website_text_remove_not_needed`, `/website_split_for_embedding` |
 | **Metadata** | `/website_is_paid`, `/website_get_next_to_correct`, `/document_states` |
+| **Auth & identity** | `/whoami`, `/api_keys` (GET/POST), `/api_keys/<id>` (DELETE) — see `library/api_key_routes.py` |
 | **Health & Info** | `/` (root), `/healthz`, `/startup`, `/readiness`, `/liveness`, `/version`, `/metrics` |
 
-All routes (except health checks) require `x-api-key` header validated against `STALKER_API_KEY` env var.
+All routes (except health checks) require an `x-api-key` header. Keys live in the `api_keys` table (`library/auth.py`: SHA-256 hash lookup with an in-process TTL cache; `kind=user` keys carry the reader identity used by `reader_routes.py`, `kind=service` keys have full access but get 403 on reader endpoints). The legacy shared `STALKER_API_KEY` env var is still accepted as a service key during client migration. Keys are managed via `imports/api_key_admin.py` (CLI) or the `/api_keys` endpoints (service keys only); the plaintext (`lk_usr_*`/`lk_svc_*`) is shown once at creation.
 
 ### Storage
 

--- a/backend/alembic/versions/d0e1f2a3b4c5_create_reader_user_tables.py
+++ b/backend/alembic/versions/d0e1f2a3b4c5_create_reader_user_tables.py
@@ -1,0 +1,76 @@
+"""create reader user tables (users, reading progress, document notes)
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same tables may already have been created by the Docker
+    # init script 19-create-reader-user-tables.sql on a fresh database.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id           SERIAL PRIMARY KEY,
+            username     VARCHAR(50) NOT NULL UNIQUE,
+            display_name VARCHAR(100),
+            created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_reading_progress (
+            id                    SERIAL PRIMARY KEY,
+            user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            document_id           INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            current_chapter       INTEGER NOT NULL,
+            current_chapter_title VARCHAR(500),
+            read_chapters         INTEGER[] NOT NULL DEFAULT '{}',
+            updated_at            TIMESTAMP NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_reading_progress_user_document UNIQUE (user_id, document_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_document_notes (
+            id               SERIAL PRIMARY KEY,
+            user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            document_id      INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            chapter_position INTEGER,
+            anchor_quote     TEXT NOT NULL,
+            anchor_prefix    VARCHAR(100),
+            anchor_suffix    VARCHAR(100),
+            run_id           INTEGER REFERENCES document_analysis_runs(id) ON DELETE SET NULL,
+            chunk_id         INTEGER REFERENCES document_chunks(id) ON DELETE SET NULL,
+            note_text        TEXT NOT NULL,
+            stance           VARCHAR(10),
+            created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at       TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_notes_document_id ON user_document_notes(document_id)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_user_notes_user_id ON user_document_notes(user_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS user_document_notes")
+    op.execute("DROP TABLE IF EXISTS user_reading_progress")
+    op.execute("DROP TABLE IF EXISTS users")

--- a/backend/alembic/versions/e1f2a3b4c5d6_create_api_keys.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_create_api_keys.py
@@ -1,0 +1,44 @@
+"""create api_keys table (service accounts + per-user keys)
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-07-07 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same table may already have been created by the Docker
+    # init script 20-create-api-keys.sql on a fresh database.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS api_keys (
+            id           SERIAL PRIMARY KEY,
+            kind         VARCHAR(10) NOT NULL CHECK (kind IN ('user', 'service')),
+            user_id      INTEGER REFERENCES users(id) ON DELETE CASCADE,
+            name         VARCHAR(100) NOT NULL UNIQUE,
+            key_hash     CHAR(64) NOT NULL UNIQUE,
+            key_prefix   VARCHAR(16) NOT NULL,
+            active       BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+            last_used_at TIMESTAMP,
+            CONSTRAINT ck_api_keys_user_id_kind CHECK ((kind = 'user') = (user_id IS NOT NULL))
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS api_keys")

--- a/backend/database/init/19-create-reader-user-tables.sql
+++ b/backend/database/init/19-create-reader-user-tables.sql
@@ -1,0 +1,50 @@
+-- Migration: reader users, per-user reading progress and per-fragment notes (Etap 7)
+-- users: lightweight identity (household trust model) — x-api-key stays the app-level
+--        auth, x-user-id header only says WHO is reading.
+-- user_reading_progress: current chapter + read chapters per (user, document);
+--        chapter positions are 1-based and match GET /document/<id>/chapters.
+-- user_document_notes: note anchored by exact quote + surrounding context
+--        (W3C TextQuoteSelector style) at the DOCUMENT level, so it survives
+--        run deletion; run_id/chunk_id are convenience links (SET NULL).
+-- stance: agree | disagree | neutral | NULL — "czy się zgadzam" reaction.
+
+\c "lenie-ai";
+
+CREATE TABLE IF NOT EXISTS public.users (
+    id           SERIAL PRIMARY KEY,
+    username     VARCHAR(50) NOT NULL UNIQUE,
+    display_name VARCHAR(100),
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_reading_progress (
+    id                    SERIAL PRIMARY KEY,
+    user_id               INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    document_id           INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    current_chapter       INTEGER NOT NULL,
+    current_chapter_title VARCHAR(500),
+    read_chapters         INTEGER[] NOT NULL DEFAULT '{}',
+    updated_at            TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_reading_progress_user_document UNIQUE (user_id, document_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.user_document_notes (
+    id               SERIAL PRIMARY KEY,
+    user_id          INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    document_id      INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    chapter_position INTEGER,
+    anchor_quote     TEXT NOT NULL,
+    anchor_prefix    VARCHAR(100),
+    anchor_suffix    VARCHAR(100),
+    run_id           INTEGER REFERENCES public.document_analysis_runs(id) ON DELETE SET NULL,
+    chunk_id         INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL,
+    note_text        TEXT NOT NULL,
+    stance           VARCHAR(10),
+    created_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_notes_document_id ON public.user_document_notes(document_id);
+CREATE INDEX IF NOT EXISTS idx_user_notes_user_id     ON public.user_document_notes(user_id);
+
+SELECT 'Reader user tables created' AS status;

--- a/backend/database/init/20-create-api-keys.sql
+++ b/backend/database/init/20-create-api-keys.sql
@@ -1,0 +1,25 @@
+-- Migration: api_keys — service accounts + per-user API keys (Etap 8)
+-- Replaces the single shared STALKER_API_KEY: kind=service keys grant full
+-- access without a reader identity; kind=user keys carry the reader identity
+-- (no x-user-id header needed). Only the SHA-256 hash of the key is stored;
+-- the plaintext is shown once at creation time. key_prefix keeps the first
+-- characters of the plaintext so keys can be recognized without revealing them.
+
+\c "lenie-ai";
+
+CREATE TABLE IF NOT EXISTS public.api_keys (
+    id           SERIAL PRIMARY KEY,
+    kind         VARCHAR(10) NOT NULL CHECK (kind IN ('user', 'service')),
+    user_id      INTEGER REFERENCES public.users(id) ON DELETE CASCADE,
+    name         VARCHAR(100) NOT NULL UNIQUE,
+    key_hash     CHAR(64) NOT NULL UNIQUE,
+    key_prefix   VARCHAR(16) NOT NULL,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMP,
+    CONSTRAINT ck_api_keys_user_id_kind CHECK ((kind = 'user') = (user_id IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON public.api_keys(user_id);
+
+SELECT 'api_keys table created' AS status;

--- a/backend/imports/api_key_admin.py
+++ b/backend/imports/api_key_admin.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Manage API keys (api_keys table, Etap 8) from the command line.
+
+Usage:
+    cd backend
+    python imports/api_key_admin.py create --kind user --user-id 1 --name frontend-krzysztof
+    python imports/api_key_admin.py create --kind service --name chrome-extension
+    python imports/api_key_admin.py list
+    python imports/api_key_admin.py list --all           # include deactivated keys
+    python imports/api_key_admin.py deactivate 3
+
+The plaintext key is printed ONCE by `create` and never stored — copy it
+straight into the client's configuration. Only the SHA-256 hash lands in
+the database. Deactivation is soft (active=false), so `list --all` keeps
+the audit trail.
+
+NOTE: the running Flask server caches key lookups in-process (TTL 300 s /
+30 s negative); changes made here are picked up after the TTL expires or
+after a server restart.
+"""
+
+import argparse
+import sys
+
+from library.auth import create_api_key, deactivate_api_key
+from library.db.engine import get_session
+from library.db.models import ApiKey
+
+__version__ = "0.1.0"
+
+
+def _print_key_row(row: ApiKey) -> None:
+    user_part = f" user_id={row.user_id}" if row.user_id is not None else ""
+    state = "active" if row.active else "DEACTIVATED"
+    last_used = row.last_used_at.isoformat() if row.last_used_at else "never"
+    print(
+        f"  [{row.id}] {row.kind:<7} {row.name:<30} prefix={row.key_prefix} "
+        f"{state}{user_part} last_used={last_used}"
+    )
+
+
+def cmd_create(session, args) -> int:
+    try:
+        row, plaintext = create_api_key(session, kind=args.kind, name=args.name, user_id=args.user_id)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"Created API key id={row.id} kind={row.kind} name={row.name}")
+    print("Plaintext (shown ONCE, copy it now):")
+    print(f"  {plaintext}")
+    return 0
+
+
+def cmd_list(session, args) -> int:
+    query = session.query(ApiKey).order_by(ApiKey.id)
+    if not args.all:
+        query = query.filter(ApiKey.active.is_(True))
+    rows = query.all()
+    if not rows:
+        print("No API keys" + ("" if args.all else " (use --all to include deactivated)"))
+        return 0
+    for row in rows:
+        _print_key_row(row)
+    return 0
+
+
+def cmd_deactivate(session, args) -> int:
+    try:
+        row = deactivate_api_key(session, args.key_id)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"Deactivated API key id={row.id} name={row.name}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Manage Lenie API keys")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_create = sub.add_parser("create", help="Create a key (prints plaintext once)")
+    p_create.add_argument("--kind", required=True, choices=["user", "service"])
+    p_create.add_argument("--name", required=True, help="Unique key name, e.g. chrome-extension")
+    p_create.add_argument("--user-id", type=int, default=None, help="users.id (required for --kind user)")
+
+    p_list = sub.add_parser("list", help="List keys (active by default)")
+    p_list.add_argument("--all", action="store_true", help="Include deactivated keys")
+
+    p_deact = sub.add_parser("deactivate", help="Soft-delete a key (active=false)")
+    p_deact.add_argument("key_id", type=int)
+
+    args = parser.parse_args()
+    session = get_session()
+    try:
+        if args.command == "create":
+            return cmd_create(session, args)
+        if args.command == "list":
+            return cmd_list(session, args)
+        return cmd_deactivate(session, args)
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/library/api_key_routes.py
+++ b/backend/library/api_key_routes.py
@@ -1,0 +1,109 @@
+"""Flask blueprint: API-key identity and management (Etap 8).
+
+Endpoints (x-api-key required via the global before_request; management
+endpoints additionally require a SERVICE key — user keys get 403):
+  GET    /whoami            — identity carried by the presented key
+  GET    /api_keys          — [service] list keys (no hashes, prefix only)
+  POST   /api_keys          — [service] create key {kind, name, user_id?};
+                              returns the plaintext ONCE
+  DELETE /api_keys/<id>     — [service] deactivate (active=false)
+"""
+
+import logging
+
+from flask import Blueprint, abort, g, jsonify, request
+from sqlalchemy import select
+
+from library.auth import create_api_key, deactivate_api_key
+from library.db.engine import get_scoped_session
+from library.db.models import ApiKey, User
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("api_keys", __name__)
+
+
+def _require_auth():
+    auth = getattr(g, "auth", None)
+    if auth is None:
+        abort(401, "request is not authenticated")
+    return auth
+
+
+def _require_service():
+    auth = _require_auth()
+    if auth.kind != "service":
+        abort(403, "API key management requires a service key")
+    return auth
+
+
+def _key_to_dict(row: ApiKey) -> dict:
+    return {
+        "id": row.id,
+        "kind": row.kind,
+        "user_id": row.user_id,
+        "name": row.name,
+        "key_prefix": row.key_prefix,
+        "active": row.active,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "last_used_at": row.last_used_at.isoformat() if row.last_used_at else None,
+    }
+
+
+@bp.route("/whoami", methods=["GET"])
+def whoami():
+    auth = _require_auth()
+    user_dict = None
+    if auth.user_id is not None:
+        user = get_scoped_session().get(User, auth.user_id)
+        if user is not None:
+            user_dict = {"id": user.id, "username": user.username, "display_name": user.display_name}
+    return jsonify({
+        "status": "success",
+        "kind": auth.kind,
+        "key_name": auth.key_name,
+        "is_legacy": auth.is_legacy,
+        "user": user_dict,
+    })
+
+
+@bp.route("/api_keys", methods=["GET"])
+def list_api_keys():
+    _require_service()
+    session = get_scoped_session()
+    rows = session.execute(select(ApiKey).order_by(ApiKey.id)).scalars().all()
+    return jsonify({"status": "success", "api_keys": [_key_to_dict(r) for r in rows]})
+
+
+@bp.route("/api_keys", methods=["POST"])
+def create_api_key_endpoint():
+    _require_service()
+    data = request.get_json(silent=True) or {}
+    user_id = data.get("user_id")
+    if user_id is not None and not isinstance(user_id, int):
+        return jsonify({"status": "error", "message": "user_id must be an integer"}), 400
+    try:
+        row, plaintext = create_api_key(
+            get_scoped_session(),
+            kind=data.get("kind") or "",
+            name=data.get("name") or "",
+            user_id=user_id,
+        )
+    except ValueError as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 400
+    return jsonify({
+        "status": "success",
+        "api_key": _key_to_dict(row),
+        # the only moment the plaintext leaves the server — it is not stored
+        "plaintext": plaintext,
+    }), 201
+
+
+@bp.route("/api_keys/<int:key_id>", methods=["DELETE"])
+def deactivate_api_key_endpoint(key_id: int):
+    _require_service()
+    try:
+        row = deactivate_api_key(get_scoped_session(), key_id)
+    except ValueError as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 404
+    return jsonify({"status": "success", "api_key": _key_to_dict(row)})

--- a/backend/library/auth.py
+++ b/backend/library/auth.py
@@ -1,0 +1,218 @@
+"""API-key authentication with an in-process cache (Etap 8).
+
+Keys live in the api_keys table (only SHA-256 hashes; plaintext is shown once
+at creation). Two kinds:
+  - service — full access, no reader identity (reader endpoints reject it),
+  - user    — full access + carries the reader identity (users.id).
+The legacy shared STALKER_API_KEY is still accepted as a service key during
+the client-migration period (is_legacy=True in the resolved context).
+
+The per-request hash→context lookup MUST NOT hit the database: results
+(including unknown keys — negative entries) are cached in the process. The
+cache is defined as a small get/set/invalidate protocol so the in-process
+dict can later be swapped for a Redis-backed implementation shared between
+workers, without touching the resolve logic.
+"""
+
+import hashlib
+import logging
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from sqlalchemy import select, update
+
+from library.db.models import ApiKey, User
+
+logger = logging.getLogger(__name__)
+
+KEY_PREFIX_LEN = 12
+POSITIVE_TTL_SECONDS = 300
+NEGATIVE_TTL_SECONDS = 30
+# last_used_at is written at most this often per key, so steady traffic on a
+# cached key does not turn into a DB write per request.
+LAST_USED_WRITE_INTERVAL_SECONDS = 300
+
+VALID_KINDS = ("user", "service")
+
+
+@dataclass(frozen=True)
+class AuthContext:
+    """Resolved identity of a request; stored in flask.g.auth by the middleware."""
+
+    kind: str  # "user" | "service"
+    key_id: int | None  # None for the legacy STALKER_API_KEY fallback
+    key_name: str
+    user_id: int | None  # only for kind="user"
+    is_legacy: bool = False
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    context: AuthContext | None  # None = known-bad key (negative entry)
+    expires_at: float  # time.monotonic() deadline
+
+
+class ApiKeyCache(Protocol):
+    """Swap point for a future Redis-backed cache (values are dataclasses,
+    trivially serializable to dicts)."""
+
+    def get(self, key_hash: str) -> CacheEntry | None: ...
+
+    def set(self, key_hash: str, entry: CacheEntry) -> None: ...
+
+    def invalidate(self, key_hash: str | None = None) -> None: ...
+
+
+class InProcessApiKeyCache:
+    """Dict + TTL cache; sufficient for the single Flask process on the NAS."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, CacheEntry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key_hash: str) -> CacheEntry | None:
+        with self._lock:
+            entry = self._entries.get(key_hash)
+            if entry is None:
+                return None
+            if entry.expires_at < time.monotonic():
+                del self._entries[key_hash]
+                return None
+            return entry
+
+    def set(self, key_hash: str, entry: CacheEntry) -> None:
+        with self._lock:
+            self._entries[key_hash] = entry
+
+    def invalidate(self, key_hash: str | None = None) -> None:
+        with self._lock:
+            if key_hash is None:
+                self._entries.clear()
+            else:
+                self._entries.pop(key_hash, None)
+
+
+_cache: ApiKeyCache = InProcessApiKeyCache()
+_last_used_written: dict[int, float] = {}
+_last_used_lock = threading.Lock()
+
+
+def get_cache() -> ApiKeyCache:
+    return _cache
+
+
+def invalidate_cache(key_hash: str | None = None) -> None:
+    """Call after any api_keys change (create/deactivate)."""
+    _cache.invalidate(key_hash)
+
+
+def hash_api_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def generate_api_key(kind: str) -> tuple[str, str, str]:
+    """Return (plaintext, key_hash, key_prefix) for a new key.
+
+    Format: lk_<usr|svc>_<token_urlsafe(32)> — the prefix makes the key kind
+    recognizable in configs and logs without revealing the secret.
+    """
+    if kind not in VALID_KINDS:
+        raise ValueError(f"kind must be one of {VALID_KINDS}, got {kind!r}")
+    plaintext = f"lk_{'usr' if kind == 'user' else 'svc'}_{secrets.token_urlsafe(32)}"
+    return plaintext, hash_api_key(plaintext), plaintext[:KEY_PREFIX_LEN]
+
+
+def create_api_key(session, kind: str, name: str, user_id: int | None = None) -> tuple[ApiKey, str]:
+    """Create a key and return (row, plaintext). The plaintext is not stored
+    anywhere — this is the only moment it exists server-side."""
+    if kind not in VALID_KINDS:
+        raise ValueError(f"kind must be one of {VALID_KINDS}, got {kind!r}")
+    name = (name or "").strip()
+    if not name:
+        raise ValueError("name is required")
+    if len(name) > 100:
+        raise ValueError("name too long (max 100)")
+    if kind == "user":
+        if user_id is None:
+            raise ValueError("user_id is required for kind=user")
+        if session.get(User, user_id) is None:
+            raise ValueError(f"User {user_id} not found")
+    elif user_id is not None:
+        raise ValueError("user_id is only allowed for kind=user")
+    existing = session.execute(select(ApiKey).where(ApiKey.name == name)).scalar_one_or_none()
+    if existing is not None:
+        raise ValueError(f"API key named '{name}' already exists")
+
+    plaintext, key_hash, key_prefix = generate_api_key(kind)
+    row = ApiKey(kind=kind, user_id=user_id, name=name, key_hash=key_hash, key_prefix=key_prefix, active=True)
+    session.add(row)
+    session.commit()
+    invalidate_cache()
+    return row, plaintext
+
+
+def deactivate_api_key(session, key_id: int) -> ApiKey:
+    row = session.get(ApiKey, key_id)
+    if row is None:
+        raise ValueError(f"API key {key_id} not found")
+    row.active = False
+    session.commit()
+    invalidate_cache()
+    return row
+
+
+def resolve_api_key(session_factory, raw_key: str, legacy_key: str | None = None) -> AuthContext | None:
+    """Resolve a raw x-api-key value to an AuthContext (None = invalid key).
+
+    session_factory is a zero-arg callable (e.g. get_scoped_session) invoked
+    ONLY when the database is actually needed: cache hits and the legacy-key
+    compare resolve without opening a session, so legacy clients keep working
+    even if the api_keys table (or the whole DB) is unreachable.
+    """
+    key_hash = hash_api_key(raw_key)
+    entry = _cache.get(key_hash)
+    if entry is not None:
+        if entry.context is not None:
+            _touch_last_used(session_factory, entry.context)
+        return entry.context
+
+    if legacy_key and raw_key == legacy_key:
+        context = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
+        _cache.set(key_hash, CacheEntry(context, time.monotonic() + POSITIVE_TTL_SECONDS))
+        return context
+
+    row = session_factory().execute(
+        select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.active.is_(True))
+    ).scalar_one_or_none()
+    if row is not None:
+        context = AuthContext(kind=row.kind, key_id=row.id, key_name=row.name, user_id=row.user_id)
+        _cache.set(key_hash, CacheEntry(context, time.monotonic() + POSITIVE_TTL_SECONDS))
+        _touch_last_used(session_factory, context)
+        return context
+
+    _cache.set(key_hash, CacheEntry(None, time.monotonic() + NEGATIVE_TTL_SECONDS))
+    return None
+
+
+def _touch_last_used(session_factory, context: AuthContext) -> None:
+    if context.key_id is None:
+        return
+    now = time.monotonic()
+    with _last_used_lock:
+        last = _last_used_written.get(context.key_id)
+        if last is not None and now - last < LAST_USED_WRITE_INTERVAL_SECONDS:
+            return
+        _last_used_written[context.key_id] = now
+    session = session_factory()
+    try:
+        session.execute(
+            update(ApiKey).where(ApiKey.id == context.key_id).values(last_used_at=datetime.now())
+        )
+        session.commit()
+    except Exception:  # noqa: BLE001 — telemetry only, must never fail the request
+        logger.warning("Failed to update last_used_at for api key %s", context.key_id, exc_info=True)
+        session.rollback()

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -801,3 +801,34 @@ class UserDocumentNote(Base):
             f"UserDocumentNote(id={self.id!r}, user_id={self.user_id!r}, "
             f"document_id={self.document_id!r}, chapter_position={self.chapter_position!r})"
         )
+
+
+class ApiKey(Base):
+    """API key: service account (kind=service) or per-user key (kind=user).
+
+    Only the SHA-256 hash of the plaintext key is stored; the plaintext is
+    returned once at creation. kind=user keys carry the reader identity
+    (user_id), replacing the x-user-id header. key_prefix keeps the first
+    characters of the plaintext for recognizing keys without revealing them.
+    """
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    kind: Mapped[str] = mapped_column(String(10), nullable=False)
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    key_prefix: Mapped[str] = mapped_column(String(16), nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=sa_text("TRUE"))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    last_used_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
+
+    user: Mapped["User | None"] = relationship(foreign_keys=[user_id])
+
+    def __repr__(self) -> str:
+        return f"ApiKey(id={self.id!r}, kind={self.kind!r}, name={self.name!r}, active={self.active!r})"

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     SmallInteger,
     String,
     Text,
+    UniqueConstraint,
     func,
     select,
     text as sa_text,
@@ -693,3 +694,110 @@ class DocumentRemovedLine(Base):
 
     def __repr__(self) -> str:
         return f"DocumentRemovedLine(id={self.id!r}, document_id={self.document_id!r}, source={self.source!r})"
+
+
+class User(Base):
+    """Reader identity (household trust model).
+
+    x-api-key stays the app-level auth; the x-user-id header only says WHO is
+    reading — no passwords. Owns reading progress and document notes.
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    display_name: Mapped[str | None] = mapped_column(String(100))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return f"User(id={self.id!r}, username={self.username!r})"
+
+
+class UserReadingProgress(Base):
+    """Per-(user, document) reading position for the /read/:id reader.
+
+    Chapter positions are 1-based and match GET /document/<id>/chapters
+    (computed on the fly from text_md — independent of analysis runs).
+    Renormalizing a book may shift positions; current_chapter_title is a
+    snapshot that lets the UI notice the mismatch.
+    """
+
+    __tablename__ = "user_reading_progress"
+    __table_args__ = (
+        UniqueConstraint("user_id", "document_id", name="uq_reading_progress_user_document"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    current_chapter: Mapped[int] = mapped_column(Integer, nullable=False)
+    current_chapter_title: Mapped[str | None] = mapped_column(String(500))
+    read_chapters: Mapped[list[int]] = mapped_column(
+        ARRAY(Integer), nullable=False, server_default=sa_text("'{}'"),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return (
+            f"UserReadingProgress(user_id={self.user_id!r}, document_id={self.document_id!r}, "
+            f"current_chapter={self.current_chapter!r})"
+        )
+
+
+class UserDocumentNote(Base):
+    """User note/reaction anchored to a document fragment.
+
+    Anchored by exact quote + surrounding context (W3C TextQuoteSelector
+    style) at the DOCUMENT level so the note survives analysis-run deletion;
+    run_id/chunk_id are convenience links only (SET NULL). chapter_position
+    is a hint where to re-anchor. stance: agree | disagree | neutral | NULL.
+    """
+
+    __tablename__ = "user_document_notes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False,
+    )
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    chapter_position: Mapped[int | None] = mapped_column(Integer)
+    anchor_quote: Mapped[str] = mapped_column(Text, nullable=False)
+    anchor_prefix: Mapped[str | None] = mapped_column(String(100))
+    anchor_suffix: Mapped[str | None] = mapped_column(String(100))
+    run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="SET NULL"),
+    )
+    chunk_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_chunks.id", ondelete="SET NULL"),
+    )
+    note_text: Mapped[str] = mapped_column(Text, nullable=False)
+    stance: Mapped[str | None] = mapped_column(String(10))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    user: Mapped["User"] = relationship(foreign_keys=[user_id])
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return (
+            f"UserDocumentNote(id={self.id!r}, user_id={self.user_id!r}, "
+            f"document_id={self.document_id!r}, chapter_position={self.chapter_position!r})"
+        )

--- a/backend/library/reader_routes.py
+++ b/backend/library/reader_routes.py
@@ -1,7 +1,8 @@
 """Flask blueprint: reader users, per-user reading progress and fragment notes (Etap 7).
 
 Endpoints (all require x-api-key via the global before_request; the ones
-marked [user] additionally require an x-user-id header of an existing user):
+marked [user] additionally require a USER API key — the reader identity comes
+from the key itself (Etap 8); service/legacy keys get 403):
   GET    /users                                — list users
   POST   /users                                — create user {username, display_name?}
   GET    /document/<doc_id>/reading_progress   — [user] progress for this document
@@ -19,7 +20,7 @@ chapter text is the frontend's job (exact match, then whitespace-normalized).
 import logging
 from datetime import datetime
 
-from flask import Blueprint, abort, jsonify, request
+from flask import Blueprint, abort, g, jsonify, request
 from sqlalchemy import select
 
 from library.db.engine import get_scoped_session
@@ -33,17 +34,22 @@ ALLOWED_STANCES = {"agree", "disagree", "neutral"}
 
 
 def _require_user(session) -> User:
-    """Resolve the x-user-id header to a User row or abort."""
+    """Resolve the reader identity from the API key (flask.g.auth) or abort.
+
+    Service/legacy keys carry no reader identity → 403. An x-user-id header,
+    if still sent by an old client, must match the key's identity — a mismatch
+    means a misconfigured client, not a way to impersonate another user."""
+    auth = getattr(g, "auth", None)
+    if auth is None:
+        abort(401, "request is not authenticated")
+    if auth.kind != "user":
+        abort(403, "reader endpoints require a user API key (service keys carry no reader identity)")
     raw = request.headers.get("x-user-id")
-    if not raw:
-        abort(400, "x-user-id header is missing")
-    try:
-        user_id = int(raw)
-    except ValueError:
-        abort(400, "x-user-id header must be an integer")
-    user = session.get(User, user_id)
+    if raw is not None and raw.strip() and raw.strip() != str(auth.user_id):
+        abort(403, "x-user-id header does not match the API key identity")
+    user = session.get(User, auth.user_id)
     if user is None:
-        abort(404, f"User {user_id} not found")
+        abort(403, f"User {auth.user_id} for this API key no longer exists")
     return user
 
 

--- a/backend/library/reader_routes.py
+++ b/backend/library/reader_routes.py
@@ -1,0 +1,325 @@
+"""Flask blueprint: reader users, per-user reading progress and fragment notes (Etap 7).
+
+Endpoints (all require x-api-key via the global before_request; the ones
+marked [user] additionally require an x-user-id header of an existing user):
+  GET    /users                                — list users
+  POST   /users                                — create user {username, display_name?}
+  GET    /document/<doc_id>/reading_progress   — [user] progress for this document
+  PUT    /document/<doc_id>/reading_progress   — [user] upsert current chapter / read chapters
+  GET    /document/<doc_id>/notes              — [user] notes (optional ?chapter=N filter)
+  POST   /document/<doc_id>/notes              — [user] add a note anchored by quote
+  PATCH  /note/<note_id>                       — [user] edit own note (note_text / stance)
+  DELETE /note/<note_id>                       — [user] delete own note
+
+Notes are anchored by exact quote + context (W3C TextQuoteSelector style) at
+the document level, so they survive analysis-run deletion; re-anchoring in the
+chapter text is the frontend's job (exact match, then whitespace-normalized).
+"""
+
+import logging
+from datetime import datetime
+
+from flask import Blueprint, abort, jsonify, request
+from sqlalchemy import select
+
+from library.db.engine import get_scoped_session
+from library.db.models import User, UserDocumentNote, UserReadingProgress, WebDocument
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint("reader", __name__)
+
+ALLOWED_STANCES = {"agree", "disagree", "neutral"}
+
+
+def _require_user(session) -> User:
+    """Resolve the x-user-id header to a User row or abort."""
+    raw = request.headers.get("x-user-id")
+    if not raw:
+        abort(400, "x-user-id header is missing")
+    try:
+        user_id = int(raw)
+    except ValueError:
+        abort(400, "x-user-id header must be an integer")
+    user = session.get(User, user_id)
+    if user is None:
+        abort(404, f"User {user_id} not found")
+    return user
+
+
+def _get_document_or_404(session, doc_id: int) -> WebDocument:
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+    return doc
+
+
+def _note_to_dict(note: UserDocumentNote) -> dict:
+    return {
+        "id": note.id,
+        "user_id": note.user_id,
+        "document_id": note.document_id,
+        "chapter_position": note.chapter_position,
+        "anchor_quote": note.anchor_quote,
+        "anchor_prefix": note.anchor_prefix,
+        "anchor_suffix": note.anchor_suffix,
+        "run_id": note.run_id,
+        "chunk_id": note.chunk_id,
+        "note_text": note.note_text,
+        "stance": note.stance,
+        "created_at": note.created_at.isoformat() if note.created_at else None,
+        "updated_at": note.updated_at.isoformat() if note.updated_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/users", methods=["GET"])
+def list_users():
+    session = get_scoped_session()
+    users = session.execute(select(User).order_by(User.id)).scalars().all()
+    return jsonify({
+        "status": "success",
+        "users": [
+            {"id": u.id, "username": u.username, "display_name": u.display_name}
+            for u in users
+        ],
+    })
+
+
+@bp.route("/users", methods=["POST"])
+def create_user():
+    data = request.get_json(silent=True) or {}
+    username = (data.get("username") or "").strip()
+    if not username:
+        return jsonify({"status": "error", "message": "username is required"}), 400
+    if len(username) > 50:
+        return jsonify({"status": "error", "message": "username too long (max 50)"}), 400
+
+    session = get_scoped_session()
+    existing = session.execute(
+        select(User).where(User.username == username)
+    ).scalar_one_or_none()
+    if existing is not None:
+        return jsonify({"status": "error", "message": f"username '{username}' already exists"}), 409
+
+    user = User(username=username, display_name=(data.get("display_name") or "").strip() or None)
+    session.add(user)
+    session.commit()
+    return jsonify({
+        "status": "success",
+        "user": {"id": user.id, "username": user.username, "display_name": user.display_name},
+    }), 201
+
+
+# ---------------------------------------------------------------------------
+# Reading progress
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/document/<int:doc_id>/reading_progress", methods=["GET"])
+def get_reading_progress(doc_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    progress = session.execute(
+        select(UserReadingProgress).where(
+            UserReadingProgress.user_id == user.id,
+            UserReadingProgress.document_id == doc_id,
+        )
+    ).scalar_one_or_none()
+
+    if progress is None:
+        return jsonify({
+            "status": "success",
+            "doc_id": doc_id,
+            "user_id": user.id,
+            "current_chapter": None,
+            "current_chapter_title": None,
+            "read_chapters": [],
+        })
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "current_chapter": progress.current_chapter,
+        "current_chapter_title": progress.current_chapter_title,
+        "read_chapters": sorted(progress.read_chapters or []),
+        "updated_at": progress.updated_at.isoformat() if progress.updated_at else None,
+    })
+
+
+@bp.route("/document/<int:doc_id>/reading_progress", methods=["PUT"])
+def put_reading_progress(doc_id: int):
+    """Upsert reading progress.
+
+    Body: current_chapter (int >= 1, required), current_chapter_title (optional
+    snapshot from the client — avoids re-slicing the whole book server-side),
+    mark_read / unmark_read (optional lists of chapter positions).
+    """
+    data = request.get_json(silent=True) or {}
+    current_chapter = data.get("current_chapter")
+    if not isinstance(current_chapter, int) or current_chapter < 1:
+        return jsonify({"status": "error", "message": "current_chapter must be a positive integer"}), 400
+    for key in ("mark_read", "unmark_read"):
+        value = data.get(key, [])
+        if not isinstance(value, list) or not all(isinstance(p, int) and p >= 1 for p in value):
+            return jsonify({"status": "error", "message": f"{key} must be a list of positive integers"}), 400
+
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    progress = session.execute(
+        select(UserReadingProgress).where(
+            UserReadingProgress.user_id == user.id,
+            UserReadingProgress.document_id == doc_id,
+        )
+    ).scalar_one_or_none()
+    if progress is None:
+        progress = UserReadingProgress(
+            user_id=user.id, document_id=doc_id,
+            current_chapter=current_chapter, read_chapters=[],
+        )
+        session.add(progress)
+
+    progress.current_chapter = current_chapter
+    title = data.get("current_chapter_title")
+    if title is not None:
+        progress.current_chapter_title = str(title)[:500] or None
+
+    read = set(progress.read_chapters or [])
+    read.update(data.get("mark_read", []))
+    read.difference_update(data.get("unmark_read", []))
+    progress.read_chapters = sorted(read)
+
+    progress.updated_at = datetime.now()
+    session.commit()
+
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "current_chapter": progress.current_chapter,
+        "current_chapter_title": progress.current_chapter_title,
+        "read_chapters": progress.read_chapters,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/document/<int:doc_id>/notes", methods=["GET"])
+def list_notes(doc_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    query = select(UserDocumentNote).where(
+        UserDocumentNote.user_id == user.id,
+        UserDocumentNote.document_id == doc_id,
+    )
+    chapter = request.args.get("chapter", type=int)
+    if chapter is not None:
+        query = query.where(UserDocumentNote.chapter_position == chapter)
+    notes = session.execute(
+        query.order_by(UserDocumentNote.chapter_position, UserDocumentNote.id)
+    ).scalars().all()
+
+    return jsonify({
+        "status": "success",
+        "doc_id": doc_id,
+        "user_id": user.id,
+        "notes": [_note_to_dict(n) for n in notes],
+    })
+
+
+@bp.route("/document/<int:doc_id>/notes", methods=["POST"])
+def create_note(doc_id: int):
+    data = request.get_json(silent=True) or {}
+    anchor_quote = (data.get("anchor_quote") or "").strip()
+    note_text = (data.get("note_text") or "").strip()
+    if not anchor_quote:
+        return jsonify({"status": "error", "message": "anchor_quote is required"}), 400
+    if not note_text:
+        return jsonify({"status": "error", "message": "note_text is required"}), 400
+    stance = data.get("stance")
+    if stance is not None and stance not in ALLOWED_STANCES:
+        return jsonify({
+            "status": "error",
+            "message": f"stance must be one of {sorted(ALLOWED_STANCES)}",
+        }), 400
+
+    session = get_scoped_session()
+    user = _require_user(session)
+    _get_document_or_404(session, doc_id)
+
+    note = UserDocumentNote(
+        user_id=user.id,
+        document_id=doc_id,
+        chapter_position=data.get("chapter_position"),
+        anchor_quote=anchor_quote,
+        # prefix keeps its END (nearest the quote), suffix keeps its beginning
+        anchor_prefix=str(data.get("anchor_prefix") or "")[-100:] or None,
+        anchor_suffix=str(data.get("anchor_suffix") or "")[:100] or None,
+        run_id=data.get("run_id"),
+        chunk_id=data.get("chunk_id"),
+        note_text=note_text,
+        stance=stance,
+    )
+    session.add(note)
+    session.commit()
+    return jsonify({"status": "success", "note": _note_to_dict(note)}), 201
+
+
+@bp.route("/note/<int:note_id>", methods=["PATCH"])
+def update_note(note_id: int):
+    data = request.get_json(silent=True) or {}
+    session = get_scoped_session()
+    user = _require_user(session)
+
+    note = session.get(UserDocumentNote, note_id)
+    if note is None:
+        abort(404, f"Note {note_id} not found")
+    if note.user_id != user.id:
+        abort(403, "Note belongs to another user")
+
+    if "note_text" in data:
+        note_text = (data.get("note_text") or "").strip()
+        if not note_text:
+            return jsonify({"status": "error", "message": "note_text cannot be empty"}), 400
+        note.note_text = note_text
+    if "stance" in data:
+        stance = data.get("stance")
+        if stance is not None and stance not in ALLOWED_STANCES:
+            return jsonify({
+                "status": "error",
+                "message": f"stance must be one of {sorted(ALLOWED_STANCES)}",
+            }), 400
+        note.stance = stance
+
+    note.updated_at = datetime.now()
+    session.commit()
+    return jsonify({"status": "success", "note": _note_to_dict(note)})
+
+
+@bp.route("/note/<int:note_id>", methods=["DELETE"])
+def delete_note(note_id: int):
+    session = get_scoped_session()
+    user = _require_user(session)
+
+    note = session.get(UserDocumentNote, note_id)
+    if note is None:
+        abort(404, f"Note {note_id} not found")
+    if note.user_id != user.id:
+        abort(403, "Note belongs to another user")
+
+    session.delete(note)
+    session.commit()
+    return jsonify({"status": "success", "deleted_note_id": note_id})

--- a/backend/server.py
+++ b/backend/server.py
@@ -14,6 +14,7 @@ from library.models.stalker_document_status import StalkerDocumentStatus
 from library.models.stalker_document_type import StalkerDocumentType
 from library.models.stalker_document_status_error import StalkerDocumentStatusError
 from library.chunk_review_routes import bp as chunk_review_bp
+from library.reader_routes import bp as reader_bp
 
 logging.basicConfig(level=logging.INFO)
 
@@ -79,6 +80,7 @@ logging.info("Flask - enabling CORS for all routes")
 CORS(app)  # This will enable CORS for all routes
 
 app.register_blueprint(chunk_review_bp)
+app.register_blueprint(reader_bp)
 
 
 @app.teardown_appcontext

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,4 +1,4 @@
-from flask import Flask, Response, request, abort, jsonify
+from flask import Flask, Response, g, request, abort, jsonify
 from flask_cors import CORS
 import logging
 
@@ -13,6 +13,8 @@ from library.ai_intent_parser import parse_intent
 from library.models.stalker_document_status import StalkerDocumentStatus
 from library.models.stalker_document_type import StalkerDocumentType
 from library.models.stalker_document_status_error import StalkerDocumentStatusError
+from library.api_key_routes import bp as api_key_bp
+from library.auth import resolve_api_key
 from library.chunk_review_routes import bp as chunk_review_bp
 from library.reader_routes import bp as reader_bp
 
@@ -64,14 +66,16 @@ logging.info("Using embedding model: %s", embedding_model)
 port = cfg.require("PORT")
 
 def check_auth_header():
-    """
-  Function to validate 'x-api-key' in request headers
-  """
+    """Resolve the 'x-api-key' header to an AuthContext (api_keys table with
+    in-process cache; legacy STALKER_API_KEY accepted as a service key during
+    client migration) and store it in flask.g.auth."""
     api_key = request.headers.get('x-api-key')
     if api_key is None:
-        abort(400, 'x-api-key header is missing')
-    if api_key != cfg.require("STALKER_API_KEY"):
-        abort(400, 'x-api-key header is wrong')
+        abort(401, 'x-api-key header is missing')
+    auth = resolve_api_key(get_scoped_session, api_key, legacy_key=cfg.require("STALKER_API_KEY"))
+    if auth is None:
+        abort(401, 'x-api-key header is wrong')
+    g.auth = auth
 
 
 logging.info("Starting flask application")
@@ -81,6 +85,7 @@ CORS(app)  # This will enable CORS for all routes
 
 app.register_blueprint(chunk_review_bp)
 app.register_blueprint(reader_bp)
+app.register_blueprint(api_key_bp)
 
 
 @app.teardown_appcontext

--- a/backend/tests/unit/test_auth_api_keys.py
+++ b/backend/tests/unit/test_auth_api_keys.py
@@ -1,0 +1,349 @@
+"""Unit tests for Etap 8: API keys (library/auth.py + library/api_key_routes.py).
+
+Covers key generation/hashing, the in-process cache (TTL, negative entries,
+invalidation), resolve_api_key (user/service/legacy/unknown/inactive, no DB
+on cache hits, last_used_at throttling) and the /whoami + /api_keys endpoints
+(service-only management) — all with mocked sessions, no DB.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+flask = pytest.importorskip("flask")
+
+from library import api_key_routes as akr  # noqa: E402
+from library import auth  # noqa: E402
+from library.auth import (  # noqa: E402
+    AuthContext,
+    CacheEntry,
+    InProcessApiKeyCache,
+    create_api_key,
+    deactivate_api_key,
+    generate_api_key,
+    hash_api_key,
+    resolve_api_key,
+)
+from library.db.models import ApiKey, User  # noqa: E402
+
+
+READER_USER = User(username="krzysztof", display_name="Krzysztof")
+READER_USER.id = 1
+
+LEGACY_KEY = "legacy-shared-secret"
+
+
+def _make_key_row(**overrides) -> ApiKey:
+    row = ApiKey(
+        kind="user", user_id=READER_USER.id, name="frontend-krzysztof",
+        key_hash="a" * 64, key_prefix="lk_usr_abcde", active=True,
+    )
+    row.id = 10
+    for key, value in overrides.items():
+        setattr(row, key, value)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_state():
+    auth.invalidate_cache()
+    auth._last_used_written.clear()
+    yield
+    auth.invalidate_cache()
+    auth._last_used_written.clear()
+
+
+# ---------------------------------------------------------------------------
+# Key generation & hashing
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateApiKey:
+    def test_user_key_format(self):
+        plaintext, key_hash, key_prefix = generate_api_key("user")
+        assert plaintext.startswith("lk_usr_")
+        assert key_hash == hash_api_key(plaintext)
+        assert len(key_hash) == 64
+        assert key_prefix == plaintext[: auth.KEY_PREFIX_LEN]
+
+    def test_service_key_format(self):
+        plaintext, _, _ = generate_api_key("service")
+        assert plaintext.startswith("lk_svc_")
+
+    def test_keys_are_unique(self):
+        assert generate_api_key("user")[0] != generate_api_key("user")[0]
+
+    def test_invalid_kind_raises(self):
+        with pytest.raises(ValueError):
+            generate_api_key("admin")
+
+
+# ---------------------------------------------------------------------------
+# In-process cache
+# ---------------------------------------------------------------------------
+
+
+class TestInProcessCache:
+    def test_set_get(self):
+        cache = InProcessApiKeyCache()
+        ctx = AuthContext(kind="service", key_id=1, key_name="x", user_id=None)
+        cache.set("h1", CacheEntry(ctx, time.monotonic() + 60))
+        assert cache.get("h1").context is ctx
+
+    def test_expired_entry_is_dropped(self):
+        cache = InProcessApiKeyCache()
+        cache.set("h1", CacheEntry(None, time.monotonic() - 1))
+        assert cache.get("h1") is None
+
+    def test_invalidate_single_and_all(self):
+        cache = InProcessApiKeyCache()
+        entry = CacheEntry(None, time.monotonic() + 60)
+        cache.set("h1", entry)
+        cache.set("h2", entry)
+        cache.invalidate("h1")
+        assert cache.get("h1") is None
+        assert cache.get("h2") is entry
+        cache.invalidate()
+        assert cache.get("h2") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveApiKey:
+    def _session_returning(self, row):
+        session = MagicMock()
+        session.execute.return_value.scalar_one_or_none.return_value = row
+        return session
+
+    def test_user_key_resolved(self):
+        session = self._session_returning(_make_key_row())
+        ctx = resolve_api_key(lambda: session, "raw-key", legacy_key=LEGACY_KEY)
+        assert ctx == AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=1)
+
+    def test_service_key_resolved(self):
+        row = _make_key_row(kind="service", user_id=None, name="chrome-extension", id=11)
+        ctx = resolve_api_key(lambda: self._session_returning(row), "raw-key")
+        assert ctx.kind == "service"
+        assert ctx.user_id is None
+        assert not ctx.is_legacy
+
+    def test_legacy_fallback(self):
+        ctx = resolve_api_key(lambda: self._session_returning(None), LEGACY_KEY, legacy_key=LEGACY_KEY)
+        assert ctx == AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
+
+    def test_unknown_key_returns_none(self):
+        assert resolve_api_key(lambda: self._session_returning(None), "bad", legacy_key=LEGACY_KEY) is None
+
+    def test_no_legacy_configured(self):
+        assert resolve_api_key(lambda: self._session_returning(None), "anything") is None
+
+    def test_cache_hit_skips_db(self):
+        session = self._session_returning(_make_key_row())
+        resolve_api_key(lambda: session, "raw-key")
+        factory2 = MagicMock()
+        ctx = resolve_api_key(factory2, "raw-key")
+        assert ctx.key_id == 10
+        factory2.assert_not_called()  # positive hit + throttled last_used — no session at all
+
+    def test_negative_cache_skips_db(self):
+        resolve_api_key(lambda: self._session_returning(None), "bad")
+        factory2 = MagicMock()
+        assert resolve_api_key(factory2, "bad") is None
+        factory2.assert_not_called()
+
+    def test_invalidate_cache_forces_db_lookup(self):
+        resolve_api_key(lambda: self._session_returning(_make_key_row()), "raw-key")
+        auth.invalidate_cache()
+        session2 = self._session_returning(None)
+        assert resolve_api_key(lambda: session2, "raw-key") is None
+        session2.execute.assert_called_once()
+
+    def test_last_used_written_once_then_throttled(self):
+        session = self._session_returning(_make_key_row())
+        resolve_api_key(lambda: session, "raw-key")
+        # select + update in the first resolve, then nothing new
+        assert session.execute.call_count == 2
+        session.commit.assert_called_once()
+        resolve_api_key(lambda: session, "raw-key")
+        assert session.execute.call_count == 2
+
+    def test_legacy_key_never_touches_db(self):
+        factory = MagicMock()
+        resolve_api_key(factory, LEGACY_KEY, legacy_key=LEGACY_KEY)
+        # legacy is a plain string compare BEFORE the DB lookup — the session
+        # factory must not even be invoked
+        factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create / deactivate
+# ---------------------------------------------------------------------------
+
+
+class TestCreateApiKey:
+    def _session(self, user=READER_USER, duplicate=None):
+        session = MagicMock()
+        session.get.side_effect = lambda model, pk: user if (model is User and pk == user.id) else None
+        session.execute.return_value.scalar_one_or_none.return_value = duplicate
+        session.add.side_effect = lambda obj: setattr(obj, "id", 77)
+        return session
+
+    def test_create_user_key(self):
+        session = self._session()
+        row, plaintext = create_api_key(session, kind="user", name="frontend-krzysztof", user_id=1)
+        assert plaintext.startswith("lk_usr_")
+        assert row.key_hash == hash_api_key(plaintext)
+        assert row.key_prefix == plaintext[: auth.KEY_PREFIX_LEN]
+        assert row.user_id == 1
+        session.commit.assert_called_once()
+
+    def test_create_service_key(self):
+        row, plaintext = create_api_key(self._session(), kind="service", name="chrome-extension")
+        assert plaintext.startswith("lk_svc_")
+        assert row.user_id is None
+
+    @pytest.mark.parametrize("kwargs", [
+        {"kind": "admin", "name": "x"},
+        {"kind": "user", "name": "x", "user_id": None},          # user key needs user_id
+        {"kind": "user", "name": "x", "user_id": 99},            # unknown user
+        {"kind": "service", "name": "x", "user_id": 1},          # service must not have user_id
+        {"kind": "service", "name": ""},                          # empty name
+        {"kind": "service", "name": "y" * 101},                   # name too long
+    ])
+    def test_validation_errors(self, kwargs):
+        with pytest.raises(ValueError):
+            create_api_key(self._session(), **kwargs)
+
+    def test_duplicate_name_raises(self):
+        with pytest.raises(ValueError, match="already exists"):
+            create_api_key(self._session(duplicate=_make_key_row()), kind="service", name="frontend-krzysztof")
+
+    def test_create_invalidates_cache(self):
+        auth.get_cache().set("h", CacheEntry(None, time.monotonic() + 60))
+        create_api_key(self._session(), kind="service", name="fresh")
+        assert auth.get_cache().get("h") is None
+
+
+class TestDeactivateApiKey:
+    def test_deactivate(self):
+        row = _make_key_row()
+        session = MagicMock()
+        session.get.return_value = row
+        result = deactivate_api_key(session, 10)
+        assert result.active is False
+        session.commit.assert_called_once()
+
+    def test_missing_key_raises(self):
+        session = MagicMock()
+        session.get.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            deactivate_api_key(session, 999)
+
+
+# ---------------------------------------------------------------------------
+# /whoami + /api_keys endpoints
+# ---------------------------------------------------------------------------
+
+
+USER_AUTH = AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=1)
+SERVICE_AUTH = AuthContext(kind="service", key_id=11, key_name="chrome-extension", user_id=None)
+LEGACY_AUTH = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    session = MagicMock()
+    session.get.side_effect = lambda model, pk: READER_USER if (model is User and pk == 1) else None
+    session.execute.return_value.scalar_one_or_none.return_value = None
+    session.add.side_effect = lambda obj: setattr(obj, "id", 77)
+    monkeypatch.setattr(akr, "get_scoped_session", lambda: session)
+    return session
+
+
+@pytest.fixture
+def auth_holder():
+    return {"ctx": SERVICE_AUTH}
+
+
+@pytest.fixture
+def client(fake_session, auth_holder):
+    app = flask.Flask(__name__)
+
+    @app.before_request
+    def _set_auth():
+        if auth_holder["ctx"] is not None:
+            flask.g.auth = auth_holder["ctx"]
+
+    app.register_blueprint(akr.bp)
+    return app.test_client()
+
+
+class TestWhoami:
+    def test_user_key(self, client, auth_holder):
+        auth_holder["ctx"] = USER_AUTH
+        data = client.get("/whoami").get_json()
+        assert data["kind"] == "user"
+        assert data["key_name"] == "frontend-krzysztof"
+        assert data["is_legacy"] is False
+        assert data["user"] == {"id": 1, "username": "krzysztof", "display_name": "Krzysztof"}
+
+    def test_service_key(self, client):
+        data = client.get("/whoami").get_json()
+        assert data["kind"] == "service"
+        assert data["user"] is None
+
+    def test_legacy_key(self, client, auth_holder):
+        auth_holder["ctx"] = LEGACY_AUTH
+        data = client.get("/whoami").get_json()
+        assert data["is_legacy"] is True
+
+    def test_unauthenticated_401(self, client, auth_holder):
+        auth_holder["ctx"] = None
+        assert client.get("/whoami").status_code == 401
+
+
+class TestApiKeyManagement:
+    def test_user_key_gets_403(self, client, auth_holder):
+        auth_holder["ctx"] = USER_AUTH
+        assert client.get("/api_keys").status_code == 403
+        assert client.post("/api_keys", json={"kind": "service", "name": "x"}).status_code == 403
+        assert client.delete("/api_keys/10").status_code == 403
+
+    def test_list_keys(self, client, fake_session):
+        fake_session.execute.return_value.scalars.return_value.all.return_value = [_make_key_row()]
+        data = client.get("/api_keys").get_json()
+        key = data["api_keys"][0]
+        assert key["name"] == "frontend-krzysztof"
+        assert key["key_prefix"] == "lk_usr_abcde"
+        assert "key_hash" not in key
+        assert "plaintext" not in key
+
+    def test_create_key_returns_plaintext_once(self, client):
+        resp = client.post("/api_keys", json={"kind": "user", "name": "reader-k", "user_id": 1})
+        data = resp.get_json()
+        assert resp.status_code == 201
+        assert data["plaintext"].startswith("lk_usr_")
+        assert data["api_key"]["name"] == "reader-k"
+        assert "key_hash" not in data["api_key"]
+
+    def test_create_key_validation_400(self, client):
+        assert client.post("/api_keys", json={"kind": "admin", "name": "x"}).status_code == 400
+        assert client.post(
+            "/api_keys", json={"kind": "user", "name": "x", "user_id": "1"},
+        ).status_code == 400  # user_id must be an int, not a string
+
+    def test_deactivate_key(self, client, fake_session):
+        row = _make_key_row()
+        fake_session.get.side_effect = lambda model, pk: row if (model is ApiKey and pk == 10) else None
+        resp = client.delete("/api_keys/10")
+        assert resp.status_code == 200
+        assert resp.get_json()["api_key"]["active"] is False
+
+    def test_deactivate_missing_404(self, client, fake_session):
+        fake_session.get.side_effect = lambda model, pk: None
+        assert client.delete("/api_keys/999").status_code == 404

--- a/backend/tests/unit/test_config_loader.py
+++ b/backend/tests/unit/test_config_loader.py
@@ -86,14 +86,37 @@ class TestCreateBackend(unittest.TestCase):
             _create_backend("redis")
 
 
+def _clear_config_singleton():
+    """Drop the cached Config WITHOUT touching os.environ.
+
+    In setUp/tearDown the test's patch.dict has already restored (or not yet
+    modified) the environment; calling reset_config() there would pop restored
+    keys whose names collide with previously injected ones (STALKER_API_KEY,
+    POSTGRESQL_HOST, ...), permanently corrupting the environment for every
+    later test in the session. reset_config() itself is still exercised
+    explicitly by test_reset_clears_cache / test_reset_removes_injected_keys
+    inside their patch.dict scope.
+    """
+    import unified_config_loader.config as _ucc
+    _ucc._config = None
+    _ucc._injected_keys.clear()
+
+
 class TestLoadConfig(unittest.TestCase):
     """load_config / get_config / reset_config."""
 
     def setUp(self):
-        reset_config()
+        _clear_config_singleton()
+        # Also neutralize the bootstrap dotenv inside load_config(): otherwise
+        # the REAL project .env (SECRETS_BACKEND=vault + credentials) leaks in
+        # when a test pops SECRETS_BACKEND, and load_config() talks to the
+        # live Vault from a unit test.
+        self._bootstrap_patch = patch("unified_config_loader.config.find_dotenv", return_value="")
+        self._bootstrap_patch.start()
 
     def tearDown(self):
-        reset_config()
+        self._bootstrap_patch.stop()
+        _clear_config_singleton()
 
     @patch("unified_config_loader.backends.env.load_dotenv")
     def test_default_backend_is_env(self, mock_dotenv):
@@ -502,10 +525,14 @@ class TestBackwardCompatInjection(unittest.TestCase):
     that still use os.getenv() during the incremental migration."""
 
     def setUp(self):
-        reset_config()
+        _clear_config_singleton()
+        # See TestLoadConfig.setUp — keep the real .env out of unit tests.
+        self._bootstrap_patch = patch("unified_config_loader.config.find_dotenv", return_value="")
+        self._bootstrap_patch.start()
 
     def tearDown(self):
-        reset_config()
+        self._bootstrap_patch.stop()
+        _clear_config_singleton()
 
     @patch("unified_config_loader.backends.vault.VaultBackend.load")
     def test_vault_values_injected_into_environ(self, mock_vault_load):

--- a/backend/tests/unit/test_flask_endpoints_document_states.py
+++ b/backend/tests/unit/test_flask_endpoints_document_states.py
@@ -81,10 +81,10 @@ class TestDocumentStates:
 
 
 class TestDocumentStatesAuth:
-    def test_missing_api_key_returns_400(self):
-        """Missing x-api-key header returns HTTP 400."""
+    def test_missing_api_key_returns_401(self):
+        """Missing x-api-key header returns HTTP 401 (Etap 8)."""
         import server
         server.app.config["TESTING"] = True
         with server.app.test_client() as c:
             resp = c.get("/document_states")
-            assert resp.status_code == 400
+            assert resp.status_code == 401

--- a/backend/tests/unit/test_reader_routes.py
+++ b/backend/tests/unit/test_reader_routes.py
@@ -1,8 +1,9 @@
 """Unit tests for Etap 7 (reader): users, reading progress and fragment notes.
 
 Covers library/reader_routes.py with a mocked scoped session (no DB): user
-CRUD + x-user-id resolution, reading-progress upsert semantics and note
-anchoring/ownership rules.
+CRUD + reader-identity resolution from the API key (Etap 8: flask.g.auth set
+by the server middleware; service keys get 403), reading-progress upsert
+semantics and note anchoring/ownership rules.
 """
 
 from unittest.mock import MagicMock
@@ -13,6 +14,7 @@ pytest.importorskip("sqlalchemy")
 flask = pytest.importorskip("flask")
 
 from library import reader_routes as rr  # noqa: E402
+from library.auth import AuthContext  # noqa: E402
 from library.db.models import User, UserDocumentNote, UserReadingProgress, WebDocument  # noqa: E402
 
 
@@ -23,6 +25,10 @@ OTHER_USER = User(username="gosc")
 OTHER_USER.id = 2
 
 DOC_ID = 9204
+
+USER_AUTH = AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=READER_USER.id)
+SERVICE_AUTH = AuthContext(kind="service", key_id=11, key_name="chrome-extension", user_id=None)
+LEGACY_AUTH = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
 
 
 def _make_note(**overrides) -> UserDocumentNote:
@@ -68,12 +74,26 @@ def fake_session(monkeypatch):
 
 
 @pytest.fixture
-def client(fake_session):
+def auth_holder():
+    """Mutable stand-in for the AuthContext the server middleware puts in g.auth."""
+    return {"ctx": USER_AUTH}
+
+
+@pytest.fixture
+def client(fake_session, auth_holder):
     app = flask.Flask(__name__)
+
+    @app.before_request
+    def _set_auth():
+        if auth_holder["ctx"] is not None:
+            flask.g.auth = auth_holder["ctx"]
+
     app.register_blueprint(rr.bp)
     return app.test_client()
 
 
+# Old clients may still send x-user-id; it must be accepted when it matches
+# the key identity, so the happy-path requests below keep sending it.
 USER_HDR = {"x-user-id": "1"}
 
 
@@ -114,22 +134,39 @@ class TestUsers:
 
 
 # ---------------------------------------------------------------------------
-# x-user-id resolution
+# Reader identity from the API key (g.auth)
 # ---------------------------------------------------------------------------
 
 
 class TestRequireUser:
-    def test_missing_header_400(self, client):
+    def test_no_auth_context_401(self, client, auth_holder):
+        auth_holder["ctx"] = None
         resp = client.get(f"/document/{DOC_ID}/reading_progress")
-        assert resp.status_code == 400
+        assert resp.status_code == 401
 
-    def test_non_integer_header_400(self, client):
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "abc"})
-        assert resp.status_code == 400
+    def test_service_key_403(self, client, auth_holder):
+        auth_holder["ctx"] = SERVICE_AUTH
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
+        assert resp.status_code == 403
 
-    def test_unknown_user_404(self, client):
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "99"})
-        assert resp.status_code == 404
+    def test_legacy_key_403(self, client, auth_holder):
+        auth_holder["ctx"] = LEGACY_AUTH
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "1"})
+        assert resp.status_code == 403
+
+    def test_no_header_needed_with_user_key(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
+        assert resp.status_code == 200
+
+    def test_mismatched_x_user_id_403(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "2"})
+        assert resp.status_code == 403
+
+    def test_key_user_gone_403(self, client, auth_holder):
+        auth_holder["ctx"] = AuthContext(kind="user", key_id=12, key_name="stale", user_id=99)
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
+        assert resp.status_code == 403
 
     def test_unknown_document_404(self, client, fake_session):
         resp = client.get("/document/12345/reading_progress", headers=USER_HDR)

--- a/backend/tests/unit/test_reader_routes.py
+++ b/backend/tests/unit/test_reader_routes.py
@@ -1,0 +1,318 @@
+"""Unit tests for Etap 7 (reader): users, reading progress and fragment notes.
+
+Covers library/reader_routes.py with a mocked scoped session (no DB): user
+CRUD + x-user-id resolution, reading-progress upsert semantics and note
+anchoring/ownership rules.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+flask = pytest.importorskip("flask")
+
+from library import reader_routes as rr  # noqa: E402
+from library.db.models import User, UserDocumentNote, UserReadingProgress, WebDocument  # noqa: E402
+
+
+READER_USER = User(username="krzysztof", display_name="Krzysztof")
+READER_USER.id = 1
+
+OTHER_USER = User(username="gosc")
+OTHER_USER.id = 2
+
+DOC_ID = 9204
+
+
+def _make_note(**overrides) -> UserDocumentNote:
+    note = UserDocumentNote(
+        user_id=READER_USER.id,
+        document_id=DOC_ID,
+        chapter_position=4,
+        anchor_quote="cytowany fragment",
+        anchor_prefix="poprzedzający tekst",
+        anchor_suffix="następujący tekst",
+        note_text="moja reakcja",
+        stance="agree",
+    )
+    note.id = 501
+    for key, value in overrides.items():
+        setattr(note, key, value)
+    return note
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    session = MagicMock()
+    doc = MagicMock(spec=WebDocument)
+    doc.id = DOC_ID
+
+    store = {"users": {1: READER_USER, 2: OTHER_USER}, "notes": {}, "doc": doc}
+
+    def fake_get(model, pk):
+        if model is User:
+            return store["users"].get(pk)
+        if model is WebDocument:
+            return store["doc"] if pk == DOC_ID else None
+        if model is UserDocumentNote:
+            return store["notes"].get(pk)
+        return None
+
+    session.get.side_effect = fake_get
+    # new objects get an id on add (stand-in for commit-time sequence values)
+    session.add.side_effect = lambda obj: setattr(obj, "id", getattr(obj, "id", None) or 900)
+    session.store = store
+    monkeypatch.setattr(rr, "get_scoped_session", lambda: session)
+    return session
+
+
+@pytest.fixture
+def client(fake_session):
+    app = flask.Flask(__name__)
+    app.register_blueprint(rr.bp)
+    return app.test_client()
+
+
+USER_HDR = {"x-user-id": "1"}
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+class TestUsers:
+    def test_list_users(self, client, fake_session):
+        fake_session.execute.return_value.scalars.return_value.all.return_value = [
+            READER_USER, OTHER_USER,
+        ]
+        resp = client.get("/users")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert [u["username"] for u in data["users"]] == ["krzysztof", "gosc"]
+
+    def test_create_user(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.post("/users", json={"username": "nowy", "display_name": " Nowy "})
+        data = resp.get_json()
+
+        assert resp.status_code == 201
+        assert data["user"]["username"] == "nowy"
+        assert data["user"]["display_name"] == "Nowy"
+        fake_session.commit.assert_called_once()
+
+    def test_create_user_duplicate_409(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = READER_USER
+        resp = client.post("/users", json={"username": "krzysztof"})
+        assert resp.status_code == 409
+
+    def test_create_user_empty_username_400(self, client):
+        resp = client.post("/users", json={"username": "  "})
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# x-user-id resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRequireUser:
+    def test_missing_header_400(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
+        assert resp.status_code == 400
+
+    def test_non_integer_header_400(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "abc"})
+        assert resp.status_code == 400
+
+    def test_unknown_user_404(self, client):
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "99"})
+        assert resp.status_code == 404
+
+    def test_unknown_document_404(self, client, fake_session):
+        resp = client.get("/document/12345/reading_progress", headers=USER_HDR)
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Reading progress
+# ---------------------------------------------------------------------------
+
+
+class TestReadingProgress:
+    def test_get_without_row_returns_nulls(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["current_chapter"] is None
+        assert data["read_chapters"] == []
+
+    def test_get_existing_row(self, client, fake_session):
+        progress = UserReadingProgress(
+            user_id=1, document_id=DOC_ID, current_chapter=7,
+            current_chapter_title="Bank centralny", read_chapters=[3, 1, 2],
+        )
+        fake_session.execute.return_value.scalar_one_or_none.return_value = progress
+        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert data["current_chapter"] == 7
+        assert data["current_chapter_title"] == "Bank centralny"
+        assert data["read_chapters"] == [1, 2, 3]
+
+    def test_put_creates_row(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 5, "current_chapter_title": "Rozdział 5", "mark_read": [4]},
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["current_chapter"] == 5
+        assert data["read_chapters"] == [4]
+        fake_session.add.assert_called_once()
+        fake_session.commit.assert_called_once()
+
+    def test_put_updates_existing_row_and_read_set(self, client, fake_session):
+        progress = UserReadingProgress(
+            user_id=1, document_id=DOC_ID, current_chapter=3, read_chapters=[1, 2, 3],
+        )
+        fake_session.execute.return_value.scalar_one_or_none.return_value = progress
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 6, "mark_read": [5, 5], "unmark_read": [2]},
+        )
+        data = resp.get_json()
+
+        assert data["current_chapter"] == 6
+        assert data["read_chapters"] == [1, 3, 5]
+        fake_session.add.assert_not_called()
+
+    def test_put_invalid_current_chapter_400(self, client):
+        for bad in (None, 0, -1, "3"):
+            resp = client.put(
+                f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+                json={"current_chapter": bad},
+            )
+            assert resp.status_code == 400
+
+    def test_put_invalid_mark_read_400(self, client):
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 1, "mark_read": [0]},
+        )
+        assert resp.status_code == 400
+
+    def test_put_truncates_title_to_500(self, client, fake_session):
+        fake_session.execute.return_value.scalar_one_or_none.return_value = None
+        resp = client.put(
+            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            json={"current_chapter": 1, "current_chapter_title": "x" * 600},
+        )
+        assert len(resp.get_json()["current_chapter_title"]) == 500
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+
+
+class TestNotes:
+    def test_create_note(self, client, fake_session):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={
+                "anchor_quote": "fragment książki",
+                "note_text": "zgadzam się z autorem",
+                "anchor_prefix": "p" * 150,
+                "anchor_suffix": "s" * 150,
+                "chapter_position": 4,
+                "stance": "agree",
+            },
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 201
+        note = data["note"]
+        assert note["anchor_quote"] == "fragment książki"
+        assert len(note["anchor_prefix"]) == 100
+        assert len(note["anchor_suffix"]) == 100
+        assert note["chapter_position"] == 4
+        assert note["stance"] == "agree"
+        fake_session.commit.assert_called_once()
+
+    def test_create_note_requires_quote_and_text(self, client):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "", "note_text": "coś"},
+        )
+        assert resp.status_code == 400
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "coś", "note_text": " "},
+        )
+        assert resp.status_code == 400
+
+    def test_create_note_invalid_stance_400(self, client):
+        resp = client.post(
+            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            json={"anchor_quote": "q", "note_text": "n", "stance": "meh"},
+        )
+        assert resp.status_code == 400
+
+    def test_list_notes(self, client, fake_session):
+        fake_session.execute.return_value.scalars.return_value.all.return_value = [_make_note()]
+        resp = client.get(f"/document/{DOC_ID}/notes", headers=USER_HDR)
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert len(data["notes"]) == 1
+        assert data["notes"][0]["note_text"] == "moja reakcja"
+
+    def test_patch_note_updates_text_and_stance(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(
+            f"/note/{note.id}", headers=USER_HDR,
+            json={"note_text": "zmienione", "stance": "disagree"},
+        )
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["note"]["note_text"] == "zmienione"
+        assert data["note"]["stance"] == "disagree"
+
+    def test_patch_note_empty_text_400(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": ""})
+        assert resp.status_code == 400
+
+    def test_patch_foreign_note_403(self, client, fake_session):
+        note = _make_note(user_id=OTHER_USER.id)
+        fake_session.store["notes"][note.id] = note
+        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": "x"})
+        assert resp.status_code == 403
+
+    def test_delete_note(self, client, fake_session):
+        note = _make_note()
+        fake_session.store["notes"][note.id] = note
+        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+
+        assert resp.status_code == 200
+        fake_session.delete.assert_called_once_with(note)
+
+    def test_delete_foreign_note_403(self, client, fake_session):
+        note = _make_note(user_id=OTHER_USER.id)
+        fake_session.store["notes"][note.id] = note
+        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+        assert resp.status_code == 403
+
+    def test_delete_missing_note_404(self, client):
+        resp = client.delete("/note/777", headers=USER_HDR)
+        assert resp.status_code == 404

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Layout from "./modules/shared/components/Layout/Layout";
 import Authorization from "./modules/shared/components/Authorization/authorization";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import Link from "./modules/shared/pages/link";
 import Webpage from "./modules/shared/pages/webpage";
 import Youtube from "./modules/shared/pages/youtube";
@@ -24,6 +24,9 @@ const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 };
 
 function App() {
+  const location = useLocation();
+  const hideAuthorizationBar = location.pathname.startsWith("/read/");
+
   return (
     <Routes>
       <Route path="/connect" element={<Connect />} />
@@ -33,7 +36,7 @@ function App() {
           <RequireAuth>
             <Layout>
               <div className="App">
-                <Authorization />
+                {!hideAuthorizationBar && <Authorization />}
                 <Routes>
                   <Route path="/" element={<Navigate to="/list" />} />
                   <Route path="/webpage/:id?" element={<Webpage />} />

--- a/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
+++ b/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
@@ -1,0 +1,320 @@
+import React from "react";
+
+// Shared reader-identity and fragment-note building blocks (Etap 7, iter. 2).
+// Used by the reader (/read/:id) and the chunk review (/chunks/:id).
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ReaderUser {
+  id: number;
+  username: string;
+  display_name: string | null;
+}
+
+export interface UserNote {
+  id: number;
+  user_id: number;
+  document_id: number;
+  chapter_position: number | null;
+  anchor_quote: string;
+  anchor_prefix: string | null;
+  anchor_suffix: string | null;
+  run_id: number | null;
+  chunk_id: number | null;
+  note_text: string;
+  stance: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface PendingNote {
+  quote: string;
+  prefix: string;
+  suffix: string;
+  x: number;
+  y: number;
+}
+
+export const USER_STORAGE_KEY = "lenie_userId";
+export const STANCE_ICON: Record<string, string> = { agree: "👍", disagree: "👎", neutral: "➖" };
+
+export const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+
+export interface ReaderIdentity {
+  users: ReaderUser[];
+  userId: number | null;
+  selectUser: (uid: number | null) => void;
+  newUsername: string;
+  setNewUsername: (v: string) => void;
+  addUser: () => Promise<void>;
+  headers: Record<string, string>;
+  jsonHeaders: Record<string, string>;
+}
+
+export function useReaderIdentity(
+  apiUrl: string,
+  apiKey: string | undefined,
+  onUserChange?: (uid: number | null) => void,
+): ReaderIdentity {
+  const [users, setUsers] = React.useState<ReaderUser[]>([]);
+  const [userId, setUserId] = React.useState<number | null>(() => {
+    const v = localStorage.getItem(USER_STORAGE_KEY);
+    return v ? Number(v) : null;
+  });
+  const [newUsername, setNewUsername] = React.useState("");
+
+  const headers = React.useMemo(() => {
+    const h: Record<string, string> = { "x-api-key": apiKey ?? "" };
+    if (userId) h["x-user-id"] = String(userId);
+    return h;
+  }, [apiKey, userId]);
+  const jsonHeaders = React.useMemo(
+    () => ({ ...headers, "Content-Type": "application/json" }), [headers]);
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/users`, { headers: { "x-api-key": apiKey ?? "" } });
+        const data = await r.json();
+        if (data.status === "success") setUsers(data.users ?? []);
+      } catch { /* users are optional — pages work without identity */ }
+    })();
+  }, [apiUrl, apiKey]);
+
+  const selectUser = (uid: number | null) => {
+    setUserId(uid);
+    if (uid) localStorage.setItem(USER_STORAGE_KEY, String(uid));
+    else localStorage.removeItem(USER_STORAGE_KEY);
+    onUserChange?.(uid);
+  };
+
+  const addUser = async () => {
+    const username = newUsername.trim();
+    if (!username) return;
+    const r = await fetch(`${apiUrl}/users`, {
+      method: "POST", headers: { "x-api-key": apiKey ?? "", "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setUsers(prev => [...prev, data.user]);
+      selectUser(data.user.id);
+      setNewUsername("");
+    } else {
+      alert(data.message ?? "Nie udało się dodać użytkownika");
+    }
+  };
+
+  return { users, userId, selectUser, newUsername, setNewUsername, addUser, headers, jsonHeaders };
+}
+
+export const UserPicker: React.FC<{ identity: ReaderIdentity; label?: string }> = ({
+  identity, label = "Czytasz jako:",
+}) => {
+  const { users, userId, selectUser, newUsername, setNewUsername, addUser } = identity;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.85em" }}>
+      <span style={{ color: "#64748b" }}>{label}</span>
+      <select value={userId ?? ""} onChange={e => selectUser(e.target.value ? Number(e.target.value) : null)}>
+        <option value="">— wybierz —</option>
+        {users.map(u => (
+          <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
+        ))}
+      </select>
+      <input
+        value={newUsername} onChange={e => setNewUsername(e.target.value)}
+        onKeyDown={e => e.key === "Enter" && addUser()}
+        placeholder="nowy użytkownik…" style={{ width: 130 }}
+      />
+      <button onClick={addUser} disabled={!newUsername.trim()}>＋</button>
+    </div>
+  );
+};
+
+// ── Notes CRUD ───────────────────────────────────────────────────────────────
+
+export interface NotesApi {
+  notes: UserNote[];
+  createNote: (payload: {
+    anchor_quote: string;
+    anchor_prefix: string;
+    anchor_suffix: string;
+    chapter_position: number | null;
+    run_id?: number | null;
+    chunk_id?: number | null;
+    note_text: string;
+    stance: string | null;
+  }) => Promise<boolean>;
+  saveNoteText: (noteId: number, text: string) => Promise<boolean>;
+  deleteNote: (noteId: number) => Promise<void>;
+}
+
+export function useUserNotes(
+  apiUrl: string,
+  docId: string | undefined,
+  identity: ReaderIdentity,
+): NotesApi {
+  const { userId, headers, jsonHeaders } = identity;
+  const [notes, setNotes] = React.useState<UserNote[]>([]);
+
+  React.useEffect(() => {
+    if (!userId || !docId) { setNotes([]); return; }
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/document/${docId}/notes`, { headers });
+        const data = await r.json();
+        if (data.status === "success") setNotes(data.notes ?? []);
+      } catch { /* notes are best-effort */ }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, docId, userId]);
+
+  const createNote: NotesApi["createNote"] = async payload => {
+    const r = await fetch(`${apiUrl}/document/${docId}/notes`, {
+      method: "POST", headers: jsonHeaders, body: JSON.stringify(payload),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => [...prev, data.note]);
+      return true;
+    }
+    alert(data.message ?? "Nie udało się zapisać notatki");
+    return false;
+  };
+
+  const saveNoteText: NotesApi["saveNoteText"] = async (noteId, text) => {
+    const r = await fetch(`${apiUrl}/note/${noteId}`, {
+      method: "PATCH", headers: jsonHeaders, body: JSON.stringify({ note_text: text }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => prev.map(n => (n.id === noteId ? data.note : n)));
+      return true;
+    }
+    return false;
+  };
+
+  const deleteNote: NotesApi["deleteNote"] = async noteId => {
+    if (!window.confirm("Usunąć notatkę?")) return;
+    const r = await fetch(`${apiUrl}/note/${noteId}`, { method: "DELETE", headers });
+    const data = await r.json();
+    if (data.status === "success") setNotes(prev => prev.filter(n => n.id !== noteId));
+  };
+
+  return { notes, createNote, saveNoteText, deleteNote };
+}
+
+// ── Selection → pending note ─────────────────────────────────────────────────
+
+/** Build a PendingNote from the current text selection, or null when there is
+ *  no usable selection. Prefix/suffix come from the nearest block element. */
+export function pendingNoteFromSelection(blockSelector = "p"): PendingNote | null {
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed) return null;
+  const quote = normalizeWs(sel.toString());
+  if (quote.length < 3 || quote.length > 2000) return null;
+
+  let prefix = "";
+  let suffix = "";
+  const anchorEl = sel.anchorNode instanceof Element ? sel.anchorNode : sel.anchorNode?.parentElement;
+  const block = anchorEl?.closest(blockSelector);
+  const blockText = block?.textContent ?? "";
+  const idx = blockText.indexOf(quote);
+  if (idx >= 0) {
+    prefix = blockText.slice(Math.max(0, idx - 50), idx);
+    suffix = blockText.slice(idx + quote.length, idx + quote.length + 50);
+  }
+  const rect = sel.getRangeAt(0).getBoundingClientRect();
+  return { quote, prefix, suffix, x: rect.left + window.scrollX, y: rect.bottom + window.scrollY + 6 };
+}
+
+// ── UI: note popover (absolute-positioned at the selection) ──────────────────
+
+export const NotePopover: React.FC<{
+  pending: PendingNote;
+  onSave: (noteText: string, stance: string | null) => void;
+  onCancel: () => void;
+}> = ({ pending, onSave, onCancel }) => {
+  const [noteText, setNoteText] = React.useState("");
+  const [stance, setStance] = React.useState<string | null>(null);
+  return (
+    <div style={{
+      position: "absolute", left: pending.x, top: pending.y, zIndex: 50,
+      background: "#fff", border: "1px solid #cbd5e1", borderRadius: 8, padding: 10,
+      boxShadow: "0 4px 12px rgba(0,0,0,0.15)", width: 340,
+    }}>
+      <div style={{ fontSize: "0.75em", color: "#94a3b8", fontStyle: "italic", marginBottom: 6 }}>
+        „{pending.quote.length > 120 ? `${pending.quote.slice(0, 120)}…` : pending.quote}"
+      </div>
+      <textarea
+        autoFocus value={noteText} onChange={e => setNoteText(e.target.value)}
+        placeholder="Twoja notatka — co myślisz o tym fragmencie?"
+        style={{ width: "100%", minHeight: 60, fontSize: "0.85em" }}
+      />
+      <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
+        {(["agree", "disagree", "neutral"] as const).map(s => (
+          <button key={s} onClick={() => setStance(stance === s ? null : s)}
+            title={{ agree: "Zgadzam się", disagree: "Nie zgadzam się", neutral: "Neutralnie" }[s]}
+            style={{
+              border: stance === s ? "2px solid #0369a1" : "1px solid #cbd5e1",
+              borderRadius: 6, background: "#fff", cursor: "pointer", padding: "2px 8px",
+            }}>
+            {STANCE_ICON[s]}
+          </button>
+        ))}
+        <span style={{ marginLeft: "auto" }}>
+          <button onClick={() => onSave(noteText.trim(), stance)} disabled={!noteText.trim()}
+            style={{ marginRight: 6 }}>Zapisz</button>
+          <button onClick={onCancel}>Anuluj</button>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+// ── UI: single note row with inline edit/delete ──────────────────────────────
+
+export const NoteRow: React.FC<{
+  note: UserNote;
+  header: React.ReactNode;
+  onHeaderClick?: () => void;
+  onSaveText: (noteId: number, text: string) => Promise<boolean>;
+  onDelete: (noteId: number) => void;
+}> = ({ note, header, onHeaderClick, onSaveText, onDelete }) => {
+  const [editing, setEditing] = React.useState(false);
+  const [text, setText] = React.useState("");
+  return (
+    <div style={{
+      padding: "6px 10px", borderBottom: "1px solid #e2e8f0", fontSize: "0.8em", lineHeight: 1.4,
+    }}>
+      <div style={{ color: "#64748b", cursor: onHeaderClick ? "pointer" : undefined }}
+        onClick={onHeaderClick}>
+        {header}
+      </div>
+      <div style={{ fontStyle: "italic", color: "#94a3b8", margin: "2px 0" }}>
+        „{note.anchor_quote.length > 90 ? `${note.anchor_quote.slice(0, 90)}…` : note.anchor_quote}"
+      </div>
+      {editing ? (
+        <div>
+          <textarea value={text} onChange={e => setText(e.target.value)}
+            style={{ width: "100%", minHeight: 50 }} />
+          <button onClick={async () => { if (await onSaveText(note.id, text.trim())) setEditing(false); }}
+            disabled={!text.trim()}>Zapisz</button>{" "}
+          <button onClick={() => setEditing(false)}>Anuluj</button>
+        </div>
+      ) : (
+        <div>
+          {note.note_text}{" "}
+          <span style={{ whiteSpace: "nowrap" }}>
+            <button title="Edytuj" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => { setEditing(true); setText(note.note_text); }}>✏</button>
+            <button title="Usuń" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => onDelete(note.id)}>🗑</button>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { useParams, useLocation, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
+import {
+  NotePopover, NoteRow, PendingNote, STANCE_ICON, UserNote, UserPicker,
+  normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
+} from "../components/ReaderNotes/readerNotes";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -373,6 +377,13 @@ const Chunks = () => {
   const [filterUnprocessed, setFilterUnprocessed] = React.useState(false);
   const [embedJobId, setEmbedJobId] = React.useState<string | null>(null);
   const [embedJobStatus, setEmbedJobStatus] = React.useState<string | null>(null);
+
+  // ── User identity + fragment notes (shared with /read) ──
+  const identity = useReaderIdentity(apiUrl, apiKey);
+  const { userId } = identity;
+  const { notes, createNote, saveNoteText, deleteNote } = useUserNotes(apiUrl, id, identity);
+  const [pendingNote, setPendingNote] = React.useState<(PendingNote & { chunkId: number }) | null>(null);
+  const [expandedNoteChunks, setExpandedNoteChunks] = React.useState<Set<number>>(new Set());
 
   const headers = { "x-api-key": apiKey ?? "", "Content-Type": "application/json" };
 
@@ -950,6 +961,57 @@ const Chunks = () => {
     && (!filterUnprocessed || (c.type === "TEMAT" && (c.obsidian_note_paths?.length ?? 0) === 0))
   );
 
+  // ── User notes: match notes to chunks of the selected run ──
+  // Direct match by chunk_id; reader notes (or notes from other runs) fall back
+  // to a quote search in the chunk text (skipped for lite chunks without texts).
+  const chunkNotes = React.useMemo(() => {
+    const byChunk = new Map<number, UserNote[]>();
+    if (!userId || notes.length === 0) return byChunk;
+    const runChunkIds = new Set(chunks.map(c => c.id));
+    for (const n of notes) {
+      if (n.chunk_id !== null && runChunkIds.has(n.chunk_id)) {
+        byChunk.set(n.chunk_id, [...(byChunk.get(n.chunk_id) ?? []), n]);
+        continue;
+      }
+      const quote = normalizeWs(n.anchor_quote);
+      for (const c of chunks) {
+        const text = c.corrected_text ?? c.original_text;
+        if (text && normalizeWs(text).includes(quote)) {
+          byChunk.set(c.id, [...(byChunk.get(c.id) ?? []), n]);
+          break;
+        }
+      }
+    }
+    return byChunk;
+  }, [notes, chunks, userId]);
+
+  const onChunkTextSelected = (chunkId: number) => {
+    if (!userId) return;
+    const pending = pendingNoteFromSelection("p,div");
+    if (pending) setPendingNote({ ...pending, chunkId });
+  };
+
+  const saveChunkNote = async (noteText: string, stance: string | null) => {
+    if (!pendingNote || !noteText) return;
+    // chapter_position: chapter-scoped runs store the chapter title in run.scope
+    const scope = runs.find(r => r.id === selectedRun)?.scope;
+    const chapter = scope ? chapters.find(ch => ch.title === scope)?.position ?? null : null;
+    const ok = await createNote({
+      anchor_quote: pendingNote.quote,
+      anchor_prefix: pendingNote.prefix,
+      anchor_suffix: pendingNote.suffix,
+      chapter_position: chapter,
+      run_id: selectedRun,
+      chunk_id: pendingNote.chunkId,
+      note_text: noteText,
+      stance,
+    });
+    if (ok) {
+      setExpandedNoteChunks(prev => new Set([...prev, pendingNote.chunkId]));
+      setPendingNote(null);
+    }
+  };
+
   // ── Render ───────────────────────────────────────────────────────────────
 
   // Karta pojedynczego chunka — używana w widoku płaskim i w accordionie sekcji
@@ -960,6 +1022,8 @@ const Chunks = () => {
         const splitSt = splitStates[chunk.id];
         const lineSplitSt = lineSplitStates[chunk.id];
         const chunkSegs = segments.slice(chunk.seg_start ?? 0, chunk.seg_end ?? segments.length);
+        const myNotes = chunkNotes.get(chunk.id) ?? [];
+        const notesExpanded = expandedNoteChunks.has(chunk.id);
 
         return (
           <div key={chunk.id} style={{ marginBottom: 18, border: "1px solid #e2e8f0", borderRadius: 8, overflow: "hidden" }}>
@@ -994,6 +1058,19 @@ const Chunks = () => {
               {!!chunk.obsidian_note_paths?.length && (
                 <span title={chunk.obsidian_note_paths.join("\n")} style={{ color: "#7c3aed" }}>
                   📝 {chunk.obsidian_note_paths.length}
+                </span>
+              )}
+              {myNotes.length > 0 && (
+                <span
+                  onClick={() => setExpandedNoteChunks(prev => {
+                    const next = new Set(prev);
+                    if (next.has(chunk.id)) next.delete(chunk.id); else next.add(chunk.id);
+                    return next;
+                  })}
+                  title={`${myNotes.length} ${myNotes.length === 1 ? "notatka" : "notatki/notatek"} — kliknij aby ${notesExpanded ? "zwinąć" : "rozwinąć"}`}
+                  style={{ color: "#0369a1", cursor: "pointer", fontWeight: 600 }}
+                >
+                  💬 {myNotes.length}
                 </span>
               )}
               {chunk.has_embeddings != null && (
@@ -1055,7 +1132,8 @@ const Chunks = () => {
             </div>
 
             {/* Treść: poprawiony tekst → segmenty transkrypcji → surowy tekst (artykuły) */}
-            <div style={{ padding: "12px 14px", fontSize: "0.88em", lineHeight: 1.6 }}>
+            <div style={{ padding: "12px 14px", fontSize: "0.88em", lineHeight: 1.6 }}
+              onMouseUp={() => onChunkTextSelected(chunk.id)}>
               {isCorrectedView && hasCorrected ? (
                 <div style={{ whiteSpace: "pre-wrap", color: "#1e293b" }}>{chunk.corrected_text}</div>
               ) : chunkSegs.length > 0 ? (
@@ -1080,6 +1158,24 @@ const Chunks = () => {
                 />
               )}
             </div>
+
+            {/* Moje notatki do tego chunka */}
+            {notesExpanded && myNotes.length > 0 && (
+              <div style={{ margin: "0 14px 14px", background: "#f0f9ff", border: "1px solid #bae6fd", borderRadius: 5 }}>
+                <strong style={{ fontSize: "0.8em", color: "#0369a1", display: "block", padding: "6px 10px 0" }}>
+                  💬 Moje notatki
+                </strong>
+                {myNotes.map(n => (
+                  <NoteRow
+                    key={n.id}
+                    note={n}
+                    header={<>{STANCE_ICON[n.stance ?? ""] ?? "📝"}{n.chapter_position ? ` rozdz. ${n.chapter_position}` : ""}</>}
+                    onSaveText={saveNoteText}
+                    onDelete={deleteNote}
+                  />
+                ))}
+              </div>
+            )}
 
             {/* Panel podziału */}
             {splitSt && (
@@ -1175,6 +1271,7 @@ const Chunks = () => {
           <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         )}
         <NavLink to={`/read/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>📖 Czytaj</NavLink>
+        <div style={{ marginLeft: "auto" }}><UserPicker identity={identity} /></div>
       </div>
 
       {/* Nowa analiza */}
@@ -1458,6 +1555,11 @@ const Chunks = () => {
 
       {!loading && chunks.length === 0 && runs.length === 0 && (
         <p style={{ color: "#64748b", fontStyle: "italic" }}>Brak analiz dla tego dokumentu. Uruchom pierwszą analizę powyżej.</p>
+      )}
+
+      {/* Popover nowej notatki (zaznaczenie tekstu w treści chunka) */}
+      {pendingNote && (
+        <NotePopover pending={pendingNote} onSave={saveChunkNote} onCancel={() => setPendingNote(null)} />
       )}
     </div>
   );

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -147,6 +147,15 @@ const List = () => {
                 <NavLink
                   className={"button"}
                   style={{ margin: "0 0 0 6px" }}
+                  to={`/read/${item.id}`}
+                >
+                  Czytaj
+                </NavLink>
+              )}
+              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && (
+                <NavLink
+                  className={"button"}
+                  style={{ margin: "0 0 0 6px" }}
                   to={`/chunks/${item.id}`}
                   state={{ docType: item.document_type }}
                 >

--- a/web_interface_react/src/modules/shared/pages/read.module.css
+++ b/web_interface_react/src/modules/shared/pages/read.module.css
@@ -1,0 +1,89 @@
+.tocToggleButton {
+  display: none;
+}
+
+.tocClose {
+  display: none;
+}
+
+.scrim {
+  display: none;
+}
+
+.tocPanel {
+  flex: 0 0 300px;
+  position: sticky;
+  top: 12px;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+  .tocToggleButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid rgb(203, 213, 225);
+    background: #f8fafc;
+    color: #1c2331;
+    font-size: 0.82rem;
+    font-weight: 600;
+    padding: 6px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+
+  .tocClose {
+    display: inline-flex;
+    border: none;
+    background: none;
+    font-size: 1rem;
+    color: #64748b;
+    cursor: pointer;
+    line-height: 1;
+    padding: 2px 4px;
+  }
+
+  .scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.42);
+    z-index: 900;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease;
+  }
+
+  .scrimOpen {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .tocPanel {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 82%;
+    max-width: 320px;
+    max-height: none;
+    background: #ffffff;
+    z-index: 901;
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    box-shadow: 12px 0 24px -12px rgba(0, 0, 0, 0.25);
+    padding: 12px;
+  }
+
+  .tocPanelOpen {
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tocPanel,
+  .scrim {
+    transition: none;
+  }
+}

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { useParams, useSearchParams, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
+import {
+  NotePopover, NoteRow, PendingNote, STANCE_ICON, UserNote, UserPicker,
+  normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
+} from "../components/ReaderNotes/readerNotes";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -22,33 +26,6 @@ interface ChapterContent {
   next: number | null;
 }
 
-interface ReaderUser {
-  id: number;
-  username: string;
-  display_name: string | null;
-}
-
-interface UserNote {
-  id: number;
-  chapter_position: number | null;
-  anchor_quote: string;
-  anchor_prefix: string | null;
-  anchor_suffix: string | null;
-  note_text: string;
-  stance: string | null;
-}
-
-interface PendingNote {
-  quote: string;
-  prefix: string;
-  suffix: string;
-  x: number;
-  y: number;
-}
-
-const USER_STORAGE_KEY = "lenie_userId";
-const STANCE_ICON: Record<string, string> = { agree: "👍", disagree: "👎", neutral: "➖" };
-
 // ── Minimal markdown rendering (headings, paragraphs, hr; images skipped) ────
 
 const IMAGE_LINE = /^!\[[^\]]*\]\([^)]*\)$/;
@@ -62,8 +39,6 @@ function renderInline(text: string): React.ReactNode[] {
     return part;
   });
 }
-
-const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
 
 /** Render a paragraph's text with <mark> around anchored note quotes.
  *  Exact match → inline highlight; whitespace-normalized match → whole
@@ -113,7 +88,9 @@ function renderMarkdown(text: string, notes: UserNote[]): React.ReactNode[] {
     if (heading) {
       const level = Math.min(heading[1].length + 1, 6);
       const Tag = `h${level}` as keyof JSX.IntrinsicElements;
-      out.push(<Tag key={i} style={{ marginTop: level === 2 ? 0 : 28 }}>{heading[2]}</Tag>);
+      // headings can carry note anchors too (e.g. a quote of the chapter title)
+      const { nodes } = renderParagraphWithNotes(heading[2].replace(/\n/g, " "), notes);
+      out.push(<Tag key={i} style={{ marginTop: level === 2 ? 0 : 28 }}>{nodes}</Tag>);
       return;
     }
     if (trimmed === "---") {
@@ -152,55 +129,23 @@ const Read: React.FC = () => {
   const [error, setError] = React.useState<string | null>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
-  // ── User identity ──
-  const [users, setUsers] = React.useState<ReaderUser[]>([]);
-  const [userId, setUserId] = React.useState<number | null>(() => {
-    const v = localStorage.getItem(USER_STORAGE_KEY);
-    return v ? Number(v) : null;
-  });
-  const [newUsername, setNewUsername] = React.useState("");
-
   // ── Reading progress ──
   const [readChapters, setReadChapters] = React.useState<number[]>([]);
   const [progressLoaded, setProgressLoaded] = React.useState(false);
   const initialRedirectDone = React.useRef(false);
 
-  // ── Notes ──
-  const [notes, setNotes] = React.useState<UserNote[]>([]);
-  const [pendingNote, setPendingNote] = React.useState<PendingNote | null>(null);
-  const [noteText, setNoteText] = React.useState("");
-  const [noteStance, setNoteStance] = React.useState<string | null>(null);
-  const [editingNoteId, setEditingNoteId] = React.useState<number | null>(null);
-  const [editingText, setEditingText] = React.useState("");
-
-  const position = Number(searchParams.get("chapter") ?? 1);
-  const headers = React.useMemo(() => {
-    const h: Record<string, string> = { "x-api-key": apiKey ?? "" };
-    if (userId) h["x-user-id"] = String(userId);
-    return h;
-  }, [apiKey, userId]);
-  const jsonHeaders = React.useMemo(
-    () => ({ ...headers, "Content-Type": "application/json" }), [headers]);
-
-  const selectUser = (uid: number | null) => {
-    setUserId(uid);
+  // ── User identity + notes (shared with /chunks) ──
+  const identity = useReaderIdentity(apiUrl, apiKey, () => {
     setProgressLoaded(false);
     initialRedirectDone.current = false;
-    if (uid) localStorage.setItem(USER_STORAGE_KEY, String(uid));
-    else localStorage.removeItem(USER_STORAGE_KEY);
-  };
+  });
+  const { userId, headers, jsonHeaders } = identity;
+  const { notes, createNote, saveNoteText, deleteNote } = useUserNotes(apiUrl, id, identity);
+  const [pendingNote, setPendingNote] = React.useState<PendingNote | null>(null);
+
+  const position = Number(searchParams.get("chapter") ?? 1);
 
   // ── Data loading ──
-
-  React.useEffect(() => {
-    (async () => {
-      try {
-        const r = await fetch(`${apiUrl}/users`, { headers: { "x-api-key": apiKey ?? "" } });
-        const data = await r.json();
-        if (data.status === "success") setUsers(data.users ?? []);
-      } catch { /* users are optional — reader works without identity */ }
-    })();
-  }, [apiUrl, apiKey]);
 
   React.useEffect(() => {
     (async () => {
@@ -232,18 +177,6 @@ const Read: React.FC = () => {
       } catch { /* progress is best-effort */ }
       initialRedirectDone.current = true;
       setProgressLoaded(true);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiUrl, id, userId]);
-
-  React.useEffect(() => {
-    if (!userId) { setNotes([]); return; }
-    (async () => {
-      try {
-        const r = await fetch(`${apiUrl}/document/${id}/notes`, { headers });
-        const data = await r.json();
-        if (data.status === "success") setNotes(data.notes ?? []);
-      } catch { /* notes are best-effort */ }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, id, userId]);
@@ -305,87 +238,23 @@ const Read: React.FC = () => {
     goTo(content.next);
   };
 
-  const addUser = async () => {
-    const username = newUsername.trim();
-    if (!username) return;
-    const r = await fetch(`${apiUrl}/users`, {
-      method: "POST", headers: { "x-api-key": apiKey ?? "", "Content-Type": "application/json" },
-      body: JSON.stringify({ username }),
-    });
-    const data = await r.json();
-    if (data.status === "success") {
-      setUsers(prev => [...prev, data.user]);
-      selectUser(data.user.id);
-      setNewUsername("");
-    } else {
-      alert(data.message ?? "Nie udało się dodać użytkownika");
-    }
-  };
-
   const onTextSelected = () => {
     if (!userId) return;
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed) return;
-    const quote = normalizeWs(sel.toString());
-    if (quote.length < 3 || quote.length > 2000) return;
-
-    let prefix = "";
-    let suffix = "";
-    const anchorEl = sel.anchorNode instanceof Element ? sel.anchorNode : sel.anchorNode?.parentElement;
-    const para = anchorEl?.closest("p");
-    const paraText = para?.textContent ?? "";
-    const idx = paraText.indexOf(quote);
-    if (idx >= 0) {
-      prefix = paraText.slice(Math.max(0, idx - 50), idx);
-      suffix = paraText.slice(idx + quote.length, idx + quote.length + 50);
-    }
-    const rect = sel.getRangeAt(0).getBoundingClientRect();
-    setPendingNote({ quote, prefix, suffix, x: rect.left + window.scrollX, y: rect.bottom + window.scrollY + 6 });
-    setNoteText("");
-    setNoteStance(null);
+    const pending = pendingNoteFromSelection("p");
+    if (pending) setPendingNote(pending);
   };
 
-  const saveNote = async () => {
-    if (!pendingNote || !noteText.trim()) return;
-    const r = await fetch(`${apiUrl}/document/${id}/notes`, {
-      method: "POST", headers: jsonHeaders,
-      body: JSON.stringify({
-        anchor_quote: pendingNote.quote,
-        anchor_prefix: pendingNote.prefix,
-        anchor_suffix: pendingNote.suffix,
-        chapter_position: position,
-        note_text: noteText.trim(),
-        stance: noteStance,
-      }),
+  const saveNote = async (noteText: string, stance: string | null) => {
+    if (!pendingNote || !noteText) return;
+    const ok = await createNote({
+      anchor_quote: pendingNote.quote,
+      anchor_prefix: pendingNote.prefix,
+      anchor_suffix: pendingNote.suffix,
+      chapter_position: position,
+      note_text: noteText,
+      stance,
     });
-    const data = await r.json();
-    if (data.status === "success") {
-      setNotes(prev => [...prev, data.note]);
-      setPendingNote(null);
-    } else {
-      alert(data.message ?? "Nie udało się zapisać notatki");
-    }
-  };
-
-  const deleteNote = async (noteId: number) => {
-    if (!window.confirm("Usunąć notatkę?")) return;
-    const r = await fetch(`${apiUrl}/note/${noteId}`, { method: "DELETE", headers });
-    const data = await r.json();
-    if (data.status === "success") setNotes(prev => prev.filter(n => n.id !== noteId));
-  };
-
-  const saveEditedNote = async (noteId: number) => {
-    const text = editingText.trim();
-    if (!text) return;
-    const r = await fetch(`${apiUrl}/note/${noteId}`, {
-      method: "PATCH", headers: jsonHeaders,
-      body: JSON.stringify({ note_text: text }),
-    });
-    const data = await r.json();
-    if (data.status === "success") {
-      setNotes(prev => prev.map(n => (n.id === noteId ? data.note : n)));
-      setEditingNoteId(null);
-    }
+    if (ok) setPendingNote(null);
   };
 
   // ── Derived ──
@@ -418,56 +287,19 @@ const Read: React.FC = () => {
     </div>
   );
 
-  const userPicker = (
-    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.85em" }}>
-      <span style={{ color: "#64748b" }}>Czytasz jako:</span>
-      <select value={userId ?? ""} onChange={e => selectUser(e.target.value ? Number(e.target.value) : null)}>
-        <option value="">— wybierz —</option>
-        {users.map(u => (
-          <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
-        ))}
-      </select>
-      <input
-        value={newUsername} onChange={e => setNewUsername(e.target.value)}
-        onKeyDown={e => e.key === "Enter" && addUser()}
-        placeholder="nowy użytkownik…" style={{ width: 130 }}
-      />
-      <button onClick={addUser} disabled={!newUsername.trim()}>＋</button>
-    </div>
-  );
-
-  const renderNoteRow = (n: UserNote, showUnanchored: boolean) => (
-    <div key={n.id} style={{
-      padding: "6px 10px", borderBottom: "1px solid #e2e8f0", fontSize: "0.8em", lineHeight: 1.4,
-    }}>
-      <div style={{ color: "#64748b", cursor: n.chapter_position ? "pointer" : undefined }}
-        onClick={() => n.chapter_position && goTo(n.chapter_position)}>
+  const renderNoteRow = (n: UserNote) => (
+    <NoteRow
+      key={n.id}
+      note={n}
+      header={<>
         {STANCE_ICON[n.stance ?? ""] ?? "📝"} rozdz. {n.chapter_position ?? "?"}
-        {showUnanchored && n.chapter_position === position && !anchoredNoteIds.has(n.id) &&
+        {n.chapter_position === position && !anchoredNoteIds.has(n.id) &&
           <span style={{ color: "#b45309" }}> ⚠ nie odnaleziono w tekście</span>}
-      </div>
-      <div style={{ fontStyle: "italic", color: "#94a3b8", margin: "2px 0" }}>
-        „{n.anchor_quote.length > 90 ? `${n.anchor_quote.slice(0, 90)}…` : n.anchor_quote}"
-      </div>
-      {editingNoteId === n.id ? (
-        <div>
-          <textarea value={editingText} onChange={e => setEditingText(e.target.value)}
-            style={{ width: "100%", minHeight: 50 }} />
-          <button onClick={() => saveEditedNote(n.id)}>Zapisz</button>{" "}
-          <button onClick={() => setEditingNoteId(null)}>Anuluj</button>
-        </div>
-      ) : (
-        <div>
-          {n.note_text}{" "}
-          <span style={{ whiteSpace: "nowrap" }}>
-            <button title="Edytuj" style={{ border: "none", background: "none", cursor: "pointer" }}
-              onClick={() => { setEditingNoteId(n.id); setEditingText(n.note_text); }}>✏</button>
-            <button title="Usuń" style={{ border: "none", background: "none", cursor: "pointer" }}
-              onClick={() => deleteNote(n.id)}>🗑</button>
-          </span>
-        </div>
-      )}
-    </div>
+      </>}
+      onHeaderClick={n.chapter_position ? () => goTo(n.chapter_position) : undefined}
+      onSaveText={saveNoteText}
+      onDelete={deleteNote}
+    />
   );
 
   return (
@@ -476,7 +308,7 @@ const Read: React.FC = () => {
         <h2 style={{ margin: 0 }}>Czytelnik — dokument #{id}</h2>
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
-        <div style={{ marginLeft: "auto" }}>{userPicker}</div>
+        <div style={{ marginLeft: "auto" }}><UserPicker identity={identity} /></div>
       </div>
 
       {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
@@ -526,7 +358,7 @@ const Read: React.FC = () => {
               marginTop: 12, padding: "10px 0",
             }}>
               <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>📝 Moje notatki ({notes.length})</strong>
-              {notes.map(n => renderNoteRow(n, true))}
+              {notes.map(renderNoteRow)}
             </div>
           )}
         </div>
@@ -546,36 +378,7 @@ const Read: React.FC = () => {
 
       {/* Note popover */}
       {pendingNote && (
-        <div style={{
-          position: "absolute", left: pendingNote.x, top: pendingNote.y, zIndex: 50,
-          background: "#fff", border: "1px solid #cbd5e1", borderRadius: 8, padding: 10,
-          boxShadow: "0 4px 12px rgba(0,0,0,0.15)", width: 340,
-        }}>
-          <div style={{ fontSize: "0.75em", color: "#94a3b8", fontStyle: "italic", marginBottom: 6 }}>
-            „{pendingNote.quote.length > 120 ? `${pendingNote.quote.slice(0, 120)}…` : pendingNote.quote}"
-          </div>
-          <textarea
-            autoFocus value={noteText} onChange={e => setNoteText(e.target.value)}
-            placeholder="Twoja notatka — co myślisz o tym fragmencie?"
-            style={{ width: "100%", minHeight: 60, fontSize: "0.85em" }}
-          />
-          <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
-            {(["agree", "disagree", "neutral"] as const).map(s => (
-              <button key={s} onClick={() => setNoteStance(noteStance === s ? null : s)}
-                title={{ agree: "Zgadzam się", disagree: "Nie zgadzam się", neutral: "Neutralnie" }[s]}
-                style={{
-                  border: noteStance === s ? "2px solid #0369a1" : "1px solid #cbd5e1",
-                  borderRadius: 6, background: "#fff", cursor: "pointer", padding: "2px 8px",
-                }}>
-                {STANCE_ICON[s]}
-              </button>
-            ))}
-            <span style={{ marginLeft: "auto" }}>
-              <button onClick={saveNote} disabled={!noteText.trim()} style={{ marginRight: 6 }}>Zapisz</button>
-              <button onClick={() => setPendingNote(null)}>Anuluj</button>
-            </span>
-          </div>
-        </div>
+        <NotePopover pending={pendingNote} onSave={saveNote} onCancel={() => setPendingNote(null)} />
       )}
     </div>
   );

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -5,6 +5,7 @@ import {
   NotePopover, NoteRow, PendingNote, STANCE_ICON, UserNote, UserPicker,
   normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
 } from "../components/ReaderNotes/readerNotes";
+import styles from "./read.module.css";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -127,6 +128,7 @@ const Read: React.FC = () => {
   const [content, setContent] = React.useState<ChapterContent | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [tocOpen, setTocOpen] = React.useState(false);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
   // ── Reading progress ──
@@ -218,6 +220,7 @@ const Read: React.FC = () => {
 
   const goTo = (pos: number | null) => {
     if (pos) setSearchParams({ chapter: String(pos) });
+    setTocOpen(false);
   };
 
   const toggleRead = (pos: number, read: boolean) => {
@@ -306,6 +309,9 @@ const Read: React.FC = () => {
     <div>
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 10, flexWrap: "wrap" }}>
         <h2 style={{ margin: 0 }}>Czytelnik — dokument #{id}</h2>
+        <button className={styles.tocToggleButton} onClick={() => setTocOpen(o => !o)}>
+          📑 Spis treści ({chapters.length})
+        </button>
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         <div style={{ marginLeft: "auto" }}><UserPicker identity={identity} /></div>
@@ -318,13 +324,21 @@ const Read: React.FC = () => {
         </p>
       )}
 
+      <div
+        className={`${styles.scrim} ${tocOpen ? styles.scrimOpen : ""}`}
+        onClick={() => setTocOpen(false)}
+      />
+
       <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
         {/* TOC sidebar + notes */}
-        <div style={{ flex: "0 0 300px", position: "sticky", top: 12, maxHeight: "85vh", overflowY: "auto" }}>
+        <div className={`${styles.tocPanel} ${tocOpen ? styles.tocPanelOpen : ""}`}>
           <nav style={{
             background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
           }}>
-            <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>Spis treści ({chapters.length})</strong>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 14px" }}>
+              <strong style={{ fontSize: "0.85em" }}>Spis treści ({chapters.length})</strong>
+              <button className={styles.tocClose} onClick={() => setTocOpen(false)} aria-label="Zamknij spis treści">✕</button>
+            </div>
             {chapters.map(ch => {
               const isRead = readChapters.includes(ch.position);
               return (

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -22,6 +22,33 @@ interface ChapterContent {
   next: number | null;
 }
 
+interface ReaderUser {
+  id: number;
+  username: string;
+  display_name: string | null;
+}
+
+interface UserNote {
+  id: number;
+  chapter_position: number | null;
+  anchor_quote: string;
+  anchor_prefix: string | null;
+  anchor_suffix: string | null;
+  note_text: string;
+  stance: string | null;
+}
+
+interface PendingNote {
+  quote: string;
+  prefix: string;
+  suffix: string;
+  x: number;
+  y: number;
+}
+
+const USER_STORAGE_KEY = "lenie_userId";
+const STANCE_ICON: Record<string, string> = { agree: "👍", disagree: "👎", neutral: "➖" };
+
 // ── Minimal markdown rendering (headings, paragraphs, hr; images skipped) ────
 
 const IMAGE_LINE = /^!\[[^\]]*\]\([^)]*\)$/;
@@ -36,7 +63,47 @@ function renderInline(text: string): React.ReactNode[] {
   });
 }
 
-function renderMarkdown(text: string): React.ReactNode[] {
+const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
+
+/** Render a paragraph's text with <mark> around anchored note quotes.
+ *  Exact match → inline highlight; whitespace-normalized match → whole
+ *  paragraph tinted (quote spans line breaks or renderer differences). */
+function renderParagraphWithNotes(
+  text: string,
+  notes: UserNote[],
+): { nodes: React.ReactNode[]; paragraphTint: UserNote | null } {
+  const matches = notes
+    .map(n => ({ note: n, idx: text.indexOf(n.anchor_quote) }))
+    .filter(m => m.idx >= 0)
+    .sort((a, b) => a.idx - b.idx);
+
+  if (matches.length === 0) {
+    const tint = notes.find(n => normalizeWs(text).includes(normalizeWs(n.anchor_quote))) ?? null;
+    return { nodes: renderInline(text), paragraphTint: tint };
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  matches.forEach((m, i) => {
+    if (m.idx < cursor) return; // overlapping quote — skip
+    if (m.idx > cursor) nodes.push(...renderInline(text.slice(cursor, m.idx)));
+    const quoted = text.slice(m.idx, m.idx + m.note.anchor_quote.length);
+    nodes.push(
+      <mark
+        key={`note-${m.note.id}-${i}`}
+        title={`${STANCE_ICON[m.note.stance ?? ""] ?? "📝"} ${m.note.note_text}`}
+        style={{ background: "#fef08a", padding: "0 1px", cursor: "help" }}
+      >
+        {renderInline(quoted)}
+      </mark>
+    );
+    cursor = m.idx + m.note.anchor_quote.length;
+  });
+  if (cursor < text.length) nodes.push(...renderInline(text.slice(cursor)));
+  return { nodes, paragraphTint: null };
+}
+
+function renderMarkdown(text: string, notes: UserNote[]): React.ReactNode[] {
   const blocks = text.split(/\n\s*\n/);
   const out: React.ReactNode[] = [];
   blocks.forEach((block, i) => {
@@ -55,11 +122,17 @@ function renderMarkdown(text: string): React.ReactNode[] {
     }
     // footnote / caption lines (superscript digits or "Wykres N.") — smaller font
     const isNote = /^([¹²³⁴⁵⁶⁷⁸⁹⁰]+|\d{1,3} )\S*\s*(http|www|[A-ZŻŹĆĄŚĘŁÓŃ])/.test(trimmed) && trimmed.length < 400;
+    const paraText = trimmed.replace(/\n/g, " ");
+    const { nodes, paragraphTint } = renderParagraphWithNotes(paraText, notes);
     out.push(
       <p key={i} style={isNote
         ? { fontSize: "0.8em", color: "#64748b", margin: "6px 0" }
-        : { lineHeight: 1.65, margin: "14px 0", textAlign: "justify" }}>
-        {renderInline(trimmed.replace(/\n/g, " "))}
+        : {
+            lineHeight: 1.65, margin: "14px 0", textAlign: "justify",
+            ...(paragraphTint ? { background: "#fefce8", borderLeft: "3px solid #eab308", paddingLeft: 8 } : {}),
+          }}
+        title={paragraphTint ? `📝 ${paragraphTint.note_text}` : undefined}>
+        {nodes}
       </p>
     );
   });
@@ -79,8 +152,55 @@ const Read: React.FC = () => {
   const [error, setError] = React.useState<string | null>(null);
   const contentRef = React.useRef<HTMLDivElement>(null);
 
+  // ── User identity ──
+  const [users, setUsers] = React.useState<ReaderUser[]>([]);
+  const [userId, setUserId] = React.useState<number | null>(() => {
+    const v = localStorage.getItem(USER_STORAGE_KEY);
+    return v ? Number(v) : null;
+  });
+  const [newUsername, setNewUsername] = React.useState("");
+
+  // ── Reading progress ──
+  const [readChapters, setReadChapters] = React.useState<number[]>([]);
+  const [progressLoaded, setProgressLoaded] = React.useState(false);
+  const initialRedirectDone = React.useRef(false);
+
+  // ── Notes ──
+  const [notes, setNotes] = React.useState<UserNote[]>([]);
+  const [pendingNote, setPendingNote] = React.useState<PendingNote | null>(null);
+  const [noteText, setNoteText] = React.useState("");
+  const [noteStance, setNoteStance] = React.useState<string | null>(null);
+  const [editingNoteId, setEditingNoteId] = React.useState<number | null>(null);
+  const [editingText, setEditingText] = React.useState("");
+
   const position = Number(searchParams.get("chapter") ?? 1);
-  const headers = React.useMemo(() => ({ "x-api-key": apiKey ?? "" }), [apiKey]);
+  const headers = React.useMemo(() => {
+    const h: Record<string, string> = { "x-api-key": apiKey ?? "" };
+    if (userId) h["x-user-id"] = String(userId);
+    return h;
+  }, [apiKey, userId]);
+  const jsonHeaders = React.useMemo(
+    () => ({ ...headers, "Content-Type": "application/json" }), [headers]);
+
+  const selectUser = (uid: number | null) => {
+    setUserId(uid);
+    setProgressLoaded(false);
+    initialRedirectDone.current = false;
+    if (uid) localStorage.setItem(USER_STORAGE_KEY, String(uid));
+    else localStorage.removeItem(USER_STORAGE_KEY);
+  };
+
+  // ── Data loading ──
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/users`, { headers: { "x-api-key": apiKey ?? "" } });
+        const data = await r.json();
+        if (data.status === "success") setUsers(data.users ?? []);
+      } catch { /* users are optional — reader works without identity */ }
+    })();
+  }, [apiUrl, apiKey]);
 
   React.useEffect(() => {
     (async () => {
@@ -93,12 +213,48 @@ const Read: React.FC = () => {
         setError(String(e));
       }
     })();
-  }, [apiUrl, id, headers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, apiKey]);
+
+  // progress: fetch once per (user, doc); redirect to last position when URL has no ?chapter
+  React.useEffect(() => {
+    if (!userId) { setProgressLoaded(true); setReadChapters([]); return; }
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/document/${id}/reading_progress`, { headers });
+        const data = await r.json();
+        if (data.status === "success") {
+          setReadChapters(data.read_chapters ?? []);
+          if (!initialRedirectDone.current && !searchParams.get("chapter") && data.current_chapter) {
+            setSearchParams({ chapter: String(data.current_chapter) }, { replace: true });
+          }
+        }
+      } catch { /* progress is best-effort */ }
+      initialRedirectDone.current = true;
+      setProgressLoaded(true);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, userId]);
 
   React.useEffect(() => {
+    if (!userId) { setNotes([]); return; }
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/document/${id}/notes`, { headers });
+        const data = await r.json();
+        if (data.status === "success") setNotes(data.notes ?? []);
+      } catch { /* notes are best-effort */ }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, userId]);
+
+  // chapter content — waits for the progress redirect so we don't flash chapter 1
+  React.useEffect(() => {
+    if (!progressLoaded) return;
     (async () => {
       setLoading(true);
       setError(null);
+      setPendingNote(null);
       try {
         const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}`, { headers });
         const data = await r.json();
@@ -112,11 +268,139 @@ const Read: React.FC = () => {
         setLoading(false);
       }
     })();
-  }, [apiUrl, id, position, headers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiUrl, id, position, progressLoaded, apiKey]);
+
+  // persist current chapter as reading position
+  React.useEffect(() => {
+    if (!userId || !content || !progressLoaded) return;
+    fetch(`${apiUrl}/document/${id}/reading_progress`, {
+      method: "PUT", headers: jsonHeaders,
+      body: JSON.stringify({ current_chapter: content.position, current_chapter_title: content.title }),
+    }).catch(() => undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content?.position, userId]);
+
+  // ── Actions ──
 
   const goTo = (pos: number | null) => {
     if (pos) setSearchParams({ chapter: String(pos) });
   };
+
+  const toggleRead = (pos: number, read: boolean) => {
+    if (!userId) return;
+    setReadChapters(prev => read ? [...prev, pos].sort((a, b) => a - b) : prev.filter(p => p !== pos));
+    fetch(`${apiUrl}/document/${id}/reading_progress`, {
+      method: "PUT", headers: jsonHeaders,
+      body: JSON.stringify({
+        current_chapter: position,
+        [read ? "mark_read" : "unmark_read"]: [pos],
+      }),
+    }).catch(() => undefined);
+  };
+
+  const goNext = () => {
+    if (!content?.next) return;
+    if (userId && !readChapters.includes(content.position)) toggleRead(content.position, true);
+    goTo(content.next);
+  };
+
+  const addUser = async () => {
+    const username = newUsername.trim();
+    if (!username) return;
+    const r = await fetch(`${apiUrl}/users`, {
+      method: "POST", headers: { "x-api-key": apiKey ?? "", "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setUsers(prev => [...prev, data.user]);
+      selectUser(data.user.id);
+      setNewUsername("");
+    } else {
+      alert(data.message ?? "Nie udało się dodać użytkownika");
+    }
+  };
+
+  const onTextSelected = () => {
+    if (!userId) return;
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed) return;
+    const quote = normalizeWs(sel.toString());
+    if (quote.length < 3 || quote.length > 2000) return;
+
+    let prefix = "";
+    let suffix = "";
+    const anchorEl = sel.anchorNode instanceof Element ? sel.anchorNode : sel.anchorNode?.parentElement;
+    const para = anchorEl?.closest("p");
+    const paraText = para?.textContent ?? "";
+    const idx = paraText.indexOf(quote);
+    if (idx >= 0) {
+      prefix = paraText.slice(Math.max(0, idx - 50), idx);
+      suffix = paraText.slice(idx + quote.length, idx + quote.length + 50);
+    }
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    setPendingNote({ quote, prefix, suffix, x: rect.left + window.scrollX, y: rect.bottom + window.scrollY + 6 });
+    setNoteText("");
+    setNoteStance(null);
+  };
+
+  const saveNote = async () => {
+    if (!pendingNote || !noteText.trim()) return;
+    const r = await fetch(`${apiUrl}/document/${id}/notes`, {
+      method: "POST", headers: jsonHeaders,
+      body: JSON.stringify({
+        anchor_quote: pendingNote.quote,
+        anchor_prefix: pendingNote.prefix,
+        anchor_suffix: pendingNote.suffix,
+        chapter_position: position,
+        note_text: noteText.trim(),
+        stance: noteStance,
+      }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => [...prev, data.note]);
+      setPendingNote(null);
+    } else {
+      alert(data.message ?? "Nie udało się zapisać notatki");
+    }
+  };
+
+  const deleteNote = async (noteId: number) => {
+    if (!window.confirm("Usunąć notatkę?")) return;
+    const r = await fetch(`${apiUrl}/note/${noteId}`, { method: "DELETE", headers });
+    const data = await r.json();
+    if (data.status === "success") setNotes(prev => prev.filter(n => n.id !== noteId));
+  };
+
+  const saveEditedNote = async (noteId: number) => {
+    const text = editingText.trim();
+    if (!text) return;
+    const r = await fetch(`${apiUrl}/note/${noteId}`, {
+      method: "PATCH", headers: jsonHeaders,
+      body: JSON.stringify({ note_text: text }),
+    });
+    const data = await r.json();
+    if (data.status === "success") {
+      setNotes(prev => prev.map(n => (n.id === noteId ? data.note : n)));
+      setEditingNoteId(null);
+    }
+  };
+
+  // ── Derived ──
+
+  const chapterNotes = React.useMemo(
+    () => notes.filter(n => n.chapter_position === position), [notes, position]);
+
+  const anchoredNoteIds = React.useMemo(() => {
+    if (!content) return new Set<number>();
+    const normText = normalizeWs(content.text);
+    return new Set(
+      chapterNotes.filter(n => normText.includes(normalizeWs(n.anchor_quote))).map(n => n.id));
+  }, [content, chapterNotes]);
+
+  // ── Render ──
 
   const navButtons = content && (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 12, margin: "18px 0" }}>
@@ -127,10 +411,62 @@ const Read: React.FC = () => {
       <span style={{ fontSize: "0.85em", color: "#64748b", alignSelf: "center" }}>
         {content.position} / {content.chapter_total}
       </span>
-      <button onClick={() => goTo(content.next)} disabled={!content.next}
+      <button onClick={goNext} disabled={!content.next}
         style={{ padding: "6px 14px", cursor: content.next ? "pointer" : "default" }}>
         Następny →
       </button>
+    </div>
+  );
+
+  const userPicker = (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.85em" }}>
+      <span style={{ color: "#64748b" }}>Czytasz jako:</span>
+      <select value={userId ?? ""} onChange={e => selectUser(e.target.value ? Number(e.target.value) : null)}>
+        <option value="">— wybierz —</option>
+        {users.map(u => (
+          <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
+        ))}
+      </select>
+      <input
+        value={newUsername} onChange={e => setNewUsername(e.target.value)}
+        onKeyDown={e => e.key === "Enter" && addUser()}
+        placeholder="nowy użytkownik…" style={{ width: 130 }}
+      />
+      <button onClick={addUser} disabled={!newUsername.trim()}>＋</button>
+    </div>
+  );
+
+  const renderNoteRow = (n: UserNote, showUnanchored: boolean) => (
+    <div key={n.id} style={{
+      padding: "6px 10px", borderBottom: "1px solid #e2e8f0", fontSize: "0.8em", lineHeight: 1.4,
+    }}>
+      <div style={{ color: "#64748b", cursor: n.chapter_position ? "pointer" : undefined }}
+        onClick={() => n.chapter_position && goTo(n.chapter_position)}>
+        {STANCE_ICON[n.stance ?? ""] ?? "📝"} rozdz. {n.chapter_position ?? "?"}
+        {showUnanchored && n.chapter_position === position && !anchoredNoteIds.has(n.id) &&
+          <span style={{ color: "#b45309" }}> ⚠ nie odnaleziono w tekście</span>}
+      </div>
+      <div style={{ fontStyle: "italic", color: "#94a3b8", margin: "2px 0" }}>
+        „{n.anchor_quote.length > 90 ? `${n.anchor_quote.slice(0, 90)}…` : n.anchor_quote}"
+      </div>
+      {editingNoteId === n.id ? (
+        <div>
+          <textarea value={editingText} onChange={e => setEditingText(e.target.value)}
+            style={{ width: "100%", minHeight: 50 }} />
+          <button onClick={() => saveEditedNote(n.id)}>Zapisz</button>{" "}
+          <button onClick={() => setEditingNoteId(null)}>Anuluj</button>
+        </div>
+      ) : (
+        <div>
+          {n.note_text}{" "}
+          <span style={{ whiteSpace: "nowrap" }}>
+            <button title="Edytuj" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => { setEditingNoteId(n.id); setEditingText(n.note_text); }}>✏</button>
+            <button title="Usuń" style={{ border: "none", background: "none", cursor: "pointer" }}
+              onClick={() => deleteNote(n.id)}>🗑</button>
+          </span>
+        </div>
+      )}
     </div>
   );
 
@@ -140,40 +476,107 @@ const Read: React.FC = () => {
         <h2 style={{ margin: 0 }}>Czytelnik — dokument #{id}</h2>
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
+        <div style={{ marginLeft: "auto" }}>{userPicker}</div>
       </div>
 
       {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
+      {!userId && (
+        <p style={{ fontSize: "0.85em", color: "#64748b", margin: "4px 0 10px" }}>
+          Wybierz użytkownika, aby zapisywać postęp czytania i dodawać notatki do fragmentów.
+        </p>
+      )}
 
       <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
-        {/* TOC sidebar */}
-        <nav style={{
-          flex: "0 0 280px", position: "sticky", top: 12, maxHeight: "85vh", overflowY: "auto",
-          background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
-        }}>
-          <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>Spis treści ({chapters.length})</strong>
-          {chapters.map(ch => (
-            <div key={ch.position}
-              onClick={() => goTo(ch.position)}
-              style={{
-                padding: "5px 14px", fontSize: "0.83em", cursor: "pointer", lineHeight: 1.3,
-                background: ch.position === position ? "#e0f2fe" : undefined,
-                fontWeight: ch.position === position ? 600 : undefined,
-              }}>
-              {ch.position}. {ch.title}
+        {/* TOC sidebar + notes */}
+        <div style={{ flex: "0 0 300px", position: "sticky", top: 12, maxHeight: "85vh", overflowY: "auto" }}>
+          <nav style={{
+            background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
+          }}>
+            <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>Spis treści ({chapters.length})</strong>
+            {chapters.map(ch => {
+              const isRead = readChapters.includes(ch.position);
+              return (
+                <div key={ch.position}
+                  style={{
+                    display: "flex", alignItems: "baseline", gap: 6,
+                    padding: "5px 8px 5px 14px", fontSize: "0.83em", lineHeight: 1.3,
+                    background: ch.position === position ? "#e0f2fe" : undefined,
+                    fontWeight: ch.position === position ? 600 : undefined,
+                  }}>
+                  <span onClick={() => goTo(ch.position)}
+                    style={{ cursor: "pointer", flex: 1, color: isRead ? "#94a3b8" : undefined }}>
+                    {ch.position === position ? "▶ " : ""}{ch.position}. {ch.title}
+                  </span>
+                  {userId && (
+                    <span
+                      title={isRead ? "Oznacz jako nieprzeczytany" : "Oznacz jako przeczytany"}
+                      onClick={() => toggleRead(ch.position, !isRead)}
+                      style={{ cursor: "pointer", color: isRead ? "#16a34a" : "#cbd5e1" }}>
+                      ✓
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </nav>
+
+          {userId && notes.length > 0 && (
+            <div style={{
+              background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+              marginTop: 12, padding: "10px 0",
+            }}>
+              <strong style={{ fontSize: "0.85em", padding: "0 14px" }}>📝 Moje notatki ({notes.length})</strong>
+              {notes.map(n => renderNoteRow(n, true))}
             </div>
-          ))}
-        </nav>
+          )}
+        </div>
 
         {/* Chapter content */}
         <div ref={contentRef} style={{ flex: 1, maxWidth: 760 }}>
           {navButtons}
           {loading && <p style={{ color: "#64748b" }}>Ładowanie…</p>}
           {!loading && content && (
-            <article style={{ fontSize: "1.02em" }}>{renderMarkdown(content.text)}</article>
+            <article style={{ fontSize: "1.02em" }} onMouseUp={onTextSelected}>
+              {renderMarkdown(content.text, chapterNotes)}
+            </article>
           )}
           {navButtons}
         </div>
       </div>
+
+      {/* Note popover */}
+      {pendingNote && (
+        <div style={{
+          position: "absolute", left: pendingNote.x, top: pendingNote.y, zIndex: 50,
+          background: "#fff", border: "1px solid #cbd5e1", borderRadius: 8, padding: 10,
+          boxShadow: "0 4px 12px rgba(0,0,0,0.15)", width: 340,
+        }}>
+          <div style={{ fontSize: "0.75em", color: "#94a3b8", fontStyle: "italic", marginBottom: 6 }}>
+            „{pendingNote.quote.length > 120 ? `${pendingNote.quote.slice(0, 120)}…` : pendingNote.quote}"
+          </div>
+          <textarea
+            autoFocus value={noteText} onChange={e => setNoteText(e.target.value)}
+            placeholder="Twoja notatka — co myślisz o tym fragmencie?"
+            style={{ width: "100%", minHeight: 60, fontSize: "0.85em" }}
+          />
+          <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
+            {(["agree", "disagree", "neutral"] as const).map(s => (
+              <button key={s} onClick={() => setNoteStance(noteStance === s ? null : s)}
+                title={{ agree: "Zgadzam się", disagree: "Nie zgadzam się", neutral: "Neutralnie" }[s]}
+                style={{
+                  border: noteStance === s ? "2px solid #0369a1" : "1px solid #cbd5e1",
+                  borderRadius: 6, background: "#fff", cursor: "pointer", padding: "2px 8px",
+                }}>
+                {STANCE_ICON[s]}
+              </button>
+            ))}
+            <span style={{ marginLeft: "auto" }}>
+              <button onClick={saveNote} disabled={!noteText.trim()} style={{ marginRight: 6 }}>Zapisz</button>
+              <button onClick={() => setPendingNote(null)}>Anuluj</button>
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Per-user reading progress + quote-anchored fragment notes for the book reader (`/read/:id`)
- Fragment notes in chunk review, sharing the `ReaderNotes` module with the reader
- API keys: service accounts + per-user keys with in-process TTL cache (legacy shared key still accepted during migration)
- Reader UX polish: chapter TOC collapses into a slide-over drawer below 768px, "Czytaj" link added to the document list, connection-status bar hidden on `/read/:id`

## Test plan
- [x] `tsc --noEmit` passes (web_interface_react)
- [x] Backend unit tests for API keys and reader routes (`test_auth_api_keys.py`, `test_reader_routes.py`)
- [x] Manually tested reader (progress, notes, mobile TOC drawer) and chunk fragment notes on NAS deployment
- [ ] Backend (API keys) not yet deployed to NAS — frontend iteration 2 for API keys still pending; only frontend has been deployed so far

🤖 Generated with [Claude Code](https://claude.com/claude-code)