### PR TITLE
feat(reader): resolve reader identity from API key via /whoami (Etap 8, iter. 2)

### DIFF
--- a/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
+++ b/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
@@ -35,20 +35,31 @@ export interface PendingNote {
   y: number;
 }
 
-export const USER_STORAGE_KEY = "lenie_userId";
+// Legacy localStorage key from the pre-Etap-8 user picker; identity now comes
+// exclusively from the API key, so any leftover value is stale and ignored.
+const LEGACY_USER_STORAGE_KEY = "lenie_userId";
+
 export const STANCE_ICON: Record<string, string> = { agree: "👍", disagree: "👎", neutral: "➖" };
 
 export const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
 
 // ── Identity ─────────────────────────────────────────────────────────────────
+// Etap 8: reader identity is resolved from GET /whoami (which reflects the
+// presented API key). A "user" key carries the reader's identity outright —
+// no selector, no x-user-id header. A "service"/legacy key has no reader
+// identity at all: the reading-progress/notes endpoints 403 for it, so the
+// pages must not call them (gated by `userId === null` below).
+
+export type ReaderKind = "user" | "service" | null;
 
 export interface ReaderIdentity {
-  users: ReaderUser[];
+  kind: ReaderKind;
+  keyName: string | null;
+  isLegacy: boolean;
+  user: ReaderUser | null;
   userId: number | null;
-  selectUser: (uid: number | null) => void;
-  newUsername: string;
-  setNewUsername: (v: string) => void;
-  addUser: () => Promise<void>;
+  loading: boolean;
+  error: string | null;
   headers: Record<string, string>;
   jsonHeaders: Record<string, string>;
 }
@@ -58,78 +69,78 @@ export function useReaderIdentity(
   apiKey: string | undefined,
   onUserChange?: (uid: number | null) => void,
 ): ReaderIdentity {
-  const [users, setUsers] = React.useState<ReaderUser[]>([]);
-  const [userId, setUserId] = React.useState<number | null>(() => {
-    const v = localStorage.getItem(USER_STORAGE_KEY);
-    return v ? Number(v) : null;
-  });
-  const [newUsername, setNewUsername] = React.useState("");
+  const [kind, setKind] = React.useState<ReaderKind>(null);
+  const [keyName, setKeyName] = React.useState<string | null>(null);
+  const [isLegacy, setIsLegacy] = React.useState(false);
+  const [user, setUser] = React.useState<ReaderUser | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
 
-  const headers = React.useMemo(() => {
-    const h: Record<string, string> = { "x-api-key": apiKey ?? "" };
-    if (userId) h["x-user-id"] = String(userId);
-    return h;
-  }, [apiKey, userId]);
+  const headers = React.useMemo(() => ({ "x-api-key": apiKey ?? "" }), [apiKey]);
   const jsonHeaders = React.useMemo(
     () => ({ ...headers, "Content-Type": "application/json" }), [headers]);
 
   React.useEffect(() => {
+    localStorage.removeItem(LEGACY_USER_STORAGE_KEY);
+  }, []);
+
+  React.useEffect(() => {
+    if (!apiKey) { setLoading(false); return; }
+    setLoading(true);
+    setError(null);
     (async () => {
       try {
-        const r = await fetch(`${apiUrl}/users`, { headers: { "x-api-key": apiKey ?? "" } });
+        const r = await fetch(`${apiUrl}/whoami`, { headers: { "x-api-key": apiKey } });
         const data = await r.json();
-        if (data.status === "success") setUsers(data.users ?? []);
-      } catch { /* users are optional — pages work without identity */ }
+        if (data.status !== "success") throw new Error(data.message ?? "Nie udało się ustalić tożsamości");
+        setKind(data.kind ?? null);
+        setKeyName(data.key_name ?? null);
+        setIsLegacy(Boolean(data.is_legacy));
+        setUser(data.user ?? null);
+      } catch (e) {
+        setKind(null);
+        setUser(null);
+        setError(String(e));
+      } finally {
+        setLoading(false);
+      }
     })();
   }, [apiUrl, apiKey]);
 
-  const selectUser = (uid: number | null) => {
-    setUserId(uid);
-    if (uid) localStorage.setItem(USER_STORAGE_KEY, String(uid));
-    else localStorage.removeItem(USER_STORAGE_KEY);
-    onUserChange?.(uid);
-  };
+  const userId = kind === "user" ? (user?.id ?? null) : null;
 
-  const addUser = async () => {
-    const username = newUsername.trim();
-    if (!username) return;
-    const r = await fetch(`${apiUrl}/users`, {
-      method: "POST", headers: { "x-api-key": apiKey ?? "", "Content-Type": "application/json" },
-      body: JSON.stringify({ username }),
-    });
-    const data = await r.json();
-    if (data.status === "success") {
-      setUsers(prev => [...prev, data.user]);
-      selectUser(data.user.id);
-      setNewUsername("");
-    } else {
-      alert(data.message ?? "Nie udało się dodać użytkownika");
+  const prevUserId = React.useRef<number | null>(null);
+  React.useEffect(() => {
+    if (prevUserId.current !== userId) {
+      prevUserId.current = userId;
+      onUserChange?.(userId);
     }
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
 
-  return { users, userId, selectUser, newUsername, setNewUsername, addUser, headers, jsonHeaders };
+  return { kind, keyName, isLegacy, user, userId, loading, error, headers, jsonHeaders };
 }
 
-export const UserPicker: React.FC<{ identity: ReaderIdentity; label?: string }> = ({
-  identity, label = "Czytasz jako:",
-}) => {
-  const { users, userId, selectUser, newUsername, setNewUsername, addUser } = identity;
+/** Read-only reader-identity indicator — replaces the old user-picker/add-user
+ *  UI (Etap 8, iter. 2): identity comes from the key, there is nothing to
+ *  choose. For non-user keys it explains why progress/notes are absent. */
+export const ReaderIdentityBadge: React.FC<{ identity: ReaderIdentity }> = ({ identity }) => {
+  const { kind, user, loading, error } = identity;
+  if (loading) return null;
+  if (error) {
+    return <span style={{ fontSize: "0.8em", color: "#b91c1c" }}>Błąd tożsamości klucza API: {error}</span>;
+  }
+  if (kind === "user") {
+    return (
+      <span style={{ fontSize: "0.85em", color: "#64748b" }}>
+        Czytasz jako: <strong>{user?.display_name || user?.username}</strong>
+      </span>
+    );
+  }
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.85em" }}>
-      <span style={{ color: "#64748b" }}>{label}</span>
-      <select value={userId ?? ""} onChange={e => selectUser(e.target.value ? Number(e.target.value) : null)}>
-        <option value="">— wybierz —</option>
-        {users.map(u => (
-          <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
-        ))}
-      </select>
-      <input
-        value={newUsername} onChange={e => setNewUsername(e.target.value)}
-        onKeyDown={e => e.key === "Enter" && addUser()}
-        placeholder="nowy użytkownik…" style={{ width: 130 }}
-      />
-      <button onClick={addUser} disabled={!newUsername.trim()}>＋</button>
-    </div>
+    <span style={{ fontSize: "0.8em", color: "#94a3b8" }}>
+      Ten klucz API nie ma tożsamości czytelnika — postęp czytania i notatki są niedostępne
+    </span>
   );
 };
 

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useParams, useLocation, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
 import {
-  NotePopover, NoteRow, PendingNote, STANCE_ICON, UserNote, UserPicker,
+  NotePopover, NoteRow, PendingNote, ReaderIdentityBadge, STANCE_ICON, UserNote,
   normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
 } from "../components/ReaderNotes/readerNotes";
 
@@ -1271,7 +1271,7 @@ const Chunks = () => {
           <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         )}
         <NavLink to={`/read/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>📖 Czytaj</NavLink>
-        <div style={{ marginLeft: "auto" }}><UserPicker identity={identity} /></div>
+        <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
       </div>
 
       {/* Nowa analiza */}

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useParams, useSearchParams, NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
 import {
-  NotePopover, NoteRow, PendingNote, STANCE_ICON, UserNote, UserPicker,
+  NotePopover, NoteRow, PendingNote, ReaderIdentityBadge, STANCE_ICON, UserNote,
   normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
 } from "../components/ReaderNotes/readerNotes";
 import styles from "./read.module.css";
@@ -314,15 +314,10 @@ const Read: React.FC = () => {
         </button>
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
-        <div style={{ marginLeft: "auto" }}><UserPicker identity={identity} /></div>
+        <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
       </div>
 
       {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
-      {!userId && (
-        <p style={{ fontSize: "0.85em", color: "#64748b", margin: "4px 0 10px" }}>
-          Wybierz użytkownika, aby zapisywać postęp czytania i dodawać notatki do fragmentów.
-        </p>
-      )}
 
       <div
         className={`${styles.scrim} ${tocOpen ? styles.scrimOpen : ""}`}


### PR DESCRIPTION
## Summary
- `useReaderIdentity` now resolves reader identity from `GET /whoami` instead of a local user picker: a `user`-kind API key carries the identity outright (no `x-user-id` header sent), a `service`/legacy key has none.
- Reading-progress and notes calls are gated on the resolved `userId`, so `service`/legacy keys never hit those endpoints (they'd get a 403 per Decyzja #2 in `plan-etap8-api-keys.md`).
- Replaced `UserPicker` (select + add-user UI) with a read-only `ReaderIdentityBadge` in `read.tsx` and `chunks.tsx`: shows "Czytasz jako: {name}" for user keys, or an explanatory message for service/legacy keys. Fully removed per user decision — no picker/add-user UI is kept for service/legacy keys, since progress/notes are unreachable for them regardless of any selection.
- Dropped the now-unused `lenie_userId` localStorage key (actively cleared on mount for stale values).

## Test plan
- [x] `tsc --noEmit` passes.
- [x] Manual verification in the browser against a local backend (Etap 8 branch) with two freshly created test keys (`kind=user`, `kind=service`):
  - `user` key: `/whoami` resolves identity, reader redirects to the last-read chapter, TOC checkmarks/notes section appear, adding a fragment note via text selection works end-to-end.
  - `service` key: no picker, no progress/notes UI; network log confirms `/reading_progress` and `/notes` are never called (no 403s).
- Note: this required applying the Etap 8 `api_keys` Alembic migration to the NAS dev DB (previously only local) to be able to test — purely additive, does not affect the currently deployed NAS backend/frontend which never query that table.

## Deploy note
Per the project plan, backend (Etap 8 iter. 1, already on `main`) and this frontend iteration must be deployed to the NAS together — the current NAS frontend still sends `x-user-id` + a legacy key, which would 403 against the new backend without this change.