### PR TITLE
feat(frontend): add Settings link to sidebar, prefill /connect from context

### DIFF
--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -90,6 +90,13 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
         >
           Upload File (Alfa)
         </NavLink>
+        <NavLink
+          to="/connect"
+          className={classes.link}
+          style={{ marginTop: 20, borderTop: "1px solid rgb(179, 179, 179)", paddingTop: 17 }}
+        >
+          Settings
+        </NavLink>
       </div>
     </aside>
   );

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -9,11 +9,11 @@ import { lenie_version } from "../constants/variables";
 
 const Connect: React.FC = () => {
   const navigate = useNavigate();
-  const { setApiKey, setApiUrl, setApiType } =
+  const { apiType, apiUrl, setApiKey, setApiUrl, setApiType } =
     React.useContext(AuthorizationContext);
 
-  const [formApiType, setFormApiType] = useState<ApiType>("Docker");
-  const [formApiUrl, setFormApiUrl] = useState(DEFAULT_API_URLS["Docker"]);
+  const [formApiType, setFormApiType] = useState<ApiType>(apiType);
+  const [formApiUrl, setFormApiUrl] = useState(apiUrl || DEFAULT_API_URLS[apiType]);
   const [formApiKey, setFormApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);


### PR DESCRIPTION
## Summary
- Added a persistent "Settings" link to the sidebar nav (`Layout.tsx`), pointing to `/connect`. The existing Backend Connection bar (with its own Settings button) is hidden on `/read/:id` for mobile reading UX, which left no way to reach the key/URL settings from a book page — e.g. on a phone, there was no way to change the API key at all while reading.
- `connect.tsx` now prefills the form's API type/URL from the current `AuthorizationContext` instead of always resetting to the Docker/localhost default. Previously, opening `/connect` just to change the key would silently reset a custom URL (e.g. the NAS address) back to `http://localhost:5000`.

## Test plan
- [x] `tsc --noEmit` passes.
- [x] Manual verification in the browser: sidebar shows "Settings" below a divider, navigates to `/connect`; after connecting to a custom URL (NAS), reopening Settings from the sidebar shows that URL prefilled instead of the default.