### PR TITLE
feat(auth): retire legacy STALKER_API_KEY fallback (Etap 8, iter. 4)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -49,7 +49,7 @@ Flask + Flask-CORS application exposing 20 REST API endpoints. **Version**: 0.3.
 | **Auth & identity** | `/whoami`, `/api_keys` (GET/POST), `/api_keys/<id>` (DELETE) — see `library/api_key_routes.py` |
 | **Health & Info** | `/` (root), `/healthz`, `/startup`, `/readiness`, `/liveness`, `/version`, `/metrics` |
 
-All routes (except health checks) require an `x-api-key` header. Keys live in the `api_keys` table (`library/auth.py`: SHA-256 hash lookup with an in-process TTL cache; `kind=user` keys carry the reader identity used by `reader_routes.py`, `kind=service` keys have full access but get 403 on reader endpoints). The legacy shared `STALKER_API_KEY` env var is still accepted as a service key during client migration. Keys are managed via `imports/api_key_admin.py` (CLI) or the `/api_keys` endpoints (service keys only); the plaintext (`lk_usr_*`/`lk_svc_*`) is shown once at creation.
+All routes (except health checks) require an `x-api-key` header. Keys live in the `api_keys` table (`library/auth.py`: SHA-256 hash lookup with an in-process TTL cache; `kind=user` keys carry the reader identity used by `reader_routes.py`, `kind=service` keys have full access but get 403 on reader endpoints). There is no shared/legacy key fallback — every client (frontend, Chrome extension, slack-bot) authenticates with its own key. Keys are managed via `imports/api_key_admin.py` (CLI) or the `/api_keys` endpoints (service keys only); the plaintext (`lk_usr_*`/`lk_svc_*`) is shown once at creation.
 
 ### Storage
 

--- a/backend/library/auth.py
+++ b/backend/library/auth.py
@@ -4,8 +4,9 @@ Keys live in the api_keys table (only SHA-256 hashes; plaintext is shown once
 at creation). Two kinds:
   - service — full access, no reader identity (reader endpoints reject it),
   - user    — full access + carries the reader identity (users.id).
-The legacy shared STALKER_API_KEY is still accepted as a service key during
-the client-migration period (is_legacy=True in the resolved context).
+The legacy shared STALKER_API_KEY fallback was retired in Etap 8 iter. 4 —
+every client now authenticates with its own key row. AuthContext.is_legacy
+is kept (always False) for API/response-shape stability.
 
 The per-request hash→context lookup MUST NOT hit the database: results
 (including unknown keys — negative entries) are cached in the process. The
@@ -165,13 +166,12 @@ def deactivate_api_key(session, key_id: int) -> ApiKey:
     return row
 
 
-def resolve_api_key(session_factory, raw_key: str, legacy_key: str | None = None) -> AuthContext | None:
+def resolve_api_key(session_factory, raw_key: str) -> AuthContext | None:
     """Resolve a raw x-api-key value to an AuthContext (None = invalid key).
 
     session_factory is a zero-arg callable (e.g. get_scoped_session) invoked
-    ONLY when the database is actually needed: cache hits and the legacy-key
-    compare resolve without opening a session, so legacy clients keep working
-    even if the api_keys table (or the whole DB) is unreachable.
+    ONLY when the database is actually needed — cache hits resolve without
+    opening a session.
     """
     key_hash = hash_api_key(raw_key)
     entry = _cache.get(key_hash)
@@ -179,11 +179,6 @@ def resolve_api_key(session_factory, raw_key: str, legacy_key: str | None = None
         if entry.context is not None:
             _touch_last_used(session_factory, entry.context)
         return entry.context
-
-    if legacy_key and raw_key == legacy_key:
-        context = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
-        _cache.set(key_hash, CacheEntry(context, time.monotonic() + POSITIVE_TTL_SECONDS))
-        return context
 
     row = session_factory().execute(
         select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.active.is_(True))

--- a/backend/library/reader_routes.py
+++ b/backend/library/reader_routes.py
@@ -2,7 +2,7 @@
 
 Endpoints (all require x-api-key via the global before_request; the ones
 marked [user] additionally require a USER API key — the reader identity comes
-from the key itself (Etap 8); service/legacy keys get 403):
+from the key itself (Etap 8); service keys get 403):
   GET    /users                                — list users
   POST   /users                                — create user {username, display_name?}
   GET    /document/<doc_id>/reading_progress   — [user] progress for this document
@@ -36,17 +36,12 @@ ALLOWED_STANCES = {"agree", "disagree", "neutral"}
 def _require_user(session) -> User:
     """Resolve the reader identity from the API key (flask.g.auth) or abort.
 
-    Service/legacy keys carry no reader identity → 403. An x-user-id header,
-    if still sent by an old client, must match the key's identity — a mismatch
-    means a misconfigured client, not a way to impersonate another user."""
+    Service keys carry no reader identity → 403."""
     auth = getattr(g, "auth", None)
     if auth is None:
         abort(401, "request is not authenticated")
     if auth.kind != "user":
         abort(403, "reader endpoints require a user API key (service keys carry no reader identity)")
-    raw = request.headers.get("x-user-id")
-    if raw is not None and raw.strip() and raw.strip() != str(auth.user_id):
-        abort(403, "x-user-id header does not match the API key identity")
     user = session.get(User, auth.user_id)
     if user is None:
         abort(403, f"User {auth.user_id} for this API key no longer exists")

--- a/backend/server.py
+++ b/backend/server.py
@@ -67,12 +67,11 @@ port = cfg.require("PORT")
 
 def check_auth_header():
     """Resolve the 'x-api-key' header to an AuthContext (api_keys table with
-    in-process cache; legacy STALKER_API_KEY accepted as a service key during
-    client migration) and store it in flask.g.auth."""
+    in-process cache) and store it in flask.g.auth."""
     api_key = request.headers.get('x-api-key')
     if api_key is None:
         abort(401, 'x-api-key header is missing')
-    auth = resolve_api_key(get_scoped_session, api_key, legacy_key=cfg.require("STALKER_API_KEY"))
+    auth = resolve_api_key(get_scoped_session, api_key)
     if auth is None:
         abort(401, 'x-api-key header is wrong')
     g.auth = auth

--- a/backend/tests/unit/test_alembic_setup.py
+++ b/backend/tests/unit/test_alembic_setup.py
@@ -232,7 +232,6 @@ class TestFlaskTeardown:
         "BACKEND_TYPE": "postgresql",
         "EMBEDDING_MODEL": "text-embedding-ada-002",
         "PORT": "5000",
-        "STALKER_API_KEY": "test-api-key",
         "SECRETS_BACKEND": "env",
     })
     @patch("library.stalker_web_documents_db_postgresql.WebsitesDBPostgreSQL")
@@ -266,7 +265,6 @@ class TestFlaskTeardown:
         "BACKEND_TYPE": "postgresql",
         "EMBEDDING_MODEL": "text-embedding-ada-002",
         "PORT": "5000",
-        "STALKER_API_KEY": "test-api-key",
         "SECRETS_BACKEND": "env",
     })
     @patch("library.stalker_web_documents_db_postgresql.WebsitesDBPostgreSQL")

--- a/backend/tests/unit/test_auth_api_keys.py
+++ b/backend/tests/unit/test_auth_api_keys.py
@@ -1,7 +1,7 @@
 """Unit tests for Etap 8: API keys (library/auth.py + library/api_key_routes.py).
 
 Covers key generation/hashing, the in-process cache (TTL, negative entries,
-invalidation), resolve_api_key (user/service/legacy/unknown/inactive, no DB
+invalidation), resolve_api_key (user/service/unknown/inactive, no DB
 on cache hits, last_used_at throttling) and the /whoami + /api_keys endpoints
 (service-only management) — all with mocked sessions, no DB.
 """
@@ -31,8 +31,6 @@ from library.db.models import ApiKey, User  # noqa: E402
 
 READER_USER = User(username="krzysztof", display_name="Krzysztof")
 READER_USER.id = 1
-
-LEGACY_KEY = "legacy-shared-secret"
 
 
 def _make_key_row(**overrides) -> ApiKey:
@@ -122,7 +120,7 @@ class TestResolveApiKey:
 
     def test_user_key_resolved(self):
         session = self._session_returning(_make_key_row())
-        ctx = resolve_api_key(lambda: session, "raw-key", legacy_key=LEGACY_KEY)
+        ctx = resolve_api_key(lambda: session, "raw-key")
         assert ctx == AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=1)
 
     def test_service_key_resolved(self):
@@ -132,15 +130,8 @@ class TestResolveApiKey:
         assert ctx.user_id is None
         assert not ctx.is_legacy
 
-    def test_legacy_fallback(self):
-        ctx = resolve_api_key(lambda: self._session_returning(None), LEGACY_KEY, legacy_key=LEGACY_KEY)
-        assert ctx == AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
-
     def test_unknown_key_returns_none(self):
-        assert resolve_api_key(lambda: self._session_returning(None), "bad", legacy_key=LEGACY_KEY) is None
-
-    def test_no_legacy_configured(self):
-        assert resolve_api_key(lambda: self._session_returning(None), "anything") is None
+        assert resolve_api_key(lambda: self._session_returning(None), "bad") is None
 
     def test_cache_hit_skips_db(self):
         session = self._session_returning(_make_key_row())
@@ -171,13 +162,6 @@ class TestResolveApiKey:
         session.commit.assert_called_once()
         resolve_api_key(lambda: session, "raw-key")
         assert session.execute.call_count == 2
-
-    def test_legacy_key_never_touches_db(self):
-        factory = MagicMock()
-        resolve_api_key(factory, LEGACY_KEY, legacy_key=LEGACY_KEY)
-        # legacy is a plain string compare BEFORE the DB lookup — the session
-        # factory must not even be invoked
-        factory.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +236,6 @@ class TestDeactivateApiKey:
 
 USER_AUTH = AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=1)
 SERVICE_AUTH = AuthContext(kind="service", key_id=11, key_name="chrome-extension", user_id=None)
-LEGACY_AUTH = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
 
 
 @pytest.fixture
@@ -296,11 +279,6 @@ class TestWhoami:
         data = client.get("/whoami").get_json()
         assert data["kind"] == "service"
         assert data["user"] is None
-
-    def test_legacy_key(self, client, auth_holder):
-        auth_holder["ctx"] = LEGACY_AUTH
-        data = client.get("/whoami").get_json()
-        assert data["is_legacy"] is True
 
     def test_unauthenticated_401(self, client, auth_holder):
         auth_holder["ctx"] = None

--- a/backend/tests/unit/test_metrics_endpoint.py
+++ b/backend/tests/unit/test_metrics_endpoint.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # This test requires Flask and other server dependencies.
 # Skip gracefully when run in minimal uvx environment without --with flags.
@@ -39,12 +39,13 @@ try:
         'POSTGRESQL_PORT': '5432',
         'EMBEDDING_MODEL': 'test-model',
         'PORT': '5000',
-        'STALKER_API_KEY': 'test-api-key',
     }
     for _key, _value in _env_defaults.items():
         os.environ.setdefault(_key, _value)
 
-    from server import app
+    import server as _server_module
+    from library.auth import AuthContext
+    app = _server_module.app
     _server_available = True
 except ImportError:
     _server_available = False
@@ -55,7 +56,15 @@ class TestMetricsEndpoint(unittest.TestCase):
 
     def setUp(self):
         self.client = app.test_client()
-        self.api_key = os.environ.get('STALKER_API_KEY', 'test-api-key')
+        self.api_key = 'test-api-key'
+        # /metrics requires auth; resolve_api_key is patched so these tests
+        # exercise the endpoint itself, not the api_keys DB lookup.
+        self._auth_patcher = patch.object(
+            _server_module, 'resolve_api_key',
+            return_value=AuthContext(kind="service", key_id=1, key_name="test", user_id=None),
+        )
+        self._auth_patcher.start()
+        self.addCleanup(self._auth_patcher.stop)
 
     def test_metrics_returns_200(self):
         response = self.client.get('/metrics', headers={'x-api-key': self.api_key})

--- a/backend/tests/unit/test_reader_routes.py
+++ b/backend/tests/unit/test_reader_routes.py
@@ -28,7 +28,6 @@ DOC_ID = 9204
 
 USER_AUTH = AuthContext(kind="user", key_id=10, key_name="frontend-krzysztof", user_id=READER_USER.id)
 SERVICE_AUTH = AuthContext(kind="service", key_id=11, key_name="chrome-extension", user_id=None)
-LEGACY_AUTH = AuthContext(kind="service", key_id=None, key_name="legacy", user_id=None, is_legacy=True)
 
 
 def _make_note(**overrides) -> UserDocumentNote:
@@ -92,11 +91,6 @@ def client(fake_session, auth_holder):
     return app.test_client()
 
 
-# Old clients may still send x-user-id; it must be accepted when it matches
-# the key identity, so the happy-path requests below keep sending it.
-USER_HDR = {"x-user-id": "1"}
-
-
 # ---------------------------------------------------------------------------
 # Users
 # ---------------------------------------------------------------------------
@@ -149,19 +143,10 @@ class TestRequireUser:
         resp = client.get(f"/document/{DOC_ID}/reading_progress")
         assert resp.status_code == 403
 
-    def test_legacy_key_403(self, client, auth_holder):
-        auth_holder["ctx"] = LEGACY_AUTH
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "1"})
-        assert resp.status_code == 403
-
     def test_no_header_needed_with_user_key(self, client, fake_session):
         fake_session.execute.return_value.scalar_one_or_none.return_value = None
         resp = client.get(f"/document/{DOC_ID}/reading_progress")
         assert resp.status_code == 200
-
-    def test_mismatched_x_user_id_403(self, client):
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers={"x-user-id": "2"})
-        assert resp.status_code == 403
 
     def test_key_user_gone_403(self, client, auth_holder):
         auth_holder["ctx"] = AuthContext(kind="user", key_id=12, key_name="stale", user_id=99)
@@ -169,7 +154,7 @@ class TestRequireUser:
         assert resp.status_code == 403
 
     def test_unknown_document_404(self, client, fake_session):
-        resp = client.get("/document/12345/reading_progress", headers=USER_HDR)
+        resp = client.get("/document/12345/reading_progress")
         assert resp.status_code == 404
 
 
@@ -181,7 +166,7 @@ class TestRequireUser:
 class TestReadingProgress:
     def test_get_without_row_returns_nulls(self, client, fake_session):
         fake_session.execute.return_value.scalar_one_or_none.return_value = None
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
         data = resp.get_json()
 
         assert resp.status_code == 200
@@ -194,7 +179,7 @@ class TestReadingProgress:
             current_chapter_title="Bank centralny", read_chapters=[3, 1, 2],
         )
         fake_session.execute.return_value.scalar_one_or_none.return_value = progress
-        resp = client.get(f"/document/{DOC_ID}/reading_progress", headers=USER_HDR)
+        resp = client.get(f"/document/{DOC_ID}/reading_progress")
         data = resp.get_json()
 
         assert data["current_chapter"] == 7
@@ -204,7 +189,7 @@ class TestReadingProgress:
     def test_put_creates_row(self, client, fake_session):
         fake_session.execute.return_value.scalar_one_or_none.return_value = None
         resp = client.put(
-            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            f"/document/{DOC_ID}/reading_progress",
             json={"current_chapter": 5, "current_chapter_title": "Rozdział 5", "mark_read": [4]},
         )
         data = resp.get_json()
@@ -221,7 +206,7 @@ class TestReadingProgress:
         )
         fake_session.execute.return_value.scalar_one_or_none.return_value = progress
         resp = client.put(
-            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            f"/document/{DOC_ID}/reading_progress",
             json={"current_chapter": 6, "mark_read": [5, 5], "unmark_read": [2]},
         )
         data = resp.get_json()
@@ -233,14 +218,14 @@ class TestReadingProgress:
     def test_put_invalid_current_chapter_400(self, client):
         for bad in (None, 0, -1, "3"):
             resp = client.put(
-                f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+                f"/document/{DOC_ID}/reading_progress",
                 json={"current_chapter": bad},
             )
             assert resp.status_code == 400
 
     def test_put_invalid_mark_read_400(self, client):
         resp = client.put(
-            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            f"/document/{DOC_ID}/reading_progress",
             json={"current_chapter": 1, "mark_read": [0]},
         )
         assert resp.status_code == 400
@@ -248,7 +233,7 @@ class TestReadingProgress:
     def test_put_truncates_title_to_500(self, client, fake_session):
         fake_session.execute.return_value.scalar_one_or_none.return_value = None
         resp = client.put(
-            f"/document/{DOC_ID}/reading_progress", headers=USER_HDR,
+            f"/document/{DOC_ID}/reading_progress",
             json={"current_chapter": 1, "current_chapter_title": "x" * 600},
         )
         assert len(resp.get_json()["current_chapter_title"]) == 500
@@ -262,7 +247,7 @@ class TestReadingProgress:
 class TestNotes:
     def test_create_note(self, client, fake_session):
         resp = client.post(
-            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            f"/document/{DOC_ID}/notes",
             json={
                 "anchor_quote": "fragment książki",
                 "note_text": "zgadzam się z autorem",
@@ -285,26 +270,26 @@ class TestNotes:
 
     def test_create_note_requires_quote_and_text(self, client):
         resp = client.post(
-            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            f"/document/{DOC_ID}/notes",
             json={"anchor_quote": "", "note_text": "coś"},
         )
         assert resp.status_code == 400
         resp = client.post(
-            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            f"/document/{DOC_ID}/notes",
             json={"anchor_quote": "coś", "note_text": " "},
         )
         assert resp.status_code == 400
 
     def test_create_note_invalid_stance_400(self, client):
         resp = client.post(
-            f"/document/{DOC_ID}/notes", headers=USER_HDR,
+            f"/document/{DOC_ID}/notes",
             json={"anchor_quote": "q", "note_text": "n", "stance": "meh"},
         )
         assert resp.status_code == 400
 
     def test_list_notes(self, client, fake_session):
         fake_session.execute.return_value.scalars.return_value.all.return_value = [_make_note()]
-        resp = client.get(f"/document/{DOC_ID}/notes", headers=USER_HDR)
+        resp = client.get(f"/document/{DOC_ID}/notes")
         data = resp.get_json()
 
         assert resp.status_code == 200
@@ -315,7 +300,7 @@ class TestNotes:
         note = _make_note()
         fake_session.store["notes"][note.id] = note
         resp = client.patch(
-            f"/note/{note.id}", headers=USER_HDR,
+            f"/note/{note.id}",
             json={"note_text": "zmienione", "stance": "disagree"},
         )
         data = resp.get_json()
@@ -327,19 +312,19 @@ class TestNotes:
     def test_patch_note_empty_text_400(self, client, fake_session):
         note = _make_note()
         fake_session.store["notes"][note.id] = note
-        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": ""})
+        resp = client.patch(f"/note/{note.id}", json={"note_text": ""})
         assert resp.status_code == 400
 
     def test_patch_foreign_note_403(self, client, fake_session):
         note = _make_note(user_id=OTHER_USER.id)
         fake_session.store["notes"][note.id] = note
-        resp = client.patch(f"/note/{note.id}", headers=USER_HDR, json={"note_text": "x"})
+        resp = client.patch(f"/note/{note.id}", json={"note_text": "x"})
         assert resp.status_code == 403
 
     def test_delete_note(self, client, fake_session):
         note = _make_note()
         fake_session.store["notes"][note.id] = note
-        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+        resp = client.delete(f"/note/{note.id}")
 
         assert resp.status_code == 200
         fake_session.delete.assert_called_once_with(note)
@@ -347,9 +332,9 @@ class TestNotes:
     def test_delete_foreign_note_403(self, client, fake_session):
         note = _make_note(user_id=OTHER_USER.id)
         fake_session.store["notes"][note.id] = note
-        resp = client.delete(f"/note/{note.id}", headers=USER_HDR)
+        resp = client.delete(f"/note/{note.id}")
         assert resp.status_code == 403
 
     def test_delete_missing_note_404(self, client):
-        resp = client.delete("/note/777", headers=USER_HDR)
+        resp = client.delete("/note/777")
         assert resp.status_code == 404

--- a/docs/api-contracts-backend.md
+++ b/docs/api-contracts-backend.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Flask REST API with **20 endpoints** (including root `/` informational endpoint). Version 0.3.13.0. All routes except health checks require `x-api-key` header validated against `STALKER_API_KEY` environment variable.
+Flask REST API with **20 endpoints** (including root `/` informational endpoint). Version 0.3.13.0. All routes except health checks require `x-api-key` header, validated against the `api_keys` table (per-client keys managed via `imports/api_key_admin.py`; see `backend/library/auth.py`).
 
 **Base URL**: `http://localhost:5000` (Docker) or AWS API Gateway endpoint (serverless)
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -408,8 +408,11 @@ POSTGRESQL_PORT=5432
 
 # Application
 PORT=5000
-STALKER_API_KEY=your-api-key       # API authentication
 ENV_DATA=dev                       # Environment identifier
+# STALKER_API_KEY=...              # Legacy name, now only the slack-bot's own key.
+                                    # Frontend/Chrome-extension/curl clients authenticate
+                                    # with a key from `imports/api_key_admin.py create` —
+                                    # there is no shared backend key anymore.
 
 # LLM Configuration
 LLM_PROVIDER=openai                # openai, bedrock, vertex, cloudferro

--- a/docs/security/prompt-injection-defense.md
+++ b/docs/security/prompt-injection-defense.md
@@ -63,7 +63,7 @@ LLM outputs in Lenie are **stored, not executed**:
 
 ### Layer 4: API Authentication
 
-All REST API endpoints (except health checks) require `x-api-key` header validated against `STALKER_API_KEY`. This prevents external actors from directly injecting content via the API.
+All REST API endpoints (except health checks) require `x-api-key` header, validated against per-client keys in the `api_keys` table (`backend/library/auth.py`). This prevents external actors from directly injecting content via the API.
 
 ## Known Gaps
 

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -286,7 +286,7 @@ groups:
         example: "tmp/youtube_to_text"
         used_by: [docker, local]
       STALKER_API_KEY:
-        description: "API authentication key for all endpoints"
+        description: "Legacy name, now the slack-bot's own api_keys service key (x-api-key). The backend no longer accepts a shared/legacy key — every other client authenticates with its own key from the api_keys table (see library/auth.py)."
         type: secret
         required: true
         used_by: [docker, lambda, local]


### PR DESCRIPTION
## Summary
- Removed the legacy shared-key fallback from `resolve_api_key()` (`backend/library/auth.py`) and the dead `x-user-id` match-check from `reader_routes._require_user()` — no client sends that header anymore.
- Every client now authenticates with its own row in the `api_keys` table. Migrated ahead of this PR (outside the diff, done directly against the NAS backend/Vault):
  - Chrome extension → new `kind=service` key `chrome-extension`.
  - slack-bot → new `kind=service` key `slack-bot`; its Vault-stored `STALKER_API_KEY` value was swapped to the new key, so `slack_bot/src/api_client.py` needed no code change (it still reads the same var name). Verified via container restart — `Backend connection OK`.
  - Frontend (`frontend-krzysztof`) and Chrome extension keys were already in place from Etap 8 iterations 2-3.
- `AuthContext.is_legacy` field is kept (always `False` now) so `/whoami`'s response shape and the frontend contract don't change.
- Updated `scripts/vars-classification.yaml` and docs (`backend/CLAUDE.md`, `docs/api-contracts-backend.md`, `docs/security/prompt-injection-defense.md`, `docs/development-guide.md`) to describe the new model.

## Tests
- Removed/updated the legacy-fallback and x-user-id-mismatch unit tests in `test_auth_api_keys.py` / `test_reader_routes.py`.
- Fixed a latent test-isolation bug in `test_metrics_endpoint.py`: it relied on the legacy fallback with a fake `STALKER_API_KEY` env value to authenticate `/metrics` requests. Now patches `resolve_api_key` on the exact `server` module object the test's Flask `app` was built from (previous string-based `patch('server.resolve_api_key', ...)` broke under module-reload interference from `test_alembic_setup.py`).
- Full suite: `874 passed`. `ruff check backend/`: clean.

## Test plan
- [x] `pytest tests/unit/` — 874 passed
- [x] `ruff check backend/` — clean
- [x] Chrome extension and slack-bot keys created and verified live against the NAS backend (`/whoami`) before this PR
- [ ] After merge: deploy backend to NAS, then spot-check the frontend, Chrome extension, and slack-bot still authenticate correctly (all three already hold real `api_keys` rows, so this should be a no-op for them)