### PR TITLE
fix(frontend): stop hamburger menu from eating mobile reading width

### DIFF
--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -116,6 +116,10 @@ const Layout = ({ children }: LayoutProps) => {
                 &#9776;
             </button>
             <SideNavigation isMenuOpen={isMenuOpen} toggleMenu={toggleMenu} />
+            <div
+                className={`${classes.scrim} ${isMenuOpen ? classes.scrimOpen : ""}`}
+                onClick={() => setIsMenuOpen(false)}
+            />
             <div className={classes.content}>{children}</div>
         </main>
     );

--- a/web_interface_react/src/modules/shared/components/Layout/layout.module.css
+++ b/web_interface_react/src/modules/shared/components/Layout/layout.module.css
@@ -27,11 +27,14 @@
     background: none;
     border: none;
     cursor: pointer;
-    position: absolute;
+    position: fixed;
     top: 15px;
     left: 15px;
     z-index: 1001; /* Higher than the menu to ensure it is clickable */
-    /* Add desired styles */
+}
+
+.scrim {
+    display: none;
 }
 
 .logo{
@@ -111,4 +114,30 @@
 
 .menuOpen + .content {
     margin-left: 250px; /* When menu is open */
+}
+
+/* On phones, don't steal reading width for the hamburger or the open menu —
+   the sidebar overlays the content instead of pushing it. */
+@media (max-width: 768px) {
+    .content,
+    .menuOpen + .content {
+        margin-left: 0;
+        padding: 55px 16px 16px; /* top clears the fixed hamburger; sides keep text off the screen edge */
+    }
+
+    .scrim {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.42);
+        z-index: 999; /* below the menu, above the content */
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.22s ease;
+    }
+
+    .scrimOpen {
+        opacity: 1;
+        pointer-events: auto;
+    }
 }


### PR DESCRIPTION
## Summary
- On phones, the sidebar reserved a fixed 50px `margin-left` and used an absolutely-positioned hamburger button, permanently shrinking the reading column and making the button disappear while scrolling.
- Below 768px the menu now overlays the content (with a scrim, tap-outside to close) instead of pushing it, the hamburger button is `position: fixed` so it stays visible while scrolling, and a 16px side margin keeps text off the screen edges.

## Test plan
- [x] `npm run lint` (tsc --noEmit) passes
- [x] Verified visually via a resized iframe (simulating a 380px phone viewport): menu overlay + scrim open/close, hamburger stays fixed, text no longer touches screen edges
- [x] Deployed to NAS and confirmed on an actual phone