### PR TITLE
feat(obsidian): clickable obsidian:// links, note filters, YouTube author backfill

### DIFF
--- a/backend/imports/CLAUDE.md
+++ b/backend/imports/CLAUDE.md
@@ -15,6 +15,7 @@ imports/
 ├── freedom_house_import.py   # Query Freedom House country ratings via OWID API (no DB)
 ├── migrate_data_to_cache.py  # One-time migration: data/ files → CACHE_DIR convention
 ├── youtube_add.py            # Ad-hoc: process a single YouTube video (optionally + LLM analysis)
+├── youtube_backfill_author.py # One-off: fetch channel name for existing videos missing 'author'
 └── youtube_batch_analyze.py  # Bielik LLM chunk analysis of an existing document (by ID)
 ```
 
@@ -199,6 +200,32 @@ python imports/youtube_add.py <URL> --analyze --speaker1 "..." --speaker2 "..."
 - `.env` file with `POSTGRESQL_*` variables and LLM API keys
 - Optional: `WEBSHARE_API_KEY` for proxy support
 - For `--analyze`: `CLOUDFERRO_SHERLOCK_KEY` (Bielik)
+
+### `youtube_backfill_author.py`
+
+One-off backfill for the `author` field (YouTube channel name) on videos added before `youtube_processing.py` started setting it automatically (`process_youtube_url()` sets `web_document.author = youtube_file.author` on every new video). Queries `web_documents` for `document_type='youtube' AND author IS NULL`, re-fetches metadata per video via `pytubefix`, and commits per document.
+
+**Data access: ORM (SQLAlchemy)** via `get_session()`.
+
+**Running:**
+```bash
+cd backend
+python imports/youtube_backfill_author.py --dry-run              # preview, no DB writes
+python imports/youtube_backfill_author.py                        # full backfill
+python imports/youtube_backfill_author.py --limit 20 --delay 2
+python imports/youtube_backfill_author.py --no-proxy             # skip Webshare (was not needed in practice — no rate-limiting observed on a 10-video sample)
+```
+
+**Arguments:**
+- `--dry-run` — preview only, no DB writes
+- `--limit N` — max number of videos to process
+- `--delay SECONDS` — sleep between requests (default: 1.5)
+- `--no-proxy` — disable Webshare proxy
+- `-v`, `--verbose` — enable debug logging
+
+**Prerequisites:**
+- `.env` with `POSTGRESQL_*` variables
+- Optional: `WEBSHARE_API_KEY` for proxy support (see `youtube_add.py`)
 
 ### `youtube_batch_analyze.py`
 

--- a/backend/imports/youtube_backfill_author.py
+++ b/backend/imports/youtube_backfill_author.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""One-off backfill: fetch the YouTube channel name (author) for existing videos missing it.
+
+`author` is populated automatically for new videos since youtube_processing.py started
+setting it (library/youtube_processing.py:130), but videos added before that change have
+NULL author. This script re-fetches metadata for those videos via pytubefix.
+
+Usage:
+    python imports/youtube_backfill_author.py --dry-run
+    python imports/youtube_backfill_author.py
+    python imports/youtube_backfill_author.py --limit 20 --delay 2
+    python imports/youtube_backfill_author.py --no-proxy
+"""
+
+import argparse
+import logging
+import time
+
+from library.config_loader import load_config
+
+cfg = load_config()  # noqa: F841 — side effect: populates os.environ for library modules
+
+from library.db.engine import get_session  # noqa: E402
+from library.db.models import WebDocument  # noqa: E402
+from pytubefix import YouTube  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def build_proxies(webshare_api_key: str) -> dict[str, str] | None:
+    """Build a requests-style proxies dict from Webshare credentials, or None if unavailable."""
+    from youtube_transcript_api.proxies import WebshareProxyConfig
+
+    from library.webshare_ip_auth import ensure_ip_authorized, get_proxy_credentials
+
+    try:
+        ensure_ip_authorized(webshare_api_key)
+    except Exception as e:
+        logger.warning(f"Webshare IP auth failed: {e} — proceeding without proxy")
+        return None
+
+    creds = get_proxy_credentials(webshare_api_key)
+    if not creds:
+        logger.warning("Webshare credentials unavailable — proceeding without proxy")
+        return None
+
+    proxy_url = WebshareProxyConfig(proxy_username=creds[0], proxy_password=creds[1]).url
+    return {"http": proxy_url, "https": proxy_url}
+
+
+def fetch_author(url: str, proxies: dict[str, str] | None) -> str | None:
+    """Fetch the channel name for a single YouTube video. Returns None on failure."""
+    yt = YouTube(url, proxies=proxies)
+    if yt.vid_info.get("playabilityStatus", {}).get("status") == "LOGIN_REQUIRED":
+        raise ValueError("private/age-restricted video (LOGIN_REQUIRED)")
+    return f"{yt.author}"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill the 'author' (YouTube channel name) field for existing videos missing it."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview only, no DB writes")
+    parser.add_argument("--limit", type=int, help="Max number of videos to process")
+    parser.add_argument("--delay", type=float, default=1.5, help="Seconds to sleep between requests (default: 1.5)")
+    parser.add_argument("--no-proxy", action="store_true", help="Disable Webshare proxy")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    webshare_api_key = cfg.get("WEBSHARE_API_KEY")
+    proxies = None
+    if args.no_proxy:
+        logging.info("--no-proxy flag set — Webshare proxy disabled")
+    elif webshare_api_key:
+        proxies = build_proxies(webshare_api_key)
+        if proxies:
+            logging.info("Using Webshare rotating residential proxy")
+    else:
+        logging.info("No WEBSHARE_API_KEY configured — proceeding without proxy")
+
+    session = get_session()
+    try:
+        query = session.query(WebDocument).filter(
+            WebDocument.document_type == "youtube",
+            WebDocument.author.is_(None),
+        ).order_by(WebDocument.id)
+        if args.limit:
+            query = query.limit(args.limit)
+        docs = query.all()
+
+        logging.info(f"Found {len(docs)} YouTube documents missing 'author'")
+
+        updated, failed = 0, 0
+        for i, doc in enumerate(docs, start=1):
+            logging.info(f"[{i}/{len(docs)}] doc #{doc.id}: {doc.url}")
+            try:
+                author = fetch_author(doc.url, proxies)
+            except Exception as e:
+                logging.warning(f"  FAILED: {e}")
+                failed += 1
+                time.sleep(args.delay)
+                continue
+
+            logging.info(f"  author: {author}")
+            if not args.dry_run:
+                doc.author = author
+                session.commit()
+            updated += 1
+            time.sleep(args.delay)
+
+        logging.info(f"Done. Updated: {updated}, failed: {failed}, total: {len(docs)}")
+        if args.dry_run:
+            logging.info("(dry-run — no changes were saved)")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -23,7 +23,8 @@ class WebsitesDBPostgreSQL:
 
     def get_list(self, limit: int = 100, offset: int = 0, document_type: str = "ALL", document_state: str = "ALL",
                  search_in_documents=None, count=False, project=None, ai_summary_needed: bool = None,
-                 start_id=None) -> list[dict[str, Any]]:
+                 start_id=None, only_missing_obsidian_notes: bool = False,
+                 only_has_obsidian_notes: bool = False) -> list[dict[str, Any]]:
 
         if count:
             stmt = select(func.count(WebDocument.id))
@@ -31,7 +32,8 @@ class WebsitesDBPostgreSQL:
             stmt = select(
                 WebDocument.id, WebDocument.url, WebDocument.title, WebDocument.document_type,
                 WebDocument.created_at, WebDocument.document_state, WebDocument.document_state_error,
-                WebDocument.note, WebDocument.project, WebDocument.uuid,
+                WebDocument.note, WebDocument.project, WebDocument.uuid, WebDocument.author,
+                WebDocument.obsidian_note_paths,
             )
 
         # Dynamic filters — column stores enum name strings directly
@@ -61,6 +63,21 @@ class WebsitesDBPostgreSQL:
                 WebDocument.chapter_list.ilike(pattern, escape="\\"),
             ))
 
+        if only_missing_obsidian_notes:
+            stmt = stmt.where(select(DocumentChunk.id).where(
+                DocumentChunk.document_id == WebDocument.id,
+                *self._missing_obsidian_note_chunk_conditions(),
+            ).exists())
+
+        if only_has_obsidian_notes:
+            stmt = stmt.where(or_(
+                func.coalesce(func.jsonb_array_length(WebDocument.obsidian_note_paths), 0) > 0,
+                select(DocumentChunk.id).where(
+                    DocumentChunk.document_id == WebDocument.id,
+                    *self._has_obsidian_note_chunk_conditions(),
+                ).exists(),
+            ))
+
         if count:
             return self.session.execute(stmt).scalar()
 
@@ -68,8 +85,12 @@ class WebsitesDBPostgreSQL:
         stmt = stmt.limit(limit).offset(offset * limit)
 
         rows = self.session.execute(stmt).all()
+        doc_ids = [row.id for row in rows]
+        obsidian_notes_by_doc = self._count_obsidian_note_chunks(doc_ids)
+
         result = []
         for row in rows:
+            missing, with_notes = obsidian_notes_by_doc.get(row.id, (0, 0))
             result.append({
                 "id": row.id,
                 "url": row.url,
@@ -81,8 +102,46 @@ class WebsitesDBPostgreSQL:
                 "note": row.note,
                 "project": row.project,
                 "uuid": row.uuid,
+                "author": row.author,
+                "obsidian_note_paths": row.obsidian_note_paths or [],
+                "chunks_missing_obsidian_notes": missing,
+                "chunks_with_obsidian_notes": with_notes,
             })
         return result
+
+    @staticmethod
+    def _missing_obsidian_note_chunk_conditions():
+        """TEMAT chunks that still need an Obsidian note: not skipped, no note path recorded yet."""
+        return (
+            DocumentChunk.type == "TEMAT",
+            DocumentChunk.status != "skipped",
+            func.coalesce(func.array_length(DocumentChunk.obsidian_note_paths, 1), 0) == 0,
+        )
+
+    @staticmethod
+    def _has_obsidian_note_chunk_conditions():
+        """TEMAT chunks that already have at least one Obsidian note recorded."""
+        return (
+            DocumentChunk.type == "TEMAT",
+            func.coalesce(func.array_length(DocumentChunk.obsidian_note_paths, 1), 0) > 0,
+        )
+
+    def _count_obsidian_note_chunks(self, doc_ids: list[int]) -> dict[int, tuple[int, int]]:
+        """Batch (missing, with_notes) TEMAT chunk counts per document_id."""
+        if not doc_ids:
+            return {}
+        missing_condition = and_(*self._missing_obsidian_note_chunk_conditions())
+        with_notes_condition = and_(*self._has_obsidian_note_chunk_conditions())
+        stmt = (
+            select(
+                DocumentChunk.document_id,
+                func.count().filter(missing_condition).label("missing"),
+                func.count().filter(with_notes_condition).label("with_notes"),
+            )
+            .where(DocumentChunk.document_id.in_(doc_ids), DocumentChunk.type == "TEMAT")
+            .group_by(DocumentChunk.document_id)
+        )
+        return {doc_id: (missing, with_notes) for doc_id, missing, with_notes in self.session.execute(stmt).all()}
 
     def get_count(self, document_type: str = "ALL") -> int:
         stmt = select(func.count(WebDocument.id))

--- a/backend/server.py
+++ b/backend/server.py
@@ -254,12 +254,21 @@ def website_list():
     document_type = request.args.get('type', 'ALL')
     document_state = request.args.get('document_state', 'ALL')
     search_in_documents = request.args.get('search_in_document', '')
+    only_missing_obsidian_notes = request.args.get('only_missing_obsidian_notes', '').lower() in ('1', 'true')
+    only_has_obsidian_notes = request.args.get('only_has_obsidian_notes', '').lower() in ('1', 'true')
     logging.debug(document_type)
 
     session = get_scoped_session()
     repo = WebsitesDBPostgreSQL(session)
-    websites_list = repo.get_list(document_type=document_type, document_state=document_state, search_in_documents=search_in_documents)
-    websites_list_count = repo.get_list(document_type=document_type, document_state=document_state, search_in_documents=search_in_documents, count=True)
+    list_kwargs = {
+        "document_type": document_type,
+        "document_state": document_state,
+        "search_in_documents": search_in_documents,
+        "only_missing_obsidian_notes": only_missing_obsidian_notes,
+        "only_has_obsidian_notes": only_has_obsidian_notes,
+    }
+    websites_list = repo.get_list(**list_kwargs)
+    websites_list_count = repo.get_list(**list_kwargs, count=True)
     logging.debug("website count: %s", websites_list_count)
 
     response = {

--- a/backend/tests/unit/test_get_list_query.py
+++ b/backend/tests/unit/test_get_list_query.py
@@ -86,3 +86,25 @@ class TestGetListParameterization:
         """Verify non-count mode returns list."""
         result = db_instance.get_list()
         assert isinstance(result, list)
+
+    def test_only_missing_obsidian_notes_filter(self, db_instance, mock_session):
+        """Verify the only_missing_obsidian_notes filter triggers query execution."""
+        result = db_instance.get_list(only_missing_obsidian_notes=True)
+        assert mock_session.execute.called
+        assert isinstance(result, list)
+
+    def test_only_missing_obsidian_notes_filter_count_mode(self, db_instance, mock_session):
+        """Verify the filter also applies in count mode."""
+        result = db_instance.get_list(only_missing_obsidian_notes=True, count=True)
+        assert result == 0
+
+    def test_only_has_obsidian_notes_filter(self, db_instance, mock_session):
+        """Verify the only_has_obsidian_notes filter triggers query execution."""
+        result = db_instance.get_list(only_has_obsidian_notes=True)
+        assert mock_session.execute.called
+        assert isinstance(result, list)
+
+    def test_only_has_obsidian_notes_filter_count_mode(self, db_instance, mock_session):
+        """Verify the filter also applies in count mode."""
+        result = db_instance.get_list(only_has_obsidian_notes=True, count=True)
+        assert result == 0

--- a/backend/tests/unit/test_repository_queries.py
+++ b/backend/tests/unit/test_repository_queries.py
@@ -78,8 +78,12 @@ class TestGetList:
         mock_row.note = "note"
         mock_row.project = "lenie"
         mock_row.uuid = "uuid-1"
+        mock_row.author = None
+        mock_row.obsidian_note_paths = None
 
-        session.execute.return_value.all.return_value = [mock_row]
+        list_result = MagicMock(all=MagicMock(return_value=[mock_row]))
+        missing_notes_result = MagicMock(all=MagicMock(return_value=[]))
+        session.execute.side_effect = [list_result, missing_notes_result]
 
         result = repo.get_list()
 
@@ -94,6 +98,46 @@ class TestGetList:
         assert result[0]["note"] == "note"
         assert result[0]["project"] == "lenie"
         assert result[0]["uuid"] == "uuid-1"
+        assert result[0]["chunks_missing_obsidian_notes"] == 0
+        assert result[0]["chunks_with_obsidian_notes"] == 0
+
+    def test_obsidian_notes_counts_are_attached_per_document(self):
+        session = MagicMock()
+        repo = _make_repo(session)
+
+        mock_row = _make_row(
+            id=1, url="https://example.com", title="Test", document_type="webpage",
+            created_at=datetime.datetime(2026, 1, 15, 10, 30, 0), document_state="URL_ADDED",
+            document_state_error=None, note=None, project=None, uuid=None, author=None,
+            obsidian_note_paths=None,
+        )
+        list_result = MagicMock(all=MagicMock(return_value=[mock_row]))
+        missing_notes_result = MagicMock(all=MagicMock(return_value=[(1, 3, 2)]))
+        session.execute.side_effect = [list_result, missing_notes_result]
+
+        result = repo.get_list()
+
+        assert result[0]["chunks_missing_obsidian_notes"] == 3
+        assert result[0]["chunks_with_obsidian_notes"] == 2
+
+    def test_document_level_obsidian_note_paths_pass_through(self):
+        """web_documents.obsidian_note_paths (set by article_browser.py) must also surface."""
+        session = MagicMock()
+        repo = _make_repo(session)
+
+        mock_row = _make_row(
+            id=1, url="https://example.com", title="Test", document_type="webpage",
+            created_at=datetime.datetime(2026, 1, 15, 10, 30, 0), document_state="URL_ADDED",
+            document_state_error=None, note=None, project=None, uuid=None, author=None,
+            obsidian_note_paths=["02-wiedza/Kraje/Chiny.md"],
+        )
+        list_result = MagicMock(all=MagicMock(return_value=[mock_row]))
+        missing_notes_result = MagicMock(all=MagicMock(return_value=[]))
+        session.execute.side_effect = [list_result, missing_notes_result]
+
+        result = repo.get_list()
+
+        assert result[0]["obsidian_note_paths"] == ["02-wiedza/Kraje/Chiny.md"]
 
     def test_single_filter_document_type(self):
         session = MagicMock()
@@ -199,7 +243,9 @@ class TestGetList:
         mock_row.project = None
         mock_row.uuid = None
 
-        session.execute.return_value.all.return_value = [mock_row]
+        list_result = MagicMock(all=MagicMock(return_value=[mock_row]))
+        missing_notes_result = MagicMock(all=MagicMock(return_value=[]))
+        session.execute.side_effect = [list_result, missing_notes_result]
 
         result = repo.get_list()
 

--- a/web_interface_react/src/modules/shared/hooks/useList.ts
+++ b/web_interface_react/src/modules/shared/hooks/useList.ts
@@ -16,14 +16,25 @@ export const useList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleGetList = async (type: string, documentState: string, searchInDocument?: string) => {
+  const handleGetList = async (
+    type: string,
+    documentState: string,
+    searchInDocument?: string,
+    obsidianNotesFilter?: { onlyMissing?: boolean; onlyHas?: boolean },
+  ) => {
     setIsLoading(true);
     try {
       const response = await axios.get(`${apiUrl}/website_list`, {
         headers: {
           "x-api-key": `${apiKey}`,
         },
-        params: { type, document_state: documentState, search_in_document: searchInDocument },
+        params: {
+          type,
+          document_state: documentState,
+          search_in_document: searchInDocument,
+          only_missing_obsidian_notes: obsidianNotesFilter?.onlyMissing || undefined,
+          only_has_obsidian_notes: obsidianNotesFilter?.onlyHas || undefined,
+        },
       });
       console.log(response.data.message);
       console.log(response.data);

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -5,6 +5,7 @@ import {
   NotePopover, NoteRow, PendingNote, ReaderIdentityBadge, STANCE_ICON, UserNote,
   normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
 } from "../components/ReaderNotes/readerNotes";
+import { buildObsidianNoteUrl } from "../utils/obsidian";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -1060,8 +1061,20 @@ const Chunks = () => {
               {chunk.speaker && <span style={{ color: "#64748b" }}>🎙 {chunk.speaker}</span>}
 
               {!!chunk.obsidian_note_paths?.length && (
-                <span title={chunk.obsidian_note_paths.join("\n")} style={{ color: "#7c3aed" }}>
-                  📝 {chunk.obsidian_note_paths.length}
+                <span style={{ color: "#7c3aed", display: "inline-flex", alignItems: "center", gap: 4 }}>
+                  📝
+                  {chunk.obsidian_note_paths.map((notePath, i) => (
+                    <React.Fragment key={notePath}>
+                      {i > 0 && ","}
+                      <a
+                        href={buildObsidianNoteUrl(notePath)}
+                        title={`Otwórz w Obsidianie: ${notePath}`}
+                        style={{ color: "#7c3aed" }}
+                      >
+                        {notePath.split("/").pop()?.replace(/\.md$/i, "")}
+                      </a>
+                    </React.Fragment>
+                  ))}
                 </span>
               )}
               {myNotes.length > 0 && (

--- a/web_interface_react/src/modules/shared/pages/connect.tsx
+++ b/web_interface_react/src/modules/shared/pages/connect.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { AuthorizationContext } from "../context/authorizationContext";
-import { saveConnectionConfig } from "../services/storage";
+import { loadObsidianVaultName, saveConnectionConfig, saveObsidianVaultName } from "../services/storage";
 import type { ApiType } from "../../../types";
 import { DEFAULT_API_URLS } from "../../../types";
 import { lenie_version } from "../constants/variables";
@@ -19,6 +19,15 @@ const Connect: React.FC = () => {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState("");
+
+  const [obsidianVaultName, setObsidianVaultName] = useState(loadObsidianVaultName());
+  const [obsidianSaved, setObsidianSaved] = useState(false);
+
+  const handleSaveObsidianVaultName = () => {
+    saveObsidianVaultName(obsidianVaultName);
+    setObsidianSaved(true);
+    setTimeout(() => setObsidianSaved(false), 2000);
+  };
 
   const handleApiTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newType = e.target.value as ApiType;
@@ -175,6 +184,34 @@ const Connect: React.FC = () => {
         {isValidating ? "Connecting..." : "Connect"}
       </button>
       {isValidating && <div className="loader" style={{ marginTop: "10px" }}></div>}
+
+      <hr style={{ margin: "30px 0", border: "none", borderTop: "1px solid #dee2e6" }} />
+
+      <h3 style={{ marginBottom: "4px" }}>Obsidian</h3>
+      <div style={{ fontSize: "12px", color: "#6c757d", marginBottom: "12px" }}>
+        Nazwa vaulta na tym urządzeniu, używana w linkach 📝 do notatek (Obsidian Sync może mieć
+        inną nazwę vaulta na każdym urządzeniu). Zostaw puste, aby otwierać ostatnio używany vault.
+      </div>
+      <label htmlFor="connect-obsidian-vault" style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+        Nazwa vaulta (to urządzenie)
+      </label>
+      <div style={{ display: "flex", gap: "8px" }}>
+        <input
+          id="connect-obsidian-vault"
+          type="text"
+          value={obsidianVaultName}
+          onChange={(e) => setObsidianVaultName(e.target.value)}
+          placeholder="np. personal"
+          style={{ flex: 1, padding: "8px", fontSize: "14px" }}
+        />
+        <button
+          type="button"
+          onClick={handleSaveObsidianVaultName}
+          style={{ padding: "8px 12px", fontSize: "14px", cursor: "pointer" }}
+        >
+          {obsidianSaved ? "Zapisano ✓" : "Zapisz"}
+        </button>
+      </div>
     </div>
   );
 };

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -5,6 +5,7 @@ import { NavLink } from "react-router-dom";
 import { AuthorizationContext } from "../context/authorizationContext";
 import { useManageLLM } from "../hooks/useManageLLM";
 import { useFormik } from 'formik';
+import { buildObsidianNoteUrl } from "../utils/obsidian";
 
 const List = () => {
     const { isLoading, isError, data, message, handleGetList, dataAllLength } = useList();
@@ -21,17 +22,29 @@ const List = () => {
   const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState } = React.useContext(AuthorizationContext);
   const { searchInDocument, setSearchInDocument} = React.useContext(AuthorizationContext);
   const { searchType, setSearchType} = React.useContext(AuthorizationContext);
+  const [obsidianFilter, setObsidianFilter] = React.useState<"none" | "missing" | "has">("none");
+
+  const obsidianFilterParams = (filter: "none" | "missing" | "has") => ({
+    onlyMissing: filter === "missing",
+    onlyHas: filter === "has",
+  });
 
   const { handleDeleteDocument } = useManageLLM({ formik, selectedDocumentType, selectedDocumentState });
 
   const handleTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
           setSelectedDocumentType(event.target.value);
-          handleGetList(event.target.value, selectedDocumentState,searchInDocument);
+          handleGetList(event.target.value, selectedDocumentState, searchInDocument, obsidianFilterParams(obsidianFilter));
   };
 
   const handleDocumentStateChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
           setSelectedDocumentState(event.target.value);
-          handleGetList(selectedDocumentType, event.target.value,searchInDocument);
+          handleGetList(selectedDocumentType, event.target.value, searchInDocument, obsidianFilterParams(obsidianFilter));
+  };
+
+  const handleObsidianFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+          const filter = event.target.value as "none" | "missing" | "has";
+          setObsidianFilter(filter);
+          handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument, obsidianFilterParams(filter));
   };
 
   const handleDocumentDeleteOnThisPage = async (document_id: string | number) => {
@@ -95,10 +108,17 @@ const List = () => {
         disabled={isLoading}
         className={"button"}
         type={"button"}
-        onClick={() => handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument)}
+        onClick={() => handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument, obsidianFilterParams(obsidianFilter))}
       >
         Search
       </button>
+      <br />
+      <label htmlFor="obsidian_filter"> 📝 Notatki Obsidian: </label>
+      <select id="obsidian_filter" value={obsidianFilter} onChange={handleObsidianFilterChange} disabled={isLoading}>
+        <option value="none">wszystkie</option>
+        <option value="missing">tylko z brakującymi</option>
+        <option value="has">tylko z notatką</option>
+      </select>
       <div>
         <p className={"errorText"}>{message}</p>
       </div>
@@ -120,6 +140,9 @@ const List = () => {
             >
               {item.id}&nbsp;&nbsp;|&nbsp;&nbsp;
               {item.title} &nbsp;
+              {item.author && (
+                <span style={{ color: "#6c757d", fontStyle: "italic" }}>({item.author}) </span>
+              )}
               <a
                 href={item.url}
                 style={{ color: "rgba(0,122,255)" }}
@@ -131,6 +154,35 @@ const List = () => {
               <span> {item.document_state}
                 {item.document_state_error !== 'NONE' && ` | ${item.document_state_error}`}
               </span>
+              {!!item.obsidian_note_paths?.length && (
+                <span style={{ margin: "0 0 0 10px", color: "#15803d" }}>
+                  📝{" "}
+                  {item.obsidian_note_paths.map((notePath: string, i: number) => (
+                    <React.Fragment key={notePath}>
+                      {i > 0 && ", "}
+                      <a href={buildObsidianNoteUrl(notePath)} title={`Otwórz w Obsidianie: ${notePath}`}>
+                        {notePath.split("/").pop()?.replace(/\.md$/i, "")}
+                      </a>
+                    </React.Fragment>
+                  ))}
+                </span>
+              )}
+              {!!item.chunks_with_obsidian_notes && (
+                <span
+                  style={{ margin: "0 0 0 10px", color: "#15803d" }}
+                  title="Chunki TEMAT z notatką Obsidian"
+                >
+                  📝 {item.chunks_with_obsidian_notes} gotowe
+                </span>
+              )}
+              {!!item.chunks_missing_obsidian_notes && (
+                <span
+                  style={{ margin: "0 0 0 10px", color: "#7c3aed" }}
+                  title="Chunki TEMAT bez notatki Obsidian"
+                >
+                  📝 {item.chunks_missing_obsidian_notes} do zrobienia
+                </span>
+              )}
               <span style={{ margin: "0 0 0 auto", fontWeight: "500" }}>
                 {item.document_type}
               </span>

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -5,6 +5,7 @@ const KEYS = {
   apiType: "lenie_apiType",
   apiUrl: "lenie_apiUrl",
   apiKey: "lenie_apiKey",
+  obsidianVaultName: "lenie_obsidianVaultName",
 } as const;
 
 export function loadConnectionConfig(): {
@@ -41,4 +42,19 @@ export function clearConnectionConfig(): void {
 
 export function isConnected(): boolean {
   return !!localStorage.getItem(KEYS.apiKey);
+}
+
+// The Obsidian vault name is device-specific (e.g. Obsidian Sync uses a
+// different display name per device for the same synced vault), so it's
+// stored locally per browser/device rather than coming from the backend.
+export function loadObsidianVaultName(): string {
+  return localStorage.getItem(KEYS.obsidianVaultName) || "";
+}
+
+export function saveObsidianVaultName(vaultName: string): void {
+  if (vaultName.trim()) {
+    localStorage.setItem(KEYS.obsidianVaultName, vaultName.trim());
+  } else {
+    localStorage.removeItem(KEYS.obsidianVaultName);
+  }
 }

--- a/web_interface_react/src/modules/shared/utils/obsidian.ts
+++ b/web_interface_react/src/modules/shared/utils/obsidian.ts
@@ -1,0 +1,11 @@
+import { loadObsidianVaultName } from "../services/storage";
+
+// Vault name is read per-device (see storage.ts) since Obsidian Sync can use a
+// different display name per device for the same synced vault. If unset, the
+// `vault` param is omitted — Obsidian falls back to the currently open vault.
+export const buildObsidianNoteUrl = (notePath: string): string => {
+  const withoutExtension = notePath.replace(/\.md$/i, "");
+  const vaultName = loadObsidianVaultName();
+  const vaultParam = vaultName ? `vault=${encodeURIComponent(vaultName)}&` : "";
+  return `obsidian://open?${vaultParam}file=${encodeURIComponent(withoutExtension)}`;
+};

--- a/web_interface_react/src/utils.tsx
+++ b/web_interface_react/src/utils.tsx
@@ -1,3 +1,5 @@
+import { buildObsidianNoteUrl } from "./modules/shared/utils/obsidian";
+
 interface ListItemSearchSimilarProps {
   item: {
     similarity: number;
@@ -27,7 +29,17 @@ const ListItemSearchSimilar = ({ item }: ListItemSearchSimilarProps) => {
                 </>
             )}
             {notes.length > 0 && (
-                <span title={notes.join("\n")}> 📝 {notes.length}</span>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                    {" "}📝
+                    {notes.map((notePath, i) => (
+                        <span key={notePath}>
+                            {i > 0 && ","}
+                            <a href={buildObsidianNoteUrl(notePath)} title={`Otwórz w Obsidianie: ${notePath}`}>
+                                {notePath.split("/").pop()?.replace(/\.md$/i, "")}
+                            </a>
+                        </span>
+                    ))}
+                </span>
             )}
         </li>
     )


### PR DESCRIPTION
## Summary
- Clickable `obsidian://` links for note paths in the chunk review panel, search results, and document list, using a per-device vault name setting (Obsidian Sync uses different vault display names per device for the same synced vault).
- `/list` gains an Obsidian-notes filter (all / missing / has) and badges — accounts for both tracking mechanisms: document-level `obsidian_note_paths` (set by `article_browser.py`'s interactive review) and per-chunk paths (set by the `/obsidian-note` skill).
- `/list` now shows the author/channel for YouTube videos.
- One-off backfill script (`imports/youtube_backfill_author.py`) filled in `author` for 146 of 151 pre-existing YouTube documents that predated automatic capture in `youtube_processing.py`.

## Test plan
- [x] `npm run lint` (tsc --noEmit) passes
- [x] Backend unit tests pass (79 tests in `test_get_list_query.py`, `test_repository_queries.py`, `test_flask_endpoints_orm.py`)
- [x] `ruff check` clean
- [x] Verified live on NAS: obsidian:// links open correctly with real vault-relative paths (Polish diacritics/spaces), filter/badges match a manual SQL cross-check, author column renders
- [x] Backfill script dry-run + full run verified against NAS DB (146/151 succeeded; 5 failures are genuinely unrecoverable — private/removed videos, malformed URL)