### PR TITLE
feat(read): TEMAT chunk fallback for /read on YouTube/movie transcripts

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -7,8 +7,8 @@ embeddings/notes and only ever supported the YouTube/transcript case.
 
 Endpoints:
   GET  /analysis_runs?doc_id=<id>            — list runs for a document
-  GET  /document/<doc_id>/chapters           — detect H1/H2 table of contents
-  GET  /document/<doc_id>/chapter/<position> — one chapter's markdown (reader view)
+  GET  /document/<doc_id>/chapters           — table of contents (H1/H2 headers, or TEMAT chunk topics as fallback)
+  GET  /document/<doc_id>/chapter/<position> — one chapter's text (reader view)
   POST /document/<doc_id>/analyze_chunks     — create a new analysis run
   GET  /analysis_run/<run_id>/chunks         — run data (chunks + segments;
                                                lite/section_id/offset/limit for books)
@@ -284,13 +284,45 @@ def split_preview(doc_id: int):
     })
 
 
+def _latest_run_for_document(session, doc_id: int) -> DocumentAnalysisRun | None:
+    return session.scalars(
+        select(DocumentAnalysisRun)
+        .where(DocumentAnalysisRun.document_id == doc_id)
+        .order_by(DocumentAnalysisRun.created_at.desc())
+    ).first()
+
+
+def _chunk_based_chapters(run: DocumentAnalysisRun) -> list[dict]:
+    """Fallback table of contents built from TEMAT chunk topics.
+
+    Used when the document's text has no markdown H1/H2 headers — the case
+    for YouTube/movie transcripts, which are split into topic chunks
+    (transcript-mode analysis) instead of markdown-structured text.
+    REKLAMA/SZUM chunks are excluded, same as the note-writing workflow.
+    """
+    temat_chunks = [c for c in sorted(run.chunks, key=lambda c: c.position) if c.type == "TEMAT"]
+    return [
+        {
+            "position": i,
+            "level": 1,
+            "title": chunk.topic or f"Fragment {i}",
+            "chunk_id": chunk.id,
+            "length": len(chunk.corrected_text or chunk.original_text or ""),
+        }
+        for i, chunk in enumerate(temat_chunks, start=1)
+    ]
+
+
 @bp.route("/document/<int:doc_id>/chapters", methods=["GET"])
 def document_chapters(doc_id: int):
-    """Detect the document's table of contents (H1/H2 markdown headers).
+    """Detect the document's table of contents.
 
-    Reads the same text an article-mode analysis would (text_md preferred).
-    Chapter positions can be passed as scope_chapter to POST /analyze_chunks
-    or GET /split_preview to analyze a single chapter.
+    Prefers markdown H1/H2 headers (text_md, article-mode analysis). When
+    none are found, falls back to TEMAT chunk topics from the latest
+    analysis run — the only structure transcript-mode documents (YouTube/
+    movie) have. Chapter positions can be passed as scope_chapter to
+    POST /analyze_chunks or GET /split_preview to analyze a single chapter
+    (markdown chapters only — chunk-based chapters aren't a valid scope there).
     """
     from library.document_analysis_service import _extract_text
     from library.text_functions import detect_chapters
@@ -301,7 +333,17 @@ def document_chapters(doc_id: int):
         abort(404, f"Document {doc_id} not found")
 
     text, field = _extract_text(doc, prefer_md=True)
-    if not text:
+    chapters = detect_chapters(text) if text else []
+    source = "markdown" if chapters else "none"
+
+    if not chapters:
+        run = _latest_run_for_document(session, doc_id)
+        if run:
+            chapters = _chunk_based_chapters(run)
+            if chapters:
+                source = "chunks"
+
+    if not text and source == "none":
         return jsonify({"status": "error", "message": "Document has no usable text"}), 400
 
     return jsonify({
@@ -309,15 +351,18 @@ def document_chapters(doc_id: int):
         "doc_id": doc_id,
         "source_field": field,
         "text_length": len(text),
-        "chapters": detect_chapters(text),
+        "chapters": chapters,
+        "chapter_source": source,
     })
 
 
 @bp.route("/document/<int:doc_id>/chapter/<int:position>", methods=["GET"])
 def document_chapter(doc_id: int, position: int):
-    """Return one chapter's markdown text for the reader view (/read/:id).
+    """Return one chapter's text for the reader view (/read/:id).
 
-    Positions are 1-based and match GET /document/<id>/chapters.
+    Positions are 1-based and match GET /document/<id>/chapters — either
+    markdown-header chapters or, as a fallback, TEMAT-chunk chapters (see
+    _chunk_based_chapters).
     """
     from library.document_analysis_service import _extract_text, _slice_chapter
     from library.text_functions import detect_chapters
@@ -328,14 +373,34 @@ def document_chapter(doc_id: int, position: int):
         abort(404, f"Document {doc_id} not found")
 
     text, _field = _extract_text(doc, prefer_md=True)
-    if not text:
-        return jsonify({"status": "error", "message": "Document has no usable text"}), 400
+    md_chapters = detect_chapters(text) if text else []
 
-    chapter_total = len(detect_chapters(text))
-    try:
-        chapter_text, title = _slice_chapter(text, position)
-    except ValueError as exc:
-        return jsonify({"status": "error", "message": str(exc)}), 400
+    if md_chapters:
+        chapter_total = len(md_chapters)
+        try:
+            chapter_text, title = _slice_chapter(text, position)
+        except ValueError as exc:
+            return jsonify({"status": "error", "message": str(exc)}), 400
+    else:
+        run = _latest_run_for_document(session, doc_id)
+        chunk_chapters = _chunk_based_chapters(run) if run else []
+        if not chunk_chapters:
+            return jsonify({
+                "status": "error",
+                "message": "Document has no detectable chapters (no H1/H2 headers, no chunk analysis run)",
+            }), 400
+
+        chapter_total = len(chunk_chapters)
+        match = next((c for c in chunk_chapters if c["position"] == position), None)
+        if match is None:
+            return jsonify({
+                "status": "error",
+                "message": f"scope_chapter {position} out of range (1..{chapter_total})",
+            }), 400
+
+        chunk = next(c for c in run.chunks if c.id == match["chunk_id"])
+        chapter_text = chunk.corrected_text or chunk.original_text or ""
+        title = match["title"]
 
     return jsonify({
         "status": "success",

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -345,3 +345,95 @@ class TestPatchTopicSection:
     def test_unknown_section_404(self, client):
         resp = client.patch("/topic_section/999", json={"title": "x"})
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Chapters fallback to TEMAT chunk topics (no markdown H1/H2 — e.g. YouTube
+# transcripts, which are split into topic chunks instead of markdown text)
+# ---------------------------------------------------------------------------
+
+
+class FakeTranscriptDoc:
+    id = 88
+    title = "Testowy film YouTube"
+    text = "Zwykła transkrypcja bez nagłówków markdown. " * 20
+    text_md = None
+    text_raw = None
+    document_type = "youtube"
+
+
+@pytest.fixture
+def transcript_run():
+    run = MagicMock(spec=DocumentAnalysisRun)
+    run.id = 5
+    run.document_id = 88
+    run.chunks = [
+        _make_chunk(id=201, document_id=88, position=1, type="TEMAT", topic="Temat pierwszy",
+                    corrected_text="Tekst poprawiony 1", original_text="Oryginał 1"),
+        _make_chunk(id=202, document_id=88, position=2, type="REKLAMA", topic="Reklama"),
+        _make_chunk(id=203, document_id=88, position=3, type="TEMAT", topic="Temat drugi",
+                    corrected_text=None, original_text="Oryginał 2"),
+    ]
+    return run
+
+
+@pytest.fixture
+def transcript_client(monkeypatch, transcript_run):
+    doc = FakeTranscriptDoc()
+    fake_session = MagicMock()
+    fake_session.get.side_effect = lambda model, pk: doc if model is WebDocument and pk == 88 else None
+    monkeypatch.setattr(crr, "get_scoped_session", lambda: fake_session)
+    monkeypatch.setattr(crr, "_latest_run_for_document",
+                        lambda _session, doc_id: transcript_run if doc_id == 88 else None)
+
+    app = flask.Flask(__name__)
+    app.register_blueprint(crr.bp)
+    return app.test_client()
+
+
+class TestChaptersFallbackToChunks:
+    def test_chapters_list_uses_temat_chunk_topics(self, transcript_client):
+        resp = transcript_client.get("/document/88/chapters")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["chapter_source"] == "chunks"
+        titles = [c["title"] for c in data["chapters"]]
+        assert titles == ["Temat pierwszy", "Temat drugi"]  # REKLAMA excluded
+
+    def test_chapter_content_prefers_corrected_text(self, transcript_client):
+        resp = transcript_client.get("/document/88/chapter/1")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["title"] == "Temat pierwszy"
+        assert data["text"] == "Tekst poprawiony 1"
+        assert data["chapter_total"] == 2
+        assert data["prev"] is None
+        assert data["next"] == 2
+
+    def test_chapter_content_falls_back_to_original_text(self, transcript_client):
+        resp = transcript_client.get("/document/88/chapter/2")
+        data = resp.get_json()
+
+        assert data["title"] == "Temat drugi"
+        assert data["text"] == "Oryginał 2"
+        assert data["prev"] == 1
+        assert data["next"] is None
+
+    def test_out_of_range_chunk_chapter_rejected(self, transcript_client):
+        resp = transcript_client.get("/document/88/chapter/99")
+        assert resp.status_code == 400
+
+    def test_no_headers_and_no_run_returns_error(self, monkeypatch):
+        doc = FakeTranscriptDoc()
+        fake_session = MagicMock()
+        fake_session.get.side_effect = lambda model, pk: doc if model is WebDocument else None
+        monkeypatch.setattr(crr, "get_scoped_session", lambda: fake_session)
+        monkeypatch.setattr(crr, "_latest_run_for_document", lambda _session, _doc_id: None)
+
+        app = flask.Flask(__name__)
+        app.register_blueprint(crr.bp)
+        resp = app.test_client().get("/document/88/chapter/1")
+
+        assert resp.status_code == 400

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -75,7 +75,7 @@ All protected routes wrapped in `RequireAuth` → `Layout` → `Authorization`. 
 | `/youtube/:id?` | `youtube.tsx` | Edit YouTube transcripts |
 | `/movie/:id?` | `movie.tsx` | Edit movie transcripts |
 | `/chunks/:id` | `chunks.tsx` | Review a document's chunk analysis runs (see below) |
-| `/read/:id` | `read.tsx` | Chapter-by-chapter reader view (book/article `text_md`), with per-user progress + notes |
+| `/read/:id` | `read.tsx` | Chapter-by-chapter reader view (book/article `text_md`, or TEMAT chunk topics as fallback for YouTube/movie transcripts), with per-user progress + notes |
 | `/upload-file` | `file.tsx` | Upload image files (alpha) |
 
 ### Chunk analysis review (`chunks.tsx`)

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -13,9 +13,11 @@ interface Chapter {
   position: number;
   level: number;
   title: string;
-  char_start: number;
-  char_end: number;
   length: number;
+  // Present for markdown-header chapters; absent for the TEMAT-chunk fallback
+  // used by documents with no H1/H2 structure (YouTube/movie transcripts).
+  char_start?: number;
+  char_end?: number;
 }
 
 interface ChapterContent {


### PR DESCRIPTION
## Summary
- `/read/:id` built its table of contents from markdown H1/H2 headers only — no YouTube video in the database has any (transcripts go through topic-chunk analysis, not markdown structuring), so the reader always dead-ended with "Document has no detectable chapters (H1/H2 headers)" for every video, even though the "Czytaj" button was shown for youtube/movie documents.
- `GET /document/<id>/chapters` and `.../chapter/<position>` now fall back to the latest analysis run's TEMAT chunk topics (skipping REKLAMA/SZUM) when no markdown headers are found, so transcripts get the same clean chapter-by-chapter reading experience (with progress tracking and notes) as articles/books.

## Test plan
- [x] Backend unit tests: 5 new tests for the fallback path (`test_document_analysis_book_mode.py`), 31/31 pass; existing markdown-chapter tests unaffected
- [x] `ruff check` clean, `npm run lint` (tsc) clean
- [x] Verified live on NAS against a real YouTube document (#9188, previously reproduced the reported bug): TOC now shows 12 chunk-topic chapters, chapter navigation (prev/next, TOC click) works, continuous prose renders correctly