### PR TITLE
Chunk review improvements: captions retry, sentence-per-line splitting, single-chunk speaker detection

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -237,8 +237,8 @@ def split_preview(doc_id: int):
     scope_chapter (1-based chapter position — article mode only).
     Transcript sizes are approximate (speaker labeling happens only in a real run).
     """
-    from library.document_analysis_service import ANALYSIS_MODES, _extract_text, _slice_chapter
-    from library.text_functions import split_markdown_into_chunks, split_text_into_sentence_chunks
+    from library.document_analysis_service import ANALYSIS_MODES, _extract_text
+    from library.text_functions import detect_chapters, split_markdown_into_chunks, split_text_into_sentence_chunks
 
     mode = request.args.get("mode", "article")
     chunk_size = request.args.get("chunk_size", 5000, type=int)
@@ -262,10 +262,20 @@ def split_preview(doc_id: int):
     scope_title = None
     if mode == "article":
         if scope_chapter is not None:
-            try:
-                text, scope_title = _slice_chapter(text, scope_chapter)
-            except ValueError as exc:
-                return jsonify({"status": "error", "message": str(exc)}), 400
+            chapters = detect_chapters(text)
+            if not chapters:
+                return jsonify({
+                    "status": "error",
+                    "message": "Document has no detectable chapters (H1/H2 headers)",
+                }), 400
+            match = next((c for c in chapters if c["position"] == scope_chapter), None)
+            if match is None:
+                return jsonify({
+                    "status": "error",
+                    "message": f"scope_chapter {scope_chapter} out of range (1..{len(chapters)})",
+                }), 400
+            text = text[match["char_start"]:match["char_end"]].strip()
+            scope_title = match["title"]
         parts = split_markdown_into_chunks(text, chunk_size)
     else:
         from library.chunk_llm_analysis import remove_speech_fillers
@@ -364,7 +374,7 @@ def document_chapter(doc_id: int, position: int):
     markdown-header chapters or, as a fallback, TEMAT-chunk chapters (see
     _chunk_based_chapters).
     """
-    from library.document_analysis_service import _extract_text, _slice_chapter
+    from library.document_analysis_service import _extract_text
     from library.text_functions import detect_chapters
 
     session = get_scoped_session()
@@ -377,10 +387,14 @@ def document_chapter(doc_id: int, position: int):
 
     if md_chapters:
         chapter_total = len(md_chapters)
-        try:
-            chapter_text, title = _slice_chapter(text, position)
-        except ValueError as exc:
-            return jsonify({"status": "error", "message": str(exc)}), 400
+        match = next((c for c in md_chapters if c["position"] == position), None)
+        if match is None:
+            return jsonify({
+                "status": "error",
+                "message": f"position {position} out of range (1..{chapter_total})",
+            }), 400
+        chapter_text = text[match["char_start"]:match["char_end"]].strip()
+        title = match["title"]
     else:
         run = _latest_run_for_document(session, doc_id)
         chunk_chapters = _chunk_based_chapters(run) if run else []

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -834,22 +834,40 @@ def get_embedding_job(job_id: str):
 
 @bp.route("/analysis_run/<int:run_id>/extract_speakers", methods=["POST"])
 def extract_speakers(run_id: int):
-    """Extract speaker names from the first few chunks using LLM.
+    """Extract speaker names from a few chunks using LLM.
 
-    Uses the intro text (first 3 chunks' original_text) where participants
-    typically introduce themselves. Saves result to run.speakers.
+    By default uses the intro text (first 3 chunks' original_text, ordered by
+    position) where participants typically introduce themselves. Pass
+    chunk_ids (JSON body) to use specific chunk(s) instead — e.g. a single
+    chunk the reviewer has manually split out to contain just the
+    self-introductions, so detection doesn't need the surrounding chunks.
+    Saves result to run.speakers.
     """
     session = get_scoped_session()
     run = session.get(DocumentAnalysisRun, run_id)
     if run is None:
         abort(404, f"Run {run_id} not found")
 
-    intro_chunks = session.scalars(
-        select(DocumentChunk)
-        .where(DocumentChunk.run_id == run_id)
-        .order_by(DocumentChunk.position)
-        .limit(3)
-    ).all()
+    data = request.get_json(silent=True) or {}
+    chunk_ids = data.get("chunk_ids")
+
+    if chunk_ids:
+        if not isinstance(chunk_ids, list) or not all(isinstance(i, int) for i in chunk_ids):
+            return jsonify({"status": "error", "message": "chunk_ids must be a list of integers"}), 400
+        intro_chunks = session.scalars(
+            select(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.id.in_(chunk_ids))
+            .order_by(DocumentChunk.position)
+        ).all()
+        if len(intro_chunks) != len(set(chunk_ids)):
+            return jsonify({"status": "error", "message": "One or more chunk_ids not found in this run"}), 400
+    else:
+        intro_chunks = session.scalars(
+            select(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id)
+            .order_by(DocumentChunk.position)
+            .limit(3)
+        ).all()
 
     intro_text = "\n\n".join(
         c.corrected_text or c.original_text or ""
@@ -857,7 +875,7 @@ def extract_speakers(run_id: int):
     ).strip()
 
     if not intro_text:
-        return jsonify({"status": "error", "message": "No text in first chunks"}), 400
+        return jsonify({"status": "error", "message": "No text in selected chunks"}), 400
 
     try:
         from library.chunk_llm_analysis import extract_speaker_info

--- a/backend/library/text_functions.py
+++ b/backend/library/text_functions.py
@@ -67,6 +67,11 @@ def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
     First flattens single newlines to spaces so sentences are not broken by line wrapping,
     then splits on sentence-ending punctuation.
 
+    Sentences within a chunk are joined with '\\n' (one sentence per line) rather than a
+    space — this lets the chunk-review UI's line-based split/delete tools operate at
+    sentence granularity even when the source has no paragraph breaks (see ADR-010 chunk
+    review notes: transcripts without JSON caption segments have no other split point).
+
     Falls back to mid-sentence split only when a single sentence exceeds max_chars.
     """
     flat = re.sub(r'\n(?!\n)', ' ', text)
@@ -81,13 +86,13 @@ def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
     for sent in sentences:
         if len(sent) > max_chars:
             if current:
-                chunks.append(' '.join(current))
+                chunks.append('\n'.join(current))
                 current = []
                 current_size = 0
             for i in range(0, len(sent), max_chars):
                 chunks.append(sent[i:i + max_chars])
         elif current_size + len(sent) + 1 > max_chars and current:
-            chunks.append(' '.join(current))
+            chunks.append('\n'.join(current))
             current = [sent]
             current_size = len(sent)
         else:
@@ -95,9 +100,9 @@ def split_text_into_sentence_chunks(text: str, max_chars: int) -> list[str]:
             current_size += len(sent) + 1
 
     if current:
-        chunks.append(' '.join(current))
+        chunks.append('\n'.join(current))
 
-    return _merge_small_tail(chunks, max_chars, ' ')
+    return _merge_small_tail(chunks, max_chars, '\n')
 
 
 def split_text_into_chunks(text: str, max_chars: int) -> list[str]:

--- a/backend/server.py
+++ b/backend/server.py
@@ -17,6 +17,7 @@ from library.api_key_routes import bp as api_key_bp
 from library.auth import resolve_api_key
 from library.chunk_review_routes import bp as chunk_review_bp
 from library.reader_routes import bp as reader_bp
+from library.youtube_processing import process_youtube_url
 
 logging.basicConfig(level=logging.INFO)
 
@@ -493,6 +494,69 @@ def website_download_text_content():
         "url": url,
         "language": result["language"],
     }), 200
+
+
+# Retry is only safe before a transcript has ever been captured — once a document
+# reaches NEED_MANUAL_REVIEW (or later), process_youtube_url() would overwrite the
+# already-reviewed text on a fresh run.
+_YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES = {
+    StalkerDocumentStatus.TEMPORARY_ERROR.name,
+    StalkerDocumentStatus.URL_ADDED.name,
+    StalkerDocumentStatus.NEED_TRANSCRIPTION.name,
+}
+
+
+@app.route('/website_youtube_retry_captions', methods=['POST'])
+def website_youtube_retry_captions():
+    """Retry downloading YouTube captions for a document stuck in a no-transcript
+    state (e.g. document_state_error=CAPTIONS_FETCH_ERROR)."""
+    doc_id = request.form.get('id')
+    if not doc_id:
+        json_data = request.get_json(silent=True) or {}
+        doc_id = json_data.get('id')
+
+    if not doc_id:
+        return {"status": "error", "message": "Brakujące dane. Upewnij się, że dostarczasz 'id'"}, 400
+
+    try:
+        doc_id_int = int(doc_id)
+    except (ValueError, TypeError):
+        return {"status": "error", "message": "Invalid ID parameter — must be a positive integer"}, 400
+
+    session = get_scoped_session()
+    service = DocumentService(session)
+    doc = service.get_document(doc_id_int)
+    if doc is None:
+        return {"status": "error", "message": "Document not found"}, 404
+
+    if doc.document_type != StalkerDocumentType.youtube.name:
+        return {"status": "error", "message": "Retry captions is only available for YouTube documents"}, 400
+
+    if doc.document_state not in _YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES:
+        return {
+            "status": "error",
+            "message": f"Document is in state '{doc.document_state}' — captions retry is only allowed "
+                       f"before a transcript has been captured ({', '.join(sorted(_YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES))})",
+        }, 409
+
+    webshare_api_key = cfg.get("WEBSHARE_API_KEY")
+    updated = process_youtube_url(
+        session=session,
+        youtube_url=doc.url,
+        language=doc.language,
+        chapter_list=doc.chapter_list,
+        note=doc.note,
+        source=doc.source,
+        webshare_api_key=webshare_api_key,
+    )
+
+    return {
+        "status": "success",
+        "message": "Captions retry finished",
+        "id": updated.id,
+        "document_state": updated.document_state,
+        "document_state_error": updated.document_state_error,
+    }, 200
 
 
 @app.route('/website_text_remove_not_needed', methods=['POST'])

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -437,3 +437,91 @@ class TestChaptersFallbackToChunks:
         resp = app.test_client().get("/document/88/chapter/1")
 
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /analysis_run/<id>/extract_speakers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSpeakers:
+    def _make_client(self, monkeypatch, run, chunks_for_query):
+        fake_session = MagicMock()
+        fake_session.get.side_effect = (
+            lambda model, pk: run if model is DocumentAnalysisRun and pk == run.id else None
+        )
+        fake_session.scalars.return_value = _ScalarsResult(chunks_for_query)
+        monkeypatch.setattr(crr, "get_scoped_session", lambda: fake_session)
+
+        app = flask.Flask(__name__)
+        app.register_blueprint(crr.bp)
+        return app.test_client()
+
+    def test_default_uses_first_three_chunks_by_position(self, monkeypatch):
+        run = MagicMock(spec=DocumentAnalysisRun)
+        run.id, run.model, run.speakers = 10, "m", []
+        chunks = [
+            _make_chunk(id=1, position=1, original_text="Cześć, jestem Jan."),
+            _make_chunk(id=2, position=2, original_text="A ja Anna."),
+            _make_chunk(id=3, position=3, original_text="Zaczynajmy odcinek."),
+        ]
+        captured = {}
+        monkeypatch.setattr(llm, "extract_speaker_info", lambda text, model: (
+            captured.__setitem__("text", text) or [{"name": "Jan", "role": "prowadzący", "description": ""}]
+        ))
+        client = self._make_client(monkeypatch, run, chunks)
+
+        resp = client.post(f"/analysis_run/{run.id}/extract_speakers")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["speakers"] == [{"name": "Jan", "role": "prowadzący", "description": ""}]
+        assert run.speakers == data["speakers"]
+        assert "Cześć, jestem Jan." in captured["text"]
+        assert "Zaczynajmy odcinek." in captured["text"]
+
+    def test_chunk_ids_uses_only_the_specified_chunk(self, monkeypatch):
+        run = MagicMock(spec=DocumentAnalysisRun)
+        run.id, run.model, run.speakers = 11, "m", []
+        target = _make_chunk(id=42, position=5, original_text="Nazywam się Ola, jestem gościem.")
+        captured = {}
+        monkeypatch.setattr(llm, "extract_speaker_info", lambda text, model: (
+            captured.__setitem__("text", text) or [{"name": "Ola", "role": "gość", "description": ""}]
+        ))
+        client = self._make_client(monkeypatch, run, [target])
+
+        resp = client.post(f"/analysis_run/{run.id}/extract_speakers", json={"chunk_ids": [42]})
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert captured["text"] == "Nazywam się Ola, jestem gościem."
+        assert data["speakers"] == [{"name": "Ola", "role": "gość", "description": ""}]
+
+    def test_chunk_ids_not_found_in_run_returns_400(self, monkeypatch):
+        run = MagicMock(spec=DocumentAnalysisRun)
+        run.id, run.model, run.speakers = 12, "m", []
+        client = self._make_client(monkeypatch, run, [])  # query matched nothing
+
+        resp = client.post(f"/analysis_run/{run.id}/extract_speakers", json={"chunk_ids": [999]})
+
+        assert resp.status_code == 400
+
+    def test_chunk_ids_wrong_type_returns_400(self, monkeypatch):
+        run = MagicMock(spec=DocumentAnalysisRun)
+        run.id, run.model, run.speakers = 13, "m", []
+        client = self._make_client(monkeypatch, run, [])
+
+        resp = client.post(f"/analysis_run/{run.id}/extract_speakers", json={"chunk_ids": "not-a-list"})
+
+        assert resp.status_code == 400
+
+    def test_run_not_found_returns_404(self, monkeypatch):
+        fake_session = MagicMock()
+        fake_session.get.return_value = None
+        monkeypatch.setattr(crr, "get_scoped_session", lambda: fake_session)
+        app = flask.Flask(__name__)
+        app.register_blueprint(crr.bp)
+
+        resp = app.test_client().post("/analysis_run/999/extract_speakers")
+
+        assert resp.status_code == 404

--- a/backend/tests/unit/test_flask_endpoints_orm.py
+++ b/backend/tests/unit/test_flask_endpoints_orm.py
@@ -4,7 +4,7 @@ Tests verify that Flask route handlers correctly use ORM models and scoped sessi
 while preserving the exact API response formats expected by the frontend.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -549,3 +549,94 @@ class TestUrlAdd:
         data = resp.get_json()
         assert data["status"] == "success"
         mock_service.create_document.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# /website_youtube_retry_captions
+# ---------------------------------------------------------------------------
+
+
+class TestWebsiteYoutubeRetryCaptions:
+    def _mock_doc(self, document_type="youtube", document_state="TEMPORARY_ERROR"):
+        mock_doc = MagicMock()
+        mock_doc.id = 9163
+        mock_doc.url = "https://www.youtube.com/watch?v=abc123"
+        mock_doc.document_type = document_type
+        mock_doc.document_state = document_state
+        mock_doc.language = "pl"
+        mock_doc.chapter_list = None
+        mock_doc.note = None
+        mock_doc.source = "own"
+        return mock_doc
+
+    def test_retries_when_no_transcript_yet(self, client):
+        mock_session = MagicMock()
+        mock_doc = self._mock_doc()
+        updated_doc = self._mock_doc(document_state="NEED_MANUAL_REVIEW")
+        updated_doc.document_state_error = "NONE"
+        with patch("server.get_scoped_session", return_value=mock_session):
+            with patch("server.DocumentService") as MockDS:
+                mock_service = MagicMock()
+                mock_service.get_document.return_value = mock_doc
+                MockDS.return_value = mock_service
+                with patch("server.process_youtube_url", return_value=updated_doc) as mock_process:
+                    resp = client.post("/website_youtube_retry_captions", data={"id": "9163"}, headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "success"
+        assert data["document_state"] == "NEED_MANUAL_REVIEW"
+        mock_process.assert_called_once_with(
+            session=mock_session,
+            youtube_url=mock_doc.url,
+            language=mock_doc.language,
+            chapter_list=mock_doc.chapter_list,
+            note=mock_doc.note,
+            source=mock_doc.source,
+            webshare_api_key=ANY,
+        )
+
+    def test_rejects_non_youtube_document(self, client):
+        mock_session = MagicMock()
+        mock_doc = self._mock_doc(document_type="webpage")
+        with patch("server.get_scoped_session", return_value=mock_session):
+            with patch("server.DocumentService") as MockDS:
+                mock_service = MagicMock()
+                mock_service.get_document.return_value = mock_doc
+                MockDS.return_value = mock_service
+
+                resp = client.post("/website_youtube_retry_captions", data={"id": "9163"}, headers=API_HEADERS)
+
+        assert resp.status_code == 400
+
+    def test_rejects_when_transcript_already_exists(self, client):
+        """A document already past NEED_TRANSCRIPTION has a transcript — retry
+        must not risk overwriting reviewed text."""
+        mock_session = MagicMock()
+        mock_doc = self._mock_doc(document_state="NEED_MANUAL_REVIEW")
+        with patch("server.get_scoped_session", return_value=mock_session):
+            with patch("server.DocumentService") as MockDS:
+                mock_service = MagicMock()
+                mock_service.get_document.return_value = mock_doc
+                MockDS.return_value = mock_service
+                with patch("server.process_youtube_url") as mock_process:
+                    resp = client.post("/website_youtube_retry_captions", data={"id": "9163"}, headers=API_HEADERS)
+
+        assert resp.status_code == 409
+        mock_process.assert_not_called()
+
+    def test_not_found_returns_404(self, client):
+        mock_session = MagicMock()
+        with patch("server.get_scoped_session", return_value=mock_session):
+            with patch("server.DocumentService") as MockDS:
+                mock_service = MagicMock()
+                mock_service.get_document.return_value = None
+                MockDS.return_value = mock_service
+
+                resp = client.post("/website_youtube_retry_captions", data={"id": "999"}, headers=API_HEADERS)
+
+        assert resp.status_code == 404
+
+    def test_missing_id_returns_400(self, client):
+        resp = client.post("/website_youtube_retry_captions", data={}, headers=API_HEADERS)
+        assert resp.status_code == 400

--- a/backend/tests/unit/test_split_markdown_into_chunks.py
+++ b/backend/tests/unit/test_split_markdown_into_chunks.py
@@ -89,3 +89,29 @@ class TestTailMerge:
         text = sentences + " Kropka."
         chunks = split_text_into_sentence_chunks(text, 1000)
         assert len(chunks) == 1 or len(chunks[-1]) >= 150
+
+    def test_sentence_splitter_joins_with_newline_not_space(self):
+        """One sentence per line — lets the chunk-review UI's line-based split/delete
+        tools work at sentence granularity even without paragraph breaks in the source
+        (e.g. legacy YouTube transcripts with no JSON caption segments)."""
+        from library.text_functions import split_text_into_sentence_chunks
+        text = "To jest pierwsze zdanie. To jest drugie zdanie. A to trzecie?"
+        chunks = split_text_into_sentence_chunks(text, 1000)
+        assert len(chunks) == 1
+        lines = chunks[0].split("\n")
+        assert lines == [
+            "To jest pierwsze zdanie.",
+            "To jest drugie zdanie.",
+            "A to trzecie?",
+        ]
+
+    def test_sentence_splitter_flattens_source_newlines_before_splitting(self):
+        """Source \\n (YouTube caption line-wrapping) must not leak into the output as
+        extra blank sentences — only real sentence boundaries become line breaks."""
+        from library.text_functions import split_text_into_sentence_chunks
+        text = "To jest\npierwsze zdanie. To jest\ndrugie zdanie."
+        chunks = split_text_into_sentence_chunks(text, 1000)
+        assert chunks[0].split("\n") == [
+            "To jest pierwsze zdanie.",
+            "To jest drugie zdanie.",
+        ]

--- a/web_interface_react/src/modules/shared/hooks/useManageLLM.ts
+++ b/web_interface_react/src/modules/shared/hooks/useManageLLM.ts
@@ -463,6 +463,33 @@ export const useManageLLM = ({ formik, selectedDocumentType, selectedDocumentSta
     }
   };
 
+  const handleYoutubeRetryCaptions = async (website_id: string | number) => {
+    setIsLoading(true);
+    try {
+      const response = await axios.post(
+        `${apiUrl}/website_youtube_retry_captions`,
+        { id: website_id },
+        {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "x-api-key": `${apiKey}`,
+          },
+        },
+      );
+      setMessage(response.data.message);
+      setIsLoading(false);
+      setIsError(false);
+      return response.data;
+    } catch (error: any) {
+      console.error("There was an error on handleYoutubeRetryCaptions!", error);
+      const message = error.response?.data?.message || error.message;
+      setMessage(`There was an error retrying YouTube captions: ${message}`);
+      setIsLoading(false);
+      setIsError(true);
+      return null;
+    }
+  };
+
   const handleDeleteDocument = async (website_id: string) => {
     setIsLoading(true);
     console.log("Deleting document with id: " + website_id);
@@ -512,6 +539,7 @@ export const useManageLLM = ({ formik, selectedDocumentType, selectedDocumentSta
     handleSplitTextForEmbedding,
     handleRemoveNotNeededText,
     handleDeleteDocumentNext,
-    handleDeleteDocument
+    handleDeleteDocument,
+    handleYoutubeRetryCaptions
   };
 };

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -112,6 +112,12 @@ const MODELS = [
 const STATUS_CYCLE = ["pending", "approved", "needs_reanalysis"] as const;
 const TYPE_CYCLE: ChunkType[] = ["TEMAT", "REKLAMA", "SZUM"];
 
+// Speaker self-introductions are expected near the start of a transcript, so the
+// per-chunk "detect speakers from just this chunk" button only appears on the
+// first few chunks — matches the backend default (first 3 chunks) with some
+// slack for reviewers who split the intro out into a later position.
+const SPEAKER_DETECT_CHUNK_LIMIT = 5;
+
 // Runs bigger than this are fetched lite (no chunk texts) and browsed through
 // the section accordion (books); flat runs without sections get paged instead.
 const SECTION_VIEW_THRESHOLD = 30;
@@ -360,6 +366,7 @@ const Chunks = () => {
   const [confirmingLineSplit, setConfirmingLineSplit] = React.useState<Record<number, boolean>>({});
   const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
   const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
+  const [extractingSpeakerFor, setExtractingSpeakerFor] = React.useState<number | null>(null);
   const [runStatus, setRunStatus] = React.useState("created");
   const [synthesis, setSynthesis] = React.useState("");
   const [synthesisOpen, setSynthesisOpen] = React.useState(false);
@@ -914,6 +921,24 @@ const Chunks = () => {
     finally { setExtractingSpeakers(false); }
   };
 
+  // Detect speakers from one specific chunk only — useful when the reviewer has
+  // already split out just the self-introductions, so the surrounding chunks
+  // (chit-chat, sponsor reads) don't need to be sent to the LLM too.
+  const extractSpeakersFromChunk = async (chunkId: number) => {
+    if (!selectedRun) return;
+    setExtractingSpeakerFor(chunkId);
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/extract_speakers`, {
+        method: "POST", headers,
+        body: JSON.stringify({ chunk_ids: [chunkId] }),
+      });
+      const data = await r.json();
+      if (data.status === "success") setSpeakers(data.speakers ?? []);
+      else setError("Błąd wykrywania rozmówców: " + (data.message ?? ""));
+    } catch { setError("Błąd połączenia przy wykrywaniu rozmówców"); }
+    finally { setExtractingSpeakerFor(null); }
+  };
+
   // ── Embeddings ──
 
   const pollEmbeddingJob = React.useCallback((jid: string) => {
@@ -1128,6 +1153,16 @@ const Chunks = () => {
                 <button onClick={() => setShowCorrected(prev => ({ ...prev, [chunk.id]: !prev[chunk.id] }))}
                   style={{ padding: "2px 9px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em" }}>
                   {isCorrectedView ? "Surowy" : "Poprawiony"}
+                </button>
+              )}
+              {runMode === "transcript" && chunk.position <= SPEAKER_DETECT_CHUNK_LIMIT && (
+                <button
+                  onClick={() => extractSpeakersFromChunk(chunk.id)}
+                  disabled={extractingSpeakerFor === chunk.id}
+                  title="Wykryj rozmówców tylko z tego chunka (np. gdy przedstawienie się zostało wydzielone do osobnego chunka)"
+                  style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b" }}
+                >
+                  {extractingSpeakerFor === chunk.id ? "🎙 Wykrywam…" : "🎙 Wykryj"}
                 </button>
               )}
               {chunk.position < maxPosition && (

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -7,6 +7,15 @@ import { useManageLLM } from "../hooks/useManageLLM";
 import { useFormik } from 'formik';
 import { buildObsidianNoteUrl } from "../utils/obsidian";
 
+// States where a document has no usable text yet — showing "Czytaj"/"Chunki" there
+// would just open an empty page. Mirrors the backend's YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES
+// (minus TEMPORARY_ERROR's overlap) plus TRANSCRIPTION_IN_PROGRESS.
+const NO_TEXT_STATES = ["URL_ADDED", "NEED_TRANSCRIPTION", "TRANSCRIPTION_IN_PROGRESS", "TEMPORARY_ERROR"];
+
+// Mirrors backend's _YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES — retry is only safe
+// before a transcript has ever been captured, so it can't clobber reviewed text.
+const YOUTUBE_CAPTIONS_RETRY_STATES = ["TEMPORARY_ERROR", "URL_ADDED", "NEED_TRANSCRIPTION"];
+
 const List = () => {
     const { isLoading, isError, data, message, handleGetList, dataAllLength } = useList();
     const { states: fetchedStates, types: fetchedTypes } = useDocumentStates();
@@ -38,7 +47,7 @@ const List = () => {
     onlyHas: filter === "has",
   });
 
-  const { handleDeleteDocument } = useManageLLM({ formik, selectedDocumentType, selectedDocumentState });
+  const { handleDeleteDocument, handleYoutubeRetryCaptions, message: manageMessage, isLoading: isRetrying } = useManageLLM({ formik, selectedDocumentType, selectedDocumentState });
 
   const handleTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
           setSelectedDocumentType(event.target.value);
@@ -60,6 +69,11 @@ const List = () => {
     console.log("handleDocumentDeleteOnThisPage, page id: " + document_id);
     await handleDeleteDocument(String(document_id));
     handleGetList(selectedDocumentType, selectedDocumentState);
+  };
+
+  const handleRetryCaptionsOnThisPage = async (document_id: string | number) => {
+    await handleYoutubeRetryCaptions(document_id);
+    handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument, obsidianFilterParams(obsidianFilter));
   };
 
   // Single compact indicator for the row — details (links, counts) live in an
@@ -153,6 +167,7 @@ const List = () => {
       </select>
       <div>
         <p className={"errorText"}>{message}</p>
+        {manageMessage && <p className={"errorText"}>{manageMessage}</p>}
       </div>
 
       {isLoading && (
@@ -210,7 +225,7 @@ const List = () => {
               >
                 Edit
               </NavLink>
-              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && (
+              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && !NO_TEXT_STATES.includes(item.document_state) && (
                 <NavLink
                   className={"button"}
                   style={{ margin: "0 0 0 6px" }}
@@ -219,7 +234,7 @@ const List = () => {
                   Czytaj
                 </NavLink>
               )}
-              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && (
+              {["youtube", "movie", "webpage", "text"].includes(item.document_type) && !NO_TEXT_STATES.includes(item.document_state) && (
                 <NavLink
                   className={"button"}
                   style={{ margin: "0 0 0 6px" }}
@@ -228,6 +243,16 @@ const List = () => {
                 >
                   Chunki
                 </NavLink>
+              )}
+              {item.document_type === "youtube" && YOUTUBE_CAPTIONS_RETRY_STATES.includes(item.document_state) && (
+                <button
+                  className={"button"}
+                  style={{ margin: "0 0 0 6px" }}
+                  disabled={isRetrying}
+                  onClick={() => handleRetryCaptionsOnThisPage(item.id)}
+                >
+                  Pobierz napisy ponownie
+                </button>
               )}
               <button
                 className={"button"}


### PR DESCRIPTION
## Summary
- Add `POST /website_youtube_retry_captions` to re-fetch YouTube captions for a document stuck without a transcript (e.g. `CAPTIONS_FETCH_ERROR`); frontend gets a matching retry button and hides the Czytaj/Chunki buttons for documents that have no usable text yet.
- `split_text_into_sentence_chunks()` now joins sentences with `\n` instead of a space, so each sentence lands on its own line — lets the existing chunk-review line-based split/delete tools work at sentence granularity even without paragraph breaks (e.g. legacy YouTube transcripts with no JSON caption segments).
- Fix a CodeQL information-exposure finding in `chunk_review_routes.py`: two endpoints no longer return `str(exc)` from a caught `ValueError` — they pre-validate the chapter position against the already-detected chapters list instead.
- `POST /analysis_run/<id>/extract_speakers` accepts an optional `chunk_ids` list, so speaker detection can run on a single reviewer-selected chunk (e.g. one containing just the self-introductions) instead of always the first 3 chunks of the run. Frontend adds a per-chunk "🎙 Wykryj" button on the first few chunks of transcript-mode runs.

## Test plan
- [x] `pytest tests/unit/` — 897/897 passing
- [x] `npm run lint` (tsc --noEmit) — clean
- [x] Manually verified on NAS deployment (retry captions, hidden buttons, sentence-per-line split, single-chunk speaker detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)