### PR TITLE
fix: ner_service Docker build (README.md exclusion, uv run project sync)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,7 @@ backend/.venv_wsl/
 # These README.md files are required by hatchling build (pyproject.toml readme field)
 !slack_bot/README.md
 !shared_python/unified-config-loader/README.md
+!ner_service/README.md
 
 # Project directories not needed in any Docker build
 _bmad/

--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -155,6 +155,12 @@ services:
     # (http://lenie-ner-service:8090). See ner_service/README.md.
     networks:
       - lenie-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
 
   lenie-mcp-server:
     image: 192.168.200.7:5005/lenie-mcp-server:latest

--- a/ner_service/Dockerfile
+++ b/ner_service/Dockerfile
@@ -6,6 +6,12 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 
 WORKDIR /app
 
+# Install curl (required for healthcheck)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -16,7 +22,8 @@ COPY ner_service/pyproject.toml ner_service/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 # Download Polish spaCy NER model (pl_core_news_lg, ~560MB) — see docs/geo-place-ner-plan.md / docs/person-ner-plan.md
-RUN uv run python -m spacy download pl_core_news_lg
+# --no-project: skip building/installing the local project package (README.md isn't copied in yet at this point)
+RUN uv run --no-project python -m spacy download pl_core_news_lg
 
 # Copy source code and README (required by hatchling build)
 COPY ner_service/README.md .
@@ -30,4 +37,5 @@ RUN groupadd -g 1002 lenie-ner-service && \
 USER lenie-ner-service
 
 # No EXPOSE / published port — only reachable from other containers on lenie-net
-CMD ["uv", "run", "python", "-m", "src.main"]
+# Direct venv entrypoint (not "uv run") — avoids re-syncing/rebuilding the project package on every start
+ENTRYPOINT ["/app/.venv/bin/python", "-m", "src.main"]

--- a/ner_service/README.md
+++ b/ner_service/README.md
@@ -34,6 +34,13 @@ tagging — not yet wired into the backend's tagging pipeline).
 Labels come directly from `pl_core_news_lg`: `persName`, `geogName`,
 `placeName`, `orgName`, `date`, `time`, etc.
 
+The model is loaded lazily on the first `/ner` call (not at startup), so
+`/healthz` responds immediately even before it's loaded — but that first
+`/ner` call pays the one-time load cost, which on the NAS (Celeron, cold
+disk cache after a container restart) has been observed to take up to
+~60-90s. Callers should set a generous timeout on the first request after
+a deploy/restart; subsequent calls are sub-second.
+
 ## Local development
 
 ```bash


### PR DESCRIPTION
## Summary
- `.dockerignore` excluded all `*.md` without an exception for `ner_service/README.md` (required by hatchling's `readme` field), unlike the existing `slack_bot`/`shared_python` exceptions — build failed on `COPY ner_service/README.md .`
- `uv run python -m spacy download ...` implicitly tries to build/install the local project package, which failed because `README.md` wasn't copied in yet at that Dockerfile step (this is also what broke the earlier, already-reverted backend spaCy build). Fixed with `--no-project` on the download step
- Switched container `CMD` to a direct venv entrypoint (`/app/.venv/bin/python -m src.main`) instead of `uv run python -m src.main`, so it doesn't re-sync/rebuild the project package on every container start
- Added `curl` to the image (needed for the `compose.nas.yaml` healthcheck)
- Documented lazy model-load latency in `ner_service/README.md` — first `/ner` call after a restart took ~60-90s in testing on the NAS-equivalent build; subsequent calls are sub-second since `/healthz` doesn't wait on the model

## Test plan
- [x] Fresh `docker build -f ner_service/Dockerfile .` succeeds end-to-end (verified with no build cache reused for the fixed layers)
- [x] Container starts, `/healthz` responds immediately, `/ner` correctly tags `persName`/`placeName` (verified via published port + curl)
- [x] `uv run pytest tests/` — 4 passed
- [x] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)