### PR TITLE
fix: migrate NAS Container Station storage off corrupted volume, fix postgres 18 mount path

### DIFF
--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -2,9 +2,9 @@
 # Images pulled from private registry at 192.168.200.7:5005
 #
 # Usage on NAS:
-#   DOCKER=/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/.libs/docker
-#   $DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml up -d
-#   $DOCKER compose -f /share/Container/lenie-compose/compose.nas.yaml ps
+#   DOCKER=/share/CACHEDEV4_DATA/.qpkg/container-station/usr/bin/.libs/docker
+#   $DOCKER compose -f /share/ContainerNew/lenie-compose/compose.nas.yaml up -d
+#   $DOCKER compose -f /share/ContainerNew/lenie-compose/compose.nas.yaml ps
 
 services:
   lenie-ai-db:
@@ -16,7 +16,7 @@ services:
     environment:
       POSTGRES_PASSWORD: ${NAS_DB_PASSWORD:-postgres}
     volumes:
-      - lenie-ai-db-data:/var/lib/postgresql/data
+      - lenie-ai-db-data:/var/lib/postgresql
     networks:
       - lenie-net
     healthcheck:
@@ -32,7 +32,7 @@ services:
     ports:
       - "5055:5000"
     env_file:
-      - /share/Container/lenie-env/.env
+      - /share/ContainerNew/lenie-env/.env
     volumes:
       - lenie-ai-data:/app/data
     networks:
@@ -64,7 +64,7 @@ services:
     container_name: lenie-ai-slack-bot
     restart: unless-stopped
     env_file:
-      - /share/Container/lenie-env/.env
+      - /share/ContainerNew/lenie-env/.env
     networks:
       - lenie-net
     depends_on:
@@ -78,7 +78,7 @@ services:
       - "9000:9000"   # S3 API
       - "9001:9001"   # Web console
     env_file:
-      - /share/Container/lenie-env/minio.env
+      - /share/ContainerNew/lenie-env/minio.env
     command: server /data --console-address ":9001"
     volumes:
       - lenie-minio-data:/data
@@ -132,11 +132,11 @@ services:
     cap_add:
       - IPC_LOCK
     env_file:
-      - /share/Container/lenie-env/vault.env
+      - /share/ContainerNew/lenie-env/vault.env
     volumes:
-      - /share/vault/config:/vault/config
-      - /share/vault/data:/vault/file
-      - /share/vault/logs:/vault/logs
+      - /share/ContainerNew/vault/config:/vault/config
+      - /share/ContainerNew/vault/data:/vault/file
+      - /share/ContainerNew/vault/logs:/vault/logs
     command: server
     healthcheck:
       test: ["CMD", "vault", "status", "-address=http://127.0.0.1:8200"]
@@ -169,7 +169,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - /share/Container/lenie-env/mcp_server.env
+      - /share/ContainerNew/lenie-env/mcp_server.env
     networks:
       - lenie-net
     depends_on:

--- a/infra/docker/nas-deploy.sh
+++ b/infra/docker/nas-deploy.sh
@@ -15,8 +15,8 @@ set -euo pipefail
 # --- Configuration ---
 NAS_HOST="192.168.200.7"
 NAS_USER="admin"
-NAS_DOCKER="/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/.libs/docker"
-NAS_COMPOSE_DIR="/share/Container/lenie-compose"
+NAS_DOCKER="/share/CACHEDEV4_DATA/.qpkg/container-station/usr/bin/.libs/docker"
+NAS_COMPOSE_DIR="/share/ContainerNew/lenie-compose"
 NAS_COMPOSE_FILE="${NAS_COMPOSE_DIR}/compose.nas.yaml"
 REGISTRY="${NAS_HOST}:5005"
 


### PR DESCRIPTION
## Summary
- Container Station's data volume (old `DataVol2` / `CACHEDEV2`) hit filesystem corruption again while pulling the `ner-service` image — same class of issue as the previously-resolved registry corruption incident
- Reinstalled Container Station pointed at a new dedicated volume on a different physical disk pool (`CACHEDEV4`, shared folder `ContainerNew`); migrated with full backups of Postgres, Vault, and the small `ai-data`/`minio` volumes
- `nas-deploy.sh`: docker CLI path and compose file location updated to the new volume
- `compose.nas.yaml`: `env_file` and vault bind-mount paths updated from `/share/Container/...` to `/share/ContainerNew/...`
- Also fixed an independent, real bug surfaced by the fresh init: `postgres:18` images now refuse to start with the volume mounted at the legacy `/var/lib/postgresql/data` path — they expect `/var/lib/postgresql` directly (local `compose.yaml` already had this right; `compose.nas.yaml` didn't)

## Test plan
- [x] Full NAS stack redeployed and verified healthy: db (9203 `web_documents` rows restored and verified via `pg_restore --list` + row counts), vault (auto-unsealed via KMS, all keys/secrets intact), minio, backend, frontend, app2, ner-service, slack-bot
- [x] `ner-service` verified end-to-end: `docker exec lenie-ai-server curl ... http://lenie-ner-service:8090/ner` returns correct `persName`/`placeName` tags
- [ ] `mcp-server` not yet redeployed — blocked by an unrelated port 8080 conflict with a NAS system process (`fcgi-pm`), to be resolved separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)