### PR TITLE
chore: register LOCATIONIQ_API_KEY + geocoding test findings for NER stage 3

### DIFF
--- a/docs/ner-integration-plan.md
+++ b/docs/ner-integration-plan.md
@@ -88,8 +88,19 @@ Zgodnie z [`geo-place-ner-plan.md`](geo-place-ner-plan.md):
 - UI: frontend ma już `CountryMap` (mapa z tagów `kraj-*`) — punkty miejsc ze
   współrzędnymi nanosimy na tę samą mapę.
 
-Wymaga: konto LocationIQ (weryfikacja cennika), decyzja o namespace tagów
-(`miejsce-*` vs `geo-*`), tabela cache geokodowania.
+Wymaga: konto LocationIQ (✅ założone 2026-07-10, klucz w Vault jako
+`LOCATIONIQ_API_KEY`, wpis w `scripts/vars-classification.yaml`), decyzja o
+namespace tagów (`miejsce-*` vs `geo-*`), tabela cache geokodowania.
+
+**Ustalenie z testu klucza (2026-07-10):** popularne polskie egzonimy
+rozwiązują się poprawnie („Kijów" → Kyiv, „Morze Czerwone" → Red Sea), ale
+rzadsze dają **fałszywe dopasowania fuzzy** zamiast braku wyniku — „Cieśnina
+Ormuz" zwróciła „Płytka Cieśnina" k. Iławy. Weryfikacja w etapie 3 nie może
+więc traktować samego HTTP 200 jako potwierdzenia: trzeba sprawdzić jakość
+dopasowania (podobieństwo zwróconej nazwy do zapytania, `importance`,
+`class`/`type` — np. water/strait/sea dla `geogName`) i/lub odpytywać
+angielską nazwą (LLM i tak uczestniczy w kroku oceny istotności — może przy
+okazji tłumaczyć nazwę).
 
 ## Etap 4 — osoby: model relacyjny (do zrobienia)
 

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -381,6 +381,11 @@ groups:
         type: secret
         required: false
         used_by: [docker, local]
+      LOCATIONIQ_API_KEY:
+        description: "LocationIQ API key for geocoding/place verification (NER stage 3, docs/ner-integration-plan.md; free tier 5000 req/day)"
+        type: secret
+        required: false
+        used_by: [docker, local]
       LANGFUSE_HOST:
         description: "Langfuse observability platform URL"
         type: config


### PR DESCRIPTION
## Summary
- Adds `LOCATIONIQ_API_KEY` to `scripts/vars-classification.yaml` (integrations group, secret). The key itself lives in Vault (`secret/lenie/dev`) — verified readable via config_loader and working against the LocationIQ API.
- Records live geocoding test findings in `docs/ner-integration-plan.md`: common Polish exonyms resolve correctly ("Kijów" → Kyiv, "Morze Czerwone" → Red Sea), but rare ones fuzzy-match to wrong places ("Cieśnina Ormuz" → a lake strait near Iława) — stage 3 verification must validate match quality (name similarity, importance, class/type), not just HTTP 200.

Prep work for NER stage 3 (place verification + `miejsce-*` tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)