### PR TITLE
fix: expand reader summary panel by default on /read page

### DIFF
--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -452,7 +452,7 @@ const Read: React.FC = () => {
             )}
 
             {synthesis && (
-              <details className={styles.synthesisPanel}>
+              <details className={styles.synthesisPanel} open>
                 <summary>📄 Streszczenie</summary>
                 <div style={{ fontSize: "0.85em", lineHeight: 1.55, whiteSpace: "pre-wrap", marginTop: 8 }}>
                   {synthesis}


### PR DESCRIPTION
## Summary
- The "📄 Streszczenie" panel in the reader sidebar (`/read/:id`) is now expanded by default (`<details open>`), instead of requiring a click to open.

## Test plan
- Open `/read/<id>` for a document that has a synthesis — the summary panel on the left should be visible without clicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
