### PR TITLE
feat: reader edit link + persons/places panel in /read sidebar

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -365,6 +365,9 @@ def document_chapters(doc_id: int):
     return jsonify({
         "status": "success",
         "doc_id": doc_id,
+        "document_type": doc.document_type,
+        "title": doc.title,
+        "url": doc.url,
         "source_field": field,
         "text_length": len(text),
         "chapters": chapters,

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -37,6 +37,8 @@ class FakeBookDoc:
     text_md = BOOK_TEXT
     text_raw = None
     tags = "geopolityka,kraj-polska,kraj-niemcy"
+    document_type = "text"
+    url = None
 
 
 # ---------------------------------------------------------------------------
@@ -413,6 +415,7 @@ class FakeTranscriptDoc:
     text_raw = None
     document_type = "youtube"
     tags = None
+    url = None
 
 
 @pytest.fixture

--- a/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
+++ b/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import axios from "axios";
+import { Link } from "react-router-dom";
 import { AuthorizationContext } from "../../context/authorizationContext";
 
 // NER entities detected in the document (backend: GET/POST /website_entities,
 // table document_entities — see docs/ner-integration-plan.md).
 
-interface EntityItem {
+export interface EntityItem {
   text: string;
   count: number;
   // Stage-3 place verification (geogName/placeName only): absent = not checked,
@@ -38,7 +39,16 @@ const chipStyle: React.CSSProperties = {
   fontSize: "0.85em",
 };
 
-const EntityChips = ({ label, items }: { label: string; items: EntityItem[] }) => {
+export const EntityChips = ({
+  label,
+  items,
+  linkPersons,
+}: {
+  label: string;
+  items: EntityItem[];
+  // Resolved persons (person_id) become links to /persons/:id — used by the reader view.
+  linkPersons?: boolean;
+}) => {
   if (!items.length) {
     return null;
   }
@@ -52,7 +62,7 @@ const EntityChips = ({ label, items }: { label: string; items: EntityItem[] }) =
               .filter(Boolean)
               .join(" | ")
           : undefined;
-        return (
+        const chip = (
           <span
             key={item.text}
             style={{
@@ -73,6 +83,14 @@ const EntityChips = ({ label, items }: { label: string; items: EntityItem[] }) =
             {item.count > 1 && <span style={{ color: "#667" }}> ×{item.count}</span>}
           </span>
         );
+        if (linkPersons && isResolvedPerson) {
+          return (
+            <Link key={item.text} to={`/persons/${item.person_id}`} style={{ textDecoration: "none" }}>
+              {chip}
+            </Link>
+          );
+        }
+        return chip;
       })}
     </div>
   );

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -6,6 +6,7 @@ import {
   normalizeWs, pendingNoteFromSelection, useReaderIdentity, useUserNotes,
 } from "../components/ReaderNotes/readerNotes";
 import type { CountryTag, PlaceMarker } from "../components/CountryMap/countryMap";
+import { EntityChips, EntityItem } from "../components/EntitiesPanel/entitiesPanel";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import styles from "./read.module.css";
 
@@ -125,6 +126,9 @@ function renderMarkdown(text: string, notes: UserNote[]): React.ReactNode[] {
   return out;
 }
 
+// Document types that have an editor page at /{type}/:id
+const EDITOR_TYPES = new Set(["webpage", "link", "youtube", "movie", "email"]);
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 const Read: React.FC = () => {
@@ -133,8 +137,11 @@ const Read: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [chapters, setChapters] = React.useState<Chapter[]>([]);
+  const [documentType, setDocumentType] = React.useState<string | null>(null);
   const [countries, setCountries] = React.useState<CountryTag[]>([]);
   const [places, setPlaces] = React.useState<PlaceMarker[]>([]);
+  const [personItems, setPersonItems] = React.useState<EntityItem[]>([]);
+  const [placeItems, setPlaceItems] = React.useState<EntityItem[]>([]);
   const [thematicTags, setThematicTags] = React.useState<string[]>([]);
   const [synthesis, setSynthesis] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<ChapterContent | null>(null);
@@ -169,6 +176,7 @@ const Read: React.FC = () => {
         const data = await r.json();
         if (data.status !== "success") throw new Error(data.message ?? "Błąd pobierania rozdziałów");
         setChapters(data.chapters ?? []);
+        setDocumentType(data.document_type ?? null);
         setCountries(data.countries ?? []);
         setThematicTags(data.thematic_tags ?? []);
         setSynthesis(data.synthesis ?? null);
@@ -187,6 +195,8 @@ const Read: React.FC = () => {
         const data = await r.json();
         if (data.status !== "success") return;
         const items = [...(data.entities?.geogName ?? []), ...(data.entities?.placeName ?? [])];
+        setPersonItems(data.entities?.persName ?? []);
+        setPlaceItems(items);
         setPlaces(
           items
             .filter((it: any) => it.verified === true && it.lat != null && it.lon != null)
@@ -348,6 +358,9 @@ const Read: React.FC = () => {
         <button className={styles.tocToggleButton} onClick={() => setTocOpen(o => !o)}>
           📑 Spis treści ({chapters.length})
         </button>
+        {documentType && EDITOR_TYPES.has(documentType) && (
+          <NavLink to={`/${documentType}/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>✏️ Edytuj</NavLink>
+        )}
         <NavLink to={`/chunks/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>Przegląd chunków</NavLink>
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
@@ -423,13 +436,24 @@ const Read: React.FC = () => {
           {navButtons}
         </div>
 
-        {/* Map + tags + synthesis — desktop only */}
-        {isDesktop && (countries.length > 0 || places.length > 0 || thematicTags.length > 0 || synthesis) && (
+        {/* Map + entities + tags + synthesis — desktop only */}
+        {isDesktop && (countries.length > 0 || places.length > 0 || personItems.length > 0
+          || placeItems.length > 0 || thematicTags.length > 0 || synthesis) && (
           <div className={styles.rightPanel}>
             {(countries.length > 0 || places.length > 0) && (
               <React.Suspense fallback={null}>
                 <CountryMap countries={countries} places={places} />
               </React.Suspense>
+            )}
+
+            {(personItems.length > 0 || placeItems.length > 0) && (
+              <div style={{
+                background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+                padding: 10, marginTop: 12, fontSize: "0.9em",
+              }}>
+                <EntityChips label={"👤 Osoby"} items={personItems} linkPersons />
+                <EntityChips label={"📍 Miejsca"} items={placeItems} />
+              </div>
             )}
 
             {thematicTags.length > 0 && (


### PR DESCRIPTION
## Summary
- GET /document/<id>/chapters now returns document_type, title and url of the document.
- /read/:id header gets an '✏️ Edytuj' link to the document editor (webpage/link/youtube/movie/email types).
- Right sidebar in the reader shows NER persons and places chips (persons resolved to the registry link to /persons/:id); shared EntityChips component exported from EntitiesPanel.

## Test plan
- backend: pytest tests/unit (1035 passed after fake-doc fix)
- frontend: tsc --noEmit clean; manual check on /read/9216

🤖 Generated with [Claude Code](https://claude.com/claude-code)