### PR TITLE
feat: editor form cleanup — language select, tags chips, source autocomplete

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -46,7 +46,7 @@ Flask + Flask-CORS application exposing 23 REST API endpoints. **Version**: 0.3.
 | **AI Operations** | `/ai_get_embedding`, `/website_similar` |
 | **Content Processing** | `/website_download_text_content`, `/website_text_remove_not_needed`, `/website_split_for_embedding` |
 | **Entities (NER)** | `/website_entities` (GET: stored persons/places; POST: re-run NER + verify places + resolve persons; DELETE `/website_entities/<entity_id>`: remove a stored entity + its person link), `/persons` (GET: fuzzy registry search; POST `/persons/<id>/aliases`: manually add an alias/nickname), `/person_documents` (GET: all documents mentioning a person), `/persons_review` (GET: manual_review queue; PATCH `/persons_review/<link_id>`: approve/reject/merge decision), PATCH `/document_persons/<link_id>` (same actions without the manual_review gate — editor path for undoing wrong matches), `/ner_exclusions` (GET list / POST add / DELETE `/ner_exclusions/<id>`: false-positive suppression dictionary applied at entity refresh) — see `library/entity_service.py`, `library/person_registry.py` |
-| **Metadata** | `/website_is_paid`, `/website_get_next_to_correct`, `/document_states` |
+| **Metadata** | `/website_is_paid`, `/website_get_next_to_correct`, `/document_states`, `/tags` (GET: distinct tags with usage counts), `/sources` (GET: distinct source values with counts) — editor autocomplete |
 | **Auth & identity** | `/whoami`, `/api_keys` (GET/POST), `/api_keys/<id>` (DELETE) — see `library/api_key_routes.py` |
 | **Health & Info** | `/` (root), `/healthz`, `/startup`, `/readiness`, `/liveness`, `/version`, `/metrics` |
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -694,6 +694,41 @@ def website_entities_delete(entity_id: int):
             "person_deleted": bool(link_result and link_result.get("person_deleted"))}, 200
 
 
+@app.route('/tags', methods=['GET'])
+def tags_list():
+    """Distinct tags across web_documents (CSV column), most used first — editor autocomplete."""
+    from sqlalchemy import select as sa_select
+
+    session = get_scoped_session()
+    rows = session.execute(
+        sa_select(WebDocument.tags).where(WebDocument.tags.isnot(None))
+    ).scalars().all()
+    counts: dict[str, int] = {}
+    for tags in rows:
+        for tag in (tags or "").split(","):
+            tag = tag.strip()
+            if tag:
+                counts[tag] = counts.get(tag, 0) + 1
+    ordered = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return {"status": "success", "tags": [{"tag": t, "count": c} for t, c in ordered]}, 200
+
+
+@app.route('/sources', methods=['GET'])
+def sources_list():
+    """Distinct web_documents.source values, most used first — editor autocomplete."""
+    from sqlalchemy import func as sa_func, select as sa_select
+
+    session = get_scoped_session()
+    rows = session.execute(
+        sa_select(WebDocument.source, sa_func.count())
+        .where(WebDocument.source.isnot(None))
+        .group_by(WebDocument.source)
+        .order_by(sa_func.count().desc(), WebDocument.source)
+    ).all()
+    return {"status": "success",
+            "sources": [{"source": s, "count": c} for s, c in rows if s and s.strip()]}, 200
+
+
 def _exclusion_dict(row):
     return {
         "id": row.id, "entity_text": row.entity_text, "entity_type": row.entity_type,

--- a/backend/tests/unit/test_flask_endpoints_tags_sources.py
+++ b/backend/tests/unit/test_flask_endpoints_tags_sources.py
@@ -1,0 +1,63 @@
+"""Unit tests for the /tags and /sources autocomplete endpoints."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("flask")
+
+API_HEADERS = {"x-api-key": "test-api-key"}
+
+
+@pytest.fixture()
+def client():
+    """Flask test client with auth bypassed (same pattern as test_flask_endpoints_orm)."""
+    import server
+    server.app.config["TESTING"] = True
+    with patch.object(server, "check_auth_header"):
+        with server.app.test_client() as c:
+            yield c
+
+
+class TestTagsList:
+    def test_aggregates_and_sorts_by_usage(self, client):
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = [
+            "geopolityka,kraj-polska",
+            "geopolityka, energetyka",
+            "geopolityka",
+        ]
+        with patch("server.get_scoped_session", return_value=session):
+            resp = client.get("/tags", headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        tags = resp.get_json()["tags"]
+        assert tags[0] == {"tag": "geopolityka", "count": 3}
+        assert {"tag": "energetyka", "count": 1} in tags
+        assert {"tag": "kraj-polska", "count": 1} in tags
+
+    def test_empty_database(self, client):
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = []
+        with patch("server.get_scoped_session", return_value=session):
+            resp = client.get("/tags", headers=API_HEADERS)
+        assert resp.status_code == 200
+        assert resp.get_json()["tags"] == []
+
+
+class TestSourcesList:
+    def test_returns_sources_with_counts(self, client):
+        session = MagicMock()
+        session.execute.return_value.all.return_value = [
+            ("unknow.news", 120), ("own", 80), ("  ", 3),
+        ]
+        with patch("server.get_scoped_session", return_value=session):
+            resp = client.get("/sources", headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        sources = resp.get_json()["sources"]
+        assert sources == [
+            {"source": "unknow.news", "count": 120},
+            {"source": "own", "count": 80},
+        ]

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -34,6 +34,7 @@ web_interface_react/
 │   │   │   ├── Select/                 # Reusable select dropdown
 │   │   │   ├── SharedInputs/           # Common document form fields
 │   │   │   ├── EntitiesPanel/          # NER persons/places chips + refresh button (GET/POST /website_entities)
+│   │   │   ├── TagsInput/              # Chip editor over the CSV tags field (suggestions from GET /tags)
 │   │   │   └── FormButtons/            # Save/delete action buttons
 │   │   ├── pages/
 │   │   │   ├── connect.tsx             # Connection configuration (/connect)

--- a/web_interface_react/src/modules/shared/components/SharedInputs/InputsForAllExceptLink.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/InputsForAllExceptLink.tsx
@@ -7,6 +7,9 @@ interface InputsForAllExceptLinkProps {
   handleSplitTextForEmbedding: (values: any) => void;
   handleRemoveNotNeededText: (values: any) => void;
   isLoading: boolean;
+  // "Clean Text" applies portal cleanup rules (site_rules.json) — only makes
+  // sense for webpage documents, so only the webpage editor passes true.
+  showCleanText?: boolean;
 }
 
 const InputsForAllExceptLink = ({
@@ -14,19 +17,24 @@ const InputsForAllExceptLink = ({
   handleSplitTextForEmbedding,
   handleRemoveNotNeededText,
   isLoading,
+  showCleanText,
 }: InputsForAllExceptLinkProps) => {
   return (
     <>
-      <Input
-        disabled={isLoading}
-        value={formik.values.text_md}
-        label={"Website MarkDown content"}
-        onChange={formik.handleChange}
-        id={"text_md"}
-        name={"text_md"}
-        type={"text_md"}
-        multiline
-      />
+      {formik.values.text_md && (
+        <details style={{ marginBottom: "8px" }}>
+          <summary style={{ cursor: "pointer" }}>Website MarkDown content</summary>
+          <Input
+            disabled={isLoading}
+            value={formik.values.text_md}
+            onChange={formik.handleChange}
+            id={"text_md"}
+            name={"text_md"}
+            type={"text_md"}
+            multiline
+          />
+        </details>
+      )}
       <Input
         disabled={isLoading}
         value={formik.values.text}
@@ -45,22 +53,15 @@ const InputsForAllExceptLink = ({
             >
                 Split text for Embedding
             </button>
-            <button
-                className={"button"}
-                style={{marginRight: "10px"}}
-                onClick={() => handleRemoveNotNeededText(formik.values)}
-            >
-                Clean Text
-            </button>
-            <a
-                className={"button"}
-                style={{marginRight: "10px"}}
-                href="https://platform.openai.com/tokenizer"
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                OpenAI Tokenizer
-            </a>
+            {showCleanText && (
+                <button
+                    className={"button"}
+                    style={{marginRight: "10px"}}
+                    onClick={() => handleRemoveNotNeededText(formik.values)}
+                >
+                    Clean Text
+                </button>
+            )}
         </div>
         {formik.values.text && (
             <div style={{marginTop: "10px"}}>

--- a/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
@@ -1,7 +1,10 @@
 import React from "react";
+import axios from "axios";
 import Input from "../Input/input";
 import Select from "../Select/select";
+import TagsInput from "../TagsInput/tagsInput";
 import { NavLink } from "react-router-dom";
+import { AuthorizationContext } from "../../context/authorizationContext";
 
 interface SharedInputsProps {
   formik: any;
@@ -11,6 +14,51 @@ interface SharedInputsProps {
   handleGetPageByUrl: (url: string) => void;
 }
 
+// Languages the user actually works with — anything else via "inny…"
+const PREFERRED_LANGUAGES = ["pl", "en"];
+
+const LanguageSelect = ({ formik, isLoading }: { formik: any; isLoading: boolean }) => {
+  const value: string = formik.values.language ?? "";
+  const [custom, setCustom] = React.useState(false);
+  const knownValue = value === "" || PREFERRED_LANGUAGES.includes(value);
+  return (
+    <>
+      <Select
+        disabled={isLoading}
+        value={custom ? "__other__" : value}
+        label={"Language"}
+        id={"language-select"}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          if (e.target.value === "__other__") {
+            setCustom(true);
+            return;
+          }
+          setCustom(false);
+          formik.setFieldValue("language", e.target.value);
+        }}
+      >
+        <option value="">—</option>
+        {PREFERRED_LANGUAGES.map((lang) => (
+          <option key={lang} value={lang}>{lang}</option>
+        ))}
+        {!knownValue && !custom && <option value={value}>{value}</option>}
+        <option value="__other__">inny…</option>
+      </Select>
+      {custom && (
+        <Input
+          disabled={isLoading}
+          value={value}
+          label={"Language (kod, np. de)"}
+          onChange={formik.handleChange}
+          id={"language"}
+          name={"language"}
+          type={"text"}
+        />
+      )}
+    </>
+  );
+};
+
 const SharedInputs = ({
   formik,
   isLoading,
@@ -18,6 +66,20 @@ const SharedInputs = ({
   handleGetEntryToReview,
   handleGetPageByUrl,
 }: SharedInputsProps) => {
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const [tagSuggestions, setTagSuggestions] = React.useState<string[]>([]);
+  const [sourceSuggestions, setSourceSuggestions] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    const headers = { "x-api-key": `${apiKey}` };
+    axios.get(`${apiUrl}/tags`, { headers })
+      .then((r) => setTagSuggestions((r.data.tags ?? []).map((t: any) => t.tag)))
+      .catch(() => undefined);
+    axios.get(`${apiUrl}/sources`, { headers })
+      .then((r) => setSourceSuggestions((r.data.sources ?? []).map((s: any) => s.source)))
+      .catch(() => undefined);
+  }, [apiUrl, apiKey]);
+
   return (
     <>
       <Input
@@ -92,16 +154,16 @@ const SharedInputs = ({
         id={"source"}
         name={"source"}
         type={"text"}
+        list={"source-suggestions"}
       />
-      <Input
-        disabled={isLoading}
-        value={formik.values.language}
-        label={"Language"}
-        onChange={formik.handleChange}
-        id={"language"}
-        name={"language"}
-        type={"text"}
-      />
+      {sourceSuggestions.length > 0 && (
+        <datalist id="source-suggestions">
+          {sourceSuggestions.map((s) => (
+            <option key={s} value={s} />
+          ))}
+        </datalist>
+      )}
+      <LanguageSelect formik={formik} isLoading={isLoading} />
       {formik.values.document_state_error && (
         <div>
           <p style={{ marginBottom: "10px", fontSize: "15px" }}>
@@ -183,23 +245,12 @@ const SharedInputs = ({
         name={"summary"}
         type={"text"}
       />
-      <Input
+      <TagsInput
         disabled={isLoading}
-        value={formik.values.language}
-        label={"Language"}
-        onChange={formik.handleChange}
-        id={"language"}
-        name={"language"}
-        type={"text"}
-      />
-      <Input
-        disabled={isLoading}
-        value={formik.values.tags}
+        value={formik.values.tags ?? ""}
         label={"Tags"}
-        onChange={formik.handleChange}
-        id={"tags"}
-        name={"tags"}
-        type={"text"}
+        suggestions={tagSuggestions}
+        onChange={(csv) => formik.setFieldValue("tags", csv)}
       />
     </>
   );

--- a/web_interface_react/src/modules/shared/components/TagsInput/tagsInput.tsx
+++ b/web_interface_react/src/modules/shared/components/TagsInput/tagsInput.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+// Chip editor over a CSV string (web_documents.tags stays a comma-separated
+// column — no DB migration). Enter/comma adds a tag, × removes one;
+// suggestions come from GET /tags via a <datalist>.
+
+const chipStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 4,
+  padding: "2px 8px",
+  margin: "2px 4px 2px 0",
+  borderRadius: "10px",
+  background: "#eef2f7",
+  border: "1px solid #c3cfdd",
+  fontSize: "0.85em",
+};
+
+interface TagsInputProps {
+  value: string; // CSV
+  onChange: (csv: string) => void;
+  suggestions?: string[];
+  disabled?: boolean;
+  label?: string;
+}
+
+const TagsInput = ({ value, onChange, suggestions, disabled, label }: TagsInputProps) => {
+  const [draft, setDraft] = React.useState("");
+  const tags = (value || "").split(",").map((t) => t.trim()).filter(Boolean);
+
+  const addDraft = () => {
+    const tag = draft.trim().replace(/,+$/, "");
+    if (!tag) {
+      return;
+    }
+    if (!tags.includes(tag)) {
+      onChange([...tags, tag].join(","));
+    }
+    setDraft("");
+  };
+
+  const remove = (tag: string) => {
+    onChange(tags.filter((t) => t !== tag).join(","));
+  };
+
+  return (
+    <div style={{ margin: "6px 0" }}>
+      {label && <label style={{ display: "block" }}>{label}</label>}
+      <div>
+        {tags.map((tag) => (
+          <span key={tag} style={chipStyle}>
+            {tag}
+            {!disabled && (
+              <button
+                type="button"
+                onClick={() => remove(tag)}
+                style={{ border: "none", background: "transparent", cursor: "pointer", padding: 0, color: "#a33" }}
+                title="Usuń tag"
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+        <input
+          value={draft}
+          disabled={disabled}
+          list="tags-suggestions"
+          placeholder="dodaj tag…"
+          onChange={(e) => {
+            // a trailing comma commits the tag immediately (also covers fast typing)
+            if (e.target.value.endsWith(",")) {
+              const tag = e.target.value.slice(0, -1).trim();
+              if (tag && !tags.includes(tag)) {
+                onChange([...tags, tag].join(","));
+              }
+              setDraft("");
+              return;
+            }
+            setDraft(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addDraft();
+            }
+          }}
+          onBlur={addDraft}
+          style={{ padding: "3px 8px", minWidth: 160, margin: "2px 0" }}
+        />
+        {suggestions && suggestions.length > 0 && (
+          <datalist id="tags-suggestions">
+            {suggestions.filter((s) => !tags.includes(s)).map((s) => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TagsInput;

--- a/web_interface_react/src/modules/shared/pages/webpage.tsx
+++ b/web_interface_react/src/modules/shared/pages/webpage.tsx
@@ -85,6 +85,7 @@ const Webpage = () => {
           handleSplitTextForEmbedding={handleSplitTextForEmbedding}
           isLoading={isLoading}
           handleRemoveNotNeededText={handleRemoveNotNeededText}
+          showCleanText
         />
 
         <FormButtons


### PR DESCRIPTION
## Summary
- Removes the duplicated Language field; Language is now a select (pl/en + 'inny…' free-text fallback).
- Tags: chip editor with autocomplete from new GET /tags (distinct tags + usage counts); value stays a CSV string.
- Source: datalist autocomplete from new GET /sources.
- 'Website MarkDown content' renders only when non-empty, collapsed in <details> (YouTube transcripts have no text_md).
- 'Clean Text' shown only on the webpage editor; the OpenAI Tokenizer link is removed (wrong tokenizer for Bielik).

## Test plan
- pytest: new test_flask_endpoints_tags_sources.py (3 tests) green
- tsc --noEmit + vitest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)