### PR TITLE
fix: exact-token entity matching in chapter filter and reader highlight (PR 1/3 of NER cleanup)

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -487,10 +487,12 @@ def document_chapter_entities(doc_id: int, position: int):
     The expensive document-level verification (geocoder, Wikidata, LLM) is
     reused as-is — this endpoint only attributes the already-verified entities
     to the chapter by matching their surface variants in the chapter's text
-    (entity_service.filter_entities_to_text), and intersects the document's
-    kraj-* tags with countries the gazetteer finds in the chapter. The reader
-    sidebar uses it so a long video's map/persons/places reflect the chapter
-    being read instead of the whole material.
+    (entity_service.filter_entities_to_text). Each kept entity carries
+    chapter_variants with only the variants actually matched in this chapter.
+    The endpoint also intersects the document's kraj-* tags with countries the
+    gazetteer finds in the chapter. The reader sidebar uses it so a long video's
+    map/persons/places reflect the chapter being read instead of the whole
+    material.
     """
     from library.country_gazetteer import detect_countries
     from library.entity_service import filter_entities_to_text, get_document_entities
@@ -1474,4 +1476,3 @@ def reanalyze_chunk(chunk_id: int):
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
     return jsonify({"status": "success", "chunk": _chunk_to_dict(chunk)})
-

--- a/backend/library/entity_service.py
+++ b/backend/library/entity_service.py
@@ -153,11 +153,12 @@ def filter_entities_to_text(grouped: dict[str, list[dict]], text: str) -> dict[s
 
     Chapter-scoped attribution: the expensive verification (geocoder, Wikidata,
     LLM) stays document-level; this only checks which of the already-verified
-    entities appear in the given fragment. Matching is case-insensitive at a
-    word-start boundary with the variant as a prefix — "Iran" matches "Iranu"
-    (Polish suffix inflection) but not mid-word. Rows without stored variants
-    (predating the variants column) fall back to entity_text, which may itself
-    be a lemma absent from the text — those match again after the next refresh.
+    entities appear in the given fragment. Stored surface variants match as
+    complete tokens (Unicode-aware boundaries on both sides). Rows without
+    stored variants (predating the variants column) retain the legacy
+    word-start prefix fallback against entity_text until the next refresh.
+    Matching is case-insensitive, except that a capitalized needle only matches
+    a surface form that is also capitalized.
 
     Kept items get their "count" REPLACED with the local mention count and are
     re-sorted by it — the reader chip "Putin ×50" in chapter scope used to show
@@ -168,13 +169,37 @@ def filter_entities_to_text(grouped: dict[str, list[dict]], text: str) -> dict[s
     for entity_type, items in grouped.items():
         kept = []
         for item in items:
-            needles = item.get("variants") or [item["text"]]
-            pattern = "|".join(re.escape(n) for n in needles if n)
-            if not pattern:
+            variants = item.get("variants") or []
+            raw_needles = variants or [item["text"]]
+            needles_by_key: dict[str, str] = {}
+            for raw_needle in raw_needles:
+                needle = raw_needle.strip()
+                if needle:
+                    needles_by_key.setdefault(needle.casefold(), needle)
+            needles = sorted(needles_by_key.values(), key=len, reverse=True)
+            if not needles:
                 continue
-            local_count = len(re.findall(rf"(?<!\w)(?:{pattern})", text, re.IGNORECASE))
+
+            alternatives = "|".join(f"(?P<v{i}>{re.escape(needle)})" for i, needle in enumerate(needles))
+            right_boundary = r"(?!\w)" if variants else ""
+            pattern = re.compile(rf"(?<!\w)(?:{alternatives}){right_boundary}", re.IGNORECASE)
+
+            matched_variant_indexes: set[int] = set()
+            local_count = 0
+            for match in pattern.finditer(text):
+                variant_index = int(match.lastgroup[1:])
+                needle = needles[variant_index]
+                matched_text = match.group(0)
+                if needle[0].isupper() and not matched_text[0].isupper():
+                    continue
+                matched_variant_indexes.add(variant_index)
+                local_count += 1
+
             if local_count:
-                kept.append({**item, "count": local_count})
+                chapter_variants = [
+                    needle for i, needle in enumerate(needles) if i in matched_variant_indexes
+                ]
+                kept.append({**item, "count": local_count, "chapter_variants": chapter_variants})
         kept.sort(key=lambda i: (-i["count"], i["text"]))
         filtered[entity_type] = kept
     return filtered

--- a/backend/tests/unit/test_entity_filtering.py
+++ b/backend/tests/unit/test_entity_filtering.py
@@ -2,7 +2,7 @@
 
 The document-level pipeline verifies entities once (geocoder/Wikidata/LLM);
 this filter only decides which verified entities appear in a given chapter's
-text, matching the stored surface variants at word-start boundaries.
+text, matching stored surface variants at complete Unicode token boundaries.
 """
 
 import pytest
@@ -19,16 +19,43 @@ def _grouped(**overrides):
 
 
 class TestFilterEntitiesToText:
-    def test_variant_matches_inflected_form_as_prefix(self):
-        """"Iran" (wariant) znajduje "Iranie" w tekście — polska odmiana to sufiks."""
-        grouped = _grouped(placeName=[{"text": "Iran", "count": 5, "variants": ["Iran"]}])
+    def test_exact_inflected_variant_matches(self):
+        grouped = _grouped(placeName=[{"text": "Iran", "count": 5, "variants": ["Iran", "Iranie"]}])
         out = filter_entities_to_text(grouped, "Konflikt w Iranie trwa od lat.")
         assert [i["text"] for i in out["placeName"]] == ["Iran"]
+        assert out["placeName"][0]["chapter_variants"] == ["Iranie"]
 
     def test_no_match_inside_word(self):
         grouped = _grouped(placeName=[{"text": "Iran", "count": 1, "variants": ["Iran"]}])
         out = filter_entities_to_text(grouped, "Samolot Airanu wystartował.")
         assert out["placeName"] == []
+
+    def test_capitalized_variant_does_not_match_lowercase_common_word(self):
+        grouped = _grouped(persName=[{"text": "Dan", "count": 3, "variants": ["Dana"]}])
+        out = filter_entities_to_text(grouped, "To dana dotycząca danych, bez żadnych dane dodatkowych.")
+        assert out["persName"] == []
+
+    def test_variant_requires_right_token_boundary(self):
+        grouped = _grouped(placeName=[{"text": "Polska", "count": 2, "variants": ["Polska"]}])
+        out = filter_entities_to_text(grouped, "To polski interes i część polskiej strategii.")
+        assert out["placeName"] == []
+
+    def test_longest_overlapping_variant_wins(self):
+        grouped = _grouped(placeName=[{"text": "Iran", "count": 2, "variants": ["Iran", "Iranie"]}])
+        out = filter_entities_to_text(grouped, "Iranie")
+        assert out["placeName"][0]["count"] == 1
+        assert out["placeName"][0]["chapter_variants"] == ["Iranie"]
+
+    def test_variants_are_deduplicated_case_insensitively(self):
+        grouped = _grouped(placeName=[{"text": "Łódź", "count": 2, "variants": ["Łódź", "ŁÓDŹ", "Łodzi"]}])
+        out = filter_entities_to_text(grouped, "Łódź i Łodzi")
+        assert out["placeName"][0]["count"] == 2
+        assert out["placeName"][0]["chapter_variants"] == ["Łodzi", "Łódź"]
+
+    def test_unicode_letters_are_token_characters_at_both_boundaries(self):
+        grouped = _grouped(placeName=[{"text": "Łódź", "count": 1, "variants": ["Łódź"]}])
+        out = filter_entities_to_text(grouped, "XŁódźY nie jest trafieniem, ale Łódź nim jest.")
+        assert out["placeName"][0]["count"] == 1
 
     def test_any_stored_variant_matches(self):
         """Lemat "Kijów" nie występuje w rozdziale, ale wariant "Kijowa" tak."""
@@ -48,6 +75,12 @@ class TestFilterEntitiesToText:
         grouped = _grouped(geogName=[{"text": "Bosfor", "count": 1, "variants": []}])
         out = filter_entities_to_text(grouped, "Statki przepłynęły Bosfor nocą.")
         assert [i["text"] for i in out["geogName"]] == ["Bosfor"]
+
+    def test_rows_without_variants_keep_prefix_fallback(self):
+        grouped = _grouped(geogName=[{"text": "Iran", "count": 1, "variants": []}])
+        out = filter_entities_to_text(grouped, "Rozmowy o Iranie trwają.")
+        assert out["geogName"][0]["count"] == 1
+        assert out["geogName"][0]["chapter_variants"] == ["Iran"]
 
     def test_unmentioned_entities_are_dropped_per_type(self):
         """Regresja na realny przypadek (doc 9216): Beludżystan nie należy do rozdziału o Iranie."""
@@ -74,7 +107,7 @@ class TestFilterEntitiesToText:
 
     def test_kept_items_sorted_by_local_count(self):
         grouped = _grouped(persName=[
-            {"text": "Putin", "count": 50, "variants": ["Putin"]},
+            {"text": "Putin", "count": 50, "variants": ["Putin", "Putinie"]},
             {"text": "Merkel", "count": 3, "variants": ["Merkel"]},
         ])
         out = filter_entities_to_text(grouped, "Merkel i Merkel rozmawiały o Putinie.")

--- a/docs/agent/windows-codex-sandbox.md
+++ b/docs/agent/windows-codex-sandbox.md
@@ -152,6 +152,22 @@ Jeśli konfiguracja ACL jest niewłaściwa dla danej maszyny, można rozważyć:
 
 Nie należy automatycznie przechodzić na pełny dostęp tylko dlatego, że pierwsza próba konfiguracji ACL nie zadziałała.
 
+## Prawo zapisu dla jednego repozytorium
+
+Jeżeli podjęto świadomą decyzję, że sandbox ma modyfikować pliki konkretnego repozytorium (np. Codex implementuje zmiany, a człowiek lub inny agent robi code review), należy nadać prawo Modify bezpośrednio kontom sandboxa:
+
+```powershell
+icacls "C:\Users\<user>\git\<repozytorium>" /grant "CodexSandboxOffline:(OI)(CI)M" "CodexSandboxOnline:(OI)(CI)M"
+```
+
+Uwaga: nadanie prawa Modify grupie `CodexSandboxUsers` NIE wystarcza — restricted token sandboxa nie honoruje uprawnień grupowych i zapis kończy się odmową dostępu. Prawa muszą być nadane bezpośrednio kontom. Weryfikacja funkcjonalna:
+
+```powershell
+codex sandbox cmd /c "echo test > C:\Users\<user>\git\<repozytorium>\.claude\exports\sandbox_write_test.txt"
+```
+
 ## Historia dla tego repozytorium
 
 W dniu 2026-07-12 problem został potwierdzony i rozwiązany na maszynie deweloperskiej. Po zmianie praw `git log`, `git status` oraz review diffa zaczęły działać dla właściwego repozytorium. Jest to stan lokalnej maszyny, a nie gwarantowany element konfiguracji repozytorium.
+
+W dniu 2026-07-13 podjęto świadomą decyzję o nadaniu kontom sandboxa prawa zapisu (Modify) do tego repozytorium, aby Codex mógł implementować zmiany bezpośrednio (workflow: Codex koduje, Claude Code robi review). Test zapisu przez `codex sandbox` przeszedł po nadaniu praw bezpośrednio kontom (wpis grupy `CodexSandboxUsers` z prawem M istniał wcześniej, ale nie działał).

--- a/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
+++ b/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
@@ -13,6 +13,8 @@ export interface EntityItem {
   // Surface forms seen in the text ("Kijów", "Kijowa") — used server-side for
   // chapter-scoped filtering; not rendered
   variants?: string[];
+  // Surface forms actually matched in the selected reader chapter.
+  chapter_variants?: string[];
   // Linear infrastructure match (Overpass/OSM, infra_geometries cache) —
   // geojson is a MultiLineString drawn on the reader map
   pipeline?: {

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -113,25 +113,41 @@ function renderInline(text: string, refs?: Map<string, ChapterReference>): React
   });
 }
 
-// All case-insensitive occurrences of the given terms in text — used to
-// highlight an entity (from the persons page or a sidebar chip click).
-// Substring (not word-boundary) matching is deliberate: Polish inflected
-// forms usually share the stem prefix ("Putin" also finds "Putina").
+// All complete-token occurrences of the given terms. Terms are matched
+// case-insensitively at Unicode-aware boundaries, except that a capitalized
+// term only matches a capitalized surface form. Longer overlapping terms win.
 function findEntityMatches(text: string, terms: string[]): { idx: number; len: number }[] {
-  const lower = text.toLowerCase();
-  const spans: { idx: number; len: number }[] = [];
-  for (const term of terms) {
-    const t = term.trim().toLowerCase();
-    if (t.length < 2) continue;
-    let start = 0;
-    while (true) {
-      const idx = lower.indexOf(t, start);
-      if (idx < 0) break;
-      spans.push({ idx, len: term.trim().length });
-      start = idx + t.length;
-    }
-  }
-  return spans;
+  const uniqueTerms = new Map<string, string>();
+  terms.forEach(rawTerm => {
+    const term = rawTerm.trim();
+    const key = term.toLowerCase();
+    if (term.length >= 2 && !uniqueTerms.has(key)) uniqueTerms.set(key, term);
+  });
+  const sortedTerms = [...uniqueTerms.values()].sort((a, b) => b.length - a.length);
+  if (!sortedTerms.length) return [];
+
+  const escaped = sortedTerms.map(term => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const pattern = new RegExp(
+    `(?<![\\p{L}\\p{N}_])(?:${escaped.join("|")})(?![\\p{L}\\p{N}_])`,
+    "giu",
+  );
+  return [...text.matchAll(pattern)]
+    .filter(match => {
+      const matchedText = match[0];
+      const term = uniqueTerms.get(matchedText.toLowerCase());
+      return term && (!isUppercaseLetter(term[0]) || isUppercaseLetter(matchedText[0]));
+    })
+    .map(match => ({ idx: match.index!, len: match[0].length }));
+}
+
+function isUppercaseLetter(char: string): boolean {
+  return char === char.toUpperCase() && char !== char.toLowerCase();
+}
+
+function entityHighlightTerms(item: EntityItem): string[] {
+  if (item.chapter_variants?.length) return item.chapter_variants;
+  if (item.variants?.length) return item.variants;
+  return [item.text];
 }
 
 /** Render a paragraph's text with <mark> around anchored note quotes and
@@ -367,6 +383,18 @@ const Read: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, id, position, scopeChapter, progressLoaded, apiKey]);
 
+  // Resolve a raw ?highlight= mention to the variants that actually occur in
+  // the loaded chapter. This keeps arrivals from the persons page aligned with
+  // the same exact-token matching used by chapter-scoped sidebar clicks.
+  React.useEffect(() => {
+    const requested = searchParams.get("highlight")?.trim().toLowerCase();
+    if (!requested || !chapterScope) return;
+    const items = [...chapterScope.persons, ...chapterScope.placeItems];
+    const item = items.find(candidate =>
+      [candidate.text, ...(candidate.variants ?? [])].some(value => value.trim().toLowerCase() === requested));
+    if (item) setHighlightTerms(entityHighlightTerms(item));
+  }, [chapterScope, searchParams]);
+
   // progress: fetch once per (user, doc); redirect to last position when URL has no ?chapter
   React.useEffect(() => {
     if (!userId) { setProgressLoaded(true); setReadChapters([]); return; }
@@ -466,8 +494,7 @@ const Read: React.FC = () => {
   // sidebar chip click in highlight mode — mark the entity's known surface
   // variants (chapter-scoped chips carry them) or fall back to its label
   const handleEntityHighlight = (item: EntityItem) => {
-    const terms = item.variants?.length ? item.variants : [item.text];
-    setHighlightTerms(terms);
+    setHighlightTerms(entityHighlightTerms(item));
     const next = new URLSearchParams(searchParams);
     next.set("highlight", item.text);
     setSearchParams(next, { replace: true });


### PR DESCRIPTION
## Problem

The reader sidebar at `/read/<id>?chapter=N` showed junk entity chips and highlighted fragments of ordinary words:

- entity **Dan** (a mislemmatized sentence-start *Dana*, from Polish *dane*) matched and highlighted `dana`, `dane`, `danych` all over the chapter;
- **Polska** counted lowercase adjectives (`polski`, `polskiej`);
- highlight used a bare case-insensitive `indexOf`, so short entities matched inside longer words.

Root causes: chapter attribution (`filter_entities_to_text`) matched variants as open-ended prefixes with no right boundary, and the frontend highlight had no token boundaries at all.

## Changes

**Backend** (`library/entity_service.py`, `library/chunk_review_routes.py`)
- stored surface variants match as complete tokens (Unicode-aware boundaries on both sides); rows without stored variants keep the legacy prefix fallback until their next refresh
- variants deduped case-insensitively, longest overlapping variant wins, local count derived from the same matches
- capitalization guard: a capitalized variant only matches a capitalized surface form (`Dana` no longer matches `dana`)
- chapter entities endpoint returns `chapter_variants` — only the variants actually found in the chapter

**Frontend** (`read.tsx`, `entitiesPanel.tsx`)
- `findEntityMatches` rewritten: Unicode-aware token boundaries (JS `\b` is ASCII-only), same capitalization guard, longest-match preference, term dedupe
- sidebar chip clicks and `?highlight=` from the persons page resolve to the entity's `chapter_variants` instead of a single lemma substring

**Tests**: regressions for `Dana` vs `dana`, `Polska` vs `polski`, exact inflected variants (`Iranie`), overlap, dedupe, Polish diacritics at boundaries.

## Verification

- backend unit suite: **1113 passed**
- `ruff check backend/`: clean; `tsc --noEmit`: clean; `vite build`: OK

This is PR 1/3 of the NER data-quality plan (next: normalization in aggregation + POS from ner_service; then a data repair script). Implemented by Codex (see commit author), reviewed by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)