### PR TITLE
feat: normalize NER entities at aggregation — POS gate, casefold merge, country canonicalization (PR 2/3)

### DIFF
--- a/backend/data/ner_normalization.json
+++ b/backend/data/ner_normalization.json
@@ -1,0 +1,23 @@
+{
+  "country_abbreviations": {
+    "PL": "Polska",
+    "UA": "Ukraina"
+  },
+  "demonyms": {
+    "finowie": "Finlandia",
+    "grecy": "Grecja",
+    "turcy": "Turcja",
+    "turk": "Turcja",
+    "węgrzy": "Węgry",
+    "wegrzy": "Węgry",
+    "włosi": "Włochy",
+    "wlosi": "Włochy"
+  },
+  "reject_surface_lemma_pairs": [
+    {
+      "surface": "Dana",
+      "lemma": "Dan",
+      "pos": ["ADJ", "NOUN", "PROPN"]
+    }
+  ]
+}

--- a/backend/library/country_gazetteer.py
+++ b/backend/library/country_gazetteer.py
@@ -248,6 +248,20 @@ class CountryEntry:
     slug: str
 
 
+@dataclass(frozen=True)
+class CountryPattern:
+    regex: re.Pattern
+    fixed_chars: int
+    stem_tokens: int
+
+    def fullmatch_with_suffix_limit(self, mention: str) -> bool:
+        """Match a complete mention while allowing at most 4 chars per stem suffix."""
+        if self.regex.fullmatch(mention) is None:
+            return False
+        mention_chars = len(re.sub(r"[\s-]+", "", mention))
+        return mention_chars - self.fixed_chars <= 4 * self.stem_tokens
+
+
 def _slug(name_pl: str) -> str:
     """Slug w konwencji article_tagging.extract_countries_with_llm (kraj-<slug>)."""
     ascii_name = unidecode(name_pl).lower()
@@ -255,18 +269,28 @@ def _slug(name_pl: str) -> str:
     return re.sub(r"\s+", "-", ascii_name.strip())
 
 
-def _compile_variant(variant: str) -> re.Pattern:
+def _compile_variant(variant: str) -> CountryPattern:
     parts = []
+    fixed_chars = 0
+    stem_tokens = 0
     for token in variant.split():
         if token.endswith("*"):
-            parts.append(r"\b" + re.escape(token[:-1]) + r"\w*")
+            fixed = token[:-1]
+            parts.append(r"\b" + re.escape(fixed) + r"\w*")
+            fixed_chars += len(fixed)
+            stem_tokens += 1
         else:
             parts.append(r"\b" + re.escape(token) + r"\b")
-    return re.compile(r"[\s-]+".join(parts))
+            fixed_chars += len(token)
+    return CountryPattern(
+        regex=re.compile(r"[\s-]+".join(parts)),
+        fixed_chars=fixed_chars,
+        stem_tokens=stem_tokens,
+    )
 
 
 @lru_cache(maxsize=1)
-def _compiled_countries() -> tuple[tuple[CountryEntry, tuple[re.Pattern, ...]], ...]:
+def _compiled_countries() -> tuple[tuple[CountryEntry, tuple[CountryPattern, ...]], ...]:
     compiled = []
     for name_pl, variants in _COUNTRY_DATA:
         entry = CountryEntry(name_pl=name_pl, slug=_slug(name_pl))
@@ -285,6 +309,25 @@ def slug_to_name(slug: str) -> str | None:
     return _slug_to_name_map().get(slug)
 
 
+def canonical_country_name(mention: str) -> str | None:
+    """Return the canonical Polish country name when one mention matches in full.
+
+    Unlike detect_countries(), this does not search inside a larger fragment:
+    every gazetteer pattern must consume the complete normalized mention. This
+    makes it safe for NER normalization ("polskiej" -> "Polska") without
+    treating an arbitrary sentence containing a country as the entity itself.
+    """
+    normalized = unidecode(mention).strip().lower()
+    if not normalized:
+        return None
+    matches = {
+        entry.name_pl
+        for entry, patterns in _compiled_countries()
+        if any(pattern.fullmatch_with_suffix_limit(normalized) for pattern in patterns)
+    }
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
 def detect_countries(text: str) -> list[CountryEntry]:
     """Zwróć kraje, których nazwa/przymiotnik/mieszkaniec pojawia się w tekście — bez LLM.
 
@@ -294,5 +337,9 @@ def detect_countries(text: str) -> list[CountryEntry]:
     nadmiarowego dopasowania.
     """
     normalized = unidecode(text).lower()
-    found = [entry for entry, patterns in _compiled_countries() if any(p.search(normalized) for p in patterns)]
+    found = [
+        entry
+        for entry, patterns in _compiled_countries()
+        if any(pattern.regex.search(normalized) for pattern in patterns)
+    ]
     return sorted(found, key=lambda e: e.name_pl)

--- a/backend/library/entity_service.py
+++ b/backend/library/entity_service.py
@@ -13,28 +13,41 @@ from sqlalchemy import delete, select
 
 from library.db.models import DocumentEntity, NerExclusion, WebDocument
 from library.ner_client import aggregate_entities_detailed, extract_entities
+from library.ner_normalization import normalize_ner_text
 
 logger = logging.getLogger(__name__)
 
 
 def is_excluded(exclusions: list[NerExclusion], entity_type: str, entity_text: str,
-                author: str | None) -> bool:
+                author: str | None, raw_terms: list[str] | None = None) -> bool:
     """True when an exclusion rule suppresses this entity.
 
-    Matching is case-insensitive on the aggregated base form; entity_type='*'
-    matches all types; scope='author' rules only apply when the document's
-    author matches the rule's author.
+    Matching is case-insensitive on the normalized base form and, when
+    provided, its raw lemmas/surface variants. entity_type='*' matches all
+    types; geogName/placeName rules remain interchangeable after place-label
+    merging; scope='author' only applies when the document's author matches.
     """
-    text_lower = entity_text.strip().lower()
-    author_lower = (author or "").strip().lower()
+    candidate_keys = {
+        normalize_ner_text(value).casefold()
+        for value in [entity_text, *(raw_terms or [])]
+        if normalize_ner_text(value)
+    }
+    author_lower = normalize_ner_text(author or "").casefold()
+    matching_types = {entity_type}
+    if entity_type in {"geogName", "placeName"}:
+        matching_types.update({"geogName", "placeName"})
     for exc in exclusions:
-        if exc.entity_type not in ("*", entity_type):
+        if exc.entity_type != "*" and exc.entity_type not in matching_types:
             continue
-        if exc.entity_text.strip().lower() != text_lower:
+        if normalize_ner_text(exc.entity_text).casefold() not in candidate_keys:
             continue
         if exc.scope == "global":
             return True
-        if exc.scope == "author" and author_lower and (exc.author or "").strip().lower() == author_lower:
+        if (
+            exc.scope == "author"
+            and author_lower
+            and normalize_ner_text(exc.author or "").casefold() == author_lower
+        ):
             return True
     return False
 
@@ -60,7 +73,17 @@ def refresh_document_entities(session, document_id: int, text: str) -> list[Docu
     if exclusions:
         doc = session.get(WebDocument, document_id)
         author = getattr(doc, "author", None)
-        excluded = [k for k in groups if is_excluded(exclusions, k[0], k[1], author)]
+        excluded = [
+            key
+            for key, group in groups.items()
+            if is_excluded(
+                exclusions,
+                key[0],
+                key[1],
+                author,
+                raw_terms=[*group.get("raw_lemmas", []), *group.get("variants", [])],
+            )
+        ]
         for key in excluded:
             del groups[key]
         if excluded:

--- a/backend/library/ner_client.py
+++ b/backend/library/ner_client.py
@@ -9,8 +9,16 @@ Integration plan: docs/ner-integration-plan.md.
 """
 
 import logging
+import re
+from collections import Counter
 
 import requests
+
+from library.ner_normalization import (
+    canonical_country_for_surface,
+    is_rejected_surface_lemma_pair,
+    normalize_ner_text,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -119,41 +127,166 @@ def warmup_async() -> None:
     threading.Thread(target=_probe, name="ner-warmup", daemon=True).start()
 
 
+def _is_initials_only(surface: str) -> bool:
+    tokens = surface.split()
+    return bool(tokens) and all(
+        re.fullmatch(r"[^\W\d_]\.", token, re.UNICODE) and token[0].isupper()
+        for token in tokens
+    )
+
+
+def _preferred_spelling(spellings: Counter[str], order: list[str]) -> str:
+    """Pick the most frequent capitalized spelling, with first-seen tie breaks."""
+    capitalized = [value for value in order if value and value[0].isupper()]
+    candidates = capitalized or order
+    return max(candidates, key=lambda value: (spellings[value], -order.index(value)))
+
+
+def _deduplicated_spellings(spellings: Counter[str], order: list[str]) -> list[str]:
+    """Collapse case-only variants while preserving first-seen key order."""
+    buckets: dict[str, Counter[str]] = {}
+    bucket_order: list[str] = []
+    spelling_order: dict[str, list[str]] = {}
+    for value in order:
+        key = value.casefold()
+        if key not in buckets:
+            buckets[key] = Counter()
+            spelling_order[key] = []
+            bucket_order.append(key)
+        if value not in spelling_order[key]:
+            spelling_order[key].append(value)
+        buckets[key][value] += spellings[value]
+    return [_preferred_spelling(buckets[key], spelling_order[key]) for key in bucket_order]
+
+
+def _is_truncated_lemma(base: str, variants: list[str]) -> bool:
+    """Detect spaCy lemmas such as Brn/Wiln/Wegr cut from every full surface."""
+    base_key = base.casefold()
+    return bool(variants) and all(
+        variant.casefold().startswith(base_key)
+        and variant.casefold() != base_key
+        and len(variant) - len(base) >= 2
+        for variant in variants
+    )
+
+
 def aggregate_entities_detailed(
     entities: list[dict], types: tuple[str, ...] = ENTITY_TYPES,
 ) -> dict[tuple[str, str], dict]:
-    """Group raw mentions by (entity_type, base form): occurrence counts + surface variants.
+    """Normalize and group raw mentions into stable person/place entities.
 
-    The base form is the lemma when the service provides one (groups Polish
-    inflected variants: "Tuska" -> "Tusk"), falling back to the surface text.
-    Each group also collects its distinct surface forms in first-seen order
-    ("Kijów", "Kijowa") — the chapter-scoped entity filter matches on them,
-    since the lemma itself may never appear in the text.
+    New ner_service payloads are filtered by root-token POS; payloads without
+    POS retain legacy behavior. Country names, selected demonyms and exact
+    uppercase abbreviations are canonicalized. Case-only duplicates share one
+    display spelling, and geogName/placeName duplicates share the more frequent
+    label. Suspicious cut-off lemmas fall back to their best full surface form.
 
-    Mentions whose surface text starts lowercase are dropped: Polish proper
-    names are capitalized, so a lowercase mention is an adjective/demonym the
-    model mislabeled as a place ("ukraiński", "rosyjski"). The check uses the
-    surface text, not the lemma — legitimate lemmas can start lowercase
-    ("Cieśninie Ormuz" -> "cieśnina Ormuz").
-
-    Shape: {(entity_type, base): {"count": int, "variants": [surface, ...]}}.
+    Shape: {(entity_type, base): {"count", "variants", "raw_lemmas"}}.
+    raw_lemmas is internal metadata used to preserve ner_exclusions behavior
+    after canonicalization; it is not persisted or returned by the API.
     """
-    groups: dict[tuple[str, str], dict] = {}
+    preliminary: dict[tuple[str, str], dict] = {}
     for ent in entities:
         label = ent.get("label")
         if label not in types:
             continue
-        surface = (ent.get("text") or "").strip()
-        if not surface or surface[0].islower():
+        surface = normalize_ner_text(ent.get("text") or "")
+        if not surface or _is_initials_only(surface):
             continue
-        base = (ent.get("lemma") or surface).strip()
-        if not base:
+        if surface[0].islower():
             continue
-        group = groups.setdefault((label, base), {"count": 0, "variants": []})
+        lemma = normalize_ner_text(ent.get("lemma") or surface)
+        if not lemma:
+            continue
+
+        pos = normalize_ner_text(ent.get("pos") or "").upper() or None
+        if pos is not None and pos not in {"NOUN", "PROPN"}:
+            continue
+        if is_rejected_surface_lemma_pair(surface, lemma, pos):
+            continue
+
+        country = canonical_country_for_surface(surface) if label in {"geogName", "placeName"} else None
+        base = country or lemma
+        key = (label, base.casefold())
+        group = preliminary.setdefault(
+            key,
+            {
+                "count": 0,
+                "base_spellings": Counter(),
+                "base_order": [],
+                "surface_spellings": Counter(),
+                "surface_order": [],
+                "raw_lemma_spellings": Counter(),
+                "raw_lemma_order": [],
+            },
+        )
         group["count"] += 1
-        if surface not in group["variants"]:
-            group["variants"].append(surface)
-    return groups
+        for value, counter_name, order_name in (
+            (base, "base_spellings", "base_order"),
+            (surface, "surface_spellings", "surface_order"),
+            (lemma, "raw_lemma_spellings", "raw_lemma_order"),
+        ):
+            group[counter_name][value] += 1
+            if value not in group[order_name]:
+                group[order_name].append(value)
+
+    normalized_groups: list[dict] = []
+    for (label, _base_key), group in preliminary.items():
+        base = _preferred_spelling(group["base_spellings"], group["base_order"])
+        variants = _deduplicated_spellings(group["surface_spellings"], group["surface_order"])
+        if _is_truncated_lemma(base, variants):
+            base = _preferred_spelling(group["surface_spellings"], group["surface_order"])
+        normalized_groups.append({"label": label, "base": base, "variants": variants, **group})
+
+    merged: dict[tuple[str, str], dict] = {}
+    for source in normalized_groups:
+        family = "persName" if source["label"] == "persName" else "place"
+        key = (family, source["base"].casefold())
+        group = merged.setdefault(
+            key,
+            {
+                "count": 0,
+                "label_counts": Counter(),
+                "label_order": [],
+                "base_spellings": Counter(),
+                "base_order": [],
+                "surface_spellings": Counter(),
+                "surface_order": [],
+                "raw_lemma_spellings": Counter(),
+                "raw_lemma_order": [],
+            },
+        )
+        group["count"] += source["count"]
+        group["label_counts"][source["label"]] += source["count"]
+        if source["label"] not in group["label_order"]:
+            group["label_order"].append(source["label"])
+        group["base_spellings"][source["base"]] += source["count"]
+        if source["base"] not in group["base_order"]:
+            group["base_order"].append(source["base"])
+        for value, counter_name, order_name in (
+            *[(value, "surface_spellings", "surface_order") for value in source["surface_order"]],
+            *[(value, "raw_lemma_spellings", "raw_lemma_order") for value in source["raw_lemma_order"]],
+        ):
+            source_counter = source[counter_name]
+            group[counter_name][value] += source_counter[value]
+            if value not in group[order_name]:
+                group[order_name].append(value)
+
+    result: dict[tuple[str, str], dict] = {}
+    for group in merged.values():
+        label = max(
+            group["label_order"],
+            key=lambda value: (group["label_counts"][value], -group["label_order"].index(value)),
+        )
+        base = _preferred_spelling(group["base_spellings"], group["base_order"])
+        result[(label, base)] = {
+            "count": group["count"],
+            "variants": _deduplicated_spellings(group["surface_spellings"], group["surface_order"]),
+            "raw_lemmas": _deduplicated_spellings(
+                group["raw_lemma_spellings"], group["raw_lemma_order"],
+            ),
+        }
+    return result
 
 
 def aggregate_entities(entities: list[dict], types: tuple[str, ...] = ENTITY_TYPES) -> dict[tuple[str, str], int]:

--- a/backend/library/ner_normalization.py
+++ b/backend/library/ner_normalization.py
@@ -1,0 +1,58 @@
+"""Deterministic Polish NER normalization rules loaded from versioned data."""
+
+import json
+import unicodedata
+from functools import lru_cache
+from pathlib import Path
+
+from library.country_gazetteer import canonical_country_name
+
+RULES_PATH = Path(__file__).resolve().parents[1] / "data" / "ner_normalization.json"
+
+
+def normalize_ner_text(value: str) -> str:
+    """Normalize storage/comparison text without changing meaningful spacing."""
+    return unicodedata.normalize("NFC", value).strip()
+
+
+@lru_cache(maxsize=1)
+def load_ner_normalization_rules() -> dict:
+    """Load curated rules once per backend process."""
+    with RULES_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def canonical_country_for_surface(surface: str) -> str | None:
+    """Map one surface form to a canonical country, including curated aliases."""
+    normalized = normalize_ner_text(surface)
+    rules = load_ner_normalization_rules()
+
+    abbreviations = rules.get("country_abbreviations", {})
+    if normalized == normalized.upper() and normalized in abbreviations:
+        return normalize_ner_text(abbreviations[normalized])
+
+    demonyms = {
+        normalize_ner_text(key).casefold(): normalize_ner_text(value)
+        for key, value in rules.get("demonyms", {}).items()
+    }
+    demonym_country = demonyms.get(normalized.casefold())
+    if demonym_country:
+        return demonym_country
+    return canonical_country_name(normalized)
+
+
+def is_rejected_surface_lemma_pair(surface: str, lemma: str, pos: str | None) -> bool:
+    """Check context-sensitive false-positive pairs; legacy payloads stay allowed."""
+    if not pos:
+        return False
+    surface_key = normalize_ner_text(surface).casefold()
+    lemma_key = normalize_ner_text(lemma).casefold()
+    pos_key = pos.strip().upper()
+    for rule in load_ner_normalization_rules().get("reject_surface_lemma_pairs", []):
+        if normalize_ner_text(rule.get("surface", "")).casefold() != surface_key:
+            continue
+        if normalize_ner_text(rule.get("lemma", "")).casefold() != lemma_key:
+            continue
+        if pos_key in {value.upper() for value in rule.get("pos", [])}:
+            return True
+    return False

--- a/backend/tests/unit/test_country_gazetteer.py
+++ b/backend/tests/unit/test_country_gazetteer.py
@@ -55,3 +55,27 @@ class TestSlugConvention:
     def test_slug_matches_kraj_prefix_convention(self):
         found = country_gazetteer.detect_countries("Arabia Saudyjska zwiększyła wydobycie ropy.")
         assert any(c.slug == "arabia-saudyjska" for c in found)
+
+
+class TestCanonicalCountryName:
+    @pytest.mark.parametrize("mention", ["Polska", "polska", "polski", "polskiej"])
+    def test_matches_one_complete_country_mention(self, mention):
+        assert country_gazetteer.canonical_country_name(mention) == "Polska"
+
+    def test_does_not_search_inside_a_sentence(self):
+        assert country_gazetteer.canonical_country_name("Rozmowy z Polską") is None
+
+    @pytest.mark.parametrize(
+        ("mention", "country"),
+        [
+            ("Iranem", "Iran"),
+            ("Rosjanie", "Rosja"),
+            ("Ukraińcami", "Ukraina"),
+            ("włoskiej", "Włochy"),
+        ],
+    )
+    def test_accepts_inflection_with_up_to_four_suffix_chars(self, mention, country):
+        assert country_gazetteer.canonical_country_name(mention) == country
+
+    def test_rejects_longer_word_that_only_shares_country_stem(self):
+        assert country_gazetteer.canonical_country_name("Włoszczowa") is None

--- a/backend/tests/unit/test_entity_service.py
+++ b/backend/tests/unit/test_entity_service.py
@@ -21,6 +21,7 @@ RAW = [
 def _session_with_exclusions(exclusions):
     session = MagicMock()
     session.execute.return_value.scalars.return_value.all.return_value = exclusions
+    session.get.return_value = MagicMock(author=None)
     return session
 
 
@@ -68,6 +69,24 @@ class TestRefreshDocumentEntities:
 
         assert {r.entity_text for r in rows} == {"cieśnina Ormuz"}
 
+    def test_exclusion_matches_raw_variant_after_country_canonicalization(self):
+        session = _session_with_exclusions(
+            [NerExclusion(entity_text="Turcy", entity_type="placeName", scope="global")]
+        )
+        raw = [{"text": "Turcy", "label": "placeName", "lemma": "Turk", "pos": "NOUN"}]
+        with patch("library.entity_service.extract_entities", return_value=raw):
+            rows = refresh_document_entities(session, 42, "Turcy")
+        assert rows == []
+
+    def test_exclusion_matches_raw_lemma_after_country_canonicalization(self):
+        session = _session_with_exclusions(
+            [NerExclusion(entity_text="Turk", entity_type="placeName", scope="global")]
+        )
+        raw = [{"text": "Turcy", "label": "placeName", "lemma": "Turk", "pos": "NOUN"}]
+        with patch("library.entity_service.extract_entities", return_value=raw):
+            rows = refresh_document_entities(session, 42, "Turcy")
+        assert rows == []
+
     def test_author_exclusion_applies_only_to_matching_author(self):
         exclusions = [NerExclusion(entity_text="Tusk", entity_type="*", scope="author",
                                    author="Good Times Bad Times")]
@@ -98,12 +117,20 @@ class TestIsExcluded:
         rules = [NerExclusion(entity_text="Taliban", entity_type="persName", scope="global")]
         assert is_excluded(rules, "geogName", "Taliban", None) is False
 
+    def test_place_types_are_equivalent_after_label_merging(self):
+        rules = [NerExclusion(entity_text="Ukraina", entity_type="geogName", scope="global")]
+        assert is_excluded(rules, "placeName", "Ukraina", None) is True
+
     def test_author_scope_needs_author(self):
         rules = [NerExclusion(entity_text="Starlinek", entity_type="persName",
                               scope="author", author="Kanał X")]
         assert is_excluded(rules, "persName", "Starlinek", None) is False
         assert is_excluded(rules, "persName", "Starlinek", "kanał x") is True
         assert is_excluded(rules, "persName", "Starlinek", "Inny") is False
+
+    def test_matches_raw_terms(self):
+        rules = [NerExclusion(entity_text="Turcy", entity_type="placeName", scope="global")]
+        assert is_excluded(rules, "placeName", "Turcja", None, raw_terms=["Turk", "Turcy"]) is True
 
 
 class TestGetDocumentEntities:

--- a/backend/tests/unit/test_ner_client.py
+++ b/backend/tests/unit/test_ner_client.py
@@ -155,7 +155,7 @@ class TestAggregateEntities:
     def test_skips_lowercase_mentions(self):
         """Przymiotniki ('ukraiński') błędnie oznaczane jako placeName — odpadają po wielkości litery."""
         entities = [
-            {"text": "ukraiński", "label": "placeName", "lemma": "ukraiński"},
+            {"text": "ukraiński", "label": "placeName", "lemma": "ukraiński", "pos": "ADJ"},
             {"text": "Ukraina", "label": "placeName", "lemma": "Ukraina"},
         ]
         assert aggregate_entities(entities) == {("placeName", "Ukraina"): 1}
@@ -174,7 +174,11 @@ class TestAggregateEntitiesDetailed:
             {"text": "Kijowa", "label": "placeName", "lemma": "Kijów"},
         ]
         assert aggregate_entities_detailed(entities) == {
-            ("placeName", "Kijów"): {"count": 3, "variants": ["Kijowie", "Kijowa"]},
+            ("placeName", "Kijów"): {
+                "count": 3,
+                "variants": ["Kijowie", "Kijowa"],
+                "raw_lemmas": ["Kijów"],
+            },
         }
 
     def test_counts_match_aggregate_entities(self):
@@ -185,3 +189,93 @@ class TestAggregateEntitiesDetailed:
         ]
         detailed = aggregate_entities_detailed(entities)
         assert {k: g["count"] for k, g in detailed.items()} == aggregate_entities(entities)
+
+
+class TestAggregateNormalization:
+    def test_lowercase_legacy_country_forms_are_rejected(self):
+        entities = [
+            {"text": "Polska", "label": "placeName", "lemma": "Polska"},
+            {"text": "polski", "label": "placeName", "lemma": "polski"},
+            {"text": "polska", "label": "placeName", "lemma": "polska"},
+        ]
+        assert aggregate_entities_detailed(entities) == {
+            ("placeName", "Polska"): {
+                "count": 1,
+                "variants": ["Polska"],
+                "raw_lemmas": ["Polska"],
+            },
+        }
+
+    def test_ukraine_case_variants_share_canonical_name(self):
+        entities = [
+            {"text": "Ukraina", "label": "placeName", "lemma": "Ukraina"},
+            {"text": "UKRAINA", "label": "placeName", "lemma": "ukraina"},
+        ]
+        assert aggregate_entities(entities) == {("placeName", "Ukraina"): 2}
+
+    def test_lowercase_inflected_country_is_rejected_without_pos(self):
+        entities = [{"text": "polskiej", "label": "placeName", "lemma": "polski"}]
+        assert aggregate_entities(entities) == {}
+
+    def test_person_name_is_never_canonicalized_as_country(self):
+        entities = [{"text": "Czechowa", "label": "persName", "lemma": "Czechow", "pos": "PROPN"}]
+        assert aggregate_entities(entities) == {("persName", "Czechow"): 1}
+
+    def test_initials_only_are_rejected_but_initial_with_surname_stays(self):
+        entities = [
+            {"text": "A.", "label": "persName", "lemma": "A."},
+            {"text": "J. K.", "label": "persName", "lemma": "J. K."},
+            {"text": "J. Kowalski", "label": "persName", "lemma": "J. Kowalski"},
+        ]
+        assert aggregate_entities(entities) == {("persName", "J. Kowalski"): 1}
+
+    def test_curated_demonym_maps_to_country(self):
+        entities = [{"text": "Turcy", "label": "placeName", "lemma": "Turk", "pos": "NOUN"}]
+        assert aggregate_entities(entities) == {("placeName", "Turcja"): 1}
+
+    def test_kurds_are_not_mapped_to_a_country(self):
+        entities = [{"text": "Kurdowie", "label": "placeName", "lemma": "Kurd", "pos": "NOUN"}]
+        assert aggregate_entities(entities) == {("placeName", "Kurdowie"): 1}
+
+    def test_truncated_lemma_falls_back_to_full_surface(self):
+        entities = [{"text": "Brnem", "label": "placeName", "lemma": "Brn", "pos": "PROPN"}]
+        assert aggregate_entities(entities) == {("placeName", "Brnem"): 1}
+
+    def test_uppercase_country_abbreviation_maps_to_country(self):
+        entities = [{"text": "PL", "label": "geogName", "lemma": "PL", "pos": "PROPN"}]
+        assert aggregate_entities(entities) == {("geogName", "Polska"): 1}
+
+    def test_mixed_case_country_abbreviation_is_not_mapped(self):
+        entities = [{"text": "Pl", "label": "geogName", "lemma": "Pl", "pos": "PROPN"}]
+        assert aggregate_entities(entities) == {("geogName", "Pl"): 1}
+
+    def test_common_noun_dana_is_rejected_with_pos(self):
+        entities = [{"text": "Dana", "label": "persName", "lemma": "Dan", "pos": "NOUN"}]
+        assert aggregate_entities(entities) == {}
+
+    def test_dana_is_rejected_when_spacy_marks_it_as_proper_noun(self):
+        entities = [{"text": "Dana", "label": "persName", "lemma": "Dan", "pos": "PROPN"}]
+        assert aggregate_entities(entities) == {}
+
+    def test_dana_is_kept_without_pos_for_legacy_service(self):
+        entities = [{"text": "Dana", "label": "persName", "lemma": "Dan"}]
+        assert aggregate_entities(entities) == {("persName", "Dan"): 1}
+
+    def test_non_nominal_root_is_rejected(self):
+        entities = [{"text": "Polski", "label": "placeName", "lemma": "polski", "pos": "ADJ"}]
+        assert aggregate_entities(entities) == {}
+
+    def test_place_labels_merge_and_more_frequent_label_wins(self):
+        entities = [
+            {"text": "Ukraina", "label": "geogName", "lemma": "Ukraina"},
+            {"text": "Ukraina", "label": "placeName", "lemma": "Ukraina"},
+            {"text": "UKRAINA", "label": "placeName", "lemma": "ukraina"},
+        ]
+        assert aggregate_entities(entities) == {("placeName", "Ukraina"): 3}
+
+    def test_unicode_is_normalized_to_nfc_before_grouping(self):
+        entities = [
+            {"text": "Łódź", "label": "placeName", "lemma": "Łódź"},
+            {"text": "Ło\u0301dź", "label": "placeName", "lemma": "Ło\u0301dź"},
+        ]
+        assert aggregate_entities(entities) == {("placeName", "Łódź"): 2}

--- a/ner_service/README.md
+++ b/ner_service/README.md
@@ -27,8 +27,10 @@ place/person verification plans this service is the first step of.
 ```json
 {
   "entities": [
-    {"text": "Donald Tusk", "label": "persName", "lemma": "Donald Tusk", "start": 0, "end": 11},
-    {"text": "Cieśninie Ormuz", "label": "geogName", "lemma": "cieśnina Ormuz", "start": 20, "end": 35}
+    {"text": "Donald Tusk", "label": "persName", "lemma": "Donald Tusk", "start": 0, "end": 11,
+     "pos": "PROPN", "morph": "Case=Nom|Gender=Masc|Number=Sing"},
+    {"text": "Cieśninie Ormuz", "label": "geogName", "lemma": "cieśnina Ormuz", "start": 20, "end": 35,
+     "pos": "PROPN", "morph": "Case=Loc|Gender=Neut|Number=Sing"}
   ]
 }
 ```
@@ -36,7 +38,10 @@ place/person verification plans this service is the first step of.
 Labels come directly from `pl_core_news_lg`: `persName`, `geogName`,
 `placeName`, `orgName`, `date`, `time`, etc. `lemma` is the base form of the
 mention (spaCy lemmatizer) — callers use it to group inflected Polish variants
-of the same name ("Tuska" → "Tusk").
+of the same name ("Tuska" → "Tusk"). `pos` and `morph` describe the root token
+of the entity span (`ent.root`); they let callers reject false positives whose
+syntactic head is not nominal. They are additive fields, so existing clients
+that only consume the original fields remain compatible.
 
 The model is loaded lazily on the first `/ner` call (not at startup), so
 `/healthz` responds immediately even before it's loaded — but that first

--- a/ner_service/src/main.py
+++ b/ner_service/src/main.py
@@ -35,7 +35,15 @@ def ner():
     doc = get_nlp()(text)
     entities = [
         # lemma: base form for grouping inflected Polish variants ("Tuska" -> "Tusk")
-        {"text": ent.text, "label": ent.label_, "lemma": ent.lemma_, "start": ent.start_char, "end": ent.end_char}
+        {
+            "text": ent.text,
+            "label": ent.label_,
+            "lemma": ent.lemma_,
+            "start": ent.start_char,
+            "end": ent.end_char,
+            "pos": ent.root.pos_,
+            "morph": str(ent.root.morph),
+        }
         for ent in doc.ents
     ]
     return jsonify({"entities": entities})

--- a/ner_service/tests/test_main.py
+++ b/ner_service/tests/test_main.py
@@ -8,8 +8,9 @@ from src import main
 
 @pytest.fixture
 def client(monkeypatch):
+    fake_root = types.SimpleNamespace(pos_="PROPN", morph="Case=Nom|Gender=Masc|Number=Sing")
     fake_ent = types.SimpleNamespace(
-        text="Donald Tusk", label_="persName", lemma_="Donald Tusk", start_char=0, end_char=11,
+        text="Donald Tusk", label_="persName", lemma_="Donald Tusk", start_char=0, end_char=11, root=fake_root,
     )
     fake_doc = types.SimpleNamespace(ents=[fake_ent])
     monkeypatch.setattr(main, "get_nlp", lambda: MagicMock(return_value=fake_doc))
@@ -28,7 +29,15 @@ def test_ner_returns_entities(client):
     assert resp.status_code == 200
     assert resp.get_json() == {
         "entities": [
-            {"text": "Donald Tusk", "label": "persName", "lemma": "Donald Tusk", "start": 0, "end": 11}
+            {
+                "text": "Donald Tusk",
+                "label": "persName",
+                "lemma": "Donald Tusk",
+                "start": 0,
+                "end": 11,
+                "pos": "PROPN",
+                "morph": "Case=Nom|Gender=Masc|Number=Sing",
+            }
         ]
     }
 


### PR DESCRIPTION
## Problem

`document_entities` accumulated junk that PR #239 could only mask at display time: case-duplicates (`Polska`/`polska`/`ukraina`), adjective lemmas (`polski`), standalone initials (`A.`, `J.`), demonyms as separate places (`Turk` from *Turcy*), truncated spaCy lemmas (`Brn` from *Brnem*, `Wiln` from *Wilnie*), abbreviations (`PL`), and mislabeled names (`Dana` — the Czech howitzer in book 9204 — becoming person `Dan`).

## Changes

**ner_service** — `/ner` adds `pos` and `morph` of the entity root token (backward compatible).

**Aggregation** (`ner_client.py` + new `ner_normalization.py` + `backend/data/ner_normalization.json`):
- reject standalone initials and roots that are not NOUN/PROPN; payloads without `pos` keep legacy behavior (incl. unconditional lowercase-surface drop)
- NFC + casefold grouping with one canonical display spelling (`Polska`+`polska`→`Polska`)
- `geogName`/`placeName` duplicates merge into the more frequent label
- truncated-lemma fallback: a lemma cut from every full surface form is replaced by the best full variant (`Brn`→`Brnem`)
- country canonicalization for places only: gazetteer full-token match with suffix capped at +4 chars (`Iranem`→Iran, but `Włoszczowa` ≠ Włochy) + curated demonym (`Turcy`→Turcja) and abbreviation (`PL`→Polska, exact-uppercase) maps in a versioned data file; persons are never country-mapped (`Czechowa` the writer stays a person)
- context-sensitive reject rules (surface+lemma+POS): `Dana`→`Dan` incl. PROPN — verified against the actual book sentence on `pl_core_news_lg`

**Exclusions** — `is_excluded` also checks raw lemmas and surface variants, so rules added from the UI keep working after canonicalization.

## Review findings fixed during the loop (Codex ↔ Claude)

1. country mapping applied to `persName` (writer *Czechowa* → country `Czechy`) — now places only
2. gazetteer stem over-match (*Włoszczowa* → *Włochy*) — suffix limit
3. `Dana`→`Dan` rule listed only ADJ/NOUN while the real sentence yields PROPN — dead rule, fixed
4. legacy path started keeping lowercase adjectives via country mapping — unconditional drop restored

## Verification

- backend unit suite: **1143 passed**; ner_service: **4 passed**; ruff: clean
- empirical probes on `pl_core_news_lg` 3.8: POS gate keeps `USA`/`RP`/`NATO`/`PRL`/`Baltic Pipe` (PROPN), drops `polskiej`/`Polski rząd` (ADJ) and initials (X)

## Deployment note

Requires redeploying **both** the backend and `ner_service` containers. Existing rows in `document_entities` are unchanged — the mass re-extraction is PR 3/3.

Implemented by Codex (commit author), reviewed by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)