### PR TITLE
feat: NER data repair script — strict extraction, canonical mapping, dependency repair (PR 3/3)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,6 +27,7 @@ COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --frozen --extra docker --no-dev --no-install-project
 
 COPY backend/library ./library/
+COPY backend/data ./data/
 #COPY backend/tests /app/tests/
 COPY backend/server.py .
 

--- a/backend/imports/refresh_entities.py
+++ b/backend/imports/refresh_entities.py
@@ -1,0 +1,238 @@
+"""Safely rebuild normalized NER entities and their derived dependencies.
+
+Windows: PYTHONPATH=. .venv/Scripts/python imports/refresh_entities.py --document-id 9204 --dry-run
+WSL:     PYTHONPATH=. .venv/bin/python imports/refresh_entities.py --document-id 9204 --dry-run
+"""
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+from sqlalchemy import delete, select
+
+from library.db.engine import get_session
+from library.db.models import DocumentEntity, DocumentPerson, NerExclusion, WebDocument
+from library.entity_service import is_excluded
+from library.ner_client import aggregate_entities_detailed, extract_entities_strict
+from library.ner_normalization import normalize_ner_text
+from library.overpass_client import attach_document_pipelines
+from library.person_registry import reject_review_link, resolve_document_persons
+from library.place_verification import verify_document_places
+
+def _family(entity_type: str) -> str:
+    return "person" if entity_type == "persName" else "place"
+
+
+def _terms(entity_text: str, variants: list[str] | None) -> set[str]:
+    return {
+        normalize_ner_text(value).casefold()
+        for value in [entity_text, *(variants or [])]
+        if normalize_ner_text(value)
+    }
+
+
+def build_canonical_map(old_rows: list, new_groups: dict[tuple[str, str], dict]) -> dict[str, str]:
+    """Map old entity_text to one new canonical text via shared variants/lemmas."""
+    lookup: dict[tuple[str, str], set[str]] = {}
+    for (entity_type, canonical), group in new_groups.items():
+        for term in _terms(canonical, [*group.get("variants", []), *group.get("raw_lemmas", [])]):
+            lookup.setdefault((_family(entity_type), term), set()).add(canonical)
+
+    mapping: dict[str, str] = {}
+    for row in old_rows:
+        candidates: set[str] = set()
+        for term in _terms(row.entity_text, row.variants):
+            candidates.update(lookup.get((_family(row.entity_type), term), set()))
+        if len(candidates) == 1:
+            mapping[row.entity_text] = next(iter(candidates))
+    return mapping
+
+
+def classify_entity_changes(old_rows: list, new_groups: dict, mapping: dict[str, str]) -> dict:
+    """Return deterministic removed/renamed/merged/count-change decisions."""
+    new_counts = {text: group["count"] for (_entity_type, text), group in new_groups.items()}
+    target_counts = Counter(mapping.values())
+    changed = sorted((old, new) for old, new in mapping.items() if old != new)
+    removed = sorted(row.entity_text for row in old_rows if row.entity_text not in mapping)
+    merged = sorted(target for target, count in target_counts.items() if count > 1)
+    count_changes = sorted(
+        (row.entity_text, row.mention_count, new_counts.get(mapping.get(row.entity_text, ""), 0))
+        for row in old_rows
+        if row.entity_text in mapping
+        and row.mention_count != new_counts.get(mapping[row.entity_text], 0)
+    )
+    return {
+        "removed": removed,
+        "removed_count": len(removed),
+        "changed": changed,
+        "changed_count": len(changed),
+        "merged": merged,
+        "merged_count": len(merged),
+        "count_changes": count_changes,
+    }
+
+
+def _slug(value: str) -> str:
+    from unidecode import unidecode
+
+    return re.sub(r"[^a-z0-9]+", "-", unidecode(value).lower()).strip("-")
+
+
+def _orphan_tag_audit(doc, new_groups: dict) -> list[str]:
+    supported = {_slug(text) for (entity_type, text) in new_groups if entity_type != "persName"}
+    entity_tags = [
+        tag.strip()
+        for tag in (doc.tags or "").split(",")
+        if tag.strip().startswith(("miejsce-", "kraj-"))
+    ]
+    return sorted(tag for tag in entity_tags if tag.split("-", 1)[1] not in supported)
+
+
+def _filtered_groups(session, doc, raw: list[dict]) -> dict:
+    groups = aggregate_entities_detailed(raw)
+    exclusions = list(session.scalars(select(NerExclusion)).all())
+    for key, group in list(groups.items()):
+        raw_terms = [*group.get("raw_lemmas", []), *group.get("variants", [])]
+        if is_excluded(exclusions, key[0], key[1], doc.author, raw_terms=raw_terms):
+            del groups[key]
+    return groups
+
+
+def _repair_person_links(session, doc_id: int, old_rows: list, mapping: dict[str, str]) -> dict:
+    person_terms = {
+        term: row.entity_text
+        for row in old_rows
+        if row.entity_type == "persName"
+        for term in _terms(row.entity_text, row.variants)
+    }
+    updated = removed = deduplicated = 0
+    seen_people: set[int] = set()
+    links = list(session.scalars(select(DocumentPerson).where(DocumentPerson.document_id == doc_id)).all())
+    for link in links:
+        if link.person_id in seen_people:
+            reject_review_link(session, link)
+            deduplicated += 1
+            continue
+        seen_people.add(link.person_id)
+        old_text = person_terms.get(normalize_ner_text(link.raw_mention).casefold())
+        target = mapping.get(old_text) if old_text else None
+        if target:
+            if link.raw_mention != target:
+                link.raw_mention = target
+                updated += 1
+        elif old_text:
+            reject_review_link(session, link)
+            removed += 1
+    return {"updated": updated, "removed": removed, "deduplicated": deduplicated}
+
+
+def repair_document(session, doc: WebDocument, *, dry_run: bool) -> dict:
+    text = doc.text_md or doc.text or ""
+    if not text.strip():
+        raise ValueError("document has no text")
+    raw = extract_entities_strict(text)
+    groups = _filtered_groups(session, doc, raw)
+    old_rows = list(session.scalars(select(DocumentEntity).where(DocumentEntity.document_id == doc.id)).all())
+    mapping = build_canonical_map(old_rows, groups)
+    changes = classify_entity_changes(old_rows, groups, mapping)
+    report = {
+        "document_id": doc.id,
+        "dry_run": dry_run,
+        "old_entities": len(old_rows),
+        "new_entities": len(groups),
+        "old_mentions": sum(row.mention_count for row in old_rows),
+        "new_mentions": sum(group["count"] for group in groups.values()),
+        **changes,
+        "person_links_affected": sum(
+            1
+            for row in old_rows
+            if row.entity_type == "persName"
+            and (row.entity_text not in mapping or mapping[row.entity_text] != row.entity_text)
+        ),
+        "geocodes_affected": sum(
+            1
+            for row in old_rows
+            if row.geocode_id is not None and (row.entity_text in changes["removed"] or row.entity_text in mapping)
+        ),
+        "suspicious_orphan_tags": _orphan_tag_audit(doc, groups),
+    }
+    if dry_run:
+        return report
+
+    session.execute(delete(DocumentEntity).where(DocumentEntity.document_id == doc.id))
+    session.add_all([
+        DocumentEntity(
+            document_id=doc.id,
+            entity_type=entity_type,
+            entity_text=entity_text,
+            mention_count=group["count"],
+            variants=group["variants"],
+        )
+        for (entity_type, entity_text), group in groups.items()
+    ])
+    report["person_links"] = _repair_person_links(session, doc.id, old_rows, mapping)
+    session.flush()
+    report["places"] = verify_document_places(session, doc, text)
+    report["persons"] = resolve_document_persons(session, doc, text)
+    report["pipelines"] = attach_document_pipelines(session, doc.id)
+    return report
+
+
+def _load_state(path: Path) -> set[int]:
+    if not path.exists():
+        return set()
+    return {int(value) for value in json.loads(path.read_text(encoding="utf-8"))}
+
+
+def _save_state(path: Path, completed: set[int]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(completed), indent=2), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--document-id", type=int, action="append")
+    selection.add_argument("--all", action="store_true", help="Documents already having document_entities rows")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--skip-ids", type=int, nargs="*", default=[])
+    parser.add_argument("--state-file", type=Path, default=Path("tmp/refresh_entities_state.json"))
+    args = parser.parse_args()
+
+    with get_session() as session:
+        if args.all:
+            ids = list(session.scalars(select(DocumentEntity.document_id).distinct().order_by(DocumentEntity.document_id)))
+        else:
+            ids = list(dict.fromkeys(args.document_id))
+    completed = _load_state(args.state_file)
+    ids = [doc_id for doc_id in ids if doc_id not in completed and doc_id not in set(args.skip_ids)]
+    if args.limit is not None:
+        ids = ids[:args.limit]
+
+    failures = 0
+    for doc_id in ids:
+        with get_session() as session:
+            try:
+                doc = session.get(WebDocument, doc_id)
+                if doc is None:
+                    raise ValueError("document not found")
+                report = repair_document(session, doc, dry_run=args.dry_run)
+                if args.dry_run:
+                    session.rollback()
+                else:
+                    session.commit()
+                    completed.add(doc_id)
+                    _save_state(args.state_file, completed)
+                print(json.dumps(report, ensure_ascii=False, default=str))
+            except Exception as exc:
+                session.rollback()
+                failures += 1
+                print(json.dumps({"document_id": doc_id, "error": str(exc)}, ensure_ascii=False))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/library/ner_client.py
+++ b/backend/library/ner_client.py
@@ -71,7 +71,11 @@ def _iter_windows(text: str, size: int = MAX_TEXT_CHARS, total_cap: int = MAX_TE
         start = end
 
 
-def extract_entities(text: str) -> list[dict]:
+class NERExtractionError(RuntimeError):
+    """A complete NER extraction could not be obtained."""
+
+
+def _extract_entities(text: str, *, strict: bool) -> list[dict]:
     """Return raw entities from the NER service: [{text, label, lemma, start, end}, ...].
 
     Long texts are processed in windows (see _iter_windows) and the mentions
@@ -85,7 +89,7 @@ def extract_entities(text: str) -> list[dict]:
     if not text or not text.strip():
         return []
     collected: list[dict] = []
-    for window in _iter_windows(text):
+    for window_index, window in enumerate(_iter_windows(text), start=1):
         try:
             resp = requests.post(
                 f"{_service_url()}/ner",
@@ -95,16 +99,25 @@ def extract_entities(text: str) -> list[dict]:
             resp.raise_for_status()
             entities = resp.json().get("entities", [])
             if not isinstance(entities, list):
-                logger.warning("NER service returned unexpected payload shape")
-                break
+                raise ValueError("NER service returned unexpected payload shape")
             collected.extend(entities)
-        except requests.RequestException as e:
-            logger.warning("NER service unavailable (%s): %s", _service_url(), e)
-            break
-        except ValueError as e:
-            logger.warning("NER service returned invalid JSON: %s", e)
+        except (requests.RequestException, ValueError) as exc:
+            message = f"NER extraction failed in window {window_index}: {exc}"
+            if strict:
+                raise NERExtractionError(message) from exc
+            logger.warning(message)
             break
     return collected
+
+
+def extract_entities(text: str) -> list[dict]:
+    """Best-effort extraction; preserves partial-result legacy behavior."""
+    return _extract_entities(text, strict=False)
+
+
+def extract_entities_strict(text: str) -> list[dict]:
+    """Return only a complete extraction; raise on failure of any text window."""
+    return _extract_entities(text, strict=True)
 
 
 def warmup_async() -> None:

--- a/backend/library/ner_normalization.py
+++ b/backend/library/ner_normalization.py
@@ -1,11 +1,14 @@
 """Deterministic Polish NER normalization rules loaded from versioned data."""
 
 import json
+import logging
 import unicodedata
 from functools import lru_cache
 from pathlib import Path
 
 from library.country_gazetteer import canonical_country_name
+
+logger = logging.getLogger(__name__)
 
 RULES_PATH = Path(__file__).resolve().parents[1] / "data" / "ner_normalization.json"
 
@@ -18,8 +21,12 @@ def normalize_ner_text(value: str) -> str:
 @lru_cache(maxsize=1)
 def load_ner_normalization_rules() -> dict:
     """Load curated rules once per backend process."""
-    with RULES_PATH.open(encoding="utf-8") as handle:
-        return json.load(handle)
+    try:
+        with RULES_PATH.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        logger.warning("NER normalization rules file does not exist: %s", RULES_PATH)
+        return {}
 
 
 def canonical_country_for_surface(surface: str) -> str | None:

--- a/backend/tests/unit/test_ner_client.py
+++ b/backend/tests/unit/test_ner_client.py
@@ -14,6 +14,8 @@ from library.ner_client import (  # noqa: E402
     aggregate_entities,
     aggregate_entities_detailed,
     extract_entities,
+    extract_entities_strict,
+    NERExtractionError,
     warmup_async,
 )
 
@@ -99,6 +101,22 @@ class TestExtractEntities:
                 result = extract_entities("x" * (3 * MAX_TEXT_CHARS))
         assert result == first
         assert mock_post.call_count == 2  # trzecie okno pominięte
+
+    def test_strict_first_window_failure_raises(self):
+        with patch("library.ner_client.requests.post", side_effect=requests.ConnectionError("boom")):
+            with patch("library.ner_client._service_url", return_value="http://ner:8090"):
+                with pytest.raises(NERExtractionError, match="window 1"):
+                    extract_entities_strict("tekst")
+
+    def test_strict_later_window_failure_discards_partial_result(self):
+        first = [{"text": "Tusk", "label": "persName", "lemma": "Tusk"}]
+        with patch(
+            "library.ner_client.requests.post",
+            side_effect=[_response(first), requests.ConnectionError("boom")],
+        ):
+            with patch("library.ner_client._service_url", return_value="http://ner:8090"):
+                with pytest.raises(NERExtractionError, match="window 2"):
+                    extract_entities_strict("x" * (MAX_TEXT_CHARS + 500))
 
 
 class TestWarmupAsync:

--- a/backend/tests/unit/test_ner_normalization.py
+++ b/backend/tests/unit/test_ner_normalization.py
@@ -1,0 +1,19 @@
+import logging
+
+from library import ner_normalization
+
+
+def test_missing_rules_file_falls_back_to_empty_rules(monkeypatch, tmp_path, caplog):
+    missing_path = tmp_path / "missing-ner-normalization.json"
+    monkeypatch.setattr(ner_normalization, "RULES_PATH", missing_path)
+    ner_normalization.load_ner_normalization_rules.cache_clear()
+
+    try:
+        with caplog.at_level(logging.WARNING, logger=ner_normalization.__name__):
+            assert ner_normalization.load_ner_normalization_rules() == {}
+
+        assert "NER normalization rules file does not exist" in caplog.text
+        assert ner_normalization.canonical_country_for_surface("Iranem") == "Iran"
+        assert not ner_normalization.is_rejected_surface_lemma_pair("Dana", "Dan", "PROPN")
+    finally:
+        ner_normalization.load_ner_normalization_rules.cache_clear()

--- a/backend/tests/unit/test_refresh_entities.py
+++ b/backend/tests/unit/test_refresh_entities.py
@@ -1,0 +1,65 @@
+"""Unit tests for imports.refresh_entities repair planning and safety."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from imports.refresh_entities import build_canonical_map, classify_entity_changes, repair_document
+from library.ner_client import NERExtractionError
+
+
+def _row(text, entity_type="placeName", variants=None, count=1, geocode_id=None):
+    return SimpleNamespace(
+        entity_text=text,
+        entity_type=entity_type,
+        variants=variants or [],
+        mention_count=count,
+        geocode_id=geocode_id,
+    )
+
+
+def _group(count, variants, raw_lemmas=None):
+    return {"count": count, "variants": variants, "raw_lemmas": raw_lemmas or []}
+
+
+def test_build_canonical_map_uses_variants_and_raw_lemmas():
+    old = [_row("Turk", variants=["Turcy"]), _row("polska", variants=["Polska"])]
+    new = {
+        ("placeName", "Turcja"): _group(2, ["Turcy"], ["Turk"]),
+        ("geogName", "Polska"): _group(3, ["Polska"], ["polska"]),
+    }
+    assert build_canonical_map(old, new) == {"Turk": "Turcja", "polska": "Polska"}
+
+
+def test_classify_removed_merged_changed_and_counts():
+    old = [_row("Polska", count=1), _row("polska", count=2), _row("A.", count=1)]
+    new = {("placeName", "Polska"): _group(3, ["Polska"])}
+    mapping = {"Polska": "Polska", "polska": "Polska"}
+    result = classify_entity_changes(old, new, mapping)
+    assert result["removed"] == ["A."]
+    assert result["removed_count"] == 1
+    assert result["changed"] == [("polska", "Polska")]
+    assert result["changed_count"] == 1
+    assert result["merged"] == ["Polska"]
+    assert result["merged_count"] == 1
+    assert result["count_changes"] == [("Polska", 1, 3), ("polska", 2, 3)]
+
+
+def test_ambiguous_mapping_is_left_unmapped_for_safe_removal():
+    old = [_row("Kijowa", variants=["Kijowa"])]
+    new = {
+        ("placeName", "Kijów"): _group(1, ["Kijowa"]),
+        ("placeName", "Kijowa Dolnego"): _group(1, ["Kijowa"]),
+    }
+    assert build_canonical_map(old, new) == {}
+
+
+def test_ner_failure_does_not_start_database_replacement():
+    session = MagicMock()
+    doc = SimpleNamespace(id=9204, text_md="tekst", text=None, tags=None, author=None)
+    with patch("imports.refresh_entities.extract_entities_strict", side_effect=NERExtractionError("window 2")):
+        with pytest.raises(NERExtractionError):
+            repair_document(session, doc, dry_run=False)
+    session.execute.assert_not_called()
+    session.add_all.assert_not_called()


### PR DESCRIPTION
## Purpose

Final part of the NER data-quality plan (after #239, #240): existing `document_entities` rows predate the new normalization — this adds the controlled mass re-extraction tooling plus a production fix found during the pilot.

## Changes

- **`extract_entities_strict()`** (`ner_client.py`) — raises `NERExtractionError` on any window failure. A batch repair must not mistake a service outage or a partial multi-window result for a clean extraction (`extract_entities` keeps its best-effort behavior for the regular pipelines).
- **`imports/refresh_entities.py`** — `--document-id` / `--all` / `--limit` / `--dry-run` / `--skip-ids` / `--state-file`; per document: full re-extraction through the new normalization, old→new canonical mapping via shared variants/raw lemmas (**ambiguity is never guessed** — the person link is dropped and re-resolved via the alias cascade instead), JSON report, `document_persons` repair (raw_mention updates, duplicate-link cleanup, orphan person removal), re-run of place verification + pipeline attachment, one transaction per document, resumable state file.
- **Production fix (found by the pilot)**: `backend/Dockerfile` never copied `backend/data/` into the image, so #240's `ner_normalization.json` was missing on the deployed backend — entity refresh would raise `FileNotFoundError`. Added `COPY backend/data ./data/` and made the rules loader degrade to empty rules with a warning.

## Pilot — dry-run on book 9204 (NAS, real DB + NER service)

| metric | value |
|---|---|
| entities | 1136 → **907** |
| junk removed | **206** (initials `A.`/`D.`, `Dan` the howitzer, broken lemmas like `Baracko Obama`, `Chiński republika ludowy`, adjectives) |
| renamed to canonical | **198** (`Brn`→`Brnem`, `Austriak`→`Austria`, `China/Chine/Chino`→`Chiny`, `Białorusią`→`Białoruś`) |
| merges | **62** (case variants, abbreviations, demonyms) |
| suspicious orphan tags | 0 |

Known conservative behavior: old rows with overlapping variant sets (e.g. `Donald Trump` + `Donald Trumpa` + `Donaldem Trump`) map ambiguously, so their person links are re-resolved rather than guessed — for persons already in the registry this is an offline alias match; a `manual_confirmed` link may come back as `alias_matched`.

## Verification

- backend unit suite: **1150 passed**; ruff: clean
- pilot executed inside the NAS backend container (script + updated files copied in; the image itself gets them via this PR)

## After merge

1. Deploy backend (image now includes `data/`).
2. Apply run on 9204, verify in the reader, then batch over the corpus with `--all --limit` chunks.

Implemented by Codex (commit author), reviewed by Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)