### PR TITLE
fix: un-ignore backend/data in .dockerignore (broken backend Docker build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,13 +61,12 @@ web_landing_page/
 web_chrome_extension/
 infra/
 
-# Backend dev/test files (Dockerfile only copies library/ and server.py)
+# Backend dev/test files (Dockerfile copies library/, data/ and server.py)
 backend/tests/
 backend/mcp_server/tests/
 backend/test_code/
 backend/tmp/
 backend/imports/
-backend/data/
 
 # CI/CD configs
 .circleci/


### PR DESCRIPTION
## Summary

PR #241 added `COPY backend/data ./data/` to `backend/Dockerfile` (`ner_normalization.json` is needed at runtime), but `.dockerignore` still excluded `backend/data/` (exclusion dating from March, commit b3c9a60). Result: **every backend image build fails** with:

```
ERROR: "/backend/data": not found
 > [stage-0  9/11] COPY backend/data ./data/
```

Discovered during today's NAS deploy of the timeline feature — the NAS backend still runs an image from 2026-07-04, so `GET /document/<id>/events` (merged in #242) returns 404 in production.

## Fix

Remove the `backend/data/` line from `.dockerignore` (the directory is 152K — negligible build-context cost) and update the stale comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)