### PR TITLE
fix: recover events from truncated timeline LLM responses

### DIFF
--- a/backend/library/timeline_events.py
+++ b/backend/library/timeline_events.py
@@ -19,7 +19,7 @@ from library.text_functions import detect_chapters
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMELINE_MODEL = "Bielik-11B-v3.0-Instruct"
-MAX_FRAGMENT_CHARS = 20_000
+MAX_FRAGMENT_CHARS = 10_000
 
 _MONTHS = {
     "stycznia": 1,
@@ -199,22 +199,72 @@ def normalize_date_text(date_text: str) -> dict | None:
     return _date_result("unknown", value.year, value, value)
 
 
-def parse_events_response(raw_response: str) -> list[dict]:
-    """Parse a JSON event list, tolerating a surrounding Markdown code fence."""
+def _complete_array_prefix(raw: str) -> str | None:
+    """Return a JSON array containing all complete top-level objects in a truncated array."""
+    array_start = raw.find("[")
+    if array_start < 0:
+        return None
+
+    in_string = escaped = False
+    array_depth = object_depth = 0
+    last_complete_object = None
+    for position, character in enumerate(raw[array_start:], start=array_start):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character == "[":
+            array_depth += 1
+        elif character == "]":
+            array_depth -= 1
+        elif character == "{":
+            object_depth += 1
+        elif character == "}":
+            object_depth -= 1
+            if array_depth == 1 and object_depth == 0:
+                last_complete_object = position
+
+    if last_complete_object is None:
+        return None
+    return raw[array_start:last_complete_object + 1].rstrip().rstrip(",") + "]"
+
+
+def _parse_events_response(raw_response: str) -> tuple[list[dict], bool]:
+    """Parse an event list and report whether the original JSON was invalid."""
     raw = (raw_response or "").strip()
     fence = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", raw, re.IGNORECASE | re.DOTALL)
     if fence:
         raw = fence.group(1).strip()
+    invalid_json = False
     try:
         payload = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
-        logger.warning("timeline LLM returned invalid JSON")
-        return []
+        invalid_json = True
+        repaired = _complete_array_prefix(raw)
+        try:
+            payload = json.loads(repaired) if repaired is not None else None
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if payload is None:
+            logger.warning("timeline LLM returned invalid JSON that could not be recovered")
+            return [], True
     if isinstance(payload, dict):
         payload = payload.get("events", payload.get("wydarzenia", []))
     if not isinstance(payload, list):
-        return []
-    return [item for item in payload if isinstance(item, dict)]
+        return [], invalid_json
+    return [item for item in payload if isinstance(item, dict)], invalid_json
+
+
+def parse_events_response(raw_response: str) -> list[dict]:
+    """Parse a JSON event list, recovering complete objects from a truncated array."""
+    events, _invalid_json = _parse_events_response(raw_response)
+    return events
 
 
 def _normalize_quote_typography(value: str) -> str:
@@ -286,11 +336,12 @@ def _response_usage(response) -> tuple[int, float | None]:
 
 def extract_fragment_events(fragment: str, chapter_position: int | None, model: str) -> tuple[list[dict], dict]:
     """Make one LLM call and retain only grounded events with normalizable dates."""
-    response = ai_ask(_timeline_prompt(fragment), model=model, temperature=0.1, max_token_count=1600)
+    response = ai_ask(_timeline_prompt(fragment), model=model, temperature=0.1, max_token_count=4000)
     tokens, cost = _response_usage(response)
     events: list[dict] = []
     rejected_quote = rejected_date = 0
-    for candidate in parse_events_response(response.response_text):
+    candidates, invalid_json = _parse_events_response(response.response_text)
+    for candidate in candidates:
         date_text = str(candidate.get("date_text") or "").strip()
         description = str(candidate.get("description") or "").strip()
         quote = str(candidate.get("quote") or "").strip()
@@ -311,6 +362,7 @@ def extract_fragment_events(fragment: str, chapter_position: int | None, model: 
     return events, {
         "rejected_without_quote": rejected_quote,
         "rejected_without_date": rejected_date,
+        "invalid_json": int(invalid_json),
         "llm_calls": 1,
         "llm_tokens": tokens,
         "llm_cost": cost,
@@ -364,6 +416,7 @@ def extract_document_events(session, doc, model: str | None = None, *, chapter_p
             "events": len(chapter_events),
             "rejected_without_quote": sum(r["rejected_without_quote"] for r in fragment_reports),
             "rejected_without_date": sum(r["rejected_without_date"] for r in fragment_reports),
+            "invalid_json": sum(r["invalid_json"] for r in fragment_reports),
             "llm_calls": sum(r["llm_calls"] for r in fragment_reports),
             "llm_tokens": sum(r["llm_tokens"] for r in fragment_reports),
             "llm_cost": _combine_costs(r["llm_cost"] for r in fragment_reports),

--- a/backend/tests/unit/test_timeline_events.py
+++ b/backend/tests/unit/test_timeline_events.py
@@ -12,6 +12,79 @@ from library import chunk_review_routes, timeline_events
 from library.db.models import DocumentEvent
 
 
+def test_truncated_response_recovers_complete_objects():
+    raw = '[{"date_text": "2020", "description": "Pierwsze", "quote": "Cytat"}, {"date_text": "2021"'
+
+    assert timeline_events.parse_events_response(raw) == [
+        {"date_text": "2020", "description": "Pierwsze", "quote": "Cytat"}
+    ]
+
+
+def test_truncated_response_without_complete_object_returns_empty_list():
+    assert timeline_events.parse_events_response('[{"date_text": "2020"') == []
+
+
+def test_valid_json_response_is_parsed_without_changes():
+    payload = [{"date_text": "2020", "description": "Wydarzenie", "quote": "Cytat"}]
+
+    assert timeline_events.parse_events_response(json.dumps(payload)) == payload
+
+
+def test_invalid_json_is_counted_in_fragment_report(monkeypatch):
+    fragment = "W 2020 wydarzyło się pierwsze wydarzenie."
+    raw = json.dumps([{
+        "date_text": "2020",
+        "description": "Pierwsze wydarzenie.",
+        "quote": "W 2020 wydarzyło się pierwsze wydarzenie.",
+    }])[:-1] + ', {"date_text": "2021"'
+    monkeypatch.setattr(
+        timeline_events,
+        "ai_ask",
+        lambda *_args, **_kwargs: SimpleNamespace(response_text=raw, total_tokens=1),
+    )
+
+    events, report = timeline_events.extract_fragment_events(fragment, 1, "model")
+
+    assert len(events) == 1
+    assert report["invalid_json"] == 1
+
+
+def test_invalid_json_is_summed_in_chapter_report(monkeypatch):
+    reports = iter([
+        {
+            "rejected_without_quote": 0,
+            "rejected_without_date": 0,
+            "invalid_json": 1,
+            "llm_calls": 1,
+            "llm_tokens": 10,
+            "llm_cost": None,
+        },
+        {
+            "rejected_without_quote": 0,
+            "rejected_without_date": 0,
+            "invalid_json": 0,
+            "llm_calls": 1,
+            "llm_tokens": 10,
+            "llm_cost": None,
+        },
+    ])
+    monkeypatch.setattr(
+        timeline_events,
+        "_chapters_for_document",
+        lambda *_args, **_kwargs: [{"position": 47, "title": "Rozdział", "text": "tekst"}],
+    )
+    monkeypatch.setattr(timeline_events, "split_timeline_fragments", lambda _text: ["jeden", "dwa"])
+    monkeypatch.setattr(
+        timeline_events,
+        "extract_fragment_events",
+        lambda *_args, **_kwargs: ([], next(reports)),
+    )
+
+    result = timeline_events.extract_document_events(None, SimpleNamespace(), model="model")
+
+    assert result["chapters"][0]["invalid_json"] == 1
+
+
 @pytest.mark.parametrize(
     "wrapper",
     [lambda payload: payload, lambda payload: f"```json\n{payload}\n```"],


### PR DESCRIPTION
## Problem

Date-dense chapters produce event JSON longer than `max_token_count=1600` — Bielik's response gets cut mid-array, `json.loads` fails, and `parse_events_response` silently returns `[]` for the whole chapter (only a log warning, report shows `events: 0` with zero rejection counters).

Real case: doc 9204 chapter 47 "Wobec Wielkiej Brytanii" (Brexit 2020, Skripal 2018, treaty 2017, Narew 2023…) had **0 events** in `document_events` despite the raw LLM response starting with a perfectly valid event array. Likely affects other empty chapters of the book too (29/59 have no events).

## Fix

- `parse_events_response`: on invalid JSON, trim the raw text to the last complete top-level object (string/escape-aware character scan, handles nested arrays) and close the array, then parse again; give up only when that also fails. Public signature unchanged.
- `max_token_count` 1600 → 4000, `MAX_FRAGMENT_CHARS` 20 000 → 10 000 — shorter per-fragment responses, less truncation in the first place.
- New `invalid_json` counter in fragment and chapter reports (next to `rejected_without_quote`/`rejected_without_date`) so parse failures are visible.
- Unit tests: truncated-response recovery, unrecoverable truncation, valid-JSON passthrough, counter propagation (26 passed).

## Verification

Dry-run of doc 9204 chapter 47 with the fix: **11 events** (was 0), report shows `invalid_json: 1` for the fragment that still truncated but was recovered:

```
2015, 2014, 2018 (Skripal), 2022, 2021 ×2, 2016, 2014 (referendum), 2022, 2020–2021, 2022–2024
```

After merge: re-run full extraction for doc 9204 and redeploy backend on NAS.

Coded by Codex, reviewed by Claude (review also fixed double-encoded Polish characters in test strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)