### PR TITLE
fix: forward temperature and max_tokens to Bielik (Sherlock) in ai_ask

### DIFF
--- a/backend/library/ai.py
+++ b/backend/library/ai.py
@@ -54,7 +54,8 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         return ai_response
     elif model in ["Bielik-11B-v2.3-Instruct", "Bielik-11B-v3.0-Instruct"]:
         from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
-        return sherlock_get_completion(query, model=model)
+        return sherlock_get_completion(query, model=model, temperature=temperature,
+                                       max_tokens=max_token_count)
     elif model.startswith("arklabs/"):
         from library.api.arklabs.arklabs_completion import arklabs_get_completion
         actual_model = model.removeprefix("arklabs/")

--- a/backend/tests/unit/test_ai.py
+++ b/backend/tests/unit/test_ai.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("openai")
+
+from library.ai import ai_ask  # noqa: E402
+
+
+def test_ai_ask_forwards_generation_parameters_to_sherlock_for_bielik():
+    with patch(
+        "library.api.cloudferro.sherlock.sherlock.sherlock_get_completion"
+    ) as mock_completion:
+        ai_ask(
+            "Extract timeline events",
+            model="Bielik-11B-v3.0-Instruct",
+            temperature=0.1,
+            max_token_count=4000,
+        )
+
+    mock_completion.assert_called_once_with(
+        "Extract timeline events",
+        model="Bielik-11B-v3.0-Instruct",
+        temperature=0.1,
+        max_tokens=4000,
+    )


### PR DESCRIPTION
## Problem

Timeline extraction (`timeline_events.py`) requests `max_token_count=4000`, but `ai_ask()` dropped both `temperature` and `max_token_count` when routing to Bielik models — `sherlock_get_completion(query, model=model)` — so the API always ran with sherlock.py's default `max_tokens=1000`. On the full extraction of book 9204, 49 of 182 fragments returned truncated JSON (`invalid_json=1`) and the tail events of those fragments were lost, even with the truncation recovery from #245.

## Fix

Pass `temperature` and `max_token_count` (as `max_tokens`) through to `sherlock_get_completion()`. All production Bielik callers (`timeline_events`, `article_tagging`, `ai_intent_parser`) already pass explicit values, so this only enforces what callers assumed. No changes to `MAX_FRAGMENT_CHARS` or the prompt were needed.

## Verification

- New unit test `tests/unit/test_ai.py` asserts Bielik routing forwards both parameters (fails against the old code); guarded with `pytest.importorskip("openai")` for the lightweight uvx environment.
- `tests/unit/test_timeline_events.py` + `test_ai_intent_parser.py`: 54 passed.
- Dry-runs on the densest chapters of document 9204: **invalid_json=0 across 35 LLM calls** (previously 49/182 fragments truncated); chapter 41: 35 events (was 30), chapter 40: 29, chapter 7: 28 (was 25).

Coded by Codex, reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)