### PR TITLE
feat: article authors, biographies and information provenance

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,11 @@ COPY shared_python/unified-config-loader/ /shared_python/unified-config-loader/
 COPY backend/pyproject.toml backend/uv.lock ./
 
 # Install dependencies using uv
-RUN uv sync --frozen --extra docker --no-dev --no-install-project
+# Bump when a private registry contains a corrupted cached dependency blob.
+# Keeping the revision marker in the layer deliberately gives it a new digest.
+ARG DEPENDENCY_LAYER_REV=20260715-provenance
+RUN printf '%s\n' "$DEPENDENCY_LAYER_REV" > /app/.dependency-layer-revision && \
+    uv sync --frozen --extra docker --no-dev --no-install-project
 
 COPY backend/library ./library/
 COPY backend/data ./data/
@@ -35,7 +39,7 @@ COPY backend/server.py .
 RUN groupadd -g 1000 lenie-ai-client && \
     useradd -u 1000 -g lenie-ai-client -m lenie-ai-client && \
     mkdir -p /app/data && \
-    chown -R 1000:1000 /app
+    chown 1000:1000 /app/data
 
 # Switch to the lenie-ai-client user
 USER lenie-ai-client

--- a/backend/alembic/versions/c1d2e3f4a5b6_add_author_biography_review.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_add_author_biography_review.py
@@ -1,0 +1,32 @@
+"""add author biography review fields
+
+Revision ID: c1d2e3f4a5b6
+Revises: b0c1d2e3f4a5
+Create Date: 2026-07-15 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "b0c1d2e3f4a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE document_persons ADD COLUMN IF NOT EXISTS role VARCHAR(30) NOT NULL DEFAULT 'mentioned'")
+    op.execute("ALTER TABLE document_persons ADD COLUMN IF NOT EXISTS source_excerpt TEXT")
+    op.execute("ALTER TABLE document_persons ADD COLUMN IF NOT EXISTS bio_review_status VARCHAR(30)")
+    op.execute("ALTER TABLE document_persons ADD COLUMN IF NOT EXISTS bio_review_result JSONB")
+    op.execute("ALTER TABLE document_persons ADD COLUMN IF NOT EXISTS bio_reviewed_at TIMESTAMP")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_document_persons_bio_review ON document_persons (bio_review_status)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_document_persons_bio_review")
+    op.execute("ALTER TABLE document_persons DROP COLUMN IF EXISTS bio_reviewed_at")
+    op.execute("ALTER TABLE document_persons DROP COLUMN IF EXISTS bio_review_result")
+    op.execute("ALTER TABLE document_persons DROP COLUMN IF EXISTS bio_review_status")
+    op.execute("ALTER TABLE document_persons DROP COLUMN IF EXISTS source_excerpt")
+    op.execute("ALTER TABLE document_persons DROP COLUMN IF EXISTS role")

--- a/backend/alembic/versions/d2e3f4a5b6c7_create_information_sources.py
+++ b/backend/alembic/versions/d2e3f4a5b6c7_create_information_sources.py
@@ -1,0 +1,60 @@
+"""create information provenance tables
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-07-15 13:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS information_sources (
+            id SERIAL PRIMARY KEY,
+            canonical_name TEXT NOT NULL UNIQUE,
+            source_type VARCHAR(30),
+            domain TEXT,
+            description TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+    """)
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS information_source_aliases (
+            id SERIAL PRIMARY KEY,
+            source_id INTEGER NOT NULL REFERENCES information_sources(id) ON DELETE CASCADE,
+            alias TEXT NOT NULL,
+            UNIQUE (source_id, alias)
+        )
+    """)
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS document_information_sources (
+            id SERIAL PRIMARY KEY,
+            document_id INTEGER NOT NULL REFERENCES web_documents(id) ON DELETE CASCADE,
+            source_id INTEGER NOT NULL REFERENCES information_sources(id) ON DELETE CASCADE,
+            role VARCHAR(30) NOT NULL,
+            raw_mention TEXT NOT NULL,
+            source_url TEXT,
+            evidence_excerpt TEXT,
+            confidence INTEGER,
+            extraction_method VARCHAR(30) NOT NULL,
+            review_status VARCHAR(30) NOT NULL DEFAULT 'auto_accepted',
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            UNIQUE (document_id, source_id, role)
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS idx_info_source_alias_lower ON information_source_aliases (LOWER(alias))")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_doc_info_sources_document ON document_information_sources (document_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS idx_doc_info_sources_source_role ON document_information_sources (source_id, role)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS document_information_sources")
+    op.execute("DROP TABLE IF EXISTS information_source_aliases")
+    op.execute("DROP TABLE IF EXISTS information_sources")

--- a/backend/database/init/29-add-author-biography-review.sql
+++ b/backend/database/init/29-add-author-biography-review.sql
@@ -1,0 +1,9 @@
+ALTER TABLE public.document_persons
+    ADD COLUMN IF NOT EXISTS role VARCHAR(30) NOT NULL DEFAULT 'mentioned',
+    ADD COLUMN IF NOT EXISTS source_excerpt TEXT,
+    ADD COLUMN IF NOT EXISTS bio_review_status VARCHAR(30),
+    ADD COLUMN IF NOT EXISTS bio_review_result JSONB,
+    ADD COLUMN IF NOT EXISTS bio_reviewed_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_document_persons_bio_review
+    ON public.document_persons (bio_review_status);

--- a/backend/database/init/30-create-information-sources.sql
+++ b/backend/database/init/30-create-information-sources.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS public.information_sources (
+    id SERIAL PRIMARY KEY,
+    canonical_name TEXT NOT NULL UNIQUE,
+    source_type VARCHAR(30),
+    domain TEXT,
+    description TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.information_source_aliases (
+    id SERIAL PRIMARY KEY,
+    source_id INTEGER NOT NULL REFERENCES public.information_sources(id) ON DELETE CASCADE,
+    alias TEXT NOT NULL,
+    UNIQUE (source_id, alias)
+);
+
+CREATE TABLE IF NOT EXISTS public.document_information_sources (
+    id SERIAL PRIMARY KEY,
+    document_id INTEGER NOT NULL REFERENCES public.web_documents(id) ON DELETE CASCADE,
+    source_id INTEGER NOT NULL REFERENCES public.information_sources(id) ON DELETE CASCADE,
+    role VARCHAR(30) NOT NULL,
+    raw_mention TEXT NOT NULL,
+    source_url TEXT,
+    evidence_excerpt TEXT,
+    confidence INTEGER,
+    extraction_method VARCHAR(30) NOT NULL,
+    review_status VARCHAR(30) NOT NULL DEFAULT 'auto_accepted',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (document_id, source_id, role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_info_source_alias_lower ON public.information_source_aliases (LOWER(alias));
+CREATE INDEX IF NOT EXISTS idx_doc_info_sources_document ON public.document_information_sources (document_id);
+CREATE INDEX IF NOT EXISTS idx_doc_info_sources_source_role ON public.document_information_sources (source_id, role);

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -220,9 +220,14 @@ def process_article_content(doc_id: int, cache_base_dir: str,
 
     if article:
         print(f"  Process: LLM OK ({len(article)} chars)")
+        from library.article_metadata import extract_article_author
+
         cleaned = clean_article_text(article, doc.url)
         doc.text_extracted = article
         doc.text_md = cleaned["text"]
+        if not doc.author:
+            with open(html_file, encoding="utf-8") as f:
+                doc.author = extract_article_author(f.read(), doc.url)
         try:
             session.commit()
             print(f"  Process: saved text_extracted/text_md ({len(cleaned['text'])} chars cleaned)")

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -224,8 +224,8 @@ def _clean_lines_money(lines: list[str]) -> list[str]:
 
 def _clean_lines_wp(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla wp.pl/o2.pl/tech.wp.pl."""
-    skip_exact = {"Skomentuj", "Udostępnij"}
-    skip_startswith = ("Udostępnij na X", "Dźwięk został wygenerowany",
+    skip_exact = {"Skomentuj", "Słuchaj", "Udostępnij", "Kopiuj link"}
+    skip_startswith = ("Udostępnij na ", "Dźwięk został wygenerowany",
                        "Źródło zdjęć:", "Źródło artykułu:", "oprac.")
     cleaned = []
     for line in lines:

--- a/backend/library/article_metadata.py
+++ b/backend/library/article_metadata.py
@@ -1,0 +1,44 @@
+"""Deterministic article metadata extraction for supported news portals."""
+
+import json
+import re
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+
+def _is_wp_url(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host == "wp.pl" or host.endswith(".wp.pl") or host == "o2.pl" or host.endswith(".o2.pl")
+
+
+def extract_article_author(html: str | None, url: str = "") -> str | None:
+    """Extract a content author's name from raw HTML.
+
+    WP's standard ``<meta name="author">`` identifies the publisher (usually
+    Grupa Wirtualna Polska), not the article byline, so it is intentionally
+    ignored.  ``cauthor`` and the visible WP byline are portal-specific and
+    refer to the actual content author.
+    """
+    if not html or not _is_wp_url(url):
+        return None
+
+    # WP analytics payload. Parsing the quoted JSON value also handles escaped
+    # Unicode without maintaining a second HTML/JS unescape implementation.
+    match = re.search(r'"cauthor"\s*:\s*("(?:\\.|[^"\\])*")', html)
+    if match:
+        try:
+            author = json.loads(match.group(1)).strip()
+        except (json.JSONDecodeError, AttributeError):
+            author = ""
+        if author:
+            return author
+
+    soup = BeautifulSoup(html, "html.parser")
+    byline = soup.select_one("#wp-article-author-info .wp-article-author-link, .wp-article-author-link")
+    if byline:
+        author = byline.get_text(" ", strip=True)
+        if author:
+            return author
+
+    return None

--- a/backend/library/author_biography.py
+++ b/backend/library/author_biography.py
@@ -1,0 +1,172 @@
+"""Detection and review of trailing article-author biographies."""
+
+import datetime
+import json
+import logging
+import re
+
+from sqlalchemy import select
+
+from library.db.models import DocumentPerson, Person
+
+logger = logging.getLogger(__name__)
+
+BIO_SIGNALS_RE = re.compile(
+    r"\b(jest|był|była|pracuje|pracował|pracowała|zaczynał|zaczynała|"
+    r"zajmuje się|specjalizuje się|dziennikarzem|dziennikarką|autorem|autorką|"
+    r"ukończył|ukończyła|redakcji|studiach)\b",
+    re.IGNORECASE,
+)
+
+
+def extract_trailing_author_biography(text: str, author: str | None) -> tuple[str, str | None]:
+    """Return (article body, trailing author block).
+
+    Detection is deliberately conservative: the known author name must occur
+    near the beginning of a paragraph in the final 35% of the document and the
+    paragraph must contain biographical language. Short trailing footer/source
+    lines are kept with the biography so they can be classified as SZUM too.
+    """
+    author = (author or "").strip()
+    if not text or len(author.split()) < 2:
+        return text, None
+
+    paragraphs = list(re.finditer(r"\S(?:.*?\S)?(?=\n\s*\n|\Z)", text, re.DOTALL))
+    lower_bound = int(len(text) * 0.65)
+    author_re = re.compile(re.escape(author), re.IGNORECASE)
+    for paragraph in reversed(paragraphs):
+        value = paragraph.group().strip()
+        if paragraph.start() < lower_bound:
+            break
+        name_match = author_re.search(value)
+        if name_match and name_match.start() <= 80 and BIO_SIGNALS_RE.search(value):
+            # Only the biography paragraph belongs to the person. Any short
+            # trailing label (e.g. "The Wall Street Journal") is provenance,
+            # not part of the biography and is intentionally left out here.
+            return text[:paragraph.start()].rstrip(), value
+    return text, None
+
+
+def _json_object(raw: str) -> dict:
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        raise ValueError("LLM response contains no JSON object")
+    value = json.loads(match.group())
+    if not isinstance(value, dict):
+        raise ValueError("LLM response is not a JSON object")
+    return value
+
+
+def _evaluate_biography(person: Person, excerpt: str, model: str) -> dict:
+    from library.chunk_llm_analysis import call_model
+
+    if not (person.description or "").strip():
+        prompt = f"""Utwórz zwięzły, faktograficzny opis osoby na podstawie notki źródłowej.
+Nie dopowiadaj faktów. Zwróć wyłącznie JSON:
+{{"description": "opis w 1-3 zdaniach"}}
+
+Osoba: {person.canonical_name}
+Notka źródłowa:
+{excerpt}"""
+        raw, _ = call_model(prompt, model, max_tokens=350)
+        result = _json_object(raw)
+        description = str(result.get("description") or "").strip()
+        if not description:
+            raise ValueError("LLM returned an empty description")
+        return {"decision": "auto_applied", "proposed_description": description}
+
+    prompt = f"""Porównaj nową notkę biograficzną z obecnym opisem osoby.
+Oceń fakty, nie podobieństwo brzmienia. Zwróć wyłącznie JSON:
+{{"decision": "no_new_information|new_information|conflicting_information",
+  "new_facts": [], "conflicts": [], "proposed_description": null, "reason": "krótko"}}
+Pole proposed_description uzupełnij kompletnym scalonym opisem tylko przy nowych lub sprzecznych informacjach.
+Nie dopowiadaj faktów.
+
+Osoba: {person.canonical_name}
+Obecny opis: {person.description}
+Nowa notka źródłowa:
+{excerpt}"""
+    raw, _ = call_model(prompt, model, max_tokens=600)
+    result = _json_object(raw)
+    allowed = {"no_new_information", "new_information", "conflicting_information"}
+    if result.get("decision") not in allowed:
+        raise ValueError("LLM returned an unsupported decision")
+    return result
+
+
+def process_author_biography(session, doc, excerpt: str, model: str) -> dict:
+    """Attach an author biography to its person and evaluate it with the LLM."""
+    from library.person_registry import find_by_alias
+
+    author = (doc.author or "").strip()
+    person = find_by_alias(session, author)
+    if person is None:
+        person = Person(canonical_name=author)
+        session.add(person)
+        session.flush()
+
+    link = session.execute(select(DocumentPerson).where(
+        DocumentPerson.document_id == doc.id,
+        DocumentPerson.person_id == person.id,
+    )).scalars().first()
+    if link is None:
+        link = DocumentPerson(
+            document_id=doc.id, person_id=person.id, raw_mention=author,
+            confidence="alias_matched", role="author",
+        )
+        session.add(link)
+
+    link.role = "author"
+    link.source_excerpt = excerpt
+    try:
+        result = _evaluate_biography(person, excerpt, model)
+        decision = result["decision"]
+        if decision == "auto_applied":
+            person.description = result["proposed_description"]
+            link.bio_review_status = "auto_applied"
+        elif decision == "no_new_information":
+            link.bio_review_status = "no_new_information"
+        elif decision == "new_information":
+            link.bio_review_status = "needs_review"
+        else:
+            link.bio_review_status = "conflict"
+        link.bio_review_result = result
+    except Exception as exc:
+        logger.exception("author biography evaluation failed for document %s", doc.id)
+        link.bio_review_status = "needs_review"
+        link.bio_review_result = {"decision": "evaluation_failed", "reason": str(exc)}
+    return {"person_id": person.id, "status": link.bio_review_status}
+
+
+def list_biography_review(session) -> list[dict]:
+    rows = session.scalars(select(DocumentPerson).where(
+        DocumentPerson.bio_review_status.in_(("needs_review", "conflict"))
+    ).order_by(DocumentPerson.created_at)).all()
+    return [{
+        "link_id": row.id,
+        "document_id": row.document_id,
+        "document_title": row.document.title if row.document else None,
+        "person_id": row.person_id,
+        "canonical_name": row.person.canonical_name,
+        "current_description": row.person.description,
+        "source_excerpt": row.source_excerpt,
+        "status": row.bio_review_status,
+        "result": row.bio_review_result,
+    } for row in rows]
+
+
+def decide_biography_review(link: DocumentPerson, action: str) -> dict:
+    if link.bio_review_status not in ("needs_review", "conflict"):
+        raise ValueError("Biography is not awaiting review")
+    if action == "approve":
+        proposed = (link.bio_review_result or {}).get("proposed_description")
+        if not proposed:
+            raise ValueError("Review has no proposed description")
+        link.person.description = proposed
+        link.bio_review_status = "approved"
+    elif action == "reject":
+        link.bio_review_status = "rejected"
+    else:
+        raise ValueError("action must be approve or reject")
+    link.bio_reviewed_at = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    return {"link_id": link.id, "status": link.bio_review_status, "person_id": link.person_id}

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -1023,6 +1023,11 @@ class DocumentPerson(Base):
     )
     raw_mention: Mapped[str] = mapped_column(Text, nullable=False)
     confidence: Mapped[str] = mapped_column(String(20), nullable=False)
+    role: Mapped[str] = mapped_column(String(30), nullable=False, server_default="mentioned")
+    source_excerpt: Mapped[str | None] = mapped_column(Text)
+    bio_review_status: Mapped[str | None] = mapped_column(String(30))
+    bio_review_result: Mapped[dict | None] = mapped_column(JSONB)
+    bio_reviewed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(),
     )
@@ -1035,6 +1040,75 @@ class DocumentPerson(Base):
             f"DocumentPerson(id={self.id!r}, document_id={self.document_id!r}, "
             f"person_id={self.person_id!r}, confidence={self.confidence!r})"
         )
+
+
+class InformationSource(Base):
+    """Canonical publisher/reporting/data source mentioned by documents.
+
+    This is intentionally separate from ``Source``: Source records how the
+    user discovered a document, while InformationSource records where claims
+    or reporting contained in the document originated.
+    """
+
+    __tablename__ = "information_sources"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    canonical_name: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    source_type: Mapped[str | None] = mapped_column(String(30))
+    domain: Mapped[str | None] = mapped_column(Text)
+    description: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    aliases: Mapped[list["InformationSourceAlias"]] = relationship(
+        back_populates="source", cascade="all, delete-orphan",
+    )
+
+
+class InformationSourceAlias(Base):
+    """Observed alternate name, e.g. WSJ for The Wall Street Journal."""
+
+    __tablename__ = "information_source_aliases"
+    __table_args__ = (UniqueConstraint("source_id", "alias"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source_id: Mapped[int] = mapped_column(
+        ForeignKey("information_sources.id", ondelete="CASCADE"), nullable=False,
+    )
+    alias: Mapped[str] = mapped_column(Text, nullable=False)
+
+    source: Mapped["InformationSource"] = relationship(back_populates="aliases")
+
+
+class DocumentInformationSource(Base):
+    """Document-to-information-source provenance with role and evidence."""
+
+    __tablename__ = "document_information_sources"
+    __table_args__ = (UniqueConstraint("document_id", "source_id", "role"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("web_documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    source_id: Mapped[int] = mapped_column(
+        ForeignKey("information_sources.id", ondelete="CASCADE"), nullable=False,
+    )
+    role: Mapped[str] = mapped_column(String(30), nullable=False)
+    raw_mention: Mapped[str] = mapped_column(Text, nullable=False)
+    source_url: Mapped[str | None] = mapped_column(Text)
+    evidence_excerpt: Mapped[str | None] = mapped_column(Text)
+    confidence: Mapped[int | None] = mapped_column(Integer)
+    extraction_method: Mapped[str] = mapped_column(String(30), nullable=False)
+    review_status: Mapped[str] = mapped_column(
+        String(30), nullable=False, server_default="auto_accepted",
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    document: Mapped["WebDocument"] = relationship(foreign_keys=[document_id])
+    source: Mapped["InformationSource"] = relationship(foreign_keys=[source_id])
 
 
 class User(Base):

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -357,6 +357,8 @@ class DocumentAnalysisService:
         log(f"doc={doc_id} mode={mode} field={text_field} len={len(text):,}")
 
         scope: str | None = None
+        author_bio = None
+        author_bio_position = None
         if is_transcript:
             # 3. Detect format (multi-speaker = has >> speaker markers)
             speaker_changes = len(re.findall(r'>>', text))
@@ -408,7 +410,14 @@ class DocumentAnalysisService:
                 text, scope_title = _slice_chapter(text, scope_chapter)
                 scope = scope_title[:200]
                 log(f'scope: chapter {scope_chapter} "{scope}" ({len(text):,} chars)')
-            chunk_texts = split_markdown_into_chunks(text, chunk_size)
+            from library.author_biography import extract_trailing_author_biography
+
+            article_body, author_bio = extract_trailing_author_biography(text, getattr(doc, "author", None))
+            chunk_texts = split_markdown_into_chunks(article_body, chunk_size)
+            if author_bio:
+                chunk_texts.append(author_bio)
+                author_bio_position = len(chunk_texts) - 1
+                log(f"author biography isolated ({len(author_bio):,} chars)")
             segments = []
         log(f"split={len(chunk_texts)} chunks, max {chunk_size:,} chars")
 
@@ -425,14 +434,14 @@ class DocumentAnalysisService:
             log(f"split_only: {total} chunks without LLM analysis")
             sections = [
                 {
-                    "type": "TEMAT",
-                    "topic": None,
+                    "type": "SZUM" if i == author_bio_position else "TEMAT",
+                    "topic": "Notka biograficzna autora" if i == author_bio_position else None,
                     "original": chunk_text,
                     "text": None,
                     "ratio": None,
                     "summary": None,
                 }
-                for chunk_text in chunk_texts
+                for i, chunk_text in enumerate(chunk_texts)
             ]
             chunk_texts_iter: list[str] = []
         else:
@@ -440,7 +449,15 @@ class DocumentAnalysisService:
         for i, chunk_text in enumerate(chunk_texts_iter):
             log(f"chunk {i + 1}/{total} ({len(chunk_text):,} chars)...")
             try:
-                if is_transcript:
+                if i == author_bio_position:
+                    result = {
+                        "type": "SZUM",
+                        "topic": "Notka biograficzna autora",
+                        "corrected_text": None,
+                        "summary": None,
+                        "rewrite_ratio": None,
+                    }
+                elif is_transcript:
                     result = analyze_chunk(
                         chunk_text, model,
                         position=i + 1, total=total,
@@ -547,6 +564,23 @@ class DocumentAnalysisService:
                     log(f"persons: linked={len(p_summary['linked'])} skipped={len(p_summary['skipped'])}")
                 except Exception:
                     logger.exception("person resolution failed, continuing without person links")
+
+                if author_bio:
+                    try:
+                        from library.author_biography import process_author_biography
+
+                        bio_summary = process_author_biography(session, doc, author_bio, model)
+                        log(f"author biography: {bio_summary['status']}")
+                    except Exception:
+                        logger.exception("author biography processing failed, continuing")
+
+                try:
+                    from library.information_provenance import refresh_document_information_sources
+
+                    provenance = refresh_document_information_sources(session, doc, text, model)
+                    log(f"information sources: {len(provenance['sources'])}")
+                except Exception:
+                    logger.exception("information-source extraction failed, continuing")
 
         # 12. Persist to DB
         run = DocumentAnalysisRun(

--- a/backend/library/information_provenance.py
+++ b/backend/library/information_provenance.py
@@ -1,0 +1,173 @@
+"""Extract and persist where a document's reporting/information originated."""
+
+import json
+import logging
+import re
+from urllib.parse import urlparse
+
+from sqlalchemy import delete, func, select
+
+from library.db.models import (
+    DocumentInformationSource,
+    InformationSource,
+    InformationSourceAlias,
+)
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_ROLES = {"original_reporting", "cited", "republication", "data_source"}
+
+
+def publisher_domain(url: str) -> str | None:
+    host = (urlparse(url or "").hostname or "").lower()
+    return host.removeprefix("www.") or None
+
+
+def _json_array(raw: str) -> list[dict]:
+    match = re.search(r"\[.*\]", raw, re.DOTALL)
+    if not match:
+        raise ValueError("LLM response contains no JSON array")
+    value = json.loads(match.group())
+    if not isinstance(value, list):
+        raise ValueError("LLM response is not a JSON array")
+    return [item for item in value if isinstance(item, dict)]
+
+
+def extract_information_sources(text: str, title: str, model: str) -> list[dict]:
+    """Use the LLM to classify explicitly attributed sources in an article."""
+    from library.chunk_llm_analysis import call_model
+
+    prompt = f"""Wykryj źródła informacji jawnie wymienione w artykule.
+Nie wpisuj autora artykułu ani portalu publikującego, jeśli nie jest on źródłem cytowanych ustaleń.
+Rozróżnij role:
+- original_reporting: artykuł przypisuje źródłu pierwotne ustalenia/śledztwo,
+- cited: źródło jest cytowane lub przywołane,
+- republication: tekst jest przedrukiem lub opracowaniem materiału źródła,
+- data_source: raport, urząd, badanie albo baza dostarczająca dane.
+
+Ujednolicaj nazwy (np. WSJ -> The Wall Street Journal), ale raw_mention zachowaj tak jak w tekście.
+evidence_excerpt musi być dokładnym, krótkim cytatem z tekstu potwierdzającym relację.
+Zwróć wyłącznie JSON:
+[{{"canonical_name":"...", "raw_mention":"...", "role":"original_reporting|cited|republication|data_source",
+   "source_type":"newspaper|portal|agency|institution|report|database|other",
+   "domain":null, "evidence_excerpt":"...", "confidence":0}}]
+Pomiń niepewne pozycje poniżej confidence 60. Nie dopowiadaj domen ani URL-i.
+
+Tytuł: {title}
+Tekst:
+{text}"""
+    raw, _ = call_model(prompt, model, max_tokens=1200)
+    candidates = _json_array(raw)
+    result = []
+    for item in candidates:
+        name = str(item.get("canonical_name") or "").strip()
+        mention = str(item.get("raw_mention") or "").strip()
+        evidence = str(item.get("evidence_excerpt") or "").strip()
+        role = item.get("role")
+        try:
+            confidence = max(0, min(100, int(item.get("confidence", 0))))
+        except (TypeError, ValueError):
+            confidence = 0
+        # Grounding guard: never persist an invented quote/name.
+        if (not name or not mention or role not in ALLOWED_ROLES or confidence < 60
+                or mention.lower() not in text.lower() or evidence not in text):
+            continue
+        result.append({
+            "canonical_name": name,
+            "raw_mention": mention,
+            "role": role,
+            "source_type": str(item.get("source_type") or "other")[:30],
+            "domain": (str(item.get("domain")).strip() if item.get("domain") else None),
+            "evidence_excerpt": evidence,
+            "confidence": confidence,
+        })
+    return result
+
+
+def _find_source(session, canonical_name: str) -> InformationSource | None:
+    lowered = canonical_name.lower()
+    source = session.scalar(select(InformationSource).where(
+        func.lower(InformationSource.canonical_name) == lowered
+    ))
+    if source is not None:
+        return source
+    alias = session.scalar(select(InformationSourceAlias).where(
+        func.lower(InformationSourceAlias.alias) == lowered
+    ))
+    return alias.source if alias is not None else None
+
+
+def _get_or_create_source(session, item: dict) -> InformationSource:
+    source = _find_source(session, item["canonical_name"])
+    if source is None:
+        source = InformationSource(
+            canonical_name=item["canonical_name"],
+            source_type=item.get("source_type"),
+            domain=item.get("domain"),
+        )
+        session.add(source)
+        session.flush()
+    elif not source.domain and item.get("domain"):
+        source.domain = item["domain"]
+    mention = item.get("raw_mention", "").strip()
+    known = {a.alias.lower() for a in source.aliases}
+    if mention and mention.lower() != source.canonical_name.lower() and mention.lower() not in known:
+        session.add(InformationSourceAlias(source=source, alias=mention))
+    return source
+
+
+def refresh_document_information_sources(session, doc, text: str, model: str) -> dict:
+    """Replace document provenance links, always including the URL publisher."""
+    session.execute(delete(DocumentInformationSource).where(
+        DocumentInformationSource.document_id == doc.id
+    ))
+
+    created = []
+    domain = publisher_domain(doc.url)
+    if domain:
+        publisher_item = {
+            "canonical_name": domain,
+            "raw_mention": domain,
+            "source_type": "portal",
+            "domain": domain,
+        }
+        publisher = _get_or_create_source(session, publisher_item)
+        session.add(DocumentInformationSource(
+            document_id=doc.id,
+            source_id=publisher.id,
+            role="publisher",
+            raw_mention=domain,
+            source_url=doc.url,
+            evidence_excerpt=None,
+            confidence=100,
+            extraction_method="url",
+            review_status="auto_accepted",
+        ))
+        created.append((publisher.canonical_name, "publisher"))
+
+    try:
+        candidates = extract_information_sources(text, doc.title or "", model)
+    except Exception:
+        logger.exception("information-source LLM extraction failed for document %s", doc.id)
+        candidates = []
+
+    seen = {(name.lower(), role) for name, role in created}
+    for item in candidates:
+        source = _get_or_create_source(session, item)
+        key = (source.canonical_name.lower(), item["role"])
+        if key in seen:
+            continue
+        seen.add(key)
+        session.add(DocumentInformationSource(
+            document_id=doc.id,
+            source_id=source.id,
+            role=item["role"],
+            raw_mention=item["raw_mention"],
+            source_url=None,
+            evidence_excerpt=item["evidence_excerpt"],
+            confidence=item["confidence"],
+            extraction_method="llm",
+            review_status="auto_accepted" if item["confidence"] >= 80 else "needs_review",
+        ))
+        created.append((source.canonical_name, item["role"]))
+    return {"sources": created}

--- a/backend/server.py
+++ b/backend/server.py
@@ -596,6 +596,149 @@ def persons_review_list():
     return {"status": "success", "count": len(entries), "entries": entries}, 200
 
 
+@app.route('/person_biographies_review', methods=['GET'])
+def person_biographies_review_list():
+    """Author biographies whose new/conflicting facts need a human decision."""
+    from library.author_biography import list_biography_review
+
+    session = get_scoped_session()
+    entries = list_biography_review(session)
+    return {"status": "success", "count": len(entries), "entries": entries}, 200
+
+
+@app.route('/person_biographies_review/<int:link_id>', methods=['PATCH', 'OPTIONS'])
+def person_biographies_review_decide(link_id: int):
+    """Approve the proposed merged description or reject the biography update."""
+    if request.method == 'OPTIONS':
+        return {"status": "OK"}, 200
+
+    from library.author_biography import decide_biography_review
+    from library.db.models import DocumentPerson
+
+    data = request.get_json(silent=True) or {}
+    session = get_scoped_session()
+    link = session.get(DocumentPerson, link_id)
+    if link is None:
+        return {"status": "error", "message": "Review entry not found"}, 404
+    try:
+        result = decide_biography_review(link, data.get('action'))
+        session.commit()
+    except ValueError as exc:
+        session.rollback()
+        return {"status": "error", "message": str(exc)}, 400
+    except Exception:
+        session.rollback()
+        logging.exception("biography review decision failed for link %s", link_id)
+        return {"status": "error", "message": "DB error"}, 500
+    return {"status": "success", **result}, 200
+
+
+@app.route('/information_sources', methods=['GET'])
+def information_sources_list():
+    """Search canonical information sources and return document counts."""
+    from sqlalchemy import func, or_, select
+    from library.db.models import (
+        DocumentInformationSource, InformationSource, InformationSourceAlias,
+    )
+
+    session = get_scoped_session()
+    query = (request.args.get('q') or '').strip()
+    statement = (
+        select(
+            InformationSource,
+            func.count(func.distinct(DocumentInformationSource.document_id)).label('document_count'),
+        )
+        .outerjoin(DocumentInformationSource, DocumentInformationSource.source_id == InformationSource.id)
+        .group_by(InformationSource.id)
+        .order_by(InformationSource.canonical_name)
+    )
+    if query:
+        pattern = f"%{query}%"
+        alias_match = select(InformationSourceAlias.source_id).where(
+            InformationSourceAlias.alias.ilike(pattern)
+        )
+        statement = statement.where(or_(
+            InformationSource.canonical_name.ilike(pattern),
+            InformationSource.domain.ilike(pattern),
+            InformationSource.id.in_(alias_match),
+        ))
+    rows = session.execute(statement).all()
+    entries = [{
+        "id": source.id,
+        "canonical_name": source.canonical_name,
+        "source_type": source.source_type,
+        "domain": source.domain,
+        "description": source.description,
+        "aliases": [alias.alias for alias in source.aliases],
+        "document_count": count,
+    } for source, count in rows]
+    return {"status": "success", "count": len(entries), "entries": entries}, 200
+
+
+@app.route('/information_sources/<int:source_id>/documents', methods=['GET'])
+def information_source_documents(source_id: int):
+    """Return documents attributed to one source, optionally filtered by role."""
+    from sqlalchemy import select
+    from library.db.models import DocumentInformationSource, InformationSource
+
+    session = get_scoped_session()
+    source = session.get(InformationSource, source_id)
+    if source is None:
+        return {"status": "error", "message": "Information source not found"}, 404
+    statement = select(DocumentInformationSource).where(
+        DocumentInformationSource.source_id == source_id
+    ).order_by(DocumentInformationSource.created_at.desc())
+    role = (request.args.get('role') or '').strip()
+    if role:
+        statement = statement.where(DocumentInformationSource.role == role)
+    links = session.scalars(statement).all()
+    entries = [{
+        "document_id": link.document_id,
+        "title": link.document.title,
+        "url": link.document.url,
+        "role": link.role,
+        "raw_mention": link.raw_mention,
+        "evidence_excerpt": link.evidence_excerpt,
+        "confidence": link.confidence,
+        "review_status": link.review_status,
+    } for link in links]
+    return {
+        "status": "success",
+        "source": {"id": source.id, "canonical_name": source.canonical_name, "domain": source.domain},
+        "count": len(entries),
+        "entries": entries,
+    }, 200
+
+
+@app.route('/document/<int:doc_id>/information_sources', methods=['GET'])
+def document_information_sources(doc_id: int):
+    """Return structured provenance links for a document."""
+    from sqlalchemy import select
+    from library.db.models import DocumentInformationSource
+
+    session = get_scoped_session()
+    if session.get(WebDocument, doc_id) is None:
+        return {"status": "error", "message": "Document not found"}, 404
+    links = session.scalars(select(DocumentInformationSource).where(
+        DocumentInformationSource.document_id == doc_id
+    ).order_by(DocumentInformationSource.role, DocumentInformationSource.id)).all()
+    entries = [{
+        "id": link.id,
+        "source_id": link.source_id,
+        "canonical_name": link.source.canonical_name,
+        "source_type": link.source.source_type,
+        "domain": link.source.domain,
+        "role": link.role,
+        "raw_mention": link.raw_mention,
+        "source_url": link.source_url,
+        "evidence_excerpt": link.evidence_excerpt,
+        "confidence": link.confidence,
+        "extraction_method": link.extraction_method,
+        "review_status": link.review_status,
+    } for link in links]
+    return {"status": "success", "count": len(entries), "entries": entries}, 200
+
+
 def _decide_person_link(link_id: int, require_review: bool):
     """Shared handler for person-link decisions (approve/reject/merge).
 

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -182,3 +182,14 @@ class TestWpCleaning:
             "Treść artykułu wp.",
         ]
         assert _clean_lines_wp(lines) == ["Treść artykułu wp."]
+
+    def test_wp_audio_and_share_controls_removed(self):
+        lines = [
+            "Słuchaj",
+            "Udostępnij na Facebooku",
+            "Udostępnij na X",
+            "Udostępnij na WhatsApp",
+            "Kopiuj link",
+            "Treść artykułu wp.",
+        ]
+        assert _clean_lines_wp(lines) == ["Treść artykułu wp."]

--- a/backend/tests/unit/test_article_metadata.py
+++ b/backend/tests/unit/test_article_metadata.py
@@ -1,0 +1,32 @@
+"""Tests for deterministic portal metadata extraction."""
+
+from library.article_metadata import extract_article_author
+
+
+def test_wp_author_prefers_cauthor_over_publisher_meta():
+    html = """
+    <meta name="author" content="Grupa Wirtualna Polska">
+    <script>window.page={"cauthor":"Łukasz Maziewski"};</script>
+    <a class="wp-article-author-link">Inna osoba</a>
+    """
+    assert extract_article_author(html, "https://wiadomosci.wp.pl/artykul") == "Łukasz Maziewski"
+
+
+def test_wp_author_falls_back_to_visible_byline():
+    html = """
+    <meta name="author" content="Grupa Wirtualna Polska">
+    <div id="wp-article-author-info">
+      <a class="wp-article-author-link"> Łukasz Maziewski </a>
+    </div>
+    """
+    assert extract_article_author(html, "https://tech.wp.pl/artykul") == "Łukasz Maziewski"
+
+
+def test_publisher_meta_is_not_used_as_wp_author():
+    html = '<meta name="author" content="Grupa Wirtualna Polska">'
+    assert extract_article_author(html, "https://wiadomosci.wp.pl/artykul") is None
+
+
+def test_wp_rule_does_not_apply_to_other_domains():
+    html = '<script>window.page={"cauthor":"Jan Kowalski"};</script>'
+    assert extract_article_author(html, "https://example.com/artykul") is None

--- a/backend/tests/unit/test_author_biography.py
+++ b/backend/tests/unit/test_author_biography.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from library.author_biography import (
+    decide_biography_review,
+    extract_trailing_author_biography,
+    process_author_biography,
+)
+from library.db.models import DocumentPerson, Person
+
+
+BIO = (
+    "Jacek Losik dziennikarzem jest od 2014 r. Zaczynał po studiach "
+    "w Dzienniku Łódzkim. W money.pl zajmuje się inwestycjami "
+    "infrastrukturalnymi oraz transportem."
+)
+
+
+def test_extracts_known_author_biography_from_document_tail():
+    text = ("Treść artykułu. " * 80) + "\n\n## Rozdział\n\nDalsza treść.\n\n" + BIO + "\n\nThe Wall Street Journal"
+
+    body, excerpt = extract_trailing_author_biography(text, "Jacek Losik")
+
+    assert body.endswith("Dalsza treść.")
+    assert excerpt == BIO
+
+
+def test_does_not_extract_author_mention_without_biographical_language():
+    text = ("Treść artykułu. " * 80) + "\n\nJacek Losik opisał najnowszy raport."
+
+    body, excerpt = extract_trailing_author_biography(text, "Jacek Losik")
+
+    assert body == text
+    assert excerpt is None
+
+
+def test_first_biography_fills_empty_person_description():
+    person = Person(canonical_name="Jacek Losik", description=None)
+    person.id = 236
+    link = DocumentPerson(
+        id=244, document_id=9245, person_id=236, raw_mention="Jacek Losik",
+        confidence="manual_review",
+    )
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.first.return_value = link
+    doc = SimpleNamespace(id=9245, author="Jacek Losik")
+    result = {"decision": "auto_applied", "proposed_description": "Polski dziennikarz."}
+
+    with patch("library.person_registry.find_by_alias", return_value=person), \
+            patch("library.author_biography._evaluate_biography", return_value=result):
+        summary = process_author_biography(session, doc, BIO, "model")
+
+    assert summary == {"person_id": 236, "status": "auto_applied"}
+    assert person.description == "Polski dziennikarz."
+    assert link.role == "author"
+    assert link.source_excerpt == BIO
+    assert link.bio_review_result == result
+
+
+def test_new_information_is_queued_without_overwriting_description():
+    person = Person(canonical_name="Jacek Losik", description="Dziennikarz money.pl.")
+    person.id = 236
+    link = DocumentPerson(
+        id=244, document_id=9245, person_id=236, raw_mention="Jacek Losik",
+        confidence="alias_matched",
+    )
+    session = MagicMock()
+    session.execute.return_value.scalars.return_value.first.return_value = link
+    doc = SimpleNamespace(id=9245, author="Jacek Losik")
+    result = {
+        "decision": "new_information",
+        "proposed_description": "Dziennikarz money.pl specjalizujący się w transporcie.",
+    }
+
+    with patch("library.person_registry.find_by_alias", return_value=person), \
+            patch("library.author_biography._evaluate_biography", return_value=result):
+        process_author_biography(session, doc, BIO, "model")
+
+    assert person.description == "Dziennikarz money.pl."
+    assert link.bio_review_status == "needs_review"
+
+
+def test_approve_review_applies_proposed_description():
+    person = Person(canonical_name="Jacek Losik", description="Stary opis")
+    person.id = 236
+    link = DocumentPerson(
+        id=244, document_id=9245, person_id=236, raw_mention="Jacek Losik",
+        confidence="alias_matched", bio_review_status="needs_review",
+        bio_review_result={"proposed_description": "Nowy opis"},
+    )
+    link.person = person
+
+    result = decide_biography_review(link, "approve")
+
+    assert person.description == "Nowy opis"
+    assert link.bio_review_status == "approved"
+    assert link.bio_reviewed_at is not None
+    assert result["status"] == "approved"

--- a/backend/tests/unit/test_information_provenance.py
+++ b/backend/tests/unit/test_information_provenance.py
@@ -1,0 +1,76 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from library.db.models import DocumentInformationSource
+from library.information_provenance import (
+    extract_information_sources,
+    publisher_domain,
+    refresh_document_information_sources,
+)
+
+
+def test_publisher_domain_normalizes_www():
+    assert publisher_domain("https://www.money.pl/a/b.html") == "money.pl"
+
+
+def test_llm_sources_are_grounded_and_roles_validated():
+    text = 'Ustalenia ujawnił dziennik "The Wall Street Journal". Inne zdanie.'
+    payload = [
+        {
+            "canonical_name": "The Wall Street Journal",
+            "raw_mention": "The Wall Street Journal",
+            "role": "original_reporting",
+            "source_type": "newspaper",
+            "domain": None,
+            "evidence_excerpt": 'Ustalenia ujawnił dziennik "The Wall Street Journal".',
+            "confidence": 95,
+        },
+        {
+            "canonical_name": "Invented News",
+            "raw_mention": "Invented News",
+            "role": "cited",
+            "source_type": "portal",
+            "domain": None,
+            "evidence_excerpt": "Nieistniejący cytat",
+            "confidence": 99,
+        },
+    ]
+    response = SimpleNamespace(response_text=json.dumps(payload), prompt_tokens=10)
+
+    with patch("library.chunk_llm_analysis.call_model", return_value=(response.response_text, 10)):
+        result = extract_information_sources(text, "Tytuł", "model")
+
+    assert len(result) == 1
+    assert result[0]["canonical_name"] == "The Wall Street Journal"
+    assert result[0]["role"] == "original_reporting"
+
+
+def test_refresh_always_adds_publisher_and_llm_sources():
+    session = MagicMock()
+    doc = SimpleNamespace(id=9245, url="https://www.money.pl/test.html", title="Tytuł")
+    publisher = SimpleNamespace(id=1, canonical_name="money.pl")
+    wsj = SimpleNamespace(id=2, canonical_name="The Wall Street Journal")
+    candidate = {
+        "canonical_name": "The Wall Street Journal",
+        "raw_mention": "WSJ",
+        "role": "original_reporting",
+        "source_type": "newspaper",
+        "domain": None,
+        "evidence_excerpt": "WSJ ustalił",
+        "confidence": 95,
+    }
+
+    with patch("library.information_provenance._get_or_create_source", side_effect=[publisher, wsj]), \
+            patch("library.information_provenance.extract_information_sources", return_value=[candidate]):
+        result = refresh_document_information_sources(session, doc, "WSJ ustalił", "model")
+
+    links = [call.args[0] for call in session.add.call_args_list
+             if isinstance(call.args[0], DocumentInformationSource)]
+    assert [(link.source_id, link.role) for link in links] == [
+        (1, "publisher"), (2, "original_reporting"),
+    ]
+    assert result["sources"] == [
+        ("money.pl", "publisher"),
+        ("The Wall Street Journal", "original_reporting"),
+    ]

--- a/infra/docker/nas-deploy.sh
+++ b/infra/docker/nas-deploy.sh
@@ -118,7 +118,9 @@ build_image() {
 
     log "Budowanie obrazu: ${image} (${dockerfile})..."
     cd "$PROJECT_ROOT"
-    docker build -t "$image" -f "$dockerfile" . 2>&1 | tail -5
+    # Plain progress remains readable in non-interactive Codex/CI logs and
+    # makes long dependency/export steps visible instead of buffering them.
+    docker build --progress=plain -t "$image" -f "$dockerfile" .
     ok "Obraz ${image} zbudowany"
 }
 


### PR DESCRIPTION
## Summary
- detect WP article authors from portal-specific metadata and remove audio/share controls
- isolate and review trailing author biographies during document analysis
- persist structured information-source provenance with migrations and read APIs
- make NAS Docker builds observable and invalidate the dependency layer safely

## Validation
- python -m pytest tests/unit -q — 1207 passed
- targeted Ruff checks — passed
- git diff --check — passed
- gitleaks and TruffleHog pre-commit/pre-push checks — passed