### PR TITLE
feat: tagged reader notes and robust Gazeta.pl extraction

### DIFF
--- a/backend/database/init/31-add-tags-to-user-document-notes.sql
+++ b/backend/database/init/31-add-tags-to-user-document-notes.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.user_document_notes
+    ADD COLUMN IF NOT EXISTS tags VARCHAR(80)[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS idx_user_document_notes_tags
+    ON public.user_document_notes USING GIN (tags);

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -256,6 +256,34 @@ def _clean_lines_wp(lines: list[str]) -> list[str]:
     return cleaned
 
 
+def _clean_lines_gazeta(lines: list[str]) -> list[str]:
+    """Usuń śródtekstowe karty rekomendacji Gazeta.pl, zachowując dalszy artykuł."""
+    cleaned = []
+    in_recommendation = False
+
+    for line in lines:
+        stripped = line.strip()
+        stripped_no_links = re.sub(r'\s*\[link\d+\]', '', stripped).strip()
+
+        if stripped_no_links in ("Czytaj także:", "Czytaj również:"):
+            in_recommendation = True
+            continue
+
+        if in_recommendation:
+            if not stripped or stripped in ("SUBSKRYPCJA", "REKLAMA"):
+                continue
+            # Po karcie rekomendacji właściwy artykuł wraca jako zwykły,
+            # odpowiednio długi akapit. Przetwórz go już normalnie.
+            if len(stripped_no_links) >= 100 and not stripped.startswith(("[", "!")):
+                in_recommendation = False
+            else:
+                continue
+
+        cleaned.append(line)
+
+    return cleaned
+
+
 def clean_article_text(text: str, url: str = "") -> dict:
     """Wyczyść wyekstrahowany markdown. Zwraca dict: {text, links, images}."""
     extracted_links = []
@@ -375,6 +403,8 @@ def clean_article_text(text: str, url: str = "") -> dict:
         lines = _clean_lines_money(lines)
     elif portal == "wp":
         lines = _clean_lines_wp(lines)
+    elif portal == "gazeta":
+        lines = _clean_lines_gazeta(lines)
 
     text = "\n".join(lines)
     text = re.sub(r'\n{3,}', '\n\n', text)

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -86,6 +86,8 @@ def _detect_portal(url: str) -> str | None:
         return "businessinsider"
     if "national-geographic.pl" in url_lower:
         return "natgeo"
+    if "gazeta.pl" in url_lower:
+        return "gazeta"
     return None
 
 
@@ -129,6 +131,15 @@ PORTAL_FOOTER_MARKERS = {
         "#### Nasz autor",
         "Redakcja poleca",
         "### ZAPISZ SIĘ NA NEWSLETTER",
+    ],
+    # Gazeta.pl osadza karty "Czytaj także" pomiędzy akapitami artykułu, więc
+    # nie mogą one wyznaczać końca. Te markery występują dopiero po ostatnim
+    # akapicie właściwej treści.
+    "gazeta": [
+        "*Źródło:",
+        "Źródło:",
+        "Dziękujemy za przeczytanie",
+        "#### Obserwuj nas",
     ],
 }
 

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -1200,6 +1200,9 @@ class UserDocumentNote(Base):
         ForeignKey("document_chunks.id", ondelete="SET NULL"),
     )
     note_text: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list[str]] = mapped_column(
+        ARRAY(String(80)), nullable=False, server_default=sa_text("'{}'"),
+    )
     stance: Mapped[str | None] = mapped_column(String(10))
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(),

--- a/backend/library/reader_routes.py
+++ b/backend/library/reader_routes.py
@@ -67,6 +67,7 @@ def _note_to_dict(note: UserDocumentNote) -> dict:
         "run_id": note.run_id,
         "chunk_id": note.chunk_id,
         "note_text": note.note_text,
+        "tags": note.tags or [],
         "stance": note.stance,
         "created_at": note.created_at.isoformat() if note.created_at else None,
         "updated_at": note.updated_at.isoformat() if note.updated_at else None,
@@ -241,6 +242,19 @@ def list_notes(doc_id: int):
     })
 
 
+@bp.route("/notes", methods=["GET"])
+def search_notes():
+    """Search the current reader's tagged fragments across all documents."""
+    session = get_scoped_session()
+    user = _require_user(session)
+    tag = (request.args.get("tag") or "").strip().lower()
+    query = select(UserDocumentNote).where(UserDocumentNote.user_id == user.id)
+    if tag:
+        query = query.where(UserDocumentNote.tags.any(tag))
+    notes = session.execute(query.order_by(UserDocumentNote.updated_at.desc())).scalars().all()
+    return jsonify({"status": "success", "notes": [_note_to_dict(n) for n in notes]})
+
+
 @bp.route("/document/<int:doc_id>/notes", methods=["POST"])
 def create_note(doc_id: int):
     data = request.get_json(silent=True) or {}
@@ -248,8 +262,14 @@ def create_note(doc_id: int):
     note_text = (data.get("note_text") or "").strip()
     if not anchor_quote:
         return jsonify({"status": "error", "message": "anchor_quote is required"}), 400
-    if not note_text:
-        return jsonify({"status": "error", "message": "note_text is required"}), 400
+    raw_tags = data.get("tags") or []
+    if not isinstance(raw_tags, list):
+        return jsonify({"status": "error", "message": "tags must be a list"}), 400
+    tags = list(dict.fromkeys(str(tag).strip().lower() for tag in raw_tags if str(tag).strip()))
+    if any(len(tag) > 80 for tag in tags) or len(tags) > 20:
+        return jsonify({"status": "error", "message": "at most 20 tags, each up to 80 characters"}), 400
+    if not note_text and not tags:
+        return jsonify({"status": "error", "message": "note_text or tags are required"}), 400
     stance = data.get("stance")
     if stance is not None and stance not in ALLOWED_STANCES:
         return jsonify({
@@ -272,6 +292,7 @@ def create_note(doc_id: int):
         run_id=data.get("run_id"),
         chunk_id=data.get("chunk_id"),
         note_text=note_text,
+        tags=tags,
         stance=stance,
     )
     session.add(note)

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -11,11 +11,61 @@ from library.article_cleaner import (
     _is_portal_internal_link,
     clean_article_text,
 )
+from library.article_extractor import _detect_portal, extract_article_by_markers
 
 LONG_PARAGRAPH = (
     "To jest długi akapit właściwej treści artykułu, który ma zdecydowanie ponad "
     "osiemdziesiąt znaków i powinien zostać zachowany po czyszczeniu."
 )
+
+
+class TestGazetaExtraction:
+    URL = "https://wiadomosci.gazeta.pl/swiat/7,123,artykul.html"
+
+    def test_detects_gazeta_portal(self):
+        assert _detect_portal(self.URL) == "gazeta"
+
+    def test_footer_overrides_llm_end_before_embedded_recommendation(self):
+        markdown = "\n\n".join([
+            "Pierwsze zdanie właściwego artykułu ma zdecydowanie więcej niż czterdzieści znaków.",
+            "Zdanie błędnie wskazane przez model jako koniec artykułu, choć tekst trwa dalej.",
+            "Czytaj także:",
+            "SUBSKRYPCJA",
+            "[Polecany tekst](https://wyborcza.pl/polecany)",
+            "Dalszy akapit artykułu znajdujący się za osadzoną kartą rekomendacji portalu.",
+            "- To jest prawidłowe ostatnie zdanie całego artykułu wypowiedziane przez polityka.",
+            "REKLAMA",
+            "*Źródło: PAP*",
+            "Dziękujemy za przeczytanie",
+        ])
+        markers = {
+            "article_first_sentence": "Pierwsze zdanie właściwego artykułu ma zdecydowanie więcej niż czterdzieści znaków.",
+            "article_last_sentence": "Zdanie błędnie wskazane przez model jako koniec artykułu, choć tekst trwa dalej.",
+        }
+
+        result = extract_article_by_markers(markdown, markers, url=self.URL)
+
+        assert "prawidłowe ostatnie zdanie" in result
+        assert "Źródło: PAP" not in result
+
+    def test_cleaner_removes_embedded_recommendation_but_keeps_following_text(self):
+        text = "\n\n".join([
+            LONG_PARAGRAPH,
+            "Czytaj także:",
+            "SUBSKRYPCJA",
+            "[Polecany tekst](https://wyborcza.pl/polecany)",
+            "Dalszy akapit właściwego artykułu, który znajduje się za kartą polecanego tekstu "
+            "i musi pozostać w ostatecznie oczyszczonej treści dokumentu.",
+            "*Źródło: PAP*",
+        ])
+
+        result = clean_article_text(text, url=self.URL)["text"]
+
+        assert "Dalszy akapit właściwego artykułu" in result
+        assert "Czytaj także" not in result
+        assert "SUBSKRYPCJA" not in result
+        assert "Polecany tekst" not in result
+        assert "Źródło: PAP" not in result
 
 
 class TestImageExtraction:

--- a/backend/tests/unit/test_reader_routes.py
+++ b/backend/tests/unit/test_reader_routes.py
@@ -39,6 +39,7 @@ def _make_note(**overrides) -> UserDocumentNote:
         anchor_prefix="poprzedzający tekst",
         anchor_suffix="następujący tekst",
         note_text="moja reakcja",
+        tags=[],
         stance="agree",
     )
     note.id = 501

--- a/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
+++ b/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
@@ -22,6 +22,7 @@ export interface UserNote {
   run_id: number | null;
   chunk_id: number | null;
   note_text: string;
+  tags: string[];
   stance: string | null;
   created_at: string | null;
   updated_at: string | null;
@@ -156,6 +157,7 @@ export interface NotesApi {
     run_id?: number | null;
     chunk_id?: number | null;
     note_text: string;
+    tags?: string[];
     stance: string | null;
   }) => Promise<boolean>;
   saveNoteText: (noteId: number, text: string) => Promise<boolean>;
@@ -245,10 +247,12 @@ export function pendingNoteFromSelection(blockSelector = "p"): PendingNote | nul
 
 export const NotePopover: React.FC<{
   pending: PendingNote;
-  onSave: (noteText: string, stance: string | null) => void;
+  onSave: (noteText: string, stance: string | null, tags: string[]) => void;
+  onSearch?: (quote: string) => void;
   onCancel: () => void;
-}> = ({ pending, onSave, onCancel }) => {
+}> = ({ pending, onSave, onSearch, onCancel }) => {
   const [noteText, setNoteText] = React.useState("");
+  const [tagText, setTagText] = React.useState("");
   const [stance, setStance] = React.useState<string | null>(null);
   return (
     <div style={{
@@ -264,6 +268,11 @@ export const NotePopover: React.FC<{
         placeholder="Twoja notatka — co myślisz o tym fragmencie?"
         style={{ width: "100%", minHeight: 60, fontSize: "0.85em" }}
       />
+      <input
+        value={tagText} onChange={e => setTagText(e.target.value)}
+        placeholder="Tagi, np. ESSI (oddziel przecinkami)"
+        style={{ width: "100%", marginTop: 6, fontSize: "0.85em" }}
+      />
       <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 6 }}>
         {(["agree", "disagree", "neutral"] as const).map(s => (
           <button key={s} onClick={() => setStance(stance === s ? null : s)}
@@ -276,11 +285,18 @@ export const NotePopover: React.FC<{
           </button>
         ))}
         <span style={{ marginLeft: "auto" }}>
-          <button onClick={() => onSave(noteText.trim(), stance)} disabled={!noteText.trim()}
+          <button onClick={() => onSave(noteText.trim(), stance,
+            tagText.split(",").map(t => t.trim()).filter(Boolean))}
+            disabled={!noteText.trim() && !tagText.trim()}
             style={{ marginRight: 6 }}>Zapisz</button>
           <button onClick={onCancel}>Anuluj</button>
         </span>
       </div>
+      {onSearch && (
+        <button type="button" onClick={() => onSearch(pending.quote)} style={{ marginTop: 8, width: "100%" }}>
+          🔎 Szukaj tego fragmentu w bazie Lenie
+        </button>
+      )}
     </div>
   );
 };
@@ -307,6 +323,11 @@ export const NoteRow: React.FC<{
       <div style={{ fontStyle: "italic", color: "#94a3b8", margin: "2px 0" }}>
         „{note.anchor_quote.length > 90 ? `${note.anchor_quote.slice(0, 90)}…` : note.anchor_quote}"
       </div>
+      {(note.tags?.length ?? 0) > 0 && (
+        <div style={{ display: "flex", gap: 4, flexWrap: "wrap", margin: "3px 0" }}>
+          {note.tags.map(tag => <span key={tag} style={{ color: "#0369a1" }}>#{tag}</span>)}
+        </div>
+      )}
       {editing ? (
         <div>
           <textarea value={text} onChange={e => setText(e.target.value)}

--- a/web_interface_react/src/modules/shared/hooks/useSearch.ts
+++ b/web_interface_react/src/modules/shared/hooks/useSearch.ts
@@ -11,12 +11,6 @@ export const useSearch = ({ callback }: { callback: () => void }) => {
   const [results, setResults] = React.useState<any[] | null>(null);
   const [searchSimilar, setSearchSimilar] = React.useState('');
 
-  React.useEffect(() => {
-    handleSearchSimilar().then(() => null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-
   const handleSearchSimilar = async (search?: string, searchLimit?: string, translate?: boolean) => {
     setIsLoading(true);
     console.log("searching: " + search)

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -351,6 +351,8 @@ const Read: React.FC = () => {
   const { userId, headers, jsonHeaders } = identity;
   const { notes, createNote, saveNoteText, deleteNote } = useUserNotes(apiUrl, id, identity);
   const [pendingNote, setPendingNote] = React.useState<PendingNote | null>(null);
+  const [tagQuery, setTagQuery] = React.useState("");
+  const [tagResults, setTagResults] = React.useState<UserNote[]>([]);
 
   const position = Number(searchParams.get("chapter") ?? 1);
 
@@ -600,23 +602,40 @@ const Read: React.FC = () => {
     goTo(content.next);
   };
 
-  const onTextSelected = () => {
+  const onTextContextMenu = (event: React.MouseEvent<HTMLElement>) => {
     if (!userId) return;
     const pending = pendingNoteFromSelection("p");
-    if (pending) setPendingNote(pending);
+    if (pending) {
+      event.preventDefault();
+      setPendingNote({ ...pending, x: event.pageX, y: event.pageY });
+    }
   };
 
-  const saveNote = async (noteText: string, stance: string | null) => {
-    if (!pendingNote || !noteText) return;
+  const saveNote = async (noteText: string, stance: string | null, tags: string[]) => {
+    if (!pendingNote || (!noteText && tags.length === 0)) return;
     const ok = await createNote({
       anchor_quote: pendingNote.quote,
       anchor_prefix: pendingNote.prefix,
       anchor_suffix: pendingNote.suffix,
       chapter_position: position,
       note_text: noteText,
+      tags,
       stance,
     });
     if (ok) setPendingNote(null);
+  };
+
+  const searchSelectedQuote = (quote: string) => {
+    window.open(`/search?q=${encodeURIComponent(quote)}`, "_blank", "noopener,noreferrer");
+    setPendingNote(null);
+  };
+
+  const searchByTag = async (tag: string) => {
+    const normalized = tag.trim().toLowerCase().replace(/^#/, "");
+    if (!normalized) { setTagResults([]); return; }
+    const r = await fetch(`${apiUrl}/notes?tag=${encodeURIComponent(normalized)}`, { headers });
+    const data = await r.json();
+    setTagResults(data.status === "success" ? (data.notes ?? []) : []);
   };
 
   // ── Derived ──
@@ -754,6 +773,33 @@ const Read: React.FC = () => {
               {notes.map(renderNoteRow)}
             </div>
           )}
+
+          {userId && (
+            <div style={{
+              background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+              marginTop: 12, padding: 10,
+            }}>
+              <strong style={{ fontSize: "0.85em" }}>🏷️ Szukaj po tagu</strong>
+              <form onSubmit={e => { e.preventDefault(); void searchByTag(tagQuery); }}
+                style={{ display: "flex", gap: 4, marginTop: 7 }}>
+                <input value={tagQuery} onChange={e => setTagQuery(e.target.value)}
+                  placeholder="np. ESSI" style={{ minWidth: 0, flex: 1 }} />
+                <button type="submit">Szukaj</button>
+              </form>
+              {tagResults.map(n => (
+                <NavLink key={n.id}
+                  to={`/read/${n.document_id}?chapter=${n.chapter_position ?? 1}&highlight=${encodeURIComponent(n.anchor_quote)}`}
+                  style={{ display: "block", fontSize: "0.78em", marginTop: 7, color: "#0369a1" }}>
+                  dokument #{n.document_id}, rozdz. {n.chapter_position ?? "?"}: {n.anchor_quote.slice(0, 70)}
+                </NavLink>
+              ))}
+              {tagQuery && tagResults.length === 0 && (
+                <div style={{ color: "#94a3b8", fontSize: "0.75em", marginTop: 6 }}>
+                  Wpisz tag i wybierz „Szukaj”.
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Chapter content — fixed reading width, does not grow to soak up wide-screen space.
@@ -788,7 +834,7 @@ const Read: React.FC = () => {
           )}
           {loading && <p style={{ color: "#64748b" }}>Ładowanie…</p>}
           {!loading && content && (
-            <article style={{ fontSize: "1.02em" }} onMouseUp={onTextSelected}>
+            <article style={{ fontSize: "1.02em" }} onContextMenu={onTextContextMenu}>
               {renderMarkdown(
                 content.text, chapterNotes, referencesByMarker, highlightTerms, timelineHighlight?.quote,
               )}
@@ -926,7 +972,8 @@ const Read: React.FC = () => {
 
       {/* Note popover */}
       {pendingNote && (
-        <NotePopover pending={pendingNote} onSave={saveNote} onCancel={() => setPendingNote(null)} />
+        <NotePopover pending={pendingNote} onSave={saveNote} onSearch={searchSelectedQuote}
+          onCancel={() => setPendingNote(null)} />
       )}
     </div>
   );

--- a/web_interface_react/src/modules/shared/pages/search.tsx
+++ b/web_interface_react/src/modules/shared/pages/search.tsx
@@ -4,8 +4,11 @@ import { useFormik } from "formik";
 import Input from "../components/Input/input";
 import { useSearch } from "../hooks/useSearch";
 import Select from "../components/Select/select";
+import { useSearchParams } from "react-router-dom";
 
 const Search = () => {
+  const [searchParams] = useSearchParams();
+  const initialQuery = searchParams.get("q") ?? "";
   const { handleSearchSimilar, results, setResults, isLoading, message, setMessage, isError } =
       useSearch({
         callback: () => formik.resetForm(),
@@ -19,14 +22,22 @@ const Search = () => {
 
   const formik: any = useFormik({
     initialValues: {
-      search: "",
-      searchLimit: "",
+      search: initialQuery,
+      searchLimit: "10",
       translate: false
     },
     onSubmit: async (data) => {
       await handleSearchSimilar(data.search, data.searchLimit, data.translate);
     },
   });
+
+  const initialSearchDone = React.useRef(false);
+  React.useEffect(() => {
+    if (!initialSearchDone.current && initialQuery) {
+      initialSearchDone.current = true;
+      void handleSearchSimilar(initialQuery, "10", false);
+    }
+  }, [handleSearchSimilar, initialQuery]);
 
   return (
       <form onSubmit={formik.handleSubmit}>


### PR DESCRIPTION
## Summary
- add tags to reader notes with a GIN-backed database column and cross-document tag search
- support quote search from selected reader text and query-driven search initialization
- preserve Gazeta.pl article endings when embedded recommendation cards appear inside the article
- add regression coverage for Gazeta.pl boundary extraction and cleanup

## Verification
- 59 focused backend tests passed
- frontend production build passed
- Ruff and git diff checks passed
- pre-commit gitleaks and TruffleHog checks passed

## Data follow-up
Document 9242 was reprocessed locally with the corrected pipeline and a new complete analysis run was created.