### PR TITLE
feat: hybrid search and readable result cards

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -52,6 +52,43 @@ ALLOWED_TYPES = {"TEMAT", "REKLAMA", "SZUM"}
 ALLOWED_RUN_STATUSES = {"created", "in_review", "reviewed"}
 
 
+def _start_embedding_job(run_id: int) -> str:
+    """Start background indexing for a reviewed run and return its job id."""
+    job_id = uuid.uuid4().hex[:8]
+    _embedding_jobs[job_id] = {
+        "status": "running", "run_id": run_id, "result": None,
+        "error": None, "progress": "Startowanie...",
+    }
+
+    def _run_embeddings() -> None:
+        from library.db.engine import get_session
+        from library.document_analysis_service import generate_embeddings_from_run
+
+        job_session = get_session()
+        try:
+            def _progress(msg: str) -> None:
+                _embedding_jobs[job_id]["progress"] = msg
+
+            result = generate_embeddings_from_run(job_session, run_id, progress_fn=_progress)
+            _embedding_jobs[job_id].update({
+                "status": "done", "result": result,
+                "progress": f"Gotowe: {result['embeddings_created']} embeddingów "
+                            f"z {result['chunks_considered']} chunków",
+            })
+        except ValueError as exc:
+            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        except Exception as exc:
+            logger.exception("background embedding generation failed for run %d", run_id)
+            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
+        finally:
+            job_session.close()
+
+    threading.Thread(
+        target=_run_embeddings, daemon=True, name=f"embeddings-{job_id}",
+    ).start()
+    return job_id
+
+
 def _removed_lines_diff(old_text: str, new_text: str) -> list[str]:
     """Return non-empty lines (stripped) present in old_text but absent from new_text.
 
@@ -852,6 +889,7 @@ def update_run(run_id: int):
         abort(404, f"Run {run_id} not found")
 
     data = request.get_json() or {}
+    embedding_job_id = None
     if "status" in data:
         if data["status"] not in ALLOWED_RUN_STATUSES:
             return jsonify({"status": "error", "message": f"Invalid run status: {data['status']}"}), 400
@@ -863,9 +901,23 @@ def update_run(run_id: int):
             logger.exception("Failed to update run %d", run_id)
             return jsonify({"status": "error", "message": "DB error"}), 500
 
+        # Newly analysed chunks are pending. Closing human review is the safe
+        # boundary for indexing only approved TEMAT content.
+        if data["status"] == "reviewed":
+            approved_count = session.scalar(
+                select(func.count()).select_from(DocumentChunk).where(
+                    DocumentChunk.run_id == run_id,
+                    DocumentChunk.type == "TEMAT",
+                    DocumentChunk.status == "approved",
+                )
+            ) or 0
+            if approved_count:
+                embedding_job_id = _start_embedding_job(run_id)
+
     return jsonify({
         "status": "success",
         "run": {"id": run.id, "mode": run.mode, "status": run.status, "scope": run.scope},
+        "embedding_job_id": embedding_job_id,
     })
 
 
@@ -996,41 +1048,7 @@ def generate_embeddings(run_id: int):
     if run is None:
         abort(404, f"Run {run_id} not found")
 
-    job_id = uuid.uuid4().hex[:8]
-    _embedding_jobs[job_id] = {
-        "status": "running",
-        "run_id": run_id,
-        "result": None,
-        "error": None,
-        "progress": "Startowanie...",
-    }
-
-    def _run_embeddings() -> None:
-        from library.db.engine import get_session
-        from library.document_analysis_service import generate_embeddings_from_run
-
-        job_session = get_session()
-        try:
-            def _progress(msg: str) -> None:
-                _embedding_jobs[job_id]["progress"] = msg
-
-            result = generate_embeddings_from_run(job_session, run_id, progress_fn=_progress)
-            _embedding_jobs[job_id].update({
-                "status": "done",
-                "result": result,
-                "progress": f"Gotowe: {result['embeddings_created']} embeddingów "
-                            f"z {result['chunks_considered']} chunków",
-            })
-        except ValueError as exc:
-            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
-        except Exception as exc:
-            logger.exception("background embedding generation failed for run %d", run_id)
-            _embedding_jobs[job_id].update({"status": "failed", "error": str(exc)})
-        finally:
-            job_session.close()
-
-    t = threading.Thread(target=_run_embeddings, daemon=True, name=f"embeddings-{job_id}")
-    t.start()
+    job_id = _start_embedding_job(run_id)
 
     return jsonify({"status": "started", "job_id": job_id, "run_id": run_id})
 

--- a/backend/library/search_service.py
+++ b/backend/library/search_service.py
@@ -10,6 +10,8 @@ Session is passed in by the caller, not created here.
 """
 
 import logging
+import re
+import unicodedata
 
 from sqlalchemy.orm import Session
 
@@ -40,18 +42,75 @@ class SearchService:
         return embedding.get_embedding(model=self._get_model(), text=text)
 
     def search_similar(self, text: str, limit: int = 3, project: str | None = None) -> list[dict]:
-        """Search for semantically similar documents.
+        """Hybrid text/vector search returning unique documents.
 
         Raises RuntimeError if embedding generation fails.
         """
+        if not text or not text.strip():
+            return []
+
+        candidate_limit = max(limit * 5, 20)
+        lexical = self.repo.search_text(text, limit=candidate_limit, project=project)
+
         model = self._get_model()
         result = embedding.get_embedding(model=model, text=text)
-        if result.status != "success" or len(result.embedding) == 0:
+        semantic = []
+        if result.status == "success" and result.embedding:
+            semantic = self.repo.get_similar(
+                result.embedding, model, limit=candidate_limit, project=project,
+            ) or []
+        elif not lexical:
             raise RuntimeError(f"Embedding generation failed: {result.status}")
+        else:
+            logger.warning("Embedding generation failed; returning lexical results: %s", result.status)
 
-        return self.repo.get_similar(
-            result.embedding,
-            model,
-            limit=limit,
-            project=project,
-        )
+        return self._merge_results(text, lexical, semantic, limit)
+
+    @staticmethod
+    def _normalise(value: str | None) -> str:
+        value = unicodedata.normalize("NFKD", value or "")
+        return " ".join(re.findall(r"[\w]+", value.casefold()))
+
+    def _merge_results(self, query: str, lexical: list[dict], semantic: list[dict], limit: int) -> list[dict]:
+        """Combine signals and keep only the best fragment for each document."""
+        query_norm = self._normalise(query)
+        tokens = {t for t in query_norm.split() if len(t) >= 3}
+        merged: dict[int, dict] = {}
+
+        for item in semantic:
+            website_id = item["website_id"]
+            candidate = dict(item)
+            candidate["semantic_similarity"] = float(item.get("similarity") or 0.0)
+            candidate["text_score"] = 0.0
+            merged[website_id] = candidate
+
+        for item in lexical:
+            website_id = item["website_id"]
+            title = self._normalise(item.get("title"))
+            body = self._normalise(" ".join(filter(None, [item.get("title"), item.get("tags"), item.get("note"), item.get("text")])))
+            coverage = sum(token in body for token in tokens) / max(len(tokens), 1)
+            phrase_in_title = bool(query_norm and query_norm in title)
+            phrase_in_body = bool(query_norm and query_norm in body)
+            title_coverage = sum(token in title for token in tokens) / max(len(tokens), 1)
+            text_score = min(1.0, 0.45 * coverage + 0.35 * title_coverage
+                             + 0.20 * phrase_in_body + 0.35 * phrase_in_title)
+
+            candidate = merged.get(website_id, dict(item))
+            candidate["text_score"] = text_score
+            candidate.setdefault("semantic_similarity", 0.0)
+            # Prefer semantic chunk text/snippet when one exists.
+            for key, value in item.items():
+                candidate.setdefault(key, value)
+            merged[website_id] = candidate
+
+        for candidate in merged.values():
+            semantic_score = candidate.get("semantic_similarity", 0.0)
+            text_score = candidate.get("text_score", 0.0)
+            candidate["similarity"] = round(max(
+                text_score, semantic_score, 0.65 * semantic_score + 0.35 * text_score,
+            ), 6)
+            candidate["search_match"] = "hybrid" if semantic_score and text_score else ("semantic" if semantic_score else "text")
+            candidate.pop("tags", None)
+            candidate.pop("note", None)
+
+        return sorted(merged.values(), key=lambda row: row["similarity"], reverse=True)[:limit]

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -300,6 +300,63 @@ class WebsitesDBPostgreSQL:
             for r in rows
         ]
 
+    def search_text(self, query: str, limit: int = 20, project=None) -> list[dict[str, Any]]:
+        """Return documents matching query words in user-visible text fields.
+
+        This deliberately uses portable ILIKE predicates instead of requiring a
+        PostgreSQL text-search migration. Ranking/merging with vector results is
+        handled by SearchService. Short words (for example Polish prepositions)
+        do not restrict token matching.
+        """
+        query = (query or "").strip()
+        if not query:
+            return []
+
+        tokens = list(dict.fromkeys(word for word in query.split() if len(word) >= 3))
+        searchable = func.concat_ws(
+            " ",
+            func.coalesce(WebDocument.title, ""),
+            func.coalesce(WebDocument.tags, ""),
+            func.coalesce(WebDocument.note, ""),
+            func.coalesce(WebDocument.text, ""),
+        )
+        phrase = f"%{query}%"
+        conditions = [WebDocument.title.ilike(phrase), searchable.ilike(phrase)]
+        if tokens:
+            conditions.append(and_(*(searchable.ilike(f"%{token}%") for token in tokens)))
+
+        stmt = (
+            select(WebDocument)
+            .where(or_(*conditions))
+            .order_by(WebDocument.created_at.desc(), WebDocument.id.desc())
+            .limit(limit)
+        )
+        if project:
+            stmt = stmt.where(WebDocument.project == project)
+
+        documents = self.session.scalars(stmt).all()
+        return [
+            {
+                "website_id": doc.id,
+                "text": (doc.text or "")[:1000],
+                "similarity": 0.0,
+                "id": None,
+                "url": doc.url,
+                "language": doc.language,
+                "text_original": (doc.text or "")[:1000],
+                "websites_text_length": len(doc.text or ""),
+                "embeddings_text_length": 0,
+                "title": doc.title,
+                "document_type": doc.document_type,
+                "project": doc.project,
+                "chunk_id": None,
+                "obsidian_note_paths": doc.obsidian_note_paths or [],
+                "tags": doc.tags,
+                "note": doc.note,
+            }
+            for doc in documents
+        ]
+
     # ------------------------------------------------------------------
     # Embedding CRUD
     # ------------------------------------------------------------------
@@ -328,12 +385,10 @@ class WebsitesDBPostgreSQL:
     # ------------------------------------------------------------------
 
     def get_documents_needing_embedding(self, embedding_model: str) -> list[int]:
-        # Documents in READY_FOR_EMBEDDING state
-        stmt1 = select(WebDocument.id).where(
-            WebDocument.document_state == StalkerDocumentStatus.READY_FOR_EMBEDDING.name,
-        )
-        # Documents in EMBEDDING_EXIST state missing embedding for this model
-        stmt2 = (
+        # Only states which explicitly declare content ready for indexing are
+        # processed automatically. DOCUMENT_INTO_DATABASE may still be waiting
+        # for chunk review; closing that review starts indexing directly.
+        stmt = (
             select(WebDocument.id)
             .outerjoin(
                 WebsiteEmbedding,
@@ -343,11 +398,23 @@ class WebsitesDBPostgreSQL:
                 ),
             )
             .where(
-                WebDocument.document_state == StalkerDocumentStatus.EMBEDDING_EXIST.name,
                 WebsiteEmbedding.website_id.is_(None),
+                WebDocument.document_state.in_([
+                    StalkerDocumentStatus.READY_FOR_EMBEDDING.name,
+                    StalkerDocumentStatus.EMBEDDING_EXIST.name,
+                    StalkerDocumentStatus.MD_SIMPLIFIED.name,
+                ]),
+                or_(
+                    func.length(func.coalesce(WebDocument.text_md, "")) > 0,
+                    func.length(func.coalesce(WebDocument.text, "")) > 0,
+                    and_(
+                        WebDocument.document_type == StalkerDocumentType.link.name,
+                        func.length(func.coalesce(WebDocument.title, "")) > 0,
+                    ),
+                ),
             )
+            .order_by(WebDocument.id)
         )
-        stmt = union(stmt1, stmt2).order_by(column("id"))
         rows = self.session.execute(stmt).all()
         return [row[0] for row in rows]
 

--- a/backend/tests/unit/test_embedding_crud_orm.py
+++ b/backend/tests/unit/test_embedding_crud_orm.py
@@ -167,18 +167,19 @@ class TestGetDocumentsNeedingEmbeddingORM:
         # Should be a SQLAlchemy construct, not a raw string
         assert hasattr(stmt, "compile"), "Statement should be a SQLAlchemy construct"
 
-    def test_query_uses_union_and_outerjoin(self, repo, mock_session):
-        """Verify the ORM statement contains UNION and LEFT OUTER JOIN for correct logic."""
+    def test_query_uses_outerjoin_and_ready_state_filter(self, repo, mock_session):
+        """Verify missing-model detection is limited to index-ready states."""
         mock_session.execute.return_value.all.return_value = []
 
         repo.get_documents_needing_embedding("some-model")
 
         stmt = mock_session.execute.call_args[0][0]
         compiled_sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
-        assert "UNION" in compiled_sql.upper(), f"Expected UNION in SQL: {compiled_sql}"
         assert "LEFT OUTER JOIN" in compiled_sql.upper() or "OUTER JOIN" in compiled_sql.upper(), (
             f"Expected OUTER JOIN in SQL: {compiled_sql}"
         )
+        assert "READY_FOR_EMBEDDING" in compiled_sql
+        assert "DOCUMENT_INTO_DATABASE" not in compiled_sql
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_search_service.py
+++ b/backend/tests/unit/test_search_service.py
@@ -109,14 +109,17 @@ class TestSearchSimilar:
         service = SearchService(session)
 
         expected_results = [{"website_id": 1, "similarity": 0.9}]
-        with patch.object(service.repo, "get_similar", return_value=expected_results) as mock_similar:
+        with patch.object(service.repo, "search_text", return_value=[]), \
+             patch.object(service.repo, "get_similar", return_value=expected_results) as mock_similar:
             result = service.search_similar("test query")
 
-        assert result == expected_results
+        assert result[0]["website_id"] == 1
+        assert result[0]["similarity"] == 0.9
+        assert result[0]["search_match"] == "semantic"
         mock_similar.assert_called_once_with(
             [0.1, 0.2, 0.3],
             "text-embedding-ada-002",
-            limit=3,
+            limit=20,
             project=None,
         )
 
@@ -171,7 +174,7 @@ class TestSearchSimilar:
         mock_similar.assert_called_once_with(
             [0.1, 0.2, 0.3],
             "text-embedding-ada-002",
-            limit=10,
+            limit=50,
             project=None,
         )
 
@@ -194,7 +197,7 @@ class TestSearchSimilar:
         mock_similar.assert_called_once_with(
             [0.1, 0.2, 0.3],
             "text-embedding-ada-002",
-            limit=3,
+            limit=20,
             project="my-project",
         )
 
@@ -215,3 +218,26 @@ class TestSearchSimilar:
             result = service.search_similar("obscure query")
 
         assert result == []
+
+    @patch("library.search_service.embedding.get_embedding")
+    @patch("library.search_service.load_config")
+    def test_exact_title_is_returned_without_document_embedding(self, mock_config, mock_get_embedding):
+        cfg = MagicMock()
+        cfg.require.return_value = "test-model"
+        mock_config.return_value = cfg
+        mock_get_embedding.return_value = _make_embedding_result(status="error", embedding=[])
+        service = SearchService(_make_session())
+        lexical = [{
+            "website_id": 9242,
+            "title": "Wojna w Ukrainie. Rosyjscy szpiedzy przenieśli działalność do Japonii",
+            "text": "Artykuł o rosyjskich agentach w Japonii.",
+            "similarity": 0.0,
+        }]
+        with patch.object(service.repo, "search_text", return_value=lexical), \
+             patch.object(service.repo, "get_similar", return_value=[]) as mock_similar:
+            result = service.search_similar("Rosyjscy szpiedzy w Japonii", limit=10)
+
+        assert result[0]["website_id"] == 9242
+        assert result[0]["search_match"] == "text"
+        assert result[0]["similarity"] > 0.5
+        mock_similar.assert_not_called()

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -857,6 +857,14 @@ const Chunks = () => {
       if (data.status === "success") {
         setRunStatus(data.run.status);
         setRuns(prev => prev.map(rr => rr.id === selectedRun ? { ...rr, status: data.run.status } : rr));
+        if (data.embedding_job_id) {
+          setEmbedJobId(data.embedding_job_id);
+          setEmbedJobStatus("running");
+          pollEmbeddingJob(data.embedding_job_id);
+          setInfo("Review zamknięty — automatycznie generuję embeddingi z zatwierdzonych chunków TEMAT.");
+        } else if (status === "reviewed" && approvedCount === 0) {
+          setInfo("Review zamknięty, ale nie utworzono embeddingów: brak zatwierdzonych chunków TEMAT.");
+        }
       } else { setError("Błąd zmiany statusu analizy"); }
     } catch { setError("Błąd połączenia przy zmianie statusu analizy"); }
   };
@@ -1464,6 +1472,20 @@ const Chunks = () => {
       )}
 
       {/* Pasek postępu */}
+      {selectedRun !== null && (
+        <div style={{
+          marginBottom: 10, padding: "10px 14px", border: "1px solid #bae6fd",
+          borderRadius: 6, background: "#f0f9ff", color: "#0c4a6e", fontSize: "0.84em",
+        }}>
+          <strong>Jak powstają embeddingi:</strong>{" "}
+          analiza tworzy chunki ze statusem <code>pending</code> → zatwierdź merytoryczne chunki
+          <code> TEMAT</code> → kliknij <strong>Zamknij review</strong>. Zamknięcie automatycznie
+          przebuduje indeks wyszukiwania tylko z zatwierdzonych treści. Chunki <code>REKLAMA</code>
+          i <code>SZUM</code> są pomijane. Po późniejszej edycji lub ponownym otwarciu review użyj
+          przycisku <strong>Generuj embeddingi</strong>, aby odświeżyć indeks ręcznie.
+        </div>
+      )}
+
       {chunks.length > 0 && (
         <div style={{ marginBottom: 12, padding: "8px 14px", background: "#0f172a", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <span style={{ color: "#94a3b8", fontSize: "0.82em" }}>

--- a/web_interface_react/src/modules/shared/pages/search.tsx
+++ b/web_interface_react/src/modules/shared/pages/search.tsx
@@ -9,6 +9,7 @@ import { useSearchParams } from "react-router-dom";
 const Search = () => {
   const [searchParams] = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
+  const [submittedQuery, setSubmittedQuery] = React.useState(initialQuery);
   const { handleSearchSimilar, results, setResults, isLoading, message, setMessage, isError } =
       useSearch({
         callback: () => formik.resetForm(),
@@ -18,6 +19,7 @@ const Search = () => {
     formik.resetForm();
     setResults([]);
     setMessage("");
+    setSubmittedQuery("");
   };
 
   const formik: any = useFormik({
@@ -27,6 +29,7 @@ const Search = () => {
       translate: false
     },
     onSubmit: async (data) => {
+      setSubmittedQuery(data.search.trim());
       await handleSearchSimilar(data.search, data.searchLimit, data.translate);
     },
   });
@@ -41,14 +44,15 @@ const Search = () => {
 
   return (
       <form onSubmit={formik.handleSubmit}>
-        <h2 style={{ marginBottom: "10px" }}>Search Similar</h2>
-        <div style={{display: "flex", alignItems: "center"}}>
-          <div style={{minWidth: "400px", marginRight: "20px"}}>
+        <h2 style={{ marginBottom: "4px" }}>Wyszukiwanie</h2>
+        <p style={{ marginTop: 0, color: "#64748b", fontSize: ".88rem" }}>Wyniki łączą dopasowanie tekstowe i semantyczne.</p>
+        <div style={{display: "flex", alignItems: "center", flexWrap: "wrap", gap: 12}}>
+          <div style={{minWidth: "min(520px, 100%)", flex: "1 1 420px"}}>
             <Input
                 required
                 disabled={isLoading}
                 value={formik.values.search}
-                label={"Search"}
+                label={"Szukana fraza"}
                 onChange={formik.handleChange}
                 id={"search"}
                 name={"search"}
@@ -59,7 +63,7 @@ const Search = () => {
           <Select
               disabled={isLoading}
               value={formik.values.searchLimit}
-              label={"search Limit"}
+              label={"Liczba wyników"}
               onChange={formik.handleChange}
               id={"searchLimit"}
               name={"searchLimit"}
@@ -71,25 +75,13 @@ const Search = () => {
             <option value="50">50</option>
           </Select>
 
-          <div style={{marginLeft: '20px'}}>
-            <label htmlFor="translate" style={{marginRight: '10px'}}>Translate</label>
-            <input
-                type="checkbox"
-                id="translate"
-                name="translate"
-                checked={formik.values.translate}
-                onChange={formik.handleChange}
-                disabled={isLoading}
-            />
-          </div>
-
           <button
               type={"submit"}
               style={{marginTop: "11px"}}
               className={"button"}
               disabled={isLoading}
           >
-            Search
+            Szukaj
           </button>
 
           <button
@@ -97,18 +89,23 @@ const Search = () => {
               style={{marginTop: "11px", marginLeft: "10px"}}
               onClick={() => handleClean()}
           >
-            Clean
+            Wyczyść
           </button>
         </div>
 
         {isLoading && <div className={"loader"}></div>}
         {isError && <p className={"errorText"}>{message}</p>}
 
-        <ul>
+        {results && !isLoading && (
+          <div style={{ margin: "18px 0 10px", color: "#64748b", fontSize: ".85rem" }}>
+            Znaleziono: <strong style={{ color: "#334155" }}>{results.length}</strong>
+          </div>
+        )}
+        <div style={{ display: "grid", gap: 12, maxWidth: 1050, paddingBottom: 30 }}>
           {results?.map((item: any) => (
-              <ListItemSearchSimilar key={item.id} item={item}/>
+              <ListItemSearchSimilar key={`${item.website_id}-${item.chunk_id ?? item.id ?? "text"}`} item={item} query={submittedQuery}/>
           ))}
-        </ul>
+        </div>
       </form>
   );
 };

--- a/web_interface_react/src/utils.tsx
+++ b/web_interface_react/src/utils.tsx
@@ -1,10 +1,17 @@
+import React from "react";
 import { buildObsidianNoteUrl } from "./modules/shared/utils/obsidian";
 
 interface ListItemSearchSimilarProps {
+  query: string;
   item: {
     similarity: number;
-    id: number;
+    semantic_similarity?: number;
+    text_score?: number;
+    search_match?: "text" | "semantic" | "hybrid";
+    id: number | null;
     text: string;
+    title?: string | null;
+    document_type?: string | null;
     website_id: number;
     url: string;
     chunk_id?: number | null;
@@ -12,38 +19,86 @@ interface ListItemSearchSimilarProps {
   };
 }
 
-const ListItemSearchSimilar = ({ item }: ListItemSearchSimilarProps) => {
-    const notes = item.obsidian_note_paths ?? [];
-    return (
-        <li>
-            {item.similarity} {item.id} - {item.text}
+const meaningfulTerms = (query: string) =>
+  Array.from(new Set(query.trim().split(/\s+/).filter(term => term.length >= 3)))
+    .sort((a, b) => b.length - a.length);
 
-            ({item.website_id})
-            <a href={item.url} target="_blank" rel="noopener noreferrer">
-                {item.url}
-            </a>
-            {item.chunk_id != null && (
-                <>
-                    {" "}
-                    <a href={`/chunks/${item.website_id}`}>chunk #{item.chunk_id}</a>
-                </>
-            )}
-            {notes.length > 0 && (
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
-                    {" "}📝
-                    {notes.map((notePath, i) => (
-                        <span key={notePath}>
-                            {i > 0 && ","}
-                            <a href={buildObsidianNoteUrl(notePath)} title={`Otwórz w Obsidianie: ${notePath}`}>
-                                {notePath.split("/").pop()?.replace(/\.md$/i, "")}
-                            </a>
-                        </span>
-                    ))}
-                </span>
-            )}
-        </li>
-    )
-}
+const makeSnippet = (text: string, query: string, maxLength = 460) => {
+  const compact = (text || "").replace(/\s+/g, " ").trim();
+  if (compact.length <= maxLength) return compact;
 
+  const lower = compact.toLocaleLowerCase("pl");
+  const positions = meaningfulTerms(query)
+    .map(term => lower.indexOf(term.toLocaleLowerCase("pl")))
+    .filter(position => position >= 0);
+  const matchAt = positions.length ? Math.min(...positions) : 0;
+  let start = Math.max(0, matchAt - Math.floor(maxLength * 0.28));
+  let end = Math.min(compact.length, start + maxLength);
+  if (end === compact.length) start = Math.max(0, end - maxLength);
+  if (start > 0) start = compact.indexOf(" ", start) + 1;
+  if (end < compact.length) end = compact.lastIndexOf(" ", end);
+  return `${start > 0 ? "…" : ""}${compact.slice(start, end)}${end < compact.length ? "…" : ""}`;
+};
 
-export default ListItemSearchSimilar
+const Highlight = ({ text, query }: { text: string; query: string }) => {
+  const terms = meaningfulTerms(query);
+  if (!terms.length) return <>{text}</>;
+  const escaped = terms.map(term => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const regex = new RegExp(`(${escaped.join("|")})`, "giu");
+  return <>{text.split(regex).map((part, index) =>
+    terms.some(term => term.toLocaleLowerCase("pl") === part.toLocaleLowerCase("pl")) ? (
+      <mark key={index} style={{ background: "#fef08a", color: "inherit", padding: "0 1px", borderRadius: 2 }}>{part}</mark>
+    ) : <React.Fragment key={index}>{part}</React.Fragment>
+  )}</>;
+};
+
+const MATCH_LABELS = {
+  text: "dopasowanie tekstowe",
+  semantic: "dopasowanie semantyczne",
+  hybrid: "dopasowanie hybrydowe",
+};
+
+const ListItemSearchSimilar = ({ item, query }: ListItemSearchSimilarProps) => {
+  const notes = item.obsidian_note_paths ?? [];
+  const match = item.search_match ?? "semantic";
+  const score = Math.round((item.similarity ?? 0) * 100);
+  const snippet = makeSnippet(item.text, query);
+
+  return (
+    <article style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: "16px 18px", background: "#fff", boxShadow: "0 1px 2px rgba(15,23,42,.04)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 16 }}>
+        <div style={{ minWidth: 0 }}>
+          <a href={`/read/${item.website_id}`} style={{ color: "#0f4c81", fontSize: "1.05rem", fontWeight: 700, lineHeight: 1.35, textDecoration: "none" }}>
+            <Highlight text={item.title || `Dokument #${item.website_id}`} query={query} />
+          </a>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 7, color: "#64748b", fontSize: ".76rem" }}>
+            <span style={{ background: match === "text" ? "#ecfccb" : match === "hybrid" ? "#e0f2fe" : "#f1f5f9", color: "#334155", borderRadius: 999, padding: "2px 8px" }}>
+              {MATCH_LABELS[match]}
+            </span>
+            {item.document_type && <span>{item.document_type}</span>}
+            <span>ID {item.website_id}</span>
+            {item.chunk_id != null && <span>chunk #{item.chunk_id}</span>}
+          </div>
+        </div>
+        <div title={`Wynik dopasowania: ${item.similarity}`} style={{ flexShrink: 0, borderRadius: 999, background: score >= 70 ? "#dcfce7" : "#f1f5f9", color: score >= 70 ? "#166534" : "#475569", padding: "5px 9px", fontWeight: 700, fontSize: ".78rem" }}>
+          {score}%
+        </div>
+      </div>
+
+      {snippet && <p style={{ margin: "13px 0", color: "#334155", lineHeight: 1.58, fontSize: ".91rem" }}><Highlight text={snippet} query={query} /></p>}
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 14, alignItems: "center", fontSize: ".82rem" }}>
+        <a href={`/read/${item.website_id}`} style={{ fontWeight: 600 }}>📖 Czytaj</a>
+        {item.chunk_id != null && <a href={`/chunks/${item.website_id}`}>🧩 Otwórz chunki</a>}
+        <a href={item.url} target="_blank" rel="noopener noreferrer">↗ Źródło</a>
+        {notes.map(notePath => (
+          <a key={notePath} href={buildObsidianNoteUrl(notePath)} title={`Otwórz w Obsidianie: ${notePath}`}>
+            📝 {notePath.split("/").pop()?.replace(/\.md$/i, "")}
+          </a>
+        ))}
+      </div>
+    </article>
+  );
+};
+
+export default ListItemSearchSimilar;


### PR DESCRIPTION
## Summary
- combine lexical title/content/tag/note matches with vector similarity
- deduplicate results by document and keep lexical fallback when embeddings are missing
- generate embeddings automatically when a reviewed chunk run is closed
- explain the chunk-to-embedding flow in the review UI
- replace raw search output with highlighted, contextual result cards

## Verification
- 35 focused backend unit tests passed
- TypeScript typecheck passed
- production Docker images deployed and verified on NAS
- query \Rosyjscy szpiedzy w Japonii\ returns document 9242 first