### PR TITLE
Expose information provenance in reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ Project Lenie is a personal AI assistant for collecting, managing, and searching
 
 ## Common Commands
 
+### Default Runtime Environment
+
+The NAS deployment at `192.168.200.7` is the default runtime environment for
+the document UI and backend processing. After a backend change, do not advise
+the user to rerun document analysis until the updated backend image has been
+deployed to NAS and the running service has been verified. Always state
+explicitly whether a relevant change is only local or already deployed.
+
 ### Development (Docker Compose)
 ```bash
 make build          # Build docker containers

--- a/backend/library/information_provenance.py
+++ b/backend/library/information_provenance.py
@@ -17,10 +17,69 @@ logger = logging.getLogger(__name__)
 
 ALLOWED_ROLES = {"original_reporting", "cited", "republication", "data_source"}
 
+KNOWN_REPORTING_SOURCES = (
+    {
+        "canonical_name": "The New York Times",
+        "source_type": "newspaper",
+        "domain": "nytimes.com",
+        "aliases": ("The New York Times", "New York Times", "NYT"),
+    },
+)
+
+# These verbs are deliberately conservative: a bare mention of a newspaper is
+# not enough to claim that the document is based on its reporting.
+REPORTING_VERBS = re.compile(
+    r"\b(?:ujawni(?:ł|ła|ło)|ustali(?:ł|ła|ło)|poda(?:ł|ła|ło)|opisa(?:ł|ła|ło)|"
+    r"donosi(?:ł|ła)?|informuje|poinformowa(?:ł|ła|ło)|napisa(?:ł|ła|ło))\b",
+    re.IGNORECASE,
+)
+
 
 def publisher_domain(url: str) -> str | None:
     host = (urlparse(url or "").hostname or "").lower()
     return host.removeprefix("www.") or None
+
+
+def extract_known_reporting_sources(text: str) -> list[dict]:
+    """Detect well-known reporting sources using grounded, conservative rules."""
+    sentences = re.split(r"(?<=[.!?])\s+|\n+", text)
+    result = []
+    for known in KNOWN_REPORTING_SOURCES:
+        for sentence in sentences:
+            mention = next((
+                alias for alias in known["aliases"]
+                if re.search(rf"(?<!\w){re.escape(alias)}(?!\w)", sentence, re.IGNORECASE)
+            ), None)
+            if mention and REPORTING_VERBS.search(sentence):
+                result.append({
+                    "canonical_name": known["canonical_name"],
+                    "raw_mention": mention,
+                    "role": "original_reporting",
+                    "source_type": known["source_type"],
+                    "domain": known["domain"],
+                    "evidence_excerpt": sentence.strip(),
+                    "confidence": 100,
+                    "extraction_method": "rule",
+                })
+                break
+    return result
+
+
+def _normalize_known_source(item: dict) -> dict:
+    """Map LLM spelling variants onto the same canonical source record."""
+    names = {
+        str(item.get("canonical_name") or "").strip().lower(),
+        str(item.get("raw_mention") or "").strip().lower(),
+    }
+    for known in KNOWN_REPORTING_SOURCES:
+        if names & {alias.lower() for alias in known["aliases"]}:
+            return {
+                **item,
+                "canonical_name": known["canonical_name"],
+                "source_type": known["source_type"],
+                "domain": known["domain"],
+            }
+    return item
 
 
 def _json_array(raw: str) -> list[dict]:
@@ -145,11 +204,13 @@ def refresh_document_information_sources(session, doc, text: str, model: str) ->
         ))
         created.append((publisher.canonical_name, "publisher"))
 
+    candidates = extract_known_reporting_sources(text)
     try:
-        candidates = extract_information_sources(text, doc.title or "", model)
+        llm_candidates = extract_information_sources(text, doc.title or "", model)
     except Exception:
         logger.exception("information-source LLM extraction failed for document %s", doc.id)
-        candidates = []
+        llm_candidates = []
+    candidates.extend(_normalize_known_source(item) for item in llm_candidates)
 
     seen = {(name.lower(), role) for name, role in created}
     for item in candidates:
@@ -166,7 +227,7 @@ def refresh_document_information_sources(session, doc, text: str, model: str) ->
             source_url=None,
             evidence_excerpt=item["evidence_excerpt"],
             confidence=item["confidence"],
-            extraction_method="llm",
+            extraction_method=item.get("extraction_method", "llm"),
             review_status="auto_accepted" if item["confidence"] >= 80 else "needs_review",
         ))
         created.append((source.canonical_name, item["role"]))

--- a/backend/server.py
+++ b/backend/server.py
@@ -698,6 +698,7 @@ def information_source_documents(source_id: int):
         "url": link.document.url,
         "role": link.role,
         "raw_mention": link.raw_mention,
+        "source_url": link.source_url,
         "evidence_excerpt": link.evidence_excerpt,
         "confidence": link.confidence,
         "review_status": link.review_status,
@@ -707,6 +708,66 @@ def information_source_documents(source_id: int):
         "source": {"id": source.id, "canonical_name": source.canonical_name, "domain": source.domain},
         "count": len(entries),
         "entries": entries,
+    }, 200
+
+
+@app.route('/information_sources/<int:source_id>/publisher_stats', methods=['GET'])
+def information_source_publisher_stats(source_id: int):
+    """Summarize external provenance for documents published by one source."""
+    from sqlalchemy import func, select
+    from library.db.models import DocumentInformationSource, InformationSource
+
+    session = get_scoped_session()
+    source = session.get(InformationSource, source_id)
+    if source is None:
+        return {"status": "error", "message": "Information source not found"}, 404
+
+    published_ids = select(DocumentInformationSource.document_id).where(
+        DocumentInformationSource.source_id == source_id,
+        DocumentInformationSource.role == "publisher",
+    )
+    published_count = session.scalar(select(func.count()).select_from(published_ids.subquery())) or 0
+    external_document_count = session.scalar(select(
+        func.count(func.distinct(DocumentInformationSource.document_id))
+    ).where(
+        DocumentInformationSource.document_id.in_(published_ids),
+        DocumentInformationSource.role != "publisher",
+    )) or 0
+    role_rows = session.execute(select(
+        DocumentInformationSource.role,
+        func.count(func.distinct(DocumentInformationSource.document_id)),
+    ).where(
+        DocumentInformationSource.document_id.in_(published_ids),
+        DocumentInformationSource.role != "publisher",
+    ).group_by(DocumentInformationSource.role)).all()
+    origin_rows = session.execute(select(
+        InformationSource.id,
+        InformationSource.canonical_name,
+        DocumentInformationSource.role,
+        func.count(func.distinct(DocumentInformationSource.document_id)),
+    ).join(
+        DocumentInformationSource, DocumentInformationSource.source_id == InformationSource.id,
+    ).where(
+        DocumentInformationSource.document_id.in_(published_ids),
+        DocumentInformationSource.role != "publisher",
+    ).group_by(
+        InformationSource.id, InformationSource.canonical_name, DocumentInformationSource.role,
+    ).order_by(func.count(func.distinct(DocumentInformationSource.document_id)).desc())).all()
+
+    return {
+        "status": "success",
+        "source": {"id": source.id, "canonical_name": source.canonical_name, "domain": source.domain},
+        "published_document_count": published_count,
+        # Absence of a detected source is not proof that reporting is original.
+        "without_external_source_count": max(0, published_count - external_document_count),
+        "with_external_source_count": external_document_count,
+        "role_counts": {role: count for role, count in role_rows},
+        "origins": [{
+            "source_id": origin_id,
+            "canonical_name": name,
+            "role": role,
+            "document_count": count,
+        } for origin_id, name, role, count in origin_rows],
     }, 200
 
 

--- a/backend/tests/unit/test_information_provenance.py
+++ b/backend/tests/unit/test_information_provenance.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from library.db.models import DocumentInformationSource
 from library.information_provenance import (
     extract_information_sources,
+    extract_known_reporting_sources,
     publisher_domain,
     refresh_document_information_sources,
 )
@@ -12,6 +13,28 @@ from library.information_provenance import (
 
 def test_publisher_domain_normalizes_www():
     assert publisher_domain("https://www.money.pl/a/b.html") == "money.pl"
+
+
+def test_known_nyt_reporting_is_detected_from_grounded_attribution():
+    text = ('Dziennik "New York Times" ujawnił, że w Tokio działa jednostka GRU. '
+            'W innym miejscu wspomniano NYT bez przypisania ustaleń.')
+
+    result = extract_known_reporting_sources(text)
+
+    assert result == [{
+        "canonical_name": "The New York Times",
+        "raw_mention": "New York Times",
+        "role": "original_reporting",
+        "source_type": "newspaper",
+        "domain": "nytimes.com",
+        "evidence_excerpt": 'Dziennik "New York Times" ujawnił, że w Tokio działa jednostka GRU.',
+        "confidence": 100,
+        "extraction_method": "rule",
+    }]
+
+
+def test_known_nyt_bare_mention_is_not_enough():
+    assert extract_known_reporting_sources("Czytam dziś New York Times.") == []
 
 
 def test_llm_sources_are_grounded_and_roles_validated():
@@ -73,4 +96,54 @@ def test_refresh_always_adds_publisher_and_llm_sources():
     assert result["sources"] == [
         ("money.pl", "publisher"),
         ("The Wall Street Journal", "original_reporting"),
+    ]
+
+
+def test_refresh_keeps_rule_source_when_llm_extraction_fails():
+    session = MagicMock()
+    doc = SimpleNamespace(id=9242, url="https://wiadomosci.gazeta.pl/test.html", title="Tytuł")
+    publisher = SimpleNamespace(id=1, canonical_name="wiadomosci.gazeta.pl")
+    nyt = SimpleNamespace(id=2, canonical_name="The New York Times")
+    text = 'Dziennik "New York Times" ujawnił nowe informacje.'
+
+    with patch("library.information_provenance._get_or_create_source", side_effect=[publisher, nyt]), \
+            patch("library.information_provenance.extract_information_sources", side_effect=RuntimeError):
+        result = refresh_document_information_sources(session, doc, text, "model")
+
+    links = [call.args[0] for call in session.add.call_args_list
+             if isinstance(call.args[0], DocumentInformationSource)]
+    assert [(link.source_id, link.role, link.extraction_method) for link in links] == [
+        (1, "publisher", "url"),
+        (2, "original_reporting", "rule"),
+    ]
+    assert result["sources"][-1] == ("The New York Times", "original_reporting")
+
+
+def test_refresh_deduplicates_nyt_rule_and_llm_name_variant():
+    session = MagicMock()
+    doc = SimpleNamespace(id=9242, url="https://wiadomosci.gazeta.pl/test.html", title="Tytuł")
+    publisher = SimpleNamespace(id=1, canonical_name="wiadomosci.gazeta.pl")
+    nyt = SimpleNamespace(id=2, canonical_name="The New York Times")
+    llm_candidate = {
+        "canonical_name": "New York Times",
+        "raw_mention": "NYT",
+        "role": "original_reporting",
+        "source_type": "newspaper",
+        "domain": None,
+        "evidence_excerpt": "NYT podał nowe informacje.",
+        "confidence": 95,
+    }
+    text = 'Dziennik "New York Times" ujawnił nowe informacje. NYT podał nowe informacje.'
+
+    with patch("library.information_provenance._get_or_create_source",
+               side_effect=[publisher, nyt, nyt]), \
+            patch("library.information_provenance.extract_information_sources",
+                  return_value=[llm_candidate]):
+        refresh_document_information_sources(session, doc, text, "model")
+
+    links = [call.args[0] for call in session.add.call_args_list
+             if isinstance(call.args[0], DocumentInformationSource)]
+    assert [(link.source_id, link.role) for link in links] == [
+        (1, "publisher"),
+        (2, "original_reporting"),
     ]

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -16,6 +16,7 @@ import Read from "./modules/shared/pages/read";
 import Persons from "./modules/shared/pages/persons";
 import PersonsReview from "./modules/shared/pages/personsReview";
 import Sources from "./modules/shared/pages/sources";
+import InformationSources from "./modules/shared/pages/informationSources";
 import { AuthorizationContext } from "./modules/shared/context/authorizationContext";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -53,6 +54,7 @@ function App() {
                   <Route path="/persons/:id?" element={<Persons />} />
                   <Route path="/persons-review" element={<PersonsReview />} />
                   <Route path="/sources" element={<Sources />} />
+                  <Route path="/information-sources" element={<InformationSources />} />
                   <Route path="/search" element={<Search />} />
                   <Route path="/upload-file" element={<UploadFile />} />
                   <Route path="*" element={<p>404</p>} />

--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -107,6 +107,14 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
           Sources
         </NavLink>
         <NavLink
+          to="/information-sources"
+          className={({ isActive }) =>
+            isActive ? classes.activeLink : classes.link
+          }
+        >
+          Information Sources
+        </NavLink>
+        <NavLink
           to="/upload-file"
           className={({ isActive }) =>
             isActive ? classes.activeLink : classes.link

--- a/web_interface_react/src/modules/shared/pages/informationSources.tsx
+++ b/web_interface_react/src/modules/shared/pages/informationSources.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import axios from "axios";
+import { NavLink, useSearchParams } from "react-router-dom";
+import { AuthorizationContext } from "../context/authorizationContext";
+
+interface InformationSource {
+  id: number;
+  canonical_name: string;
+  source_type: string | null;
+  domain: string | null;
+  aliases: string[];
+  document_count: number;
+}
+
+interface SourceDocument {
+  document_id: number;
+  title: string;
+  url: string;
+  role: string;
+  raw_mention: string;
+  evidence_excerpt: string | null;
+}
+
+interface PublisherStats {
+  published_document_count: number;
+  without_external_source_count: number;
+  with_external_source_count: number;
+  role_counts: Record<string, number>;
+  origins: Array<{ source_id: number; canonical_name: string; role: string; document_count: number }>;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  publisher: "publikacja",
+  original_reporting: "źródło ustaleń",
+  republication: "przedruk / opracowanie",
+  cited: "cytowanie",
+  data_source: "źródło danych",
+};
+
+const box: React.CSSProperties = {
+  border: "1px solid #e2e8f0", borderRadius: 8, padding: 14, background: "#fff",
+};
+
+const InformationSources: React.FC = () => {
+  const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
+  const [params, setParams] = useSearchParams();
+  const selectedId = Number(params.get("id")) || null;
+  const [query, setQuery] = React.useState(params.get("q") ?? "");
+  const [sources, setSources] = React.useState<InformationSource[]>([]);
+  const [documents, setDocuments] = React.useState<SourceDocument[]>([]);
+  const [stats, setStats] = React.useState<PublisherStats | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const headers = React.useMemo(() => ({ "x-api-key": `${apiKey}` }), [apiKey]);
+
+  const search = React.useCallback(async (value: string) => {
+    setLoading(true); setError("");
+    try {
+      const response = await axios.get(`${apiUrl}/information_sources`, {
+        params: value.trim() ? { q: value.trim() } : {}, headers,
+      });
+      setSources(response.data.entries ?? []);
+    } catch (e: any) {
+      setError(e.response?.data?.message || e.message);
+    } finally { setLoading(false); }
+  }, [apiUrl, headers]);
+
+  React.useEffect(() => { search(params.get("q") ?? ""); }, [params, search]);
+
+  React.useEffect(() => {
+    if (!selectedId) { setDocuments([]); setStats(null); return; }
+    Promise.all([
+      axios.get(`${apiUrl}/information_sources/${selectedId}/documents`, { headers }),
+      axios.get(`${apiUrl}/information_sources/${selectedId}/publisher_stats`, { headers }),
+    ]).then(([docs, publisher]) => {
+      setDocuments(docs.data.entries ?? []);
+      setStats(publisher.data);
+    }).catch((e: any) => setError(e.response?.data?.message || e.message));
+  }, [apiUrl, headers, selectedId]);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const next: Record<string, string> = {};
+    if (query.trim()) next.q = query.trim();
+    setParams(next);
+  };
+  const selected = sources.find(source => source.id === selectedId);
+
+  return (
+    <div style={{ maxWidth: 1050, margin: "0 auto", padding: 20 }}>
+      <h2>Źródła informacji</h2>
+      <p style={{ color: "#64748b" }}>Wyszukuj media i instytucje, z których pochodzą ustalenia, cytaty lub dane.</p>
+      <form onSubmit={submit} style={{ display: "flex", gap: 8, marginBottom: 18 }}>
+        <input value={query} onChange={e => setQuery(e.target.value)} placeholder="np. NYT, Reuters, BBC"
+          style={{ flex: 1, padding: 9, border: "1px solid #cbd5e1", borderRadius: 6 }} />
+        <button className="button" type="submit">Szukaj</button>
+      </form>
+      {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
+      {loading ? <p>Ładowanie…</p> : (
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(260px, 1fr) minmax(420px, 2fr)", gap: 16 }}>
+          <div style={box}>
+            <strong>Źródła ({sources.length})</strong>
+            {sources.map(source => (
+              <button key={source.id} onClick={() => {
+                const next: Record<string, string> = { id: String(source.id) };
+                if (params.get("q")) next.q = params.get("q")!;
+                setParams(next);
+              }} style={{
+                display: "block", width: "100%", textAlign: "left", marginTop: 8, padding: 8,
+                border: "none", borderRadius: 6, cursor: "pointer",
+                background: selectedId === source.id ? "#e0f2fe" : "#f8fafc",
+              }}>
+                <strong>{source.canonical_name}</strong> <span style={{ color: "#64748b" }}>×{source.document_count}</span>
+                {source.domain && <div style={{ fontSize: "0.8em", color: "#64748b" }}>{source.domain}</div>}
+              </button>
+            ))}
+          </div>
+          <div>
+            {!selectedId && <div style={box}>Wybierz źródło, aby zobaczyć dokumenty i statystyki.</div>}
+            {selectedId && <>
+              <div style={box}>
+                <h3 style={{ marginTop: 0 }}>{selected?.canonical_name ?? "Źródło"}</h3>
+                {stats && <>
+                  <strong>Jako portal publikujący</strong>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 8 }}>
+                    <span>wszystkie: {stats.published_document_count}</span>
+                    <span>z wykrytym źródłem zewnętrznym: {stats.with_external_source_count}</span>
+                    <span>bez wykrytego źródła zewnętrznego: {stats.without_external_source_count}</span>
+                  </div>
+                  <small style={{ display: "block", color: "#64748b", marginTop: 7 }}>
+                    „Bez wykrytego źródła” nie jest automatycznie dowodem własnego reportingu.
+                  </small>
+                  {stats.origins.length > 0 && <div style={{ marginTop: 12 }}>
+                    <strong>Najczęstsze źródła zewnętrzne</strong>
+                    {stats.origins.map(origin => <div key={`${origin.source_id}-${origin.role}`}>
+                      <NavLink to={`/information-sources?id=${origin.source_id}`}>{origin.canonical_name}</NavLink>
+                      {" — "}{ROLE_LABELS[origin.role] ?? origin.role}: {origin.document_count}
+                    </div>)}
+                  </div>}
+                </>}
+              </div>
+              <div style={{ ...box, marginTop: 14 }}>
+                <strong>Powiązane dokumenty ({documents.length})</strong>
+                {documents.map(doc => <div key={`${doc.document_id}-${doc.role}`} style={{ padding: "10px 0", borderBottom: "1px solid #e2e8f0" }}>
+                  <NavLink to={`/read/${doc.document_id}`}>{doc.title || `Dokument #${doc.document_id}`}</NavLink>
+                  <div style={{ fontSize: "0.82em", color: "#64748b" }}>{ROLE_LABELS[doc.role] ?? doc.role}</div>
+                  {doc.evidence_excerpt && <div style={{ fontSize: "0.86em", marginTop: 3 }}>„{doc.evidence_excerpt}”</div>}
+                </div>)}
+              </div>
+            </>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InformationSources;

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -58,6 +58,24 @@ interface ChapterScope {
   countries: CountryTag[];
 }
 
+interface InformationSourceLink {
+  id: number;
+  source_id: number;
+  canonical_name: string;
+  domain: string | null;
+  role: string;
+  source_url: string | null;
+  evidence_excerpt: string | null;
+}
+
+const SOURCE_ROLE_LABELS: Record<string, string> = {
+  publisher: "Publikacja",
+  original_reporting: "Źródło ustaleń",
+  republication: "Przedruk / opracowanie",
+  cited: "Cytowane źródło",
+  data_source: "Źródło danych",
+};
+
 // ── Minimal markdown rendering (headings, paragraphs, hr; images skipped) ────
 
 const IMAGE_LINE = /^!\[[^\]]*\]\([^)]*\)$/;
@@ -310,6 +328,7 @@ const Read: React.FC = () => {
   const [placeItems, setPlaceItems] = React.useState<EntityItem[]>([]);
   const [thematicTags, setThematicTags] = React.useState<string[]>([]);
   const [synthesis, setSynthesis] = React.useState<string | null>(null);
+  const [informationSources, setInformationSources] = React.useState<InformationSourceLink[]>([]);
   const [content, setContent] = React.useState<ChapterContent | null>(null);
   // sidebar scope: current chapter (default) vs whole document
   const [scopeChapter, setScopeChapter] = React.useState(true);
@@ -375,6 +394,18 @@ const Read: React.FC = () => {
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiUrl, id, apiKey]);
+
+  React.useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch(`${apiUrl}/document/${id}/information_sources`, { headers });
+        const data = await response.json();
+        if (data.status === "success") setInformationSources(data.entries ?? []);
+      } catch {
+        // Provenance enriches the reader but must not block document reading.
+      }
+    })();
+  }, [apiUrl, id, apiKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // verified NER places (stage 3) → point markers on the country map
   React.useEffect(() => {
@@ -911,6 +942,30 @@ const Read: React.FC = () => {
                 Ładowanie danych rozdziału…
               </div>
             ) : <>
+            {informationSources.length > 0 && (
+              <div style={{
+                background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+                padding: 10, marginTop: 12,
+              }}>
+                <strong style={{ fontSize: "0.85em", display: "block", marginBottom: 8 }}>📰 Pochodzenie</strong>
+                {informationSources.map(source => (
+                  <div key={source.id} style={{ marginTop: 7 }}>
+                    <div style={{ fontSize: "0.75em", color: "#64748b" }}>
+                      {SOURCE_ROLE_LABELS[source.role] ?? source.role}
+                    </div>
+                    <NavLink to={`/information-sources?id=${source.source_id}`} style={{ color: "#0369a1", fontWeight: 600 }}>
+                      {source.canonical_name}
+                    </NavLink>
+                    {source.source_url && <>{" "}<a href={source.source_url} target="_blank" rel="noreferrer" title="Otwórz publikację">↗</a></>}
+                    {source.evidence_excerpt && (
+                      <div style={{ fontSize: "0.76em", color: "#475569", marginTop: 2 }}>
+                        „{source.evidence_excerpt}”
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
             {(shownCountries.length > 0 || shownMarkers.length > 0 || shownPipelines.length > 0) && (
               <React.Suspense fallback={null}>
                 <CountryMap countries={shownCountries} places={shownMarkers} pipelines={shownPipelines} />


### PR DESCRIPTION
## Summary
- detect NYT reporting with a grounded deterministic fallback
- show publisher and original information sources in the reader sidebar
- add searchable information-sources page with publisher provenance statistics
- document NAS as the default runtime environment

## Verification
- backend provenance tests: 7 passed
- frontend production build passed
- backend and frontend deployed and verified on NAS