### PR TITLE
feat(reader): show short articles continuously

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -360,6 +360,32 @@ def _chunk_based_chapters(run: DocumentAnalysisRun) -> list[dict]:
     ]
 
 
+# Short articles read more naturally as one continuous page. Keep their
+# detected markdown chapters for analysis/scoping, but collapse them in the
+# reader API so headings remain visible without forcing extra navigation.
+READER_COMPACT_MAX_WORDS = 1_000
+READER_COMPACT_MAX_CHARS = 10_000
+
+
+def _compact_reader_chapters(text: str, chapters: list[dict]) -> tuple[list[dict], bool]:
+    """Return a single reader chapter for a short, multi-chapter article."""
+    compact = (
+        len(chapters) > 1
+        and len(text) <= READER_COMPACT_MAX_CHARS
+        and len(text.split()) <= READER_COMPACT_MAX_WORDS
+    )
+    if not compact:
+        return chapters, False
+    return [{
+        "position": 1,
+        "level": chapters[0]["level"],
+        "title": "(całość)",
+        "char_start": 0,
+        "char_end": len(text),
+        "length": len(text),
+    }], True
+
+
 @bp.route("/document/<int:doc_id>/chapters", methods=["GET"])
 def document_chapters(doc_id: int):
     """Detect the document's table of contents.
@@ -382,6 +408,9 @@ def document_chapters(doc_id: int):
     text, field = _extract_text(doc, prefer_md=True)
     chapters = detect_chapters(text) if text else []
     source = "markdown" if chapters else "none"
+    reader_compact = False
+    if request.args.get("reader") == "1" and chapters:
+        chapters, reader_compact = _compact_reader_chapters(text, chapters)
 
     run = _latest_run_for_document(session, doc_id)
     if not chapters and run:
@@ -418,13 +447,16 @@ def document_chapters(doc_id: int):
         "text_length": len(text),
         "chapters": chapters,
         "chapter_source": source,
+        "reader_compact": reader_compact,
         "countries": countries,
         "thematic_tags": thematic_tags,
         "synthesis": doc_run.synthesis if doc_run else None,
     })
 
 
-def _resolve_chapter_text(session, doc, position: int) -> tuple[tuple[str, str, int] | None, str | None]:
+def _resolve_chapter_text(
+    session, doc, position: int, *, compact_reader: bool = False,
+) -> tuple[tuple[str, str, int] | None, str | None]:
     """Resolve one reader chapter to ((text, title, chapter_total), None).
 
     Positions are 1-based and match GET /document/<id>/chapters — markdown
@@ -440,6 +472,8 @@ def _resolve_chapter_text(session, doc, position: int) -> tuple[tuple[str, str, 
     md_chapters = detect_chapters(text) if text else []
 
     if md_chapters:
+        if compact_reader:
+            md_chapters, _reader_compact = _compact_reader_chapters(text, md_chapters)
         chapter_total = len(md_chapters)
         match = next((c for c in md_chapters if c["position"] == position), None)
         if match is None:
@@ -473,7 +507,9 @@ def document_chapter(doc_id: int, position: int):
     if doc is None:
         abort(404, f"Document {doc_id} not found")
 
-    resolved, error = _resolve_chapter_text(session, doc, position)
+    resolved, error = _resolve_chapter_text(
+        session, doc, position, compact_reader=request.args.get("reader") == "1",
+    )
     if resolved is None:
         return jsonify({"status": "error", "message": error}), 400
     chapter_text, title, chapter_total = resolved
@@ -482,15 +518,14 @@ def document_chapter(doc_id: int, position: int):
     # renders them as a "Przypisy" section at the end of the chapter
     from library.db.models import DocumentReference
 
+    reference_query = session.query(DocumentReference).filter(
+        DocumentReference.document_id == doc_id,
+    )
+    if chapter_total > 1:
+        reference_query = reference_query.filter(DocumentReference.chapter_position == position)
     references = [
         {"marker": r.marker, "text": r.ref_text, "url": r.url}
-        for r in session.query(DocumentReference)
-        .filter(
-            DocumentReference.document_id == doc_id,
-            DocumentReference.chapter_position == position,
-        )
-        .order_by(DocumentReference.id)
-        .all()
+        for r in reference_query.order_by(DocumentReference.id).all()
     ]
 
     # A run analysed with scope_chapter=position sets run.scope to the chapter
@@ -539,7 +574,9 @@ def document_chapter_entities(doc_id: int, position: int):
     if doc is None:
         abort(404, f"Document {doc_id} not found")
 
-    resolved, error = _resolve_chapter_text(session, doc, position)
+    resolved, error = _resolve_chapter_text(
+        session, doc, position, compact_reader=request.args.get("reader") == "1",
+    )
     if resolved is None:
         return jsonify({"status": "error", "message": error}), 400
     chapter_text, title, chapter_total = resolved

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -21,6 +21,7 @@ from library.db.models import (  # noqa: E402
     DocumentAnalysisRun, DocumentChunk, DocumentTopicSection, WebDocument,
 )
 from library.document_analysis_service import DocumentAnalysisService, _slice_chapter  # noqa: E402
+from library.text_functions import detect_chapters  # noqa: E402
 
 
 BOOK_TEXT = (
@@ -230,6 +231,16 @@ class TestChaptersEndpoint:
         titles = [c["title"] for c in data["chapters"]]
         assert titles == ["(wstęp)", "Rozdział 1: Geneza", "Rozdział 2: Rozwój"]
 
+    def test_reader_collapses_short_markdown_document(self, client):
+        resp = client.get("/document/77/chapters?reader=1")
+        data = resp.get_json()
+
+        assert resp.status_code == 200
+        assert data["reader_compact"] is True
+        assert len(data["chapters"]) == 1
+        assert data["chapters"][0]["title"] == "(całość)"
+        assert data["chapters"][0]["length"] == data["text_length"]
+
     def test_returns_countries_from_kraj_tags(self, client):
         resp = client.get("/document/77/chapters")
         data = resp.get_json()
@@ -263,6 +274,17 @@ class TestChaptersEndpoint:
         assert data["synthesis"] is None
 
 
+class TestCompactReaderChapters:
+    def test_long_document_keeps_its_chapters(self):
+        long_text = BOOK_TEXT + (" bardzo długi tekst" * 1_000)
+        chapters = detect_chapters(long_text)
+
+        result, compact = crr._compact_reader_chapters(long_text, chapters)
+
+        assert compact is False
+        assert result == chapters
+
+
 class TestChapterContentEndpoint:
     def test_returns_chapter_text_with_nav(self, client):
         resp = client.get("/document/77/chapter/2")
@@ -274,6 +296,15 @@ class TestChapterContentEndpoint:
         assert data["chapter_total"] == 3
         assert data["prev"] == 1
         assert data["next"] == 3
+
+    def test_short_document_is_returned_as_one_continuous_chapter(self, client):
+        data = client.get("/document/77/chapter/1?reader=1").get_json()
+
+        assert data["title"] == "(całość)"
+        assert data["text"] == BOOK_TEXT.strip()
+        assert data["chapter_total"] == 1
+        assert data["prev"] is None
+        assert data["next"] is None
 
     def test_first_and_last_chapter_nav_boundaries(self, client):
         first = client.get("/document/77/chapter/1").get_json()

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -321,6 +321,7 @@ const Read: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [chapters, setChapters] = React.useState<Chapter[]>([]);
+  const [readerCompact, setReaderCompact] = React.useState(false);
   const [documentType, setDocumentType] = React.useState<string | null>(null);
   const [countries, setCountries] = React.useState<CountryTag[]>([]);
   const [places, setPlaces] = React.useState<PlaceMarker[]>([]);
@@ -373,17 +374,24 @@ const Read: React.FC = () => {
   const [tagQuery, setTagQuery] = React.useState("");
   const [tagResults, setTagResults] = React.useState<UserNote[]>([]);
 
-  const position = Number(searchParams.get("chapter") ?? 1);
+  const requestedPosition = Number(searchParams.get("chapter") ?? 1);
+  const position = readerCompact ? 1 : requestedPosition;
 
   // ── Data loading ──
 
   React.useEffect(() => {
     (async () => {
       try {
-        const r = await fetch(`${apiUrl}/document/${id}/chapters`, { headers });
+        const r = await fetch(`${apiUrl}/document/${id}/chapters?reader=1`, { headers });
         const data = await r.json();
         if (data.status !== "success") throw new Error(data.message ?? "Błąd pobierania rozdziałów");
         setChapters(data.chapters ?? []);
+        setReaderCompact(data.reader_compact === true);
+        if (data.reader_compact === true && requestedPosition !== 1) {
+          const next = new URLSearchParams(searchParams);
+          next.set("chapter", "1");
+          setSearchParams(next, { replace: true });
+        }
         setDocumentType(data.document_type ?? null);
         setCountries(data.countries ?? []);
         setThematicTags(data.thematic_tags ?? []);
@@ -442,7 +450,7 @@ const Read: React.FC = () => {
     setChapterScopeLoading(true);
     (async () => {
       try {
-        const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}/entities`, { headers });
+        const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}/entities?reader=1`, { headers });
         const data = await r.json();
         if (requestId !== chapterScopeRequestId.current) return;
         if (data.status !== "success") { setChapterScope(null); return; }
@@ -510,7 +518,7 @@ const Read: React.FC = () => {
       setError(null);
       setPendingNote(null);
       try {
-        const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}`, { headers });
+        const r = await fetch(`${apiUrl}/document/${id}/chapter/${position}?reader=1`, { headers });
         const data = await r.json();
         if (requestId !== contentRequestId.current) return;
         if (data.status !== "success") throw new Error(data.message ?? "Błąd pobierania rozdziału");
@@ -672,7 +680,10 @@ const Read: React.FC = () => {
   // ── Derived ──
 
   const chapterNotes = React.useMemo(
-    () => notes.filter(n => n.chapter_position === position), [notes, position]);
+    () => content?.chapter_total === 1
+      ? notes
+      : notes.filter(n => n.chapter_position === position),
+    [notes, position, content?.chapter_total]);
 
   // footnotes by marker — for ¹⁸ tooltips/anchors in the text
   const referencesByMarker = React.useMemo(
@@ -705,7 +716,7 @@ const Read: React.FC = () => {
 
   // ── Render ──
 
-  const navButtons = content && (
+  const navButtons = content && content.chapter_total > 1 && (
     <div style={{ display: "flex", justifyContent: "space-between", gap: 12, margin: "18px 0" }}>
       <button onClick={() => goTo(content.prev)} disabled={!content.prev}
         style={{ padding: "6px 14px", cursor: content.prev ? "pointer" : "default" }}>
@@ -730,7 +741,7 @@ const Read: React.FC = () => {
         {n.chapter_position === position && !anchoredNoteIds.has(n.id) &&
           <span style={{ color: "#b45309" }}> ⚠ nie odnaleziono w tekście</span>}
       </>}
-      onHeaderClick={n.chapter_position ? () => goTo(n.chapter_position) : undefined}
+      onHeaderClick={n.chapter_position ? () => goTo(readerCompact ? 1 : n.chapter_position) : undefined}
       onSaveText={saveNoteText}
       onDelete={deleteNote}
     />
@@ -740,9 +751,11 @@ const Read: React.FC = () => {
     <div>
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 10, flexWrap: "wrap" }}>
         <h2 style={{ margin: 0 }}>Czytelnik — dokument #{id}</h2>
-        <button className={styles.tocToggleButton} onClick={() => setTocOpen(o => !o)}>
-          📑 Spis treści ({chapters.length})
-        </button>
+        {chapters.length > 1 && (
+          <button className={styles.tocToggleButton} onClick={() => setTocOpen(o => !o)}>
+            📑 Spis treści ({chapters.length})
+          </button>
+        )}
         {documentType && EDITOR_TYPES.has(documentType) && (
           <NavLink to={`/${documentType}/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>✏️ Edytuj</NavLink>
         )}
@@ -761,7 +774,7 @@ const Read: React.FC = () => {
       <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
         {/* TOC sidebar + notes */}
         <div className={`${styles.tocPanel} ${tocOpen ? styles.tocPanelOpen : ""}`}>
-          <nav style={{
+          {chapters.length > 1 && <nav style={{
             background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: "10px 0",
           }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 14px" }}>
@@ -793,7 +806,7 @@ const Read: React.FC = () => {
                 </div>
               );
             })}
-          </nav>
+          </nav>}
 
           {userId && notes.length > 0 && (
             <div style={{

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -387,6 +387,7 @@ const Read: React.FC = () => {
         if (data.status !== "success") throw new Error(data.message ?? "Błąd pobierania rozdziałów");
         setChapters(data.chapters ?? []);
         setReaderCompact(data.reader_compact === true);
+        setScopeChapter(data.reader_compact !== true);
         if (data.reader_compact === true && requestedPosition !== 1) {
           const next = new URLSearchParams(searchParams);
           next.set("chapter", "1");
@@ -907,7 +908,7 @@ const Read: React.FC = () => {
         {/* Map + entities + tags + synthesis — desktop only */}
         {isDesktop && (
           <div className={styles.rightPanel}>
-            <div style={{ fontSize: "0.78em", color: "#64748b", display: "flex", gap: 8, alignItems: "center" }}>
+            {!readerCompact && <div style={{ fontSize: "0.78em", color: "#64748b", display: "flex", gap: 8, alignItems: "center" }}>
               Zakres:
               {([["rozdział", true], ["cały dokument", false]] as const).map(([label, value]) => (
                 <button
@@ -923,7 +924,7 @@ const Read: React.FC = () => {
                   {label}
                 </button>
               ))}
-            </div>
+            </div>}
             <div style={{
               fontSize: "0.78em", color: "#64748b", display: "flex", gap: 8, alignItems: "center", marginTop: 4,
             }}>


### PR DESCRIPTION
## Summary
- collapse short markdown articles into one continuous reader page
- preserve analytical chapter structure and chapter headings
- hide redundant TOC, navigation, and scope selector in compact mode
- keep notes, references, and entities available across the full article

## Verification
- 27 focused backend tests passed
- TypeScript check passed
- deployed and manually verified on NAS with document 9242