### PR TITLE
feat(chunks): guide cleanup review and embedding flow

### DIFF
--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 REWRITE_MAX_TOKENS = 2_500
 REWRITE_MIN_RATIO = 0.80
 SUMMARY_MAX_TOKENS = 400
+PRECLEAN_MAX_TOKENS = 1_200
 
 SECTION_HEADER_RE = re.compile(r"^### (REKLAMA|TEMAT|SZUM): ?(.+)$", re.MULTILINE)
 
@@ -26,6 +27,77 @@ _FILLER_SOUND_RE = re.compile(
 )
 _STANDALONE_Y_RE = re.compile(r"(?<!\w)y(?!\w)", re.IGNORECASE)
 _WORD_REPEAT_RE = re.compile(r"\b(\w+)\s+\1\b", re.IGNORECASE)
+
+
+def _parse_cleanup_ranges(raw: str, line_count: int) -> list[dict]:
+    """Parse and clamp line-range cleanup decisions returned by the LLM."""
+    match = re.search(r"\[.*\]", raw, re.DOTALL)
+    if not match:
+        return []
+    try:
+        rows = json.loads(match.group())
+    except (TypeError, ValueError):
+        return []
+    result = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict) or row.get("type") not in {"REKLAMA", "SZUM"}:
+            continue
+        try:
+            start = max(1, min(line_count, int(row["start_line"])))
+            end = max(start, min(line_count, int(row["end_line"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+        result.append({
+            "start_line": start, "end_line": end, "type": row["type"],
+            "reason": str(row.get("reason") or "Treść niemerytoryczna")[:500],
+        })
+    return result
+
+
+def propose_article_cleanup(text: str, model: str, max_chars: int = 12_000) -> list[dict]:
+    """Return a lossless TEMAT/REKLAMA/SZUM partition before final chunking.
+
+    The model only identifies exact numbered line ranges. Original text is never
+    rewritten, and anything not explicitly rejected remains TEMAT.
+    """
+    lines = text.splitlines()
+    if not lines:
+        return []
+    labels = [("TEMAT", "Treść merytoryczna") for _ in lines]
+    batch_start = 0
+    while batch_start < len(lines):
+        batch_end = batch_start
+        size = 0
+        while batch_end < len(lines) and (batch_end == batch_start or size + len(lines[batch_end]) + 12 <= max_chars):
+            size += len(lines[batch_end]) + 12
+            batch_end += 1
+        numbered = "\n".join(f"{i - batch_start + 1}: {lines[i]}" for i in range(batch_start, batch_end))
+        prompt = f"""Oceń linie surowego artykułu PRZED jego podziałem na fragmenty.
+Wskaż wyłącznie zakresy, które należy wykluczyć:
+- REKLAMA: sponsor, afiliacja, autopromocja, newsletter lub CTA,
+- SZUM: menu, stopka, cookies, nawigacja, lista linków, podpis techniczny.
+Nie oznaczaj jako szum nagłówków ani krótkich merytorycznych akapitów.
+Zwróć TYLKO JSON: [{{"start_line": 2, "end_line": 4, "type": "SZUM", "reason": "lista linków"}}].
+Gdy nic nie trzeba wykluczyć, zwróć [].
+
+--- PONUMEROWANE LINIE ---
+{numbered}
+--- KONIEC ---"""
+        raw, _ = call_model(prompt, model, PRECLEAN_MAX_TOKENS)
+        for decision in _parse_cleanup_ranges(raw, batch_end - batch_start):
+            for local_idx in range(decision["start_line"] - 1, decision["end_line"]):
+                labels[batch_start + local_idx] = (decision["type"], decision["reason"])
+        batch_start = batch_end
+
+    pieces: list[dict] = []
+    start = 0
+    for i in range(1, len(lines) + 1):
+        if i == len(lines) or labels[i] != labels[start]:
+            piece_text = "\n".join(lines[start:i]).strip()
+            if piece_text:
+                pieces.append({"type": labels[start][0], "topic": labels[start][1], "text": piece_text})
+            start = i
+    return pieces
 
 
 def extract_speaker_info(intro_text: str, model: str) -> list[dict]:

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -185,6 +185,8 @@ def analyze_document_chunks(doc_id: int):
         no_synthesis — skip final synthesis step (default: false)
         mode         — "transcript" (default) or "article"
         split_only   — split into chunks without any LLM analysis (default: false)
+        preclean     — article-only LLM cleanup proposal before final split;
+                       saved as the first stage of the same run (default: false)
         scope_chapter — 1-based chapter position (see GET /document/<id>/chapters);
                        analyze only that chapter (article mode only)
 
@@ -198,9 +200,12 @@ def analyze_document_chunks(doc_id: int):
     no_synthesis = bool(data.get("no_synthesis", False))
     mode = data.get("mode", "transcript")
     split_only = bool(data.get("split_only", False))
+    preclean = bool(data.get("preclean", False))
     scope_chapter = data.get("scope_chapter")
     if mode not in ANALYSIS_MODES:
         return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
+    if preclean and mode != "article":
+        return jsonify({"status": "error", "message": "preclean requires article mode"}), 400
     if scope_chapter is not None:
         try:
             scope_chapter = int(scope_chapter)
@@ -241,6 +246,7 @@ def analyze_document_chunks(doc_id: int):
                 progress_fn=_progress,
                 mode=mode,
                 split_only=split_only,
+                preclean=preclean,
                 scope_chapter=scope_chapter,
             )
             ad_count = sum(1 for c in run.chunks if c.type == "REKLAMA")
@@ -747,6 +753,12 @@ def list_runs():
                 "approved_count": sum(
                     1 for c in r.chunks if c.type == "TEMAT" and c.status == "approved"
                 ),
+                "workflow_stage": (
+                    "reviewed" if r.status == "reviewed"
+                    else "analysis" if any(c.type == "TEMAT" and c.summary for c in r.chunks)
+                    else "cleanup_proposal" if any(c.type in {"REKLAMA", "SZUM"} for c in r.chunks)
+                    else "split_proposal"
+                ),
             }
             for r in runs
         ],
@@ -839,6 +851,12 @@ def get_run_chunks(run_id: int):
             "synthesis": run.synthesis,
             "speakers": run.speakers or [],
             "created_at": run.created_at.isoformat(),
+            "workflow_stage": (
+                "reviewed" if run.status == "reviewed"
+                else "analysis" if any(c.type == "TEMAT" and c.summary for c in all_chunks)
+                else "cleanup_proposal" if any(c.type in {"REKLAMA", "SZUM"} for c in all_chunks)
+                else "split_proposal"
+            ),
         },
         "document": {
             "id": doc.id if doc else None,
@@ -1203,8 +1221,8 @@ def update_chunk(chunk_id: int):
     if "original_text" in data:
         # Manual cleanup: UI line-removal mode sends the whole edited text
         val = data["original_text"]
-        if not isinstance(val, str) or not val.strip():
-            return jsonify({"status": "error", "message": "original_text must be a non-empty string"}), 400
+        if not isinstance(val, str):
+            return jsonify({"status": "error", "message": "original_text must be a string"}), 400
         manually_removed = _removed_lines_diff(chunk.original_text, val)
         chunk.original_text = val
         changed = True

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -297,6 +297,7 @@ class DocumentAnalysisService:
         speakers: list[dict] | None = None,
         mode: str = "transcript",
         split_only: bool = False,
+        preclean: bool = False,
         scope_chapter: int | None = None,
     ) -> DocumentAnalysisRun:
         """Create a new analysis run for an existing document and persist to DB.
@@ -314,6 +315,9 @@ class DocumentAnalysisService:
             split_only:   Split into chunks WITHOUT any LLM calls — chunks land as
                           TEMAT/pending with no topic/summary, so the user can first
                           clean lines, merge or re-split, then analyze on demand.
+            preclean:     Article-only pre-pass: LLM marks exact REKLAMA/SZUM line
+                          ranges before final chunking. The resulting lossless proposal
+                          is saved in this same run without semantic chunk analysis.
             scope_chapter: 1-based chapter position (as returned by detect_chapters /
                           GET /document/<id>/chapters) — analyze only that chapter;
                           run.scope is set to the chapter title. Article mode only.
@@ -327,7 +331,7 @@ class DocumentAnalysisService:
         """
         from library.chunk_llm_analysis import (
             analyze_article_chunk, analyze_chunk, assign_speakers,
-            extract_speaker_info, remove_speech_fillers,
+            extract_speaker_info, propose_article_cleanup, remove_speech_fillers,
         )
         from library.text_functions import split_markdown_into_chunks, split_text_into_sentence_chunks
 
@@ -336,6 +340,9 @@ class DocumentAnalysisService:
         is_transcript = mode == "transcript"
         if scope_chapter is not None and is_transcript:
             raise ValueError("scope_chapter requires article mode")
+        if preclean and is_transcript:
+            raise ValueError("preclean requires article mode")
+        proposal_only = split_only or preclean
 
         def log(msg: str) -> None:
             logger.info(msg)
@@ -413,10 +420,26 @@ class DocumentAnalysisService:
             from library.author_biography import extract_trailing_author_biography
 
             article_body, author_bio = extract_trailing_author_biography(text, getattr(doc, "author", None))
-            chunk_texts = split_markdown_into_chunks(article_body, chunk_size)
+            preclean_meta: list[tuple[str, str | None]] = []
+            if preclean:
+                log("preclean: detecting ads and noisy line ranges before final split...")
+                proposed = propose_article_cleanup(article_body, model)
+                chunk_texts = []
+                for piece in proposed:
+                    piece_chunks = (
+                        split_markdown_into_chunks(piece["text"], chunk_size)
+                        if piece["type"] == "TEMAT" else [piece["text"]]
+                    )
+                    chunk_texts.extend(piece_chunks)
+                    preclean_meta.extend([(piece["type"], piece["topic"])] * len(piece_chunks))
+                log(f"preclean: {sum(1 for t, _ in preclean_meta if t != 'TEMAT')} excluded ranges proposed")
+            else:
+                chunk_texts = split_markdown_into_chunks(article_body, chunk_size)
             if author_bio:
                 chunk_texts.append(author_bio)
                 author_bio_position = len(chunk_texts) - 1
+                if preclean:
+                    preclean_meta.append(("SZUM", "Notka biograficzna autora"))
                 log(f"author biography isolated ({len(author_bio):,} chars)")
             segments = []
         log(f"split={len(chunk_texts)} chunks, max {chunk_size:,} chars")
@@ -430,12 +453,12 @@ class DocumentAnalysisService:
         #    split_only: no LLM at all — chunks await manual cleanup + on-demand analysis.
         sections: list[dict] = []
         total = len(chunk_texts)
-        if split_only:
-            log(f"split_only: {total} chunks without LLM analysis")
+        if proposal_only:
+            log(f"proposal: {total} chunks without semantic LLM analysis")
             sections = [
                 {
-                    "type": "SZUM" if i == author_bio_position else "TEMAT",
-                    "topic": "Notka biograficzna autora" if i == author_bio_position else None,
+                    "type": preclean_meta[i][0] if preclean else ("SZUM" if i == author_bio_position else "TEMAT"),
+                    "topic": preclean_meta[i][1] if preclean else ("Notka biograficzna autora" if i == author_bio_position else None),
                     "original": chunk_text,
                     "text": None,
                     "ratio": None,
@@ -480,7 +503,7 @@ class DocumentAnalysisService:
             })
 
         # 10. Group chunks into logical topic sections (skip LLM grouping for split_only)
-        topic_groups = [] if split_only else _merge_topics(sections, model, mode=mode)
+        topic_groups = [] if proposal_only else _merge_topics(sections, model, mode=mode)
         if topic_groups:
             topic_sections_data = []
             for group in topic_groups:
@@ -497,7 +520,7 @@ class DocumentAnalysisService:
                     "chunk_indices": [i + 1 for i in valid],
                     "summary": merged_summary.strip(),
                 })
-        elif split_only:
+        elif proposal_only:
             # No LLM ran — sections would carry no information yet
             topic_sections_data = []
         else:
@@ -515,7 +538,7 @@ class DocumentAnalysisService:
 
         # 11. Optional synthesis
         synthesis = ""
-        if not no_synthesis and not split_only:
+        if not no_synthesis and not proposal_only:
             log("generating synthesis...")
             synthesis = _synthesize(sections, doc.title or f"Dokument {doc_id}", model, mode=mode)
 
@@ -523,7 +546,7 @@ class DocumentAnalysisService:
         #      actions) — uses the synthesis as input when available (concise,
         #      already LLM-summarized), else falls back to concatenated topic
         #      summaries. Skipped for split_only: no LLM output exists yet.
-        if not split_only:
+        if not proposal_only:
             tagging_text = synthesis or "\n\n".join(
                 ts["summary"] for ts in topic_sections_data if ts["summary"]
             )
@@ -546,7 +569,7 @@ class DocumentAnalysisService:
 
             # 11d. Place verification (stage 3): geocoder confirms the places
             #      exist (cached), LLM confirms relevance -> miejsce-* tags.
-            if not split_only:
+            if not proposal_only:
                 try:
                     from library.place_verification import verify_document_places
 

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -88,6 +88,27 @@ def article_env(monkeypatch, session):
 
 
 class TestSzumType:
+    def test_cleanup_range_parser_clamps_and_ignores_temat(self):
+        rows = llm._parse_cleanup_ranges(
+            '[{"start_line": 0, "end_line": 2, "type": "SZUM", "reason": "menu"}, '
+            '{"start_line": 3, "end_line": 9, "type": "REKLAMA", "reason": "cta"}, '
+            '{"start_line": 1, "end_line": 1, "type": "TEMAT"}]',
+            4,
+        )
+        assert rows == [
+            {"start_line": 1, "end_line": 2, "type": "SZUM", "reason": "menu"},
+            {"start_line": 3, "end_line": 4, "type": "REKLAMA", "reason": "cta"},
+        ]
+
+    def test_preclean_is_lossless_and_keeps_unmarked_lines(self, monkeypatch):
+        monkeypatch.setattr(
+            llm, "call_model",
+            lambda *_a, **_kw: ('[{"start_line": 2, "end_line": 2, "type": "SZUM", "reason": "linki"}]', 5),
+        )
+        pieces = llm.propose_article_cleanup("Treść\nLink 1 | Link 2\nDalsza treść", "m")
+        assert [p["type"] for p in pieces] == ["TEMAT", "SZUM", "TEMAT"]
+        assert "\n".join(p["text"] for p in pieces) == "Treść\nLink 1 | Link 2\nDalsza treść"
+
     def test_parse_szum_header(self):
         from library.chunk_llm_analysis import parse_rewritten_chunk
         t, topic, rest = parse_rewritten_chunk("### SZUM: nawigacja portalu WP\n")
@@ -170,6 +191,23 @@ class TestArticleMode:
         from library.db.models import DocumentTopicSection
         sections = [o for o in session.added if isinstance(o, DocumentTopicSection)]
         assert sections == []
+
+    def test_preclean_saves_proposal_in_same_run_without_semantic_analysis(
+        self, session, article_env, monkeypatch,
+    ):
+        monkeypatch.setattr("library.entity_service.refresh_document_entities", lambda *_a, **_kw: [])
+        monkeypatch.setattr(llm, "propose_article_cleanup", lambda text, model: [
+            {"type": "TEMAT", "topic": "Treść merytoryczna", "text": "Wartościowy akapit."},
+            {"type": "SZUM", "topic": "lista linków", "text": "Czytaj także: link"},
+        ])
+        run = DocumentAnalysisService(session).create_run(
+            doc_id=42, model="test-model", mode="article", preclean=True,
+        )
+        chunks = [o for o in session.added if isinstance(o, DocumentChunk)]
+        assert [c.type for c in chunks] == ["TEMAT", "SZUM"]
+        assert all(c.run_id == run.id for c in chunks)
+        assert all(c.summary is None and c.status == "pending" for c in chunks)
+        assert article_env["article"] == 0
 
     def test_tags_document_using_synthesis_text(self, session, article_env, monkeypatch):
         doc = FakeDoc()

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -48,6 +48,7 @@ interface AnalysisRun {
   scope: string | null;
   temat_count?: number;
   approved_count?: number;
+  workflow_stage?: "split_proposal" | "cleanup_proposal" | "analysis" | "reviewed";
 }
 
 interface TopicSection {
@@ -352,6 +353,7 @@ const Chunks = () => {
   const [newModel, setNewModel]     = React.useState(MODELS[0]);
   const [newMode, setNewMode]       = React.useState("transcript");
   const [splitOnly, setSplitOnly]   = React.useState(false);
+  const [preclean, setPreclean]     = React.useState(true);
   const [chunkSize, setChunkSize]   = React.useState(5000);
   const [splitPreview, setSplitPreview] = React.useState<{ count: number; sizes: number[]; length: number } | null>(null);
   const [previewNonce, setPreviewNonce] = React.useState(0);
@@ -479,6 +481,18 @@ const Chunks = () => {
 
   React.useEffect(() => { fetchRuns(); }, [fetchRuns]);
   React.useEffect(() => { if (selectedRun !== null) fetchChunks(selectedRun); }, [selectedRun, fetchChunks]);
+  // Direct links to /chunks/:id do not carry router state. Load the document
+  // type so the basic flow can choose article/transcript without user input.
+  React.useEffect(() => {
+    if (!id || docType) return;
+    (async () => {
+      try {
+        const r = await fetch(`${apiUrl}/website_get?id=${id}`, { headers: { "x-api-key": apiKey ?? "" } });
+        const data = await r.json();
+        if (data.document_type) setDocType(data.document_type);
+      } catch { /* analysis can still be configured manually */ }
+    })();
+  }, [id, docType, apiUrl, apiKey]);
   // Clean documents (articles, webpages) default to article mode for new analyses
   React.useEffect(() => {
     if (docType && docType !== "youtube" && docType !== "movie") setNewMode("article");
@@ -561,6 +575,7 @@ const Chunks = () => {
           model: newModel, chunk_size: chunkSize,
           mode,
           split_only: splitOnlyOverride ?? splitOnly,
+          preclean: mode === "article" && !(splitOnlyOverride ?? splitOnly) && preclean,
           ...(scope !== null ? { scope_chapter: scope } : {}),
         }),
       });
@@ -676,18 +691,23 @@ const Chunks = () => {
     if (!marked || marked.size === 0) return;
     const lines = (chunk.original_text ?? "").split("\n");
     const newText = lines.filter((_, i) => !marked.has(i)).join("\n");
-    if (!newText.trim()) { setError("Nie można usunąć wszystkich linii"); return; }
     const removedLines = lines.filter((_, i) => marked.has(i)).map(l => l.trim()).filter(Boolean);
     setSavingLines(prev => ({ ...prev, [chunk.id]: true }));
     const res = await patchChunk(chunk.id, {
       original_text: newText,
+      ...(!newText.trim() ? { type: "SZUM", status: "skipped", topic: "Usunięty fragment" } : {}),
       ...(removeFromDocument && removedLines.length ? { remove_lines_from_document: removedLines } : {}),
     });
     setSavingLines(prev => ({ ...prev, [chunk.id]: false }));
     if (res?.status === "success") {
       clearLineMarks(chunk.id);
-      if (res.document_lines_removed > 0) {
-        setInfo(`Usunięto ${res.document_lines_removed} linii z dokumentu źródłowego`);
+      const sourceCount = res.document_lines_removed ?? 0;
+      if (!newText.trim()) {
+        setInfo(`Usunięto całą treść chunka #${chunk.position} i oznaczono go jako SZUM${sourceCount > 0 ? `; usunięto też ${sourceCount} linii ze źródła` : ""}.`);
+      } else if (sourceCount > 0) {
+        setInfo(`Usunięto ${sourceCount} linii z dokumentu źródłowego`);
+      }
+      if (sourceCount > 0) {
         setPreviewNonce(n => n + 1);
       }
     }
@@ -729,7 +749,6 @@ const Chunks = () => {
   };
 
   const mergeWithNext = async (chunk: Chunk) => {
-    if (!window.confirm(`Scalić chunk #${chunk.position} z #${chunk.position + 1}? Scalony chunk będzie wymagał ponownej analizy.`)) return;
     try {
       const r = await fetch(`${apiUrl}/chunk/${chunk.id}/merge_with_next`, { method: "POST", headers });
       const data = await r.json();
@@ -1007,6 +1026,9 @@ const Chunks = () => {
     !hiddenChunks.has(c.id) && (!hideAds || c.type === "TEMAT")
     && (!filterUnprocessed || (c.type === "TEMAT" && (c.obsidian_note_paths?.length ?? 0) === 0))
   );
+  const embeddedCount = tematChunks.filter(c => c.has_embeddings === true).length;
+  const reviewReady = tematChunks.length > 0 && unapprovedTematCount === 0 && chunksToAnalyze.length === 0;
+  const workflowBusy = !!jobId || reanalyzingAll || approvingAll || !!embedJobId;
 
   // ── User notes: match notes to chunks of the selected run ──
   // Direct match by chunk_id; reader notes (or notes from other runs) fall back
@@ -1331,7 +1353,7 @@ const Chunks = () => {
 
 
   return (
-    <div>
+    <div className={selectedRun !== null ? "chunks-page chunks-page--with-flow" : "chunks-page"}>
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 6, flexWrap: "wrap" }}>
         <h2 style={{ margin: 0 }}>Przegląd chunków — dokument #{id}</h2>
         {EDITOR_TYPES.includes(docType) ? (
@@ -1347,6 +1369,22 @@ const Chunks = () => {
       <div style={{ margin: "16px 0", padding: "12px 16px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
         <strong style={{ fontSize: "0.9em" }}>Nowa analiza</strong>
         <div style={{ display: "flex", gap: 10, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={{ fontSize: "0.86em", color: "#475569" }}>
+            {newMode === "article" ? "Artykuł" : "Transkrypcja"}
+            {" · "}{newModel}
+            {splitPreview ? ` · około ${splitPreview.count} ${splitPreview.count === 1 ? "chunk" : "chunków"}` : ""}
+            {newMode === "article" && preclean && !splitOnly ? " · wykrywanie reklam i szumu" : ""}
+          </span>
+          <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}
+            style={{ marginLeft: "auto", fontWeight: 700, padding: "6px 12px" }}>
+            {jobId ? `Analiza… (${jobStatus})` : runs.length > 0 ? "Rozpocznij nową analizę" : "Rozpocznij analizę"}
+          </button>
+        </div>
+        <details style={{ marginTop: 9 }}>
+          <summary style={{ cursor: "pointer", color: "#64748b", fontSize: "0.82em", userSelect: "none" }}>
+            Ustawienia zaawansowane
+          </summary>
+          <div style={{ display: "flex", gap: 10, marginTop: 10, flexWrap: "wrap", alignItems: "center", paddingTop: 8, borderTop: "1px solid #e2e8f0" }}>
           <select value={newModel} onChange={e => setNewModel(e.target.value)} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
             {MODELS.map(m => <option key={m} value={m}>{m}</option>)}
           </select>
@@ -1377,6 +1415,13 @@ const Chunks = () => {
             <input type="checkbox" checked={splitOnly} onChange={e => setSplitOnly(e.target.checked)} />
             tylko podział (bez analizy LLM)
           </label>
+          {newMode === "article" && !splitOnly && (
+            <label style={{ fontSize: "0.85em", display: "flex", alignItems: "center", gap: 4 }}
+              title="LLM najpierw oznaczy dokładne zakresy reklam i szumu. Propozycja oraz docelowy podział zostaną zapisane w jednym runie.">
+              <input type="checkbox" checked={preclean} onChange={e => setPreclean(e.target.checked)} />
+              najpierw wykryj reklamy i szum
+            </label>
+          )}
           {splitPreview && (
             <span style={{ fontSize: "0.82em", color: "#475569" }}
               title={`Rozmiary chunków: ${splitPreview.sizes.join(", ")} znaków`}>
@@ -1386,9 +1431,10 @@ const Chunks = () => {
             </span>
           )}
           <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}>
-            {jobId ? `Analiza… (${jobStatus})` : "Uruchom analizę"}
+            {jobId ? `Analiza… (${jobStatus})` : runs.length > 0 ? "Rozpocznij nową analizę z tymi ustawieniami" : "Uruchom z tymi ustawieniami"}
           </button>
-        </div>
+          </div>
+        </details>
       </div>
 
       {/* Wybór runu */}
@@ -1402,6 +1448,8 @@ const Chunks = () => {
                 {" "}[{r.mode === "article" ? "artykuł" : "transkrypcja"}
                 {r.scope ? `, ${r.scope}` : ""}
                 {r.temat_count != null && r.temat_count > 0 ? `, ✓ ${r.approved_count}/${r.temat_count}` : ""}
+                {r.workflow_stage === "cleanup_proposal" ? ", propozycja czyszczenia" : ""}
+                {r.workflow_stage === "split_proposal" ? ", propozycja podziału" : ""}
                 , {RUN_STATUS_LABELS[r.status] ?? r.status}]
               </option>
             ))}
@@ -1410,7 +1458,7 @@ const Chunks = () => {
             style={{ padding: "3px 9px", border: "1px solid #fca5a5", borderRadius: 4, background: "#fff", color: "#b91c1c", cursor: "pointer", fontSize: "0.82em" }}>
             🗑 Usuń run
           </button>
-          {selectedRun !== null && (runStatus === "reviewed" ? (
+          {false && selectedRun !== null && (runStatus === "reviewed" ? (
             <button onClick={() => setRunWorkflowStatus("in_review")}
               title="Analiza jest zamknięta — otwórz ją ponownie do przeglądu"
               style={{ padding: "3px 9px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#f1f5f9", color: "#475569", cursor: "pointer", fontSize: "0.82em" }}>
@@ -1423,13 +1471,102 @@ const Chunks = () => {
               ✔ Zamknij review
             </button>
           ))}
-          {runStatus === "reviewed" && (
+          {false && runStatus === "reviewed" && (
             <span style={{ fontSize: "0.8em", color: "#15803d", fontWeight: 600 }}>zamknięta</span>
           )}
         </div>
       )}
 
       {/* Tagi dokumentu (tematyczne + kraje) */}
+      {/* Guided workflow: keep the next action in one predictable place. */}
+      {selectedRun !== null && (
+        <aside className="chunks-workflow" style={{
+          marginBottom: 14, padding: "14px 16px", border: "1px solid #cbd5e1",
+          borderRadius: 10, background: "#fff", boxShadow: "0 1px 3px rgba(15, 23, 42, .06)",
+        }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, flexWrap: "wrap" }}>
+            <strong style={{ color: "#0f172a" }}>Proces</strong>
+            <span style={{ fontSize: "0.82em", color: "#64748b" }}>run #{selectedRun}</span>
+            {workflowBusy && <span style={{ fontSize: "0.82em", color: "#0369a1" }}>Przetwarzanie…</span>}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
+            {[
+              {
+                label: "1. Analiza chunków",
+                done: chunksToAnalyze.length === 0,
+                detail: chunksToAnalyze.length > 0 ? `${chunksToAnalyze.length} wymaga analizy` : `${tematChunks.length} treści TEMAT`,
+              },
+              {
+                label: "2. Przegląd i akceptacja",
+                done: reviewReady || runStatus === "reviewed",
+                detail: `${approvedCount}/${tematChunks.length} zatwierdzonych`,
+              },
+              {
+                label: "3. Embeddingi",
+                done: runStatus === "reviewed" && embeddedCount > 0 && !embedJobId,
+                detail: embedJobId ? `generowanie: ${embedJobStatus}` : embeddedCount > 0 ? `${embeddedCount} chunków w indeksie` : "uruchomią się po zamknięciu",
+              },
+            ].map(step => (
+              <div key={step.label} style={{
+                padding: "10px 12px", borderRadius: 7,
+                border: `1px solid ${step.done ? "#86efac" : "#e2e8f0"}`,
+                background: step.done ? "#f0fdf4" : "#f8fafc",
+              }}>
+                <div style={{ fontSize: "0.84em", fontWeight: 700, color: step.done ? "#15803d" : "#334155" }}>
+                  {step.done ? "✓ " : ""}{step.label}
+                </div>
+                <div style={{ marginTop: 3, fontSize: "0.78em", color: "#64748b" }}>{step.detail}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "stretch", gap: 8, marginTop: 12 }}>
+            {chunksToAnalyze.length > 0 && runStatus !== "reviewed" ? (
+              <button className="button" onClick={reanalyzeAll} disabled={reanalyzingAll}
+                style={{ background: "#0369a1", color: "#fff", border: "none", fontWeight: 700 }}>
+                {reanalyzingAll ? "Analizuję…" : `Dalej: analizuj chunki (${chunksToAnalyze.length})`}
+              </button>
+            ) : unapprovedTematCount > 0 && runStatus !== "reviewed" ? (
+              <button className="button" onClick={approveAll} disabled={workflowBusy}
+                style={{ background: "#15803d", color: "#fff", border: "none", fontWeight: 700 }}>
+                {approvingAll ? "Zatwierdzam…" : `Dalej: zatwierdź wszystkie TEMAT (${unapprovedTematCount})`}
+              </button>
+            ) : runStatus !== "reviewed" ? (
+              <button className="button" onClick={() => setRunWorkflowStatus("reviewed")} disabled={!reviewReady || workflowBusy}
+                title={!reviewReady ? "Najpierw przeanalizuj i zatwierdź wszystkie chunki TEMAT" : "Zamknij review i automatycznie utwórz embeddingi"}
+                style={{ background: reviewReady ? "#7c3aed" : "#cbd5e1", color: "#fff", border: "none", fontWeight: 700 }}>
+                Zakończ review i utwórz embeddingi
+              </button>
+            ) : embedJobId ? (
+              <span style={{ color: "#0369a1", fontSize: "0.88em", fontWeight: 700 }}>
+                Tworzenie embeddingów… ({embedJobStatus})
+              </span>
+            ) : embeddedCount > 0 ? (
+              <span style={{ color: "#15803d", fontSize: "0.88em", fontWeight: 700 }}>✓ Proces zakończony</span>
+            ) : (
+              <span style={{ color: "#b45309", fontSize: "0.84em", fontWeight: 700 }}>
+                Review zakończone, ale brak embeddingów
+              </span>
+            )}
+            {runStatus === "reviewed" && (
+              <>
+                <button onClick={() => setRunWorkflowStatus("in_review")} disabled={!!embedJobId}
+                  style={{ padding: "4px 10px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", color: "#475569", cursor: "pointer", fontSize: "0.82em" }}>
+                  ↻ Otwórz review
+                </button>
+                <button onClick={generateEmbeddings} disabled={!!embedJobId || approvedCount === 0}
+                  title="Ręcznie odśwież embeddingi po późniejszych zmianach"
+                  style={{ padding: "4px 10px", border: "1px solid #a5f3fc", borderRadius: 4, background: "#ecfeff", color: "#0e7490", cursor: "pointer", fontSize: "0.82em" }}>
+                  {embedJobId ? `Odświeżam… (${embedJobStatus})` : "Odśwież embeddingi"}
+                </button>
+              </>
+            )}
+            <span style={{ fontSize: "0.78em", color: "#64748b", lineHeight: 1.4 }}>
+              Reklamy i szum są pomijane. Każdy chunk możesz zatwierdzić osobno poniżej.
+            </span>
+          </div>
+        </aside>
+      )}
+
       {(docThematicTags.length > 0 || docCountries.length > 0) && (
         <div style={{
           marginBottom: 12, padding: "8px 14px", border: "1px solid #e2e8f0", borderRadius: 8,
@@ -1471,21 +1608,6 @@ const Chunks = () => {
         </div>
       )}
 
-      {/* Pasek postępu */}
-      {selectedRun !== null && (
-        <div style={{
-          marginBottom: 10, padding: "10px 14px", border: "1px solid #bae6fd",
-          borderRadius: 6, background: "#f0f9ff", color: "#0c4a6e", fontSize: "0.84em",
-        }}>
-          <strong>Jak powstają embeddingi:</strong>{" "}
-          analiza tworzy chunki ze statusem <code>pending</code> → zatwierdź merytoryczne chunki
-          <code> TEMAT</code> → kliknij <strong>Zamknij review</strong>. Zamknięcie automatycznie
-          przebuduje indeks wyszukiwania tylko z zatwierdzonych treści. Chunki <code>REKLAMA</code>
-          i <code>SZUM</code> są pomijane. Po późniejszej edycji lub ponownym otwarciu review użyj
-          przycisku <strong>Generuj embeddingi</strong>, aby odświeżyć indeks ręcznie.
-        </div>
-      )}
-
       {chunks.length > 0 && (
         <div style={{ marginBottom: 12, padding: "8px 14px", background: "#0f172a", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <span style={{ color: "#94a3b8", fontSize: "0.82em" }}>
@@ -1495,13 +1617,13 @@ const Chunks = () => {
           <div style={{ flex: 1, minWidth: 80, background: "#334155", borderRadius: 4, height: 8 }}>
             <div style={{ width: `${pct}%`, height: 8, background: "#22c55e", borderRadius: 4, transition: "width .3s" }} />
           </div>
-          {unapprovedTematCount > 0 && (
+          {false && unapprovedTematCount > 0 && (
             <button className="button" onClick={approveAll} disabled={approvingAll}
               style={{ fontSize: "0.8em", padding: "3px 10px", background: "#15803d", color: "#fff", border: "none" }}>
               {approvingAll ? "Zatwierdzam…" : `Zatwierdź wszystkie (${unapprovedTematCount})`}
             </button>
           )}
-          {chunksToAnalyze.length > 0 && (
+          {false && chunksToAnalyze.length > 0 && (
             <button className="button" onClick={reanalyzeAll} disabled={reanalyzingAll}
               style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0369a1", color: "#fff", border: "none" }}>
               {reanalyzingAll ? "Analizuję…" : `Analizuj chunki (${chunksToAnalyze.length})`}
@@ -1538,13 +1660,6 @@ const Chunks = () => {
               Widok sekcji
             </button>
           )}
-          {approvedCount > 0 && (
-            <button className="button" onClick={generateEmbeddings} disabled={!!embedJobId}
-              title="Generuje embeddingi z zatwierdzonych chunków TEMAT (do wyszukiwania semantycznego)"
-              style={{ fontSize: "0.8em", padding: "3px 10px", background: "#0891b2", color: "#fff", border: "none" }}>
-              {embedJobId ? `Embeddingi… (${embedJobStatus})` : "Generuj embeddingi"}
-            </button>
-          )}
         </div>
       )}
 
@@ -1576,15 +1691,23 @@ const Chunks = () => {
       {info && <p style={{ color: "#15803d", marginBottom: 12 }}>{info}</p>}
       {loading && <div className="loader" style={{ marginBottom: 12 }} />}
 
-      {/* Czyszczenie dokumentu z runa artykułowego */}
-      {runMode === "article" && chunks.length > 0 && (
-        <div style={{ marginBottom: 12 }}>
-          <button className="button" onClick={applyCleanupAndResplit} disabled={applyingCleanup || !!jobId}
-            title="Nadpisuje tekst źródłowy dokumentu treścią chunków TEMAT (REKLAMA/SZUM i usunięte linie znikają), po czym uruchamia nową analizę"
-            style={{ fontSize: "0.85em", background: "#7c3aed", color: "#fff", border: "none", padding: "4px 12px" }}>
-            {applyingCleanup ? "Czyszczę dokument…" : "Wyczyść dokument i zaproponuj nowy podział"}
-          </button>
-        </div>
+      {/* Destructive source cleanup is optional, not part of the standard flow. */}
+      {runMode === "article" && runStatus !== "reviewed" && chunksToAnalyze.length > 0 && reklamaCount > 0 && (
+        <details style={{ marginBottom: 12, padding: "8px 12px", border: "1px solid #e2e8f0", borderRadius: 6, background: "#f8fafc" }}>
+          <summary style={{ cursor: "pointer", color: "#64748b", fontSize: "0.82em", userSelect: "none" }}>
+            Operacje zaawansowane
+          </summary>
+          <div style={{ marginTop: 9 }}>
+            <button className="button" onClick={applyCleanupAndResplit} disabled={applyingCleanup || workflowBusy}
+              title="Trwale nadpisuje tekst źródłowy treścią chunków TEMAT, usuwa REKLAMA/SZUM i tworzy nowy run"
+              style={{ fontSize: "0.82em", background: "#7c3aed", color: "#fff", border: "none", padding: "5px 10px" }}>
+              {applyingCleanup ? "Stosuję czyszczenie…" : "Zastosuj czyszczenie do tekstu źródłowego i utwórz nowy run"}
+            </button>
+            <p style={{ margin: "7px 0 0", color: "#64748b", fontSize: "0.76em", lineHeight: 1.4 }}>
+              Opcjonalne: trwale usuwa odrzucone fragmenty z dokumentu. Standardowy flow nie wymaga tej operacji.
+            </p>
+          </div>
+        </details>
       )}
 
       {/* Chunki — widok płaski */}

--- a/web_interface_react/src/modules/shared/styles/index.css
+++ b/web_interface_react/src/modules/shared/styles/index.css
@@ -100,3 +100,32 @@ input[type="file"]:disabled {
   background: rgba(0, 0, 0, 0.07);
   color: rgba(0, 0, 0, 0.42);
 }
+
+/* Chunk review workflow: a persistent vertical guide on wide screens. */
+.chunks-page,
+.chunks-page * {
+  box-sizing: border-box;
+}
+
+@media (min-width: 1200px) {
+  .chunks-page--with-flow {
+    padding-right: 270px;
+  }
+
+  .chunks-workflow {
+    position: fixed;
+    z-index: 20;
+    top: 24px;
+    right: 24px;
+    width: 246px;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
+  }
+}
+
+@media (max-width: 1199px) {
+  .chunks-workflow {
+    position: static;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Podsumowanie
- dodaje pre-cleaning LLM przed docelowym podziałem artykułu, zachowując propozycję w tym samym runie
- upraszcza formularz nowej analizy i automatycznie dobiera tryb dokumentu
- dodaje pionowy panel procesu: analiza, review, embeddingi
- usuwa zduplikowane akcje review i generowania embeddingów
- poprawia stany zajętości oraz usuwanie jedno-liniowych chunków
- przenosi trwałe czyszczenie źródła do operacji zaawansowanych

## Weryfikacja
- pytest: 6 nowych testów przechodzi
- 
px tsc --noEmit
- produkcyjne buildy Docker backendu i frontendu
- wdrożone i przetestowane na NAS