### PR TITLE
feat(chunks): delete noise and show merge sizes

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1293,6 +1293,59 @@ def update_chunk(chunk_id: int):
 # API: POST /chunk/<chunk_id>/execute_split
 # ---------------------------------------------------------------------------
 
+@bp.route("/chunk/<int:chunk_id>", methods=["DELETE"])
+def delete_noise_chunk(chunk_id: int):
+    """Delete a REKLAMA/SZUM chunk from a run and close the position gap.
+
+    This intentionally does not modify the source document. TEMAT chunks must
+    be reclassified first, which protects substantive content from accidental
+    deletion through the compact card action.
+    """
+    session = get_scoped_session()
+    chunk = session.get(DocumentChunk, chunk_id)
+    if chunk is None:
+        abort(404, f"Chunk {chunk_id} not found")
+    if chunk.type == "TEMAT":
+        return jsonify({"status": "error", "message": "TEMAT chunks cannot be deleted"}), 400
+
+    run_id = chunk.run_id
+    removed_position = chunk.position
+    sections = session.scalars(
+        select(DocumentTopicSection).where(DocumentTopicSection.run_id == run_id)
+    ).all()
+    for section in sections:
+        section.chunk_positions = [
+            pos - 1 if pos > removed_position else pos
+            for pos in (section.chunk_positions or [])
+            if pos != removed_position
+        ]
+
+    try:
+        session.delete(chunk)
+        session.flush()
+        # Two-phase shift avoids collisions with a possible unique(run, position).
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.position > removed_position)
+            .values(position=DocumentChunk.position + 10000)
+        )
+        session.execute(
+            sa_update(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.position > 10000)
+            .values(position=DocumentChunk.position - 10001)
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("Failed to delete noise chunk %d", chunk_id)
+        return jsonify({"status": "error", "message": "DB error"}), 500
+
+    return jsonify({
+        "status": "success", "deleted_chunk_id": chunk_id,
+        "run_id": run_id, "removed_position": removed_position,
+    })
+
+
 @bp.route("/chunk/<int:chunk_id>/execute_split", methods=["POST"])
 def execute_split(chunk_id: int):
     """Split a chunk into two.

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -364,6 +364,7 @@ const Chunks = () => {
   const [savingTopics, setSavingTopics]   = React.useState<Record<number, boolean>>({});
   const [savedFlash, setSavedFlash]       = React.useState<Record<number, boolean>>({});
   const [reanalyzing, setReanalyzing]     = React.useState<Record<number, boolean>>({});
+  const [deletingChunks, setDeletingChunks] = React.useState<Record<number, boolean>>({});
   const [reanalyzingAll, setReanalyzingAll] = React.useState(false);
   const [approvingAll, setApprovingAll] = React.useState(false);
   const [splitStates, setSplitStates]     = React.useState<Record<number, SplitState>>({});
@@ -758,6 +759,26 @@ const Chunks = () => {
     } catch { setError("Błąd połączenia przy scalaniu"); }
   };
 
+  const deleteNoiseChunk = async (chunk: Chunk) => {
+    if (chunk.type === "TEMAT" || deletingChunks[chunk.id]) return;
+    setDeletingChunks(prev => ({ ...prev, [chunk.id]: true }));
+    setError("");
+    try {
+      const r = await fetch(`${apiUrl}/chunk/${chunk.id}`, { method: "DELETE", headers });
+      const data = await r.json();
+      if (data.status === "success") {
+        setInfo(`Usunięto chunk #${chunk.position} (${chunk.type}) z bieżącego runu.`);
+        if (selectedRun !== null) await fetchChunks(selectedRun);
+      } else {
+        setError("Nie udało się usunąć chunka: " + (data.message ?? ""));
+      }
+    } catch {
+      setError("Błąd połączenia przy usuwaniu chunka");
+    } finally {
+      setDeletingChunks(prev => ({ ...prev, [chunk.id]: false }));
+    }
+  };
+
   const deleteRun = async () => {
     if (selectedRun === null) return;
     if (!window.confirm(
@@ -1086,6 +1107,13 @@ const Chunks = () => {
   // Karta pojedynczego chunka — używana w widoku płaskim i w accordionie sekcji
   const renderChunkCard = (chunk: Chunk) => {
         const hasCorrected = !!chunk.corrected_text;
+        const chunkLength = chunk.text_length ?? (chunk.corrected_text ?? chunk.original_text ?? "").length;
+        const nextChunk = chunks.find(c => c.position === chunk.position + 1);
+        const nextChunkLength = nextChunk
+          ? (nextChunk.text_length ?? (nextChunk.corrected_text ?? nextChunk.original_text ?? "").length)
+          : 0;
+        const mergedLength = chunkLength + nextChunkLength;
+        const mergeExceedsTarget = mergedLength > chunkSize;
         const isCorrectedView = showCorrected[chunk.id] ?? hasCorrected;
         const isReanalyzing = reanalyzing[chunk.id] ?? false;
         const splitSt = splitStates[chunk.id];
@@ -1100,6 +1128,12 @@ const Chunks = () => {
             {/* Nagłówek */}
             <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 14px", background: "#f1f5f9", borderBottom: "1px solid #e2e8f0", fontSize: "0.82em", flexWrap: "wrap" }}>
               <span style={{ fontWeight: 600, color: "#334155", minWidth: 24 }}>#{chunk.position}</span>
+              <span
+                title={`Dokładny rozmiar: ${chunkLength.toLocaleString("pl-PL")} znaków; około ${Math.ceil(chunkLength / 4).toLocaleString("pl-PL")} tokenów`}
+                style={{ color: "#64748b", fontSize: "0.9em", whiteSpace: "nowrap" }}
+              >
+                {chunkLength >= 1000 ? `${(chunkLength / 1000).toLocaleString("pl-PL", { maximumFractionDigits: 1 })} tys. zn` : `${chunkLength} zn`}
+              </span>
 
               {/* Typ — klikalny */}
               <span
@@ -1207,18 +1241,32 @@ const Chunks = () => {
               {chunk.position < maxPosition && (
                 <button
                   onClick={() => mergeWithNext(chunk)}
-                  title={`Scal z chunkiem #${chunk.position + 1}`}
-                  style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b" }}
+                  title={`Scal z chunkiem #${chunk.position + 1}: wynik ${mergedLength.toLocaleString("pl-PL")} znaków${mergeExceedsTarget ? ` (powyżej celu ${chunkSize.toLocaleString("pl-PL")})` : ""}`}
+                  style={{
+                    padding: "2px 8px", border: `1px solid ${mergeExceedsTarget ? "#f59e0b" : "#cbd5e1"}`,
+                    borderRadius: 4, background: mergeExceedsTarget ? "#fffbeb" : "#fff", cursor: "pointer",
+                    fontSize: "0.82em", color: mergeExceedsTarget ? "#92400e" : "#64748b",
+                  }}
                 >
                   ⇣ Scal
+                  {" → "}{mergedLength >= 1000
+                    ? `${(mergedLength / 1000).toLocaleString("pl-PL", { maximumFractionDigits: 1 })} tys. zn`
+                    : `${mergedLength} zn`}
                 </button>
               )}
               <button
-                onClick={() => setHiddenChunks(prev => new Set([...prev, chunk.id]))}
-                title="Ukryj ten chunk"
-                style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b", marginLeft: "auto" }}
+                onClick={() => chunk.type === "TEMAT"
+                  ? setHiddenChunks(prev => new Set([...prev, chunk.id]))
+                  : deleteNoiseChunk(chunk)}
+                disabled={!!deletingChunks[chunk.id]}
+                title={chunk.type === "TEMAT" ? "Ukryj ten chunk" : `Usuń chunk ${chunk.type} z bieżącego runu`}
+                style={{
+                  padding: "2px 8px", border: `1px solid ${chunk.type === "TEMAT" ? "#cbd5e1" : "#fca5a5"}`,
+                  borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em",
+                  color: chunk.type === "TEMAT" ? "#64748b" : "#b91c1c", marginLeft: "auto",
+                }}
               >
-                ✕
+                {deletingChunks[chunk.id] ? "…" : chunk.type === "TEMAT" ? "✕" : "🗑"}
               </button>
             </div>
 


### PR DESCRIPTION
## Podsumowanie
- usuwa chunki REKLAMA/SZUM z bieżącego runu i przelicza pozycje
- pozostawia ukrywanie dla chunków TEMAT
- pokazuje rozmiar chunka w znakach i szacowane tokeny
- pokazuje przewidywany rozmiar po scaleniu
- ostrzega kolorem po przekroczeniu docelowego chunk size

## Weryfikacja
- python -m py_compile dla routingu backendu
- 
px tsc --noEmit
- produkcyjne buildy i deploy backendu/frontendu na NAS