### PR TITLE
feat(chunks): article author detection, NER unavailability warning, chunk review UX fixes

### DIFF
--- a/backend/alembic/versions/e3f4a5b6c7d8_add_ner_unavailable_at_to_web_documents.py
+++ b/backend/alembic/versions/e3f4a5b6c7d8_add_ner_unavailable_at_to_web_documents.py
@@ -1,0 +1,22 @@
+"""add ner_unavailable_at to web_documents
+
+Revision ID: e3f4a5b6c7d8
+Revises: d2e3f4a5b6c7
+Create Date: 2026-07-16 09:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e3f4a5b6c7d8"
+down_revision: Union[str, None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS ner_unavailable_at TIMESTAMP")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE web_documents DROP COLUMN IF EXISTS ner_unavailable_at")

--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -60,7 +60,7 @@ library/
 - **`db/engine.py`** — SQLAlchemy engine and session factories: `get_session()`, `get_scoped_session()`.
 - **`stalker_web_documents_db_postgresql.py`** — `WebsitesDBPostgreSQL`: query layer using SQLAlchemy session. Requires `session` parameter. Methods: `get_list()` (paginated/filtered), `get_similar()` (pgvector cosine search), `get_next_to_correct()`, `get_count()`, `embedding_add()`, `embedding_delete()`.
 
-**Database tables:** `public.web_documents` (30 columns), `public.websites_embeddings` (vector similarity, optional `chunk_id` FK), `public.document_analysis_runs`, `public.document_chunks`, `public.document_topic_sections`, `public.document_removed_lines` — see [`database/CLAUDE.md`](../database/CLAUDE.md) for full column definitions.
+**Database tables:** `public.web_documents` (31 columns), `public.websites_embeddings` (vector similarity, optional `chunk_id` FK), `public.document_analysis_runs`, `public.document_chunks`, `public.document_topic_sections`, `public.document_removed_lines` — see [`database/CLAUDE.md`](../database/CLAUDE.md) for full column definitions.
 
 ### Models (`models/`)
 

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -129,6 +129,42 @@ Fragment transkrypcji:
     return []
 
 
+def head_tail_excerpt(text: str, chars: int = 1500) -> str:
+    """First and last `chars` characters of text — a byline can appear at either end."""
+    text = text.strip()
+    if len(text) <= chars * 2:
+        return text
+    return text[:chars] + "\n...\n" + text[-chars:]
+
+
+def extract_author_info(text: str, model: str) -> str | None:
+    """Ask LLM to identify the article's author (byline) from a text excerpt.
+
+    Returns the author's name, or None if extraction fails or no author found.
+    """
+    prompt = f"""Z poniższego fragmentu artykułu spróbuj ustalić imię i nazwisko autora (dziennikarza, publicysty).
+Zwróć TYLKO obiekt JSON bez żadnego dodatkowego tekstu, w formacie:
+{{"author": "Imię Nazwisko"}}
+
+Jeśli nie możesz jednoznacznie zidentyfikować autora, zwróć: {{"author": null}}
+
+Fragment artykułu:
+{text}"""
+
+    logger.info("extract_author_info: len=%d", len(text))
+    response_text, _ = call_model(prompt, model, max_tokens=100)
+    try:
+        match = re.search(r'\{.*\}', response_text, re.DOTALL)
+        if match:
+            result = json.loads(match.group())
+            author = result.get("author")
+            if isinstance(author, str) and author.strip():
+                return author.strip()
+    except Exception:
+        logger.warning("extract_author_info: failed to parse JSON response")
+    return None
+
+
 def assign_speakers(text: str, speaker1: str, speaker2: str) -> str:
     """Parse >> speaker-change markers from YouTube auto-transcript and label each turn.
 

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -13,6 +13,7 @@ Endpoints:
   GET  /analysis_run/<run_id>/chunks         — run data (chunks + segments;
                                                lite/section_id/offset/limit for books)
   POST /analysis_run/<run_id>/extract_speakers
+  POST /analysis_run/<run_id>/extract_author
   PATCH /analysis_run/<run_id>               — run workflow status
   PATCH /topic_section/<section_id>          — edit section title
   PATCH /chunk/<chunk_id>                    — update status / type / topic / split_at_seg
@@ -1182,6 +1183,77 @@ def extract_speakers(run_id: int):
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
     return jsonify({"status": "success", "speakers": speakers})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /analysis_run/<run_id>/extract_author
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/extract_author", methods=["POST"])
+def extract_author(run_id: int):
+    """Extract the article author's name (byline) using LLM.
+
+    Pass chunk_ids (JSON body) to use specific chunk(s) instead — e.g. a
+    chunk containing the byline the reviewer identified. Without chunk_ids,
+    uses the head+tail of the whole document's text (a byline can appear at
+    the start or the end of an article). Saves the result directly to the
+    document's author field, always overwriting any existing value — this is
+    a reviewer-triggered manual action, unlike the automatic pipeline step in
+    document_analysis_service.create_run() which never overwrites.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    chunk_ids = data.get("chunk_ids")
+
+    if chunk_ids:
+        if not isinstance(chunk_ids, list) or not all(isinstance(i, int) for i in chunk_ids):
+            return jsonify({"status": "error", "message": "chunk_ids must be a list of integers"}), 400
+        chunks = session.scalars(
+            select(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.id.in_(chunk_ids))
+            .order_by(DocumentChunk.position)
+        ).all()
+        if len(chunks) != len(set(chunk_ids)):
+            return jsonify({"status": "error", "message": "One or more chunk_ids not found in this run"}), 400
+        source_text = "\n\n".join(
+            c.corrected_text or c.original_text or "" for c in chunks
+        ).strip()
+    else:
+        doc = session.get(WebDocument, run.document_id)
+        if doc is None:
+            abort(404, f"Document {run.document_id} not found")
+        from library.chunk_llm_analysis import head_tail_excerpt
+        source_text = head_tail_excerpt(doc.text_md or doc.text or "")
+
+    if not source_text:
+        return jsonify({"status": "error", "message": "No text available for author extraction"}), 400
+
+    try:
+        from library.chunk_llm_analysis import extract_author_info
+        author = extract_author_info(source_text, run.model)
+    except Exception:
+        logger.exception("extract_author_info failed for run %d", run_id)
+        return jsonify({"status": "error", "message": "LLM call failed"}), 500
+
+    if not author:
+        return jsonify({"status": "success", "author": None})
+
+    doc = session.get(WebDocument, run.document_id)
+    if doc is None:
+        abort(404, f"Document {run.document_id} not found")
+    doc.author = author
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for run %d author", run_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "author": author})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -252,6 +252,12 @@ class WebDocument(Base):
     reviewed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
     obsidian_note_paths: Mapped[list] = mapped_column(JSONB, server_default=sa_text("'[]'"))
 
+    # Set when the last NER refresh (entity_service.refresh_document_entities)
+    # found the ner_service unreachable — distinguishes "service down" from
+    # "genuinely no entities found" so the reader can warn instead of staying
+    # silently empty. Cleared on the next successful refresh (found or not).
+    ner_unavailable_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
+
     # Lookup-table relationships (many-to-one)
     document_type_ref: Mapped["DocumentType"] = relationship(
         foreign_keys=[document_type],

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -554,6 +554,22 @@ class DocumentAnalysisService:
                 log("tagging document...")
                 _apply_tags(doc, tagging_text)
 
+            # 11b2. Article author fallback (LLM) — article_metadata.extract_article_author()
+            #       (deterministic, WP.pl only) already ran at import time; this is a
+            #       fallback for everything else. Never overwrites an existing doc.author
+            #       (deterministic or manually entered). Whole-document runs only — a
+            #       single chapter excerpt is not a reliable place to look for a byline.
+            if not is_transcript and scope is None and not (getattr(doc, "author", None) or "").strip():
+                try:
+                    from library.chunk_llm_analysis import extract_author_info, head_tail_excerpt
+
+                    author_name = extract_author_info(head_tail_excerpt(text), model)
+                    if author_name:
+                        doc.author = author_name
+                        log(f"author detected: {author_name}")
+                except Exception:
+                    logger.exception("author extraction failed, continuing without author")
+
         # 11c. NER entities (persons/places) on the full document text — offline
         #      (no LLM), stored in document_entities with replace semantics, so
         #      chapter-scoped runs skip it (a single chapter's entities must not
@@ -561,9 +577,12 @@ class DocumentAnalysisService:
         if scope is None:
             try:
                 from library.entity_service import refresh_document_entities
+                from library.ner_client import NERServiceUnavailable
 
                 entity_rows = refresh_document_entities(session, doc_id, text)
                 log(f"entities={len(entity_rows)}")
+            except NERServiceUnavailable:
+                log("WARNING: NER service unavailable — entities not refreshed for this run")
             except Exception:
                 logger.exception("entity extraction failed, continuing without entities")
 

--- a/backend/library/entity_service.py
+++ b/backend/library/entity_service.py
@@ -6,16 +6,31 @@ Entities are derived data, so a refresh replaces previous rows instead of
 merging (unlike doc.tags, which accumulates across runs).
 """
 
+import datetime
 import logging
 import re
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 
 from library.db.models import DocumentEntity, NerExclusion, WebDocument
-from library.ner_client import aggregate_entities_detailed, extract_entities
+from library.ner_client import NERServiceUnavailable, aggregate_entities_detailed, extract_entities, is_available
 from library.ner_normalization import normalize_ner_text
 
 logger = logging.getLogger(__name__)
+
+
+def _record_ner_availability(session, document_id: int, *, unavailable: bool) -> None:
+    """Persist doc.ner_unavailable_at immediately (own commit) — see its column comment.
+
+    Committed independently of the caller's transaction so the flag survives
+    even when the caller rolls back after refresh_document_entities raises
+    (e.g. article_browser.py's except blocks).
+    """
+    value = datetime.datetime.utcnow() if unavailable else None
+    session.execute(
+        update(WebDocument).where(WebDocument.id == document_id).values(ner_unavailable_at=value),
+    )
+    session.commit()
 
 
 def is_excluded(exclusions: list[NerExclusion], entity_type: str, entity_text: str,
@@ -56,22 +71,39 @@ def refresh_document_entities(session, document_id: int, text: str) -> list[Docu
     """Run NER on text and replace the document's rows in document_entities.
 
     Queues the changes on the session without committing (caller owns the
-    transaction). Returns the new DocumentEntity rows. When the NER service is
-    unavailable an empty extraction result leaves existing rows untouched —
-    "service down" must not erase previously detected entities. Entities
+    transaction) and returns the new DocumentEntity rows. When the raw
+    extraction comes back empty, a cheap /healthz probe (ner_client.is_available)
+    tells apart two cases — genuinely no entities (probe OK: clears any stale
+    doc.ner_unavailable_at, returns []) vs. the service being down (probe
+    fails: sets doc.ner_unavailable_at and raises NERServiceUnavailable). Both
+    of those writes commit immediately, independent of the caller's
+    transaction, so the flag survives even when the caller rolls back on the
+    raised exception (e.g. article_browser.py's except blocks). Existing
+    document_entities rows are left untouched on both empty-extraction paths —
+    "no fresh data" must never erase previously detected entities. Entities
     matched by an ner_exclusions rule (global, or author-scoped for the
     document's author) are dropped before persisting — they never reach
     person resolution or place verification.
     """
     raw = extract_entities(text)
     if not raw:
-        return []
+        if is_available():
+            _record_ner_availability(session, document_id, unavailable=False)
+            return []
+        _record_ner_availability(session, document_id, unavailable=True)
+        raise NERServiceUnavailable(f"NER service unreachable while refreshing entities for document {document_id}")
+
+    # Success: clear a stale unavailable flag as part of the caller's own
+    # transaction (no isolated commit needed — unlike the branches above,
+    # there is no exception here for the caller to roll back).
+    doc = session.get(WebDocument, document_id)
+    if doc is not None and doc.ner_unavailable_at is not None:
+        doc.ner_unavailable_at = None
 
     groups = aggregate_entities_detailed(raw)
 
     exclusions = list(session.execute(select(NerExclusion)).scalars().all())
     if exclusions:
-        doc = session.get(WebDocument, document_id)
         author = getattr(doc, "author", None)
         excluded = [
             key

--- a/backend/library/ner_client.py
+++ b/backend/library/ner_client.py
@@ -75,6 +75,28 @@ class NERExtractionError(RuntimeError):
     """A complete NER extraction could not be obtained."""
 
 
+class NERServiceUnavailable(RuntimeError):
+    """The NER service could not be reached at all (confirmed via /healthz).
+
+    Raised by entity_service.refresh_document_entities so callers can tell
+    "service down" apart from "ran fine, found nothing" — extract_entities()
+    itself still returns [] either way, preserving its existing contract.
+    """
+
+
+def is_available() -> bool:
+    """Cheap /healthz probe — used to confirm a real outage vs. a genuinely empty extraction.
+
+    Short timeout: this must not itself become a slow path in the common case
+    (service up). Any exception counts as unavailable.
+    """
+    try:
+        resp = requests.get(f"{_service_url()}/healthz", timeout=5)
+        return resp.ok
+    except requests.RequestException:
+        return False
+
+
 def _extract_entities(text: str, *, strict: bool) -> list[dict]:
     """Return raw entities from the NER service: [{text, label, lemma, start, end}, ...].
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -422,7 +422,12 @@ def website_entities_get():
     if doc is None:
         return {"status": "error", "message": "Document not found"}, 404
 
-    return {"status": "success", "id": doc_id, "entities": get_document_entities(session, doc_id)}, 200
+    return {
+        "status": "success",
+        "id": doc_id,
+        "entities": get_document_entities(session, doc_id),
+        "ner_unavailable_at": doc.ner_unavailable_at.isoformat() if doc.ner_unavailable_at else None,
+    }, 200
 
 
 @app.route('/website_entities', methods=['POST'])
@@ -435,6 +440,7 @@ def website_entities_refresh():
     its failure does not fail the request.
     """
     from library.entity_service import get_document_entities, refresh_document_entities
+    from library.ner_client import NERServiceUnavailable
 
     doc_id, error = _entities_doc_id(request.form.get('id') or (request.get_json(silent=True) or {}).get('id'))
     if error:
@@ -449,7 +455,15 @@ def website_entities_refresh():
     if not text.strip():
         return {"status": "error", "message": "Document has no text content"}, 400
 
-    rows = refresh_document_entities(session, doc_id, text)
+    try:
+        rows = refresh_document_entities(session, doc_id, text)
+    except NERServiceUnavailable:
+        # refresh_document_entities already committed doc.ner_unavailable_at.
+        return {
+            "status": "error",
+            "message": "Serwis NER jest niedostępny — spróbuj ponownie za chwilę.",
+            "ner_unavailable": True,
+        }, 503
     session.commit()
 
     place_tags: list[str] = []

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -160,11 +160,11 @@ class TestWebDocumentColumns:
         "text_raw", "transcript_job_id", "ai_summary_needed",
         "author", "note", "uuid", "project", "text_md",
         "text_extracted", "transcript_needed", "reviewed_at",
-        "obsidian_note_paths", "video_description",
+        "obsidian_note_paths", "video_description", "ner_unavailable_at",
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebDocument)) == 30
+        assert len(_column_names(WebDocument)) == 31
 
     def test_all_column_names(self):
         assert _column_names(WebDocument) == self.EXPECTED_COLUMNS

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -153,7 +153,9 @@ class TestArticleMode:
         assert run.mode == "article"
         assert run.status == "created"
         assert run.speakers == []
-        session.commit.assert_called_once()
+        # 2 commits: entity_service's own isolated commit of ner_unavailable_at
+        # (NER unreachable in this test env — no real ner_service) + the run persist.
+        assert session.commit.call_count == 2
 
     def test_article_chunks_have_no_corrected_text(self, session, article_env):
         service = DocumentAnalysisService(session)

--- a/backend/tests/unit/test_entity_service.py
+++ b/backend/tests/unit/test_entity_service.py
@@ -50,15 +50,29 @@ class TestRefreshDocumentEntities:
             rows = refresh_document_entities(session, 42, "jakiś tekst")
         assert rows[0].entity_text == "Tusk"
 
-    def test_service_unavailable_keeps_existing_rows(self):
-        """Empty extraction (service down) must not delete previously stored entities."""
+    def test_genuinely_empty_extraction_keeps_existing_rows(self):
+        """Empty extraction with the service reachable must not touch document_entities."""
         session = MagicMock()
-        with patch("library.entity_service.extract_entities", return_value=[]):
+        with patch("library.entity_service.extract_entities", return_value=[]), \
+             patch("library.entity_service.is_available", return_value=True):
             rows = refresh_document_entities(session, 42, "jakiś tekst")
 
         assert rows == []
-        session.execute.assert_not_called()
         session.add_all.assert_not_called()
+        session.commit.assert_called_once()  # clears any stale ner_unavailable_at
+
+    def test_service_unavailable_raises_and_flags_document_without_touching_rows(self):
+        """Empty extraction with the service down must raise, not silently return []."""
+        from library.ner_client import NERServiceUnavailable
+
+        session = MagicMock()
+        with patch("library.entity_service.extract_entities", return_value=[]), \
+             patch("library.entity_service.is_available", return_value=False):
+            with pytest.raises(NERServiceUnavailable):
+                refresh_document_entities(session, 42, "jakiś tekst")
+
+        session.add_all.assert_not_called()
+        session.commit.assert_called_once()  # sets ner_unavailable_at, own transaction
 
     def test_global_exclusion_drops_entity(self):
         session = _session_with_exclusions(

--- a/backend/tests/unit/test_flask_endpoints_entities.py
+++ b/backend/tests/unit/test_flask_endpoints_entities.py
@@ -46,7 +46,7 @@ class TestWebsiteEntitiesGet:
     def test_returns_grouped_entities(self, client):
         with patch("server.get_scoped_session", return_value=MagicMock()):
             with patch("server.WebDocument") as MockDoc:
-                MockDoc.get_by_id.return_value = MagicMock()
+                MockDoc.get_by_id.return_value = MagicMock(ner_unavailable_at=None)
                 with patch("library.entity_service.get_document_entities", return_value=GROUPED):
                     resp = client.get("/website_entities?id=42", headers=API_HEADERS)
 
@@ -55,6 +55,20 @@ class TestWebsiteEntitiesGet:
         assert data["status"] == "success"
         assert data["id"] == 42
         assert data["entities"] == GROUPED
+        assert data["ner_unavailable_at"] is None
+
+    def test_returns_ner_unavailable_timestamp_when_set(self, client):
+        import datetime as dt
+
+        with patch("server.get_scoped_session", return_value=MagicMock()):
+            with patch("server.WebDocument") as MockDoc:
+                MockDoc.get_by_id.return_value = MagicMock(
+                    ner_unavailable_at=dt.datetime(2026, 7, 15, 6, 44, 0),
+                )
+                with patch("library.entity_service.get_document_entities", return_value=GROUPED):
+                    resp = client.get("/website_entities?id=42", headers=API_HEADERS)
+
+        assert resp.get_json()["ner_unavailable_at"] == "2026-07-15T06:44:00"
 
 
 class TestWebsiteEntitiesRefresh:
@@ -99,6 +113,23 @@ class TestWebsiteEntitiesRefresh:
         mock_persons.assert_called_once_with(session, doc, "# Artykuł o Tusku")
         mock_pipes.assert_called_once_with(session, 42)
         assert session.commit.call_count == 4  # refresh + miejsca + osoby + rurociągi
+
+    def test_ner_service_unavailable_returns_503(self, client):
+        from library.ner_client import NERServiceUnavailable
+
+        doc = MagicMock(text_md="# Artykuł", text=None)
+        session = MagicMock()
+        with patch("server.get_scoped_session", return_value=session):
+            with patch("server.WebDocument") as MockDoc:
+                MockDoc.get_by_id.return_value = doc
+                with patch("library.entity_service.refresh_document_entities",
+                           side_effect=NERServiceUnavailable("boom")):
+                    resp = client.post("/website_entities", data={"id": "42"}, headers=API_HEADERS)
+
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert data["status"] == "error"
+        assert data["ner_unavailable"] is True
 
     def test_place_verification_failure_does_not_fail_request(self, client):
         doc = MagicMock(text_md="# Artykuł", text=None)

--- a/backend/tests/unit/test_ner_client.py
+++ b/backend/tests/unit/test_ner_client.py
@@ -15,6 +15,7 @@ from library.ner_client import (  # noqa: E402
     aggregate_entities_detailed,
     extract_entities,
     extract_entities_strict,
+    is_available,
     NERExtractionError,
     warmup_async,
 )
@@ -25,6 +26,26 @@ def _response(entities):
     resp.json.return_value = {"entities": entities}
     resp.raise_for_status.return_value = None
     return resp
+
+
+class TestIsAvailable:
+    def test_healthy_service_returns_true(self):
+        resp = MagicMock(ok=True)
+        with patch("library.ner_client.requests.get", return_value=resp) as mock_get:
+            with patch("library.ner_client._service_url", return_value="http://ner:8090"):
+                assert is_available() is True
+        assert mock_get.call_args.args[0] == "http://ner:8090/healthz"
+
+    def test_error_status_returns_false(self):
+        resp = MagicMock(ok=False)
+        with patch("library.ner_client.requests.get", return_value=resp):
+            with patch("library.ner_client._service_url", return_value="http://ner:8090"):
+                assert is_available() is False
+
+    def test_unreachable_service_returns_false(self):
+        with patch("library.ner_client.requests.get", side_effect=requests.ConnectionError("boom")):
+            with patch("library.ner_client._service_url", return_value="http://ner:8090"):
+                assert is_available() is False
 
 
 class TestExtractEntities:

--- a/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
+++ b/web_interface_react/src/modules/shared/components/EntitiesPanel/entitiesPanel.tsx
@@ -174,6 +174,10 @@ const EntitiesPanel = ({ docId }: { docId?: string | number }) => {
   const [entities, setEntities] = React.useState<EntitiesByType | null>(null);
   const [isRefreshing, setIsRefreshing] = React.useState(false);
   const [message, setMessage] = React.useState("");
+  // Set when the last NER refresh found ner_service unreachable (backend:
+  // web_documents.ner_unavailable_at) — lets us warn instead of implying
+  // "no entities" when the real cause was a dead service.
+  const [nerUnavailableAt, setNerUnavailableAt] = React.useState<string | null>(null);
   const [editMode, setEditMode] = React.useState(false);
   // "To inna osoba…" flow: chip whose person link is being re-pointed
   const [mergeFor, setMergeFor] = React.useState<EntityItem | null>(null);
@@ -197,7 +201,10 @@ const EntitiesPanel = ({ docId }: { docId?: string | number }) => {
     }
     axios
       .get(`${apiUrl}/website_entities`, { params: { id: docId }, headers })
-      .then((response) => setEntities(response.data.entities))
+      .then((response) => {
+        setEntities(response.data.entities);
+        setNerUnavailableAt(response.data.ner_unavailable_at ?? null);
+      })
       .catch((error) => {
         console.error("Error fetching entities", error);
         setMessage("Nie udało się pobrać encji.");
@@ -230,12 +237,18 @@ const EntitiesPanel = ({ docId }: { docId?: string | number }) => {
         { headers, timeout: 150000 },
       );
       setEntities(response.data.entities);
+      setNerUnavailableAt(null);
       if (response.data.refreshed === 0) {
-        setMessage("Nie wykryto encji (lub serwis NER jest niedostępny).");
+        setMessage("Nie wykryto żadnych osób ani miejsc w tym dokumencie.");
       }
     } catch (error: any) {
       console.error("Error refreshing entities", error);
-      setMessage(`Nie udało się wykryć encji: ${error.response?.data?.message || error.message}`);
+      if (error.response?.data?.ner_unavailable) {
+        setNerUnavailableAt(new Date().toISOString());
+        setMessage("Serwis NER jest niedostępny — spróbuj ponownie za chwilę.");
+      } else {
+        setMessage(`Nie udało się wykryć encji: ${error.response?.data?.message || error.message}`);
+      }
     }
     setIsRefreshing(false);
   };
@@ -399,6 +412,15 @@ const EntitiesPanel = ({ docId }: { docId?: string | number }) => {
           </button>
         )}
       </div>
+      {nerUnavailableAt && (
+        <div style={{
+          marginTop: 8, padding: 8, background: "#fff7ed", border: "1px solid #fdba74",
+          borderRadius: 6, fontSize: "0.85em", color: "#9a3412",
+        }}>
+          ⚠️ Serwis NER był niedostępny ({new Date(nerUnavailableAt).toLocaleString("pl-PL")}) — lista poniżej
+          może być pusta lub niepełna niezależnie od zawartości dokumentu. Spróbuj ponownie za chwilę.
+        </div>
+      )}
       <EntityChips label={"Osoby"} items={persons} actions={editMode ? editActions("persName") : undefined} />
       <EntityChips label={"Miejsca"} items={places} actions={editMode ? editActions("*") : undefined} />
 

--- a/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
+++ b/web_interface_react/src/modules/shared/components/ReaderNotes/readerNotes.tsx
@@ -122,6 +122,18 @@ export function useReaderIdentity(
   return { kind, keyName, isLegacy, user, userId, loading, error, headers, jsonHeaders };
 }
 
+// "TypeError: Failed to fetch" (Chrome/Edge) / "NetworkError when attempting
+// to fetch resource" (Firefox) means the browser could not even open a
+// connection — almost always a local network problem (tryb samolotowy, WiFi,
+// VPN), not a backend or API-key issue. Anything else is a real backend
+// error (bad key, 500, unexpected response shape).
+function friendlyIdentityError(error: string): string {
+  if (/Failed to fetch|NetworkError|Load failed/i.test(error)) {
+    return "Brak połączenia z serwerem — sprawdź internet/Wi-Fi (np. czy nie jest włączony tryb samolotowy) i czy adres backendu jest osiągalny.";
+  }
+  return `Błąd tożsamości klucza API: ${error}`;
+}
+
 /** Read-only reader-identity indicator — replaces the old user-picker/add-user
  *  UI (Etap 8, iter. 2): identity comes from the key, there is nothing to
  *  choose. For non-user keys it explains why progress/notes are absent. */
@@ -129,7 +141,7 @@ export const ReaderIdentityBadge: React.FC<{ identity: ReaderIdentity }> = ({ id
   const { kind, user, loading, error } = identity;
   if (loading) return null;
   if (error) {
-    return <span style={{ fontSize: "0.8em", color: "#b91c1c" }}>Błąd tożsamości klucza API: {error}</span>;
+    return <span style={{ fontSize: "0.8em", color: "#b91c1c" }}>{friendlyIdentityError(error)}</span>;
   }
   if (kind === "user") {
     return (

--- a/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
@@ -104,6 +104,65 @@ const SourceSelect = ({ formik, isLoading, sources }: { formik: any; isLoading: 
   );
 };
 
+// Editor-level author detection: finds the document's most recent analysis
+// run (GET /analysis_runs?doc_id=, sorted newest-first) and asks the LLM to
+// extract a byline from the head+tail of the full document text (no
+// chunk_ids — the per-chunk variant lives in chunks.tsx, where a reviewer
+// can point at one specific chunk instead). Only shown for document types
+// that go through chunk analysis; link documents have no full text to run it on.
+const AUTHOR_EXTRACT_TYPES = ["webpage", "youtube", "movie", "email"];
+
+const AuthorExtractButton = ({
+  formik, isLoading, apiUrl, apiKey,
+}: { formik: any; isLoading: boolean; apiUrl?: string; apiKey?: string }) => {
+  const [busy, setBusy] = React.useState(false);
+  const [status, setStatus] = React.useState<string | null>(null);
+
+  if (!AUTHOR_EXTRACT_TYPES.includes(formik.values.document_type)) return null;
+
+  const handleClick = async () => {
+    if (!formik.values.id) return;
+    setBusy(true);
+    setStatus(null);
+    const headers = { "x-api-key": `${apiKey}` };
+    try {
+      const runsRes = await axios.get(`${apiUrl}/analysis_runs`, {
+        headers, params: { doc_id: formik.values.id },
+      });
+      const runs = runsRes.data.runs ?? [];
+      if (runs.length === 0) {
+        setStatus("Brak analizy chunków dla tego dokumentu — najpierw ją uruchom.");
+        return;
+      }
+      const res = await axios.post(`${apiUrl}/analysis_run/${runs[0].id}/extract_author`, {}, { headers });
+      if (res.data.author) {
+        formik.setFieldValue("author", res.data.author);
+        setStatus(`Ustawiono autora: ${res.data.author}`);
+      } else {
+        setStatus("Nie udało się rozpoznać autora.");
+      }
+    } catch {
+      setStatus("Błąd podczas pobierania autora.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <span style={{ marginLeft: "10px", display: "inline-flex", alignItems: "center", gap: "8px" }}>
+      <button
+        type="button"
+        disabled={isLoading || busy || !formik.values.id}
+        className={"button"}
+        onClick={handleClick}
+      >
+        {busy ? "Pobieram…" : "✍️ Pobierz autora"}
+      </button>
+      {status && <span style={{ fontSize: "0.85em" }}>{status}</span>}
+    </span>
+  );
+};
+
 const SharedInputs = ({
   formik,
   isLoading,
@@ -127,15 +186,20 @@ const SharedInputs = ({
 
   return (
     <>
-      <Input
-        disabled={isLoading}
-        value={formik.values.author}
-        label={"Author"}
-        onChange={formik.handleChange}
-        id={"author"}
-        name={"author"}
-        type={"text"}
-      />
+      <div style={{ display: "flex", alignItems: "flex-end" }}>
+        <div className="flex-grow">
+          <Input
+            disabled={isLoading}
+            value={formik.values.author}
+            label={"Author"}
+            onChange={formik.handleChange}
+            id={"author"}
+            name={"author"}
+            type={"text"}
+          />
+        </div>
+        <AuthorExtractButton formik={formik} isLoading={isLoading} apiUrl={apiUrl} apiKey={apiKey} />
+      </div>
       <div className="flexBox">
         <div className="flex-grow">
           <Input

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -84,6 +84,16 @@ const RUN_STATUS_LABELS: Record<string, string> = {
   reviewed: "zamknięta",
 };
 
+function runLabelText(r: AnalysisRun): string {
+  const parts = [r.mode === "article" ? "artykuł" : "transkrypcja"];
+  if (r.scope) parts.push(r.scope);
+  if (r.temat_count != null && r.temat_count > 0) parts.push(`✓ ${r.approved_count}/${r.temat_count}`);
+  if (r.workflow_stage === "cleanup_proposal") parts.push("propozycja czyszczenia");
+  if (r.workflow_stage === "split_proposal") parts.push("propozycja podziału");
+  parts.push(RUN_STATUS_LABELS[r.status] ?? r.status);
+  return `#${r.id} — ${r.model} (${r.chunk_count} chunków, ${new Date(r.created_at).toLocaleString("pl")}) [${parts.join(", ")}]`;
+}
+
 type ChunkType = "TEMAT" | "REKLAMA" | "SZUM";
 
 interface SplitState {
@@ -132,6 +142,17 @@ const CHUNK_PAGE_SIZE = 20;
 // Document types with an editor route in App.tsx. Types without one
 // (text, text_message, social_media_post) get a back-link to /list instead.
 const EDITOR_TYPES = ["webpage", "link", "youtube", "movie", "email"];
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  webpage: "artykuł",
+  link: "link",
+  youtube: "YouTube",
+  movie: "film",
+  email: "e-mail",
+  text: "tekst",
+  text_message: "wiadomość",
+  social_media_post: "post społecznościowy",
+};
 
 function typeColor(type: string | null): React.CSSProperties {
   switch (type) {
@@ -341,6 +362,7 @@ const Chunks = () => {
   const [segments, setSegments]     = React.useState<Segment[]>([]);
   const [videoId, setVideoId]       = React.useState("");
   const [docType, setDocType]       = React.useState(initialDocType);
+  const [docTitle, setDocTitle]     = React.useState("");
   const [runMode, setRunMode]       = React.useState("transcript");
   const [speakers, setSpeakers]     = React.useState<Speaker[]>([]);
 
@@ -375,6 +397,7 @@ const Chunks = () => {
   const [confirmingSplit, setConfirmingSplit] = React.useState<Record<number, boolean>>({});
   const [extractingSpeakers, setExtractingSpeakers] = React.useState(false);
   const [extractingSpeakerFor, setExtractingSpeakerFor] = React.useState<number | null>(null);
+  const [extractingAuthorFor, setExtractingAuthorFor] = React.useState<number | null>(null);
   const [runStatus, setRunStatus] = React.useState("created");
   const [synthesis, setSynthesis] = React.useState("");
   const [synthesisOpen, setSynthesisOpen] = React.useState(false);
@@ -483,17 +506,19 @@ const Chunks = () => {
   React.useEffect(() => { fetchRuns(); }, [fetchRuns]);
   React.useEffect(() => { if (selectedRun !== null) fetchChunks(selectedRun); }, [selectedRun, fetchChunks]);
   // Direct links to /chunks/:id do not carry router state. Load the document
-  // type so the basic flow can choose article/transcript without user input.
+  // type (so the basic flow can choose article/transcript without user input)
+  // and title (so the page header shows what document this is, not just the id).
   React.useEffect(() => {
-    if (!id || docType) return;
+    if (!id || (docType && docTitle)) return;
     (async () => {
       try {
         const r = await fetch(`${apiUrl}/website_get?id=${id}`, { headers: { "x-api-key": apiKey ?? "" } });
         const data = await r.json();
         if (data.document_type) setDocType(data.document_type);
+        if (data.title) setDocTitle(data.title);
       } catch { /* analysis can still be configured manually */ }
     })();
-  }, [id, docType, apiUrl, apiKey]);
+  }, [id, docType, docTitle, apiUrl, apiKey]);
   // Clean documents (articles, webpages) default to article mode for new analyses
   React.useEffect(() => {
     if (docType && docType !== "youtube" && docType !== "movie") setNewMode("article");
@@ -996,6 +1021,25 @@ const Chunks = () => {
     finally { setExtractingSpeakerFor(null); }
   };
 
+  // Detect the article author (byline) from one specific chunk. Unlike speaker
+  // detection, no position limit — a byline can appear at either the start or
+  // the end of an article. Saves directly to doc.author (backend commits it).
+  const extractAuthorFromChunk = async (chunkId: number) => {
+    if (!selectedRun) return;
+    setExtractingAuthorFor(chunkId);
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/extract_author`, {
+        method: "POST", headers,
+        body: JSON.stringify({ chunk_ids: [chunkId] }),
+      });
+      const data = await r.json();
+      if (data.status === "success" && data.author) setInfo(`Ustawiono autora: ${data.author}`);
+      else if (data.status === "success") setError("Nie udało się rozpoznać autora w tym chunku");
+      else setError("Błąd wykrywania autora: " + (data.message ?? ""));
+    } catch { setError("Błąd połączenia przy wykrywaniu autora"); }
+    finally { setExtractingAuthorFor(null); }
+  };
+
   // ── Embeddings ──
 
   const pollEmbeddingJob = React.useCallback((jid: string) => {
@@ -1238,6 +1282,16 @@ const Chunks = () => {
                   {extractingSpeakerFor === chunk.id ? "🎙 Wykrywam…" : "🎙 Wykryj"}
                 </button>
               )}
+              {runMode === "article" && (
+                <button
+                  onClick={() => extractAuthorFromChunk(chunk.id)}
+                  disabled={extractingAuthorFor === chunk.id}
+                  title="Wykryj autora artykułu (byline) z tego chunka i zapisz go w dokumencie"
+                  style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b" }}
+                >
+                  {extractingAuthorFor === chunk.id ? "✍️ Wykrywam…" : "✍️ Autor"}
+                </button>
+              )}
               {chunk.position < maxPosition && (
                 <button
                   onClick={() => mergeWithNext(chunk)}
@@ -1400,10 +1454,18 @@ const Chunks = () => {
   };
 
 
+  // Any non-reviewed run means there's an analysis in progress — the top
+  // "Rozpocznij analizę" button then starts an unrelated, additional run
+  // rather than continuing it, so it's relabeled to make that explicit.
+  const hasActiveRun = runs.some(r => r.status !== "reviewed");
+
   return (
     <div className={selectedRun !== null ? "chunks-page chunks-page--with-flow" : "chunks-page"}>
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 6, flexWrap: "wrap" }}>
-        <h2 style={{ margin: 0 }}>Przegląd chunków — dokument #{id}</h2>
+        <h2 style={{ margin: 0 }}>
+          Przegląd chunków — {docTitle || `dokument #${id}`}
+          {docType && <span style={{ fontWeight: 400, color: "#64748b", fontSize: "0.7em" }}> ({DOC_TYPE_LABELS[docType] ?? docType}, #{id})</span>}
+        </h2>
         {EDITOR_TYPES.includes(docType) ? (
           <NavLink to={`/${docType}/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>← Edytuj dokument</NavLink>
         ) : (
@@ -1413,19 +1475,33 @@ const Chunks = () => {
         <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
       </div>
 
-      {/* Nowa analiza */}
       <div style={{ margin: "16px 0", padding: "12px 16px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
-        <strong style={{ fontSize: "0.9em" }}>Nowa analiza</strong>
-        <div style={{ display: "flex", gap: 10, marginTop: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
           <span style={{ fontSize: "0.86em", color: "#475569" }}>
             {newMode === "article" ? "Artykuł" : "Transkrypcja"}
             {" · "}{newModel}
-            {splitPreview ? ` · około ${splitPreview.count} ${splitPreview.count === 1 ? "chunk" : "chunków"}` : ""}
-            {newMode === "article" && preclean && !splitOnly ? " · wykrywanie reklam i szumu" : ""}
+            {splitPreview && (
+              <>
+                {` · około ${splitPreview.count} ${splitPreview.count === 1 ? "chunk" : "chunków"}`}
+                {` (${splitPreview.length.toLocaleString("pl")} zn.)`}
+              </>
+            )}
+            {newMode === "article" && preclean && !splitOnly && (
+              <>
+                {" · "}
+                <span
+                  title="Osobny wstępny krok LLM: zanim tekst zostanie podzielony na chunki do recenzji, model oznacza dokładne zakresy reklam i szumu (np. nawigacja, stopka). Propozycja czyszczenia trafia do tego samego runu do zatwierdzenia przed docelowym podziałem."
+                  style={{ borderBottom: "1px dotted #94a3b8", cursor: "help" }}
+                >
+                  wykrywanie reklam i szumu
+                </span>
+              </>
+            )}
           </span>
           <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}
+            title={hasActiveRun ? "Uruchamia dodatkowy, osobny run — nie kontynuuje istniejącej analizy poniżej. Aby ją kontynuować, użyj przycisku w panelu procesu po prawej." : undefined}
             style={{ marginLeft: "auto", fontWeight: 700, padding: "6px 12px" }}>
-            {jobId ? `Analiza… (${jobStatus})` : runs.length > 0 ? "Rozpocznij nową analizę" : "Rozpocznij analizę"}
+            {jobId ? `Analiza… (${jobStatus})` : hasActiveRun ? "+ Nowa analiza" : "▶ Rozpocznij analizę"}
           </button>
         </div>
         <details style={{ marginTop: 9 }}>
@@ -1479,7 +1555,7 @@ const Chunks = () => {
             </span>
           )}
           <button className="button" onClick={() => startAnalysis()} disabled={!!jobId}>
-            {jobId ? `Analiza… (${jobStatus})` : runs.length > 0 ? "Rozpocznij nową analizę z tymi ustawieniami" : "Uruchom z tymi ustawieniami"}
+            {jobId ? `Analiza… (${jobStatus})` : hasActiveRun ? "+ Nowa analiza z tymi ustawieniami" : "▶ Rozpocznij analizę z tymi ustawieniami"}
           </button>
           </div>
         </details>
@@ -1489,19 +1565,15 @@ const Chunks = () => {
       {runs.length > 0 && (
         <div style={{ marginBottom: 12, display: "flex", alignItems: "center", gap: 8 }}>
           <label style={{ fontSize: "0.85em", fontWeight: 600 }}>Analiza: </label>
-          <select value={selectedRun ?? ""} onChange={e => setSelectedRun(Number(e.target.value))} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
-            {runs.map(r => (
-              <option key={r.id} value={r.id}>
-                #{r.id} — {r.model} ({r.chunk_count} chunków, {new Date(r.created_at).toLocaleString("pl")})
-                {" "}[{r.mode === "article" ? "artykuł" : "transkrypcja"}
-                {r.scope ? `, ${r.scope}` : ""}
-                {r.temat_count != null && r.temat_count > 0 ? `, ✓ ${r.approved_count}/${r.temat_count}` : ""}
-                {r.workflow_stage === "cleanup_proposal" ? ", propozycja czyszczenia" : ""}
-                {r.workflow_stage === "split_proposal" ? ", propozycja podziału" : ""}
-                , {RUN_STATUS_LABELS[r.status] ?? r.status}]
-              </option>
-            ))}
-          </select>
+          {runs.length > 1 ? (
+            <select value={selectedRun ?? ""} onChange={e => setSelectedRun(Number(e.target.value))} style={{ padding: "4px 8px", fontSize: "0.88em" }}>
+              {runs.map(r => (
+                <option key={r.id} value={r.id}>{runLabelText(r)}</option>
+              ))}
+            </select>
+          ) : (
+            <span style={{ fontSize: "0.88em" }}>{runLabelText(runs[0])}</span>
+          )}
           <button onClick={deleteRun} title="Usuń wybrany run (chunki i sekcje)"
             style={{ padding: "3px 9px", border: "1px solid #fca5a5", borderRadius: 4, background: "#fff", color: "#b91c1c", cursor: "pointer", fontSize: "0.82em" }}>
             🗑 Usuń run
@@ -1711,8 +1783,11 @@ const Chunks = () => {
         </div>
       )}
 
-      {/* Pasek rozmówców (tylko transkrypcje — artykuły nie mają mówców) */}
-      {selectedRun !== null && runMode !== "article" && (
+      {/* Pasek rozmówców (tylko transkrypcje — artykuły nie mają mówców).
+          Gated on !error too: on a failed fetchChunks() runMode keeps its
+          stale/default value (the catch block never reaches setRunMode), so
+          without this an error banner could still show the transcript-only bar. */}
+      {selectedRun !== null && !error && runMode !== "article" && (
         <div style={{ marginBottom: 12, padding: "8px 14px", background: "#1e3a5f", borderRadius: 6, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
           <strong style={{ color: "#fff", fontSize: "0.85em" }}>Rozmówcy:</strong>
           {speakers.length > 0 ? (

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -327,6 +327,11 @@ const Read: React.FC = () => {
   const [places, setPlaces] = React.useState<PlaceMarker[]>([]);
   const [personItems, setPersonItems] = React.useState<EntityItem[]>([]);
   const [placeItems, setPlaceItems] = React.useState<EntityItem[]>([]);
+  // Set when the last NER refresh found ner_service unreachable (backend:
+  // web_documents.ner_unavailable_at) — distinguishes "service was down" from
+  // "genuinely no persons/places in this document" so the reader can warn
+  // instead of just staying silently empty.
+  const [nerUnavailableAt, setNerUnavailableAt] = React.useState<string | null>(null);
   const [thematicTags, setThematicTags] = React.useState<string[]>([]);
   const [synthesis, setSynthesis] = React.useState<string | null>(null);
   const [informationSources, setInformationSources] = React.useState<InformationSourceLink[]>([]);
@@ -426,6 +431,7 @@ const Read: React.FC = () => {
         const items = [...(data.entities?.geogName ?? []), ...(data.entities?.placeName ?? [])];
         setPersonItems(data.entities?.persName ?? []);
         setPlaceItems(items);
+        setNerUnavailableAt(data.ner_unavailable_at ?? null);
         setPlaces(
           items
             .filter((it: any) => it.verified === true && it.lat != null && it.lon != null)
@@ -984,6 +990,17 @@ const Read: React.FC = () => {
               <React.Suspense fallback={null}>
                 <CountryMap countries={shownCountries} places={shownMarkers} pipelines={shownPipelines} />
               </React.Suspense>
+            )}
+
+            {nerUnavailableAt && (
+              <div style={{
+                background: "#fff7ed", border: "1px solid #fdba74", borderRadius: 8,
+                padding: 10, marginTop: 12, fontSize: "0.85em", color: "#9a3412",
+              }}>
+                ⚠️ Wykrywanie osób i miejsc nie powiodło się — serwis NER był niedostępny
+                ({new Date(nerUnavailableAt).toLocaleString("pl-PL")}). Lista poniżej może być pusta lub niepełna,
+                niekoniecznie dlatego, że w dokumencie nic nie ma. Spróbuj ponownej analizy w edytorze dokumentu.
+              </div>
             )}
 
             {(shownPersons.length > 0 || shownPlaceItems.length > 0) && (


### PR DESCRIPTION
## Summary
- LLM-based article author (byline) detection: new `POST /analysis_run/<id>/extract_author` endpoint (modeled on `extract_speakers`), automatic pipeline fallback in `document_analysis_service` that only fills `doc.author` when empty, "Pobierz autora" button in the document editor and per-chunk "Autor" button in the chunk review UI (`/chunks/:id`).
- NER unavailability warning: `ner_unavailable_at` column on `web_documents`, surfaced as a banner in the reader and entities panel when the NER service was down during the last refresh.
- Chunk review UX fixes: relabels "Rozpocznij analizę" to "+ Nowa analiza" when an unreviewed run already exists, document title+type in the page header, run selector collapses to plain text when there's a single run, settings line shows text length, tooltip on the ad/noise preclean step, transcript speaker bar no longer flashes for article-mode runs on a fetch error.
- `ReaderIdentityBadge` shows a friendly connectivity message instead of a raw fetch exception.

## Test plan
- [x] `pytest backend/tests/unit/` — 1229 passed
- [x] `tsc --noEmit` (web_interface_react) — clean
- [x] `ruff check backend/` — clean on changed files
- [x] Deployed to NAS (192.168.200.7) and manually verified: author detection (per-chunk and whole-document) on a real article, "+ Nowa analiza" relabel on a document with an active run, chunk review UX changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)