### PR TITLE
feat: article quality scoring, photo-caption cleanup, truncation report, chunks/list UX

### DIFF
--- a/backend/alembic/versions/a5b6c7d8e9f0_add_article_truncated_error_type.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_add_article_truncated_error_type.py
@@ -1,0 +1,29 @@
+"""add ARTICLE_TRUNCATED to document_status_error_types
+
+Revision ID: a5b6c7d8e9f0
+Revises: f4a5b6c7d8e9
+Create Date: 2026-07-16 10:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a5b6c7d8e9f0"
+down_revision: Union[str, None] = "f4a5b6c7d8e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "INSERT INTO public.document_status_error_types (name) "
+        "VALUES ('ARTICLE_TRUNCATED') ON CONFLICT (name) DO NOTHING"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE public.web_documents SET document_state_error = 'NONE' "
+        "WHERE document_state_error = 'ARTICLE_TRUNCATED'"
+    )
+    op.execute("DELETE FROM public.document_status_error_types WHERE name = 'ARTICLE_TRUNCATED'")

--- a/backend/alembic/versions/f4a5b6c7d8e9_add_quality_to_web_documents.py
+++ b/backend/alembic/versions/f4a5b6c7d8e9_add_quality_to_web_documents.py
@@ -1,0 +1,22 @@
+"""add quality to web_documents
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-07-16 10:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f4a5b6c7d8e9"
+down_revision: Union[str, None] = "e3f4a5b6c7d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS quality JSONB")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE web_documents DROP COLUMN IF EXISTS quality")

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -12,6 +12,7 @@ i reużywalna w skryptach batch.
 import re
 
 from library.article_extractor import _detect_portal, _find_footer_line, _find_start_line
+from library.article_quality import is_photo_caption_line
 from library.lenie_markdown import links_correct, md_square_brackets_in_one_line
 
 
@@ -134,6 +135,11 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
             continue
         # "Czytaj także:" + link na tej samej lub następnej linii
         if stripped.startswith("**Czytaj także:**") or stripped.startswith("**Czytaj również:**"):
+            continue
+
+        # Podpis zdjęcia / credit fotografa ("zdjęcie ilustracyjne ... / shutterstock")
+        # — wzorce współdzielone z article_quality (tam liczone do oceny staranności)
+        if is_photo_caption_line(stripped):
             continue
 
         # Linia z samymi [imgN] markerami (osierocone po usunięciu kontekstu)

--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -40,6 +40,10 @@ _CAPTION_AGENCY_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Podpis bywa dłuższy niż _CAPTION_MAX_CHARS, ale linia KOŃCZĄCA SIĘ
+# "(zdjęcie ilustracyjne)" to zawsze podpis, niezależnie od długości.
+_CAPTION_SUFFIX_RE = re.compile(r"\(zdj[eę]cie\s+ilustracyjne\)\s*$", re.IGNORECASE)
+
 _CLICKBAIT_RE = re.compile(
     r"(?:nie uwierzysz|szok(?:uj[aą]c\w*)?\b|musisz to zobaczy[ćc]|zobacz,? co|"
     r"a[żz] trudno uwierzy[ćc]|to zmieni (?:tw[oó]j|wszystko)|jednym trikiem|"
@@ -52,7 +56,11 @@ def is_photo_caption_line(line: str) -> bool:
     """Czy linia jest podpisem zdjęcia / creditem fotografa (np.
     "zdjęcie ilustracyjne, Dmytro Buiansky / shutterstock")?"""
     stripped = line.strip()
-    if not stripped or len(stripped) > _CAPTION_MAX_CHARS:
+    if not stripped:
+        return False
+    if _CAPTION_SUFFIX_RE.search(stripped):
+        return True
+    if len(stripped) > _CAPTION_MAX_CHARS:
         return False
     # Usuń markery [imgN] — podpis często sąsiaduje z markerem obrazka
     bare = re.sub(r"\[img\d+(?::[^\]]*)?\]", "", stripped).strip()

--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -1,0 +1,162 @@
+"""Ocena staranności ("quality") artykułu + wykrywanie podpisów zdjęć.
+
+Dwie warstwy:
+- deterministyczne kary (bez LLM): podpisy zdjęć / stockowe credity, brak
+  autora, udział REKLAMA/SZUM w analizowanym tekście, bardzo krótki tekst,
+  clickbaitowy tytuł,
+- rubryka LLM (jedno wywołanie): źródła / głębia / język, każdy wymiar 0-5.
+
+Wynik (0-100, im wyżej tym staranniej) trafia do web_documents.quality (JSONB).
+Wykrywanie podpisów zdjęć jest współdzielone z article_cleaner (usuwanie linii)
+— jedna definicja wzorców dla czyszczenia i punktacji.
+"""
+
+import datetime
+import json
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+RUBRIC_MAX_TOKENS = 300
+RUBRIC_INPUT_CHARS = 6_000
+SHORT_TEXT_CHARS = 1_500
+
+# Podpis zdjęcia to KRÓTKA linia — dłuższe akapity wspominające o fotografii
+# to treść merytoryczna, nie credit.
+_CAPTION_MAX_CHARS = 120
+
+# Linie zaczynające się od typowego prefiksu creditu
+_CAPTION_PREFIX_RE = re.compile(
+    r"^\s*(?:\*{1,2}|_)?\s*(?:fot\.|foto:|zdj[eę]cie:|zdj\.|źród[łl]o\s+zdj[eę]cia|autor\s+zdj[eę]cia)",
+    re.IGNORECASE,
+)
+
+# Sygnaly stockowe/agencyjne w dowolnym miejscu krótkiej linii
+_CAPTION_AGENCY_RE = re.compile(
+    r"(?:zdj[eę]cie\s+ilustracyjne|shutterstock|getty\s*images?|east\s+news|"
+    r"adobe\s+stock|istock(?:photo)?|depositphotos|123rf|unsplash|pexels|"
+    r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bForum\b\s*/|/\s*Forum\b)",
+    re.IGNORECASE,
+)
+
+_CLICKBAIT_RE = re.compile(
+    r"(?:nie uwierzysz|szok(?:uj[aą]c\w*)?\b|musisz to zobaczy[ćc]|zobacz,? co|"
+    r"a[żz] trudno uwierzy[ćc]|to zmieni (?:tw[oó]j|wszystko)|jednym trikiem|"
+    r"zdradzi[łl]a? sekret|internauci oszaleli|wszyscy o (?:tym|niej|nim) m[oó]wi[aą])",
+    re.IGNORECASE,
+)
+
+
+def is_photo_caption_line(line: str) -> bool:
+    """Czy linia jest podpisem zdjęcia / creditem fotografa (np.
+    "zdjęcie ilustracyjne, Dmytro Buiansky / shutterstock")?"""
+    stripped = line.strip()
+    if not stripped or len(stripped) > _CAPTION_MAX_CHARS:
+        return False
+    # Usuń markery [imgN] — podpis często sąsiaduje z markerem obrazka
+    bare = re.sub(r"\[img\d+(?::[^\]]*)?\]", "", stripped).strip()
+    if not bare:
+        return False
+    return bool(_CAPTION_PREFIX_RE.match(bare) or _CAPTION_AGENCY_RE.search(bare))
+
+
+def count_photo_captions(text: str) -> int:
+    """Liczba linii-podpisów zdjęć w tekście (sygnał do oceny staranności)."""
+    if not text:
+        return 0
+    return sum(1 for line in text.splitlines() if is_photo_caption_line(line))
+
+
+def is_clickbait_title(title: str | None) -> bool:
+    return bool(title and _CLICKBAIT_RE.search(title))
+
+
+def _llm_rubric(text: str, model: str) -> dict | None:
+    """Jedno wywołanie LLM: oceny 0-5 w trzech wymiarach staranności.
+
+    Zwraca {"zrodla": n, "glebia": n, "jezyk": n, "uzasadnienie": "..."}
+    albo None, gdy wywołanie/parsowanie się nie powiedzie.
+    """
+    from library.chunk_llm_analysis import call_model
+
+    prompt = f"""Oceń staranność poniższego artykułu w trzech wymiarach, każdy w skali 0-5:
+- "zrodla": czy autor powołuje się na konkretne źródła (dokumenty, dane, ekspertów z nazwiska), czy tylko ogólniki typu "media donoszą",
+- "glebia": czy tekst zawiera własną analizę i kontekst, czy jest przepisaną notką/depeszą,
+- "jezyk": poprawność i staranność językowa.
+
+Zwróć TYLKO obiekt JSON bez dodatkowego tekstu:
+{{"zrodla": 0, "glebia": 0, "jezyk": 0, "uzasadnienie": "1-2 zdania"}}
+
+--- ARTYKUŁ ---
+{text[:RUBRIC_INPUT_CHARS]}
+--- KONIEC ---"""
+    try:
+        raw, _ = call_model(prompt, model, RUBRIC_MAX_TOKENS)
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            return None
+        data = json.loads(match.group())
+        rubric = {}
+        for key in ("zrodla", "glebia", "jezyk"):
+            rubric[key] = max(0, min(5, int(data.get(key, 0))))
+        rubric["uzasadnienie"] = str(data.get("uzasadnienie") or "")[:500]
+        return rubric
+    except Exception:
+        logger.exception("LLM quality rubric failed")
+        return None
+
+
+def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -> dict:
+    """Policz ocenę staranności dokumentu na podstawie chunków z analizy.
+
+    chunk_sections: [{"type": "TEMAT|REKLAMA|SZUM", "original": "tekst"}, ...]
+    model: model LLM do rubryki; None = tylko kary deterministyczne.
+
+    Wynik: {"score": 0-100, "penalties": {...}, "signals": {...},
+            "llm_rubric": {...}|None, "model": ..., "computed_at": ISO}
+    """
+    temat_text = "\n".join(
+        (s.get("original") or "") for s in chunk_sections if s.get("type") == "TEMAT"
+    )
+    noise_len = sum(
+        len(s.get("original") or "") for s in chunk_sections if s.get("type") != "TEMAT"
+    )
+    total_len = len(temat_text) + noise_len
+
+    full_text = "\n".join((s.get("original") or "") for s in chunk_sections)
+    captions = count_photo_captions(full_text)
+    noise_share = (noise_len / total_len) if total_len else 0.0
+
+    penalties: dict[str, int] = {}
+    if captions:
+        penalties["photo_captions"] = min(15, 5 * captions)
+    if not (getattr(doc, "author", None) or "").strip():
+        penalties["missing_author"] = 10
+    if noise_share > 0:
+        penalties["noise_share"] = min(20, round(noise_share * 50))
+    if len(temat_text.strip()) < SHORT_TEXT_CHARS:
+        penalties["short_text"] = 10
+    if is_clickbait_title(getattr(doc, "title", None)):
+        penalties["clickbait_title"] = 5
+
+    rubric = None
+    if model and temat_text.strip():
+        rubric = _llm_rubric(temat_text, model)
+        if rubric:
+            rubric_sum = rubric["zrodla"] + rubric["glebia"] + rubric["jezyk"]
+            penalties["llm_rubric"] = (15 - rubric_sum) * 2  # 0-30
+
+    score = max(0, 100 - sum(penalties.values()))
+    return {
+        "score": score,
+        "penalties": penalties,
+        "signals": {
+            "photo_captions": captions,
+            "noise_share": round(noise_share, 3),
+            "temat_chars": len(temat_text),
+        },
+        "llm_rubric": rubric,
+        "model": model if rubric else None,
+        "computed_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -75,7 +75,9 @@ def propose_article_cleanup(text: str, model: str, max_chars: int = 12_000) -> l
         prompt = f"""Oceń linie surowego artykułu PRZED jego podziałem na fragmenty.
 Wskaż wyłącznie zakresy, które należy wykluczyć:
 - REKLAMA: sponsor, afiliacja, autopromocja, newsletter lub CTA,
-- SZUM: menu, stopka, cookies, nawigacja, lista linków, podpis techniczny.
+- SZUM: menu, stopka, cookies, nawigacja, lista linków, podpis techniczny,
+  podpis pod zdjęciem / credit fotografa (np. "zdjęcie ilustracyjne", "fot. ...",
+  shutterstock, Getty, East News, PAP).
 Nie oznaczaj jako szum nagłówków ani krótkich merytorycznych akapitów.
 Zwróć TYLKO JSON: [{{"start_line": 2, "end_line": 4, "type": "SZUM", "reason": "lista linków"}}].
 Gdy nic nie trzeba wykluczyć, zwróć [].
@@ -363,7 +365,8 @@ W PIERWSZEJ LINII wpisz etykietę (tylko jedną z trzech opcji):
    ### TEMAT: <temat>        (merytoryczna treść dokumentu)
    ### REKLAMA: <opis>       (treść reklamowa lub sponsorska)
    ### SZUM: <opis>          (szum techniczny strony: nawigacja portalu, menu, stopka,
-                              cookie/zgody, listy linków "przeczytaj też", przyciski udostępniania)
+                              cookie/zgody, listy linków "przeczytaj też", przyciski udostępniania,
+                              podpisy zdjęć i credity fotografów, np. "zdjęcie ilustracyjne")
 W miejsce <temat>/<opis> wpisz KONKRETNY temat tego fragmentu w 3-5 słowach —
 nie przepisuj dosłownie tekstu "<temat>" ani nazwy etykiety.
 Jeśli fragment miesza szum z treścią merytoryczną — wybierz TEMAT.

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -862,10 +862,12 @@ def get_run_chunks(run_id: int):
         "document": {
             "id": doc.id if doc else None,
             "title": doc.title if doc else "",
+            "url": doc.url if doc else "",
             "original_id": doc.original_id if doc else "",
             "document_type": doc.document_type if doc else "",
             "countries": doc_countries,
             "thematic_tags": doc_thematic_tags,
+            "quality": doc.quality if doc else None,
         },
         "segments": segments,
         "lite": lite,
@@ -1254,6 +1256,104 @@ def extract_author(run_id: int):
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
     return jsonify({"status": "success", "author": author})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /document/<doc_id>/quality
+# ---------------------------------------------------------------------------
+
+@bp.route("/document/<int:doc_id>/quality", methods=["POST"])
+def compute_document_quality(doc_id: int):
+    """(Re)compute the article quality ("staranność") score on demand.
+
+    Body (optional JSON): {"run_id": N} — which analysis run's chunks to score;
+    defaults to the document's newest run. Deterministic penalties + one LLM
+    rubric call with the run's model (library/article_quality.py). Saves the
+    result to web_documents.quality and returns it.
+    """
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    run_id = data.get("run_id")
+    if run_id is not None:
+        run = session.get(DocumentAnalysisRun, run_id)
+        if run is None or run.document_id != doc_id:
+            return jsonify({"status": "error",
+                            "message": f"Run {run_id} not found for document {doc_id}"}), 404
+    else:
+        run = session.scalars(
+            select(DocumentAnalysisRun)
+            .where(DocumentAnalysisRun.document_id == doc_id)
+            .order_by(DocumentAnalysisRun.id.desc())
+        ).first()
+        if run is None:
+            return jsonify({"status": "error",
+                            "message": "No analysis run — run chunk analysis first"}), 400
+
+    chunks = session.scalars(
+        select(DocumentChunk)
+        .where(DocumentChunk.run_id == run.id)
+        .order_by(DocumentChunk.position)
+    ).all()
+    if not chunks:
+        return jsonify({"status": "error", "message": f"Run {run.id} has no chunks"}), 400
+
+    sections = [
+        {"type": c.type, "original": c.corrected_text or c.original_text or ""}
+        for c in chunks
+    ]
+    try:
+        from library.article_quality import compute_quality
+        doc.quality = compute_quality(doc, sections, model=run.model)
+    except Exception:
+        logger.exception("quality computation failed for document %d", doc_id)
+        return jsonify({"status": "error", "message": "Quality computation failed"}), 500
+
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for document %d quality", doc_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "run_id": run.id, "quality": doc.quality})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /document/<doc_id>/report_extraction_issue
+# ---------------------------------------------------------------------------
+
+@bp.route("/document/<int:doc_id>/report_extraction_issue", methods=["POST"])
+def report_extraction_issue(doc_id: int):
+    """Reviewer-reported flag: the extracted article text is truncated or wrong
+    compared with the original page.
+
+    Sets document_state=NEED_MANUAL_REVIEW + document_state_error=ARTICLE_TRUNCATED,
+    so the document lands in the default manual-review queue on the list page
+    and the error is visible next to its state.
+    """
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    doc.document_state = "NEED_MANUAL_REVIEW"
+    doc.document_state_error = "ARTICLE_TRUNCATED"
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed reporting extraction issue for document %d", doc_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({
+        "status": "success",
+        "document_state": doc.document_state,
+        "document_state_error": doc.document_state_error,
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -258,6 +258,12 @@ class WebDocument(Base):
     # silently empty. Cleared on the next successful refresh (found or not).
     ner_unavailable_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
 
+    # Article quality ("staranność") assessment — JSONB: score 0-100, per-signal
+    # penalties (photo captions, missing author, noise share, ...) and the LLM
+    # rubric. Computed by library/article_quality.py at the end of an article-mode
+    # analysis run, or on demand via POST /document/<id>/quality.
+    quality: Mapped[dict | None] = mapped_column(JSONB)
+
     # Lookup-table relationships (many-to-one)
     document_type_ref: Mapped["DocumentType"] = relationship(
         foreign_keys=[document_type],
@@ -428,6 +434,7 @@ class WebDocument(Base):
             "transcript_needed": self.transcript_needed,
             "reviewed_at": self.reviewed_at.isoformat() if self.reviewed_at else None,
             "obsidian_note_paths": self.obsidian_note_paths or [],
+            "quality": self.quality,
         }
 
 

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -570,6 +570,20 @@ class DocumentAnalysisService:
                 except Exception:
                     logger.exception("author extraction failed, continuing without author")
 
+            # 11f. Article quality ("staranność") scoring — deterministic
+            #      penalties + one LLM rubric call (library/article_quality.py).
+            #      Whole-document article runs only: a transcript or a single
+            #      chapter is not a fair sample of the article's care.
+            if not is_transcript and scope is None:
+                try:
+                    from library.article_quality import compute_quality
+
+                    doc.quality = compute_quality(doc, sections, model=model)
+                    log(f"quality: {doc.quality['score']}/100 "
+                        f"(penalties: {doc.quality['penalties'] or '-'})")
+                except Exception:
+                    logger.exception("quality scoring failed, continuing without quality")
+
         # 11c. NER entities (persons/places) on the full document text — offline
         #      (no LLM), stored in document_entities with replace semantics, so
         #      chapter-scoped runs skip it (a single chapter's entities must not

--- a/backend/library/models/stalker_document_status_error.py
+++ b/backend/library/models/stalker_document_status_error.py
@@ -24,4 +24,7 @@ class StalkerDocumentStatusError(Enum):
     CAPTIONS_FETCH_ERROR = 17
     TRANSCRIPTION_ERROR = 18
     TRANSCRIPTION_INSUFFICIENT_FUNDS = 19
+    # Reviewer-reported: extracted article text is truncated/wrong vs the
+    # original page (POST /document/<id>/report_extraction_issue)
+    ARTICLE_TRUNCATED = 20
 

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -39,6 +39,13 @@ class TestPhotoCaptionDetection:
     def test_zrodlo_zdjecia(self):
         assert is_photo_caption_line("Źródło zdjęcia: Unsplash")
 
+    def test_long_caption_ending_with_zdjecie_ilustracyjne(self):
+        line = (
+            "Chiński rząd nakazał zaprzestanie produkcji aut ośmiu firmom. "
+            "Niektóre były pionierami chińskiej motoryzacji (zdjęcie ilustracyjne)"
+        )
+        assert is_photo_caption_line(line)
+
     def test_long_paragraph_mentioning_photo_is_not_caption(self):
         text = (
             "Na opublikowanym przez agencję zdjęciu widać skutki wybuchu, a fotograf "

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -1,0 +1,138 @@
+"""Unit tests for library.article_quality — photo-caption detection and
+deterministic quality ("staranność") scoring.
+
+Pure-function tests, no DB/LLM/network (compute_quality tested with model=None).
+"""
+
+from library.article_quality import (
+    compute_quality,
+    count_photo_captions,
+    is_clickbait_title,
+    is_photo_caption_line,
+)
+
+LONG_PARAGRAPH = (
+    "To jest długi akapit właściwej treści artykułu, w którym autor rzetelnie "
+    "opisuje temat, cytuje ekspertów i przywołuje dane z oficjalnych raportów."
+)
+
+
+class _Doc:
+    def __init__(self, author=None, title=None):
+        self.author = author
+        self.title = title
+
+
+class TestPhotoCaptionDetection:
+    def test_zdjecie_ilustracyjne_with_stock_credit(self):
+        assert is_photo_caption_line("zdjęcie ilustracyjne, Dmytro Buiansky / shutterstock")
+
+    def test_fot_prefix(self):
+        assert is_photo_caption_line("Fot. Jan Kowalski / PAP")
+
+    def test_agency_only_line(self):
+        assert is_photo_caption_line("Getty Images")
+
+    def test_caption_next_to_img_marker(self):
+        assert is_photo_caption_line("[img3] Zdjęcie ilustracyjne / East News")
+
+    def test_zrodlo_zdjecia(self):
+        assert is_photo_caption_line("Źródło zdjęcia: Unsplash")
+
+    def test_long_paragraph_mentioning_photo_is_not_caption(self):
+        text = (
+            "Na opublikowanym przez agencję zdjęciu widać skutki wybuchu, a fotograf "
+            "Reuters relacjonował wydarzenia z centrum miasta przez kilka kolejnych dni, "
+            "dokumentując życie mieszkańców po ostrzale."
+        )
+        assert not is_photo_caption_line(text)
+
+    def test_regular_sentence_is_not_caption(self):
+        assert not is_photo_caption_line(LONG_PARAGRAPH[:100])
+
+    def test_empty_line(self):
+        assert not is_photo_caption_line("")
+
+    def test_count_in_text(self):
+        text = "\n".join([
+            LONG_PARAGRAPH,
+            "zdjęcie ilustracyjne, Dmytro Buiansky / shutterstock",
+            LONG_PARAGRAPH,
+            "Fot. Adam Nowak / East News",
+        ])
+        assert count_photo_captions(text) == 2
+
+    def test_count_empty_text(self):
+        assert count_photo_captions("") == 0
+
+
+class TestClickbaitTitle:
+    def test_clickbait(self):
+        assert is_clickbait_title("Nie uwierzysz, co zrobił ten polityk")
+        assert is_clickbait_title("Szokujące odkrycie naukowców")
+
+    def test_normal_title(self):
+        assert not is_clickbait_title("Rząd przyjął nowelizację ustawy o OZE")
+
+    def test_none_title(self):
+        assert not is_clickbait_title(None)
+
+
+class TestComputeQuality:
+    def _sections(self, temat=6, noise=0):
+        secs = [{"type": "TEMAT", "original": LONG_PARAGRAPH * 3} for _ in range(temat)]
+        secs += [{"type": "SZUM", "original": "Menu | Kontakt | Regulamin"} for _ in range(noise)]
+        return secs
+
+    def test_clean_article_scores_100(self):
+        doc = _Doc(author="Jan Kowalski", title="Rzetelny tytuł artykułu")
+        q = compute_quality(doc, self._sections(), model=None)
+        assert q["score"] == 100
+        assert q["penalties"] == {}
+        assert q["llm_rubric"] is None
+
+    def test_missing_author_penalty(self):
+        q = compute_quality(_Doc(title="Tytuł"), self._sections(), model=None)
+        assert q["penalties"]["missing_author"] == 10
+        assert q["score"] == 90
+
+    def test_photo_caption_penalty_capped(self):
+        captions = "\n".join(["Fot. X / shutterstock"] * 5)
+        secs = self._sections() + [{"type": "TEMAT", "original": captions}]
+        q = compute_quality(_Doc(author="A", title="T"), secs, model=None)
+        assert q["penalties"]["photo_captions"] == 15  # cap, nie 25
+        assert q["signals"]["photo_captions"] == 5
+
+    def test_noise_share_penalty(self):
+        secs = [
+            {"type": "TEMAT", "original": "a" * 6000},
+            {"type": "SZUM", "original": "b" * 2000},
+            {"type": "REKLAMA", "original": "c" * 2000},
+        ]
+        q = compute_quality(_Doc(author="A", title="T"), secs, model=None)
+        # 4000/10000 = 40% szumu → kara 20 (cap)
+        assert q["penalties"]["noise_share"] == 20
+        assert q["signals"]["noise_share"] == 0.4
+
+    def test_short_text_penalty(self):
+        secs = [{"type": "TEMAT", "original": "Krótka notka."}]
+        q = compute_quality(_Doc(author="A", title="T"), secs, model=None)
+        assert q["penalties"]["short_text"] == 10
+
+    def test_clickbait_title_penalty(self):
+        doc = _Doc(author="A", title="Nie uwierzysz, co się stało")
+        q = compute_quality(doc, self._sections(), model=None)
+        assert q["penalties"]["clickbait_title"] == 5
+
+    def test_score_never_negative(self):
+        secs = [
+            {"type": "TEMAT", "original": "Fot. A / shutterstock\nFot. B / getty\nFot. C / PAP"},
+            {"type": "SZUM", "original": "x" * 100000},
+        ]
+        q = compute_quality(_Doc(title="Szokujące! Nie uwierzysz"), secs, model=None)
+        assert q["score"] >= 0
+
+    def test_result_shape(self):
+        q = compute_quality(_Doc(author="A", title="T"), self._sections(), model=None)
+        assert set(q) == {"score", "penalties", "signals", "llm_rubric", "model", "computed_at"}
+        assert q["model"] is None

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -161,10 +161,11 @@ class TestWebDocumentColumns:
         "author", "note", "uuid", "project", "text_md",
         "text_extracted", "transcript_needed", "reviewed_at",
         "obsidian_note_paths", "video_description", "ner_unavailable_at",
+        "quality",
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebDocument)) == 31
+        assert len(_column_names(WebDocument)) == 32
 
     def test_all_column_names(self):
         assert _column_names(WebDocument) == self.EXPECTED_COLUMNS
@@ -496,14 +497,14 @@ class TestValidate:
 # ---------------------------------------------------------------------------
 
 class TestDict:
-    def test_dict_has_33_keys(self):
+    def test_dict_has_34_keys(self):
         doc = _make_doc(
             title="Test",
             document_state_error="NONE",
         )
         doc.created_at = datetime.datetime(2025, 1, 15, 10, 30, 0)
         result = doc.dict()
-        assert len(result) == 33
+        assert len(result) == 34
 
     def test_dict_keys(self):
         doc = _make_doc(
@@ -521,6 +522,7 @@ class TestDict:
             "ai_summary_needed", "author", "note", "uuid", "project",
             "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
+            "quality",
         }
         assert set(result.keys()) == expected_keys
 

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -40,6 +40,7 @@ class FakeBookDoc:
     tags = "geopolityka,kraj-polska,kraj-niemcy"
     document_type = "text"
     url = None
+    quality = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_orm_crud.py
+++ b/backend/tests/unit/test_orm_crud.py
@@ -429,6 +429,7 @@ class TestDictCompatibility:
             "text_raw", "transcript_job_id", "ai_summary_needed", "author",
             "note", "uuid", "project", "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
+            "quality",
         }
         assert set(d.keys()) == expected_keys
 

--- a/web_interface_react/src/modules/shared/context/authorizationContext.tsx
+++ b/web_interface_react/src/modules/shared/context/authorizationContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect } from "react";
 import type { ApiType, AuthorizationState } from "../../../types";
-import { loadConnectionConfig, saveConnectionConfig } from "../services/storage";
+import { loadConnectionConfig, saveConnectionConfig, loadListFilters, saveListFilters } from "../services/storage";
 
 export const AuthorizationContext = createContext<AuthorizationState>({
   apiKey: undefined,
@@ -22,14 +22,15 @@ export const AuthorizationContext = createContext<AuthorizationState>({
 const AuthorizationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Lazy init from localStorage
   const saved = loadConnectionConfig();
+  const savedFilters = loadListFilters();
 
   const [apiKey, setApiKey] = React.useState<string | undefined>(saved.apiKey);
   const [apiType, setApiType] = React.useState<ApiType>(saved.apiType);
   const [apiUrl, setApiUrl] = React.useState(saved.apiUrl);
-  const [selectedDocumentType, setSelectedDocumentType] = React.useState("link");
-  const [selectedDocumentState, setSelectedDocumentState] = React.useState("NEED_MANUAL_REVIEW");
-  const [searchInDocument, setSearchInDocument] = React.useState("");
-  const [searchType, setSearchType] = React.useState("strict");
+  const [selectedDocumentType, setSelectedDocumentType] = React.useState(savedFilters.documentType);
+  const [selectedDocumentState, setSelectedDocumentState] = React.useState(savedFilters.documentState);
+  const [searchInDocument, setSearchInDocument] = React.useState(savedFilters.searchText);
+  const [searchType, setSearchType] = React.useState(savedFilters.searchType);
 
   // Sync connection config changes to localStorage
   useEffect(() => {
@@ -41,6 +42,16 @@ const AuthorizationProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       });
     }
   }, [apiType, apiUrl, apiKey]);
+
+  // Persist list filters so a page reload doesn't reset the user's selections
+  useEffect(() => {
+    saveListFilters({
+      documentType: selectedDocumentType,
+      documentState: selectedDocumentState,
+      searchText: searchInDocument,
+      searchType,
+    });
+  }, [selectedDocumentType, selectedDocumentState, searchInDocument, searchType]);
 
   return (
     <AuthorizationContext.Provider

--- a/web_interface_react/src/modules/shared/hooks/useList.ts
+++ b/web_interface_react/src/modules/shared/hooks/useList.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import React from "react";
 import { AuthorizationContext } from "../context/authorizationContext";
+import { loadListFilters } from "../services/storage";
 
 export const useList = () => {
   const [data, setData] = React.useState<any[] | null>(null);
@@ -9,10 +10,16 @@ export const useList = () => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [isError, setIsError] = React.useState(false);
   const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
-  const { selectedDocumentType, selectedDocumentState} = React.useContext(AuthorizationContext);
+  const { selectedDocumentType, selectedDocumentState, searchInDocument } = React.useContext(AuthorizationContext);
 
   React.useEffect(() => {
-    handleGetList(selectedDocumentType, selectedDocumentState).then(() => null);
+    // Initial load reuses all persisted filters (incl. the list-local Obsidian
+    // filter), so a page reload shows the same results the user was browsing.
+    const { obsidianFilter } = loadListFilters();
+    handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument, {
+      onlyMissing: obsidianFilter === "missing",
+      onlyHas: obsidianFilter === "has",
+    }).then(() => null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -1094,6 +1094,10 @@ const Chunks = () => {
   const embeddedCount = tematChunks.filter(c => c.has_embeddings === true).length;
   const reviewReady = tematChunks.length > 0 && unapprovedTematCount === 0 && chunksToAnalyze.length === 0;
   const workflowBusy = !!jobId || reanalyzingAll || approvingAll || !!embedJobId;
+  const analyzedTematCount = tematChunks.filter(c => c.summary).length;
+  // Preclean leaves REKLAMA/SZUM chunks behind; a clean article leaves none,
+  // so once the LLM analysis produced summaries the detection step is also done.
+  const noiseMarkingDone = reklamaCount > 0 || analyzedTematCount > 0 || runStatus === "reviewed";
 
   // ── User notes: match notes to chunks of the selected run ──
   // Direct match by chunk_id; reader notes (or notes from other runs) fall back
@@ -1610,23 +1614,59 @@ const Chunks = () => {
             {workflowBusy && <span style={{ fontSize: "0.82em", color: "#0369a1" }}>Przetwarzanie…</span>}
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
-            {[
+            {([
               {
                 label: "1. Analiza chunków",
                 done: chunksToAnalyze.length === 0,
                 detail: chunksToAnalyze.length > 0 ? `${chunksToAnalyze.length} wymaga analizy` : `${tematChunks.length} treści TEMAT`,
+                subs: [
+                  {
+                    label: "Podział na chunki",
+                    done: chunkTotal > 0,
+                    detail: chunkTotal > 0 ? `${chunkTotal} chunków` : "brak chunków",
+                  },
+                  ...(runMode === "article" ? [{
+                    label: "Wykrywanie reklam i szumu",
+                    done: noiseMarkingDone,
+                    detail: reklamaCount > 0 ? `${reklamaCount} REKLAMA/SZUM` : noiseMarkingDone ? "nie wykryto" : "oczekuje",
+                  }] : []),
+                  {
+                    label: "Analiza LLM (tematy i streszczenia)",
+                    done: tematChunks.length > 0 && chunksToAnalyze.length === 0 && analyzedTematCount > 0,
+                    detail: `${analyzedTematCount}/${tematChunks.length} przeanalizowanych`,
+                  },
+                ],
               },
               {
                 label: "2. Przegląd i akceptacja",
                 done: reviewReady || runStatus === "reviewed",
                 detail: `${approvedCount}/${tematChunks.length} zatwierdzonych`,
+                subs: [
+                  {
+                    label: "Zatwierdzenie chunków TEMAT",
+                    done: tematChunks.length > 0 && unapprovedTematCount === 0,
+                    detail: `${approvedCount}/${tematChunks.length}`,
+                  },
+                  {
+                    label: "Zamknięcie review",
+                    done: runStatus === "reviewed",
+                    detail: RUN_STATUS_LABELS[runStatus] ?? runStatus,
+                  },
+                ],
               },
               {
                 label: "3. Embeddingi",
                 done: runStatus === "reviewed" && embeddedCount > 0 && !embedJobId,
                 detail: embedJobId ? `generowanie: ${embedJobStatus}` : embeddedCount > 0 ? `${embeddedCount} chunków w indeksie` : "uruchomią się po zamknięciu",
+                subs: [
+                  {
+                    label: "Generowanie embeddingów",
+                    done: embeddedCount > 0 && !embedJobId,
+                    detail: embedJobId ? `w toku: ${embedJobStatus}` : `${embeddedCount}/${approvedCount} zatwierdzonych w indeksie`,
+                  },
+                ],
               },
-            ].map(step => (
+            ] as { label: string; done: boolean; detail: string; subs: { label: string; done: boolean; detail: string }[] }[]).map(step => (
               <div key={step.label} style={{
                 padding: "10px 12px", borderRadius: 7,
                 border: `1px solid ${step.done ? "#86efac" : "#e2e8f0"}`,
@@ -1636,6 +1676,17 @@ const Chunks = () => {
                   {step.done ? "✓ " : ""}{step.label}
                 </div>
                 <div style={{ marginTop: 3, fontSize: "0.78em", color: "#64748b" }}>{step.detail}</div>
+                <div style={{ marginTop: 6, display: "grid", gap: 3, paddingLeft: 2 }}>
+                  {step.subs.map(sub => (
+                    <div key={sub.label} style={{ display: "flex", gap: 6, fontSize: "0.76em", alignItems: "baseline" }}>
+                      <span style={{ color: sub.done ? "#15803d" : "#94a3b8", fontWeight: 700, minWidth: 11 }}>
+                        {sub.done ? "✓" : "○"}
+                      </span>
+                      <span style={{ color: sub.done ? "#15803d" : "#475569" }}>{sub.label}</span>
+                      <span style={{ color: "#94a3b8", whiteSpace: "nowrap" }}>— {sub.detail}</span>
+                    </div>
+                  ))}
+                </div>
               </div>
             ))}
           </div>

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -78,6 +78,40 @@ interface CountryTag {
   name_pl: string;
 }
 
+interface DocQuality {
+  score: number;
+  penalties: Record<string, number>;
+  signals?: { photo_captions?: number; noise_share?: number; temat_chars?: number };
+  llm_rubric?: { zrodla: number; glebia: number; jezyk: number; uzasadnienie?: string } | null;
+}
+
+const QUALITY_PENALTY_LABELS: Record<string, string> = {
+  photo_captions: "podpisy zdjęć",
+  missing_author: "brak autora",
+  noise_share: "udział reklam/szumu",
+  short_text: "bardzo krótki tekst",
+  clickbait_title: "clickbaitowy tytuł",
+  llm_rubric: "rubryka LLM (źródła/głębia/język)",
+};
+
+function qualityTooltip(q: DocQuality): string {
+  const lines = Object.entries(q.penalties ?? {}).map(
+    ([key, pts]) => `−${pts}: ${QUALITY_PENALTY_LABELS[key] ?? key}`,
+  );
+  if (lines.length === 0) lines.push("bez zastrzeżeń");
+  if (q.llm_rubric) {
+    lines.push(`LLM — źródła: ${q.llm_rubric.zrodla}/5, głębia: ${q.llm_rubric.glebia}/5, język: ${q.llm_rubric.jezyk}/5`);
+    if (q.llm_rubric.uzasadnienie) lines.push(q.llm_rubric.uzasadnienie);
+  }
+  return lines.join("\n");
+}
+
+function qualityColors(score: number): React.CSSProperties {
+  if (score >= 75) return { background: "#dcfce7", color: "#15803d" };
+  if (score >= 50) return { background: "#fef3c7", color: "#b45309" };
+  return { background: "#fee2e2", color: "#b91c1c" };
+}
+
 const RUN_STATUS_LABELS: Record<string, string> = {
   created: "nowa",
   in_review: "w przeglądzie",
@@ -363,6 +397,10 @@ const Chunks = () => {
   const [videoId, setVideoId]       = React.useState("");
   const [docType, setDocType]       = React.useState(initialDocType);
   const [docTitle, setDocTitle]     = React.useState("");
+  const [docUrl, setDocUrl]         = React.useState("");
+  const [docQuality, setDocQuality] = React.useState<DocQuality | null>(null);
+  const [computingQuality, setComputingQuality] = React.useState(false);
+  const [reportingIssue, setReportingIssue] = React.useState(false);
   const [runMode, setRunMode]       = React.useState("transcript");
   const [speakers, setSpeakers]     = React.useState<Speaker[]>([]);
 
@@ -477,6 +515,8 @@ const Chunks = () => {
       setSegments(data.segments ?? []);
       setVideoId(data.document?.original_id ?? "");
       setDocType(data.document?.document_type ?? "");
+      setDocUrl(data.document?.url ?? "");
+      setDocQuality(data.document?.quality ?? null);
       setDocCountries(data.document?.countries ?? []);
       setDocThematicTags(data.document?.thematic_tags ?? []);
       setRunMode(data.run?.mode ?? "transcript");
@@ -516,6 +556,8 @@ const Chunks = () => {
         const data = await r.json();
         if (data.document_type) setDocType(data.document_type);
         if (data.title) setDocTitle(data.title);
+        if (data.url) setDocUrl(data.url);
+        if (data.quality) setDocQuality(data.quality);
       } catch { /* analysis can still be configured manually */ }
     })();
   }, [id, docType, docTitle, apiUrl, apiKey]);
@@ -1040,6 +1082,43 @@ const Chunks = () => {
     finally { setExtractingAuthorFor(null); }
   };
 
+  // ── Quality (staranność) + extraction issue report ──
+
+  const computeQuality = async () => {
+    if (!id || selectedRun === null || computingQuality) return;
+    setComputingQuality(true);
+    setError("");
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/quality`, {
+        method: "POST", headers, body: JSON.stringify({ run_id: selectedRun }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        setDocQuality(data.quality);
+        setInfo(`Oceniono staranność: ${data.quality.score}/100`);
+      } else { setError("Błąd oceny staranności: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy ocenie staranności"); }
+    finally { setComputingQuality(false); }
+  };
+
+  const reportExtractionIssue = async () => {
+    if (!id || reportingIssue) return;
+    if (!window.confirm(
+      "Zgłosić: artykuł błędnie obcięty względem oryginału?\n"
+      + "Dokument wróci do kolejki NEED_MANUAL_REVIEW z błędem ARTICLE_TRUNCATED."
+    )) return;
+    setReportingIssue(true);
+    setError("");
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/report_extraction_issue`, { method: "POST", headers });
+      const data = await r.json();
+      if (data.status === "success") {
+        setInfo("Zgłoszono błędne obcięcie artykułu — dokument trafił do kolejki ręcznej analizy (NEED_MANUAL_REVIEW).");
+      } else { setError("Błąd zgłoszenia: " + (data.message ?? "")); }
+    } catch { setError("Błąd połączenia przy zgłaszaniu"); }
+    finally { setReportingIssue(false); }
+  };
+
   // ── Embeddings ──
 
   const pollEmbeddingJob = React.useCallback((jid: string) => {
@@ -1476,6 +1555,36 @@ const Chunks = () => {
           <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         )}
         <NavLink to={`/read/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>📖 Czytaj</NavLink>
+        {docUrl && (
+          <a href={docUrl} target="_blank" rel="noopener noreferrer"
+            title="Otwórz oryginalny artykuł — porównaj, czy tekst nie jest obcięty"
+            style={{ fontSize: "0.85em", color: "#0369a1" }}>
+            🔗 Oryginał
+          </a>
+        )}
+        {docQuality && (
+          <span
+            title={qualityTooltip(docQuality)}
+            style={{
+              fontSize: "0.8em", fontWeight: 700, padding: "2px 9px", borderRadius: 10,
+              cursor: "help", ...qualityColors(docQuality.score),
+            }}
+          >
+            ⚖ {docQuality.score}/100
+          </span>
+        )}
+        {runMode === "article" && selectedRun !== null && (
+          <button onClick={computeQuality} disabled={computingQuality}
+            title="Policz ocenę staranności artykułu (kary deterministyczne + rubryka LLM) na chunkach wybranego runu"
+            style={{ padding: "2px 9px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.8em", color: "#64748b" }}>
+            {computingQuality ? "⚖ Oceniam…" : docQuality ? "⚖ Oceń ponownie" : "⚖ Oceń staranność"}
+          </button>
+        )}
+        <button onClick={reportExtractionIssue} disabled={reportingIssue}
+          title="Artykuł błędnie obcięty względem oryginału — odeślij dokument do kolejki ręcznej analizy (NEED_MANUAL_REVIEW + ARTICLE_TRUNCATED)"
+          style={{ padding: "2px 9px", border: "1px solid #fca5a5", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.8em", color: "#b91c1c" }}>
+          {reportingIssue ? "⚠ Zgłaszam…" : "⚠ Błędnie obcięty"}
+        </button>
         <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
       </div>
 

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -6,6 +6,7 @@ import { AuthorizationContext } from "../context/authorizationContext";
 import { useManageLLM } from "../hooks/useManageLLM";
 import { useFormik } from 'formik';
 import { buildObsidianNoteUrl } from "../utils/obsidian";
+import { loadListFilters, saveListFilters } from "../services/storage";
 
 // States where a document has no usable text yet — showing "Czytaj"/"Chunki" there
 // would just open an empty page. Mirrors the backend's YOUTUBE_CAPTIONS_RETRY_ALLOWED_STATES
@@ -31,7 +32,7 @@ const List = () => {
   const { selectedDocumentType, setSelectedDocumentType, selectedDocumentState, setSelectedDocumentState } = React.useContext(AuthorizationContext);
   const { searchInDocument, setSearchInDocument} = React.useContext(AuthorizationContext);
   const { searchType, setSearchType} = React.useContext(AuthorizationContext);
-  const [obsidianFilter, setObsidianFilter] = React.useState<"none" | "missing" | "has">("none");
+  const [obsidianFilter, setObsidianFilter] = React.useState<"none" | "missing" | "has">(() => loadListFilters().obsidianFilter);
   const [expandedObsidian, setExpandedObsidian] = React.useState<Set<number>>(new Set());
 
   const toggleObsidianExpanded = (id: number) => {
@@ -62,6 +63,7 @@ const List = () => {
   const handleObsidianFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
           const filter = event.target.value as "none" | "missing" | "has";
           setObsidianFilter(filter);
+          saveListFilters({ obsidianFilter: filter });
           handleGetList(selectedDocumentType, selectedDocumentState, searchInDocument, obsidianFilterParams(filter));
   };
 

--- a/web_interface_react/src/modules/shared/services/storage.ts
+++ b/web_interface_react/src/modules/shared/services/storage.ts
@@ -6,6 +6,7 @@ const KEYS = {
   apiUrl: "lenie_apiUrl",
   apiKey: "lenie_apiKey",
   obsidianVaultName: "lenie_obsidianVaultName",
+  listFilters: "lenie_listFilters",
 } as const;
 
 export function loadConnectionConfig(): {
@@ -42,6 +43,39 @@ export function clearConnectionConfig(): void {
 
 export function isConnected(): boolean {
   return !!localStorage.getItem(KEYS.apiKey);
+}
+
+// Document-list filters survive a page reload (stored per browser). Saved as a
+// partial merge so the context (type/state/search) and the list page
+// (obsidian filter) can persist their fields independently.
+export interface ListFilters {
+  documentType: string;
+  documentState: string;
+  searchText: string;
+  searchType: string;
+  obsidianFilter: "none" | "missing" | "has";
+}
+
+const DEFAULT_LIST_FILTERS: ListFilters = {
+  documentType: "link",
+  documentState: "NEED_MANUAL_REVIEW",
+  searchText: "",
+  searchType: "strict",
+  obsidianFilter: "none",
+};
+
+export function loadListFilters(): ListFilters {
+  try {
+    const raw = localStorage.getItem(KEYS.listFilters);
+    if (!raw) return { ...DEFAULT_LIST_FILTERS };
+    return { ...DEFAULT_LIST_FILTERS, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT_LIST_FILTERS };
+  }
+}
+
+export function saveListFilters(filters: Partial<ListFilters>): void {
+  localStorage.setItem(KEYS.listFilters, JSON.stringify({ ...loadListFilters(), ...filters }));
 }
 
 // The Obsidian vault name is device-specific (e.g. Obsidian Sync uses a


### PR DESCRIPTION
## Summary

Four improvements around article quality and the chunk-review UX, tested on the NAS deployment:

### 1. Article quality ("staranność") scoring
- New `library/article_quality.py`: deterministic penalties (photo captions / stock credits, missing author, REKLAMA+SZUM share, very short text, clickbait title) + one LLM rubric call (sources / depth / language, each 0–5).
- Score 0–100 stored in `web_documents.quality` (JSONB; migration `f4a5b6c7d8e9`). Penalties are kept per-component so future aggregation can split author-owned signals (LLM rubric) from portal-owned ones (noise, captions, title).
- Computed automatically at the end of a whole-document article analysis run (step 11f) and on demand via `POST /document/<id>/quality`.
- Chunks page shows a score badge (tooltip with penalty breakdown + rubric) and an "⚖ Oceń staranność" button.
- Live smoke test: document 9210 → 82/100 (−10 missing author, −8 rubric) with a sensible Bielik justification.

### 2. Photo-caption detection ("zdjęcie ilustracyjne, … / shutterstock")
- Shared caption/credit patterns in `article_quality.py`, verified against real captions from NAS documents (9/9 detected).
- `article_cleaner` now drops caption lines in the generic cleaner; preclean and article-analysis prompts classify captions as SZUM.

### 3. Original-article link + truncation report
- Chunks page header links to the original URL ("🔗 Oryginał") for comparing against the source.
- "⚠ Błędnie obcięty" button → `POST /document/<id>/report_extraction_issue` sets `NEED_MANUAL_REVIEW` + new `ARTICLE_TRUNCATED` error type (migration `a5b6c7d8e9f0`), sending the document back to the manual-review queue.

### 4. Chunk-review & list UX
- Document-list filters (type, state, search text, strict/similar, Obsidian filter) persist in localStorage (`lenie_listFilters`) and are reused on the initial fetch after a reload.
- The "Proces" panel on `/chunks/:id` shows sub-steps with green checkmarks: split → ad/noise detection → LLM analysis; TEMAT approval → review close; embedding generation.

## Testing
- Backend: 1251 unit tests pass (new `test_article_quality.py`; schema-shape tests updated for the new column).
- Frontend: `npm run build` (tsc + vite) and Vitest pass.
- End-to-end on NAS: migrations applied, quality endpoint verified live, report endpoint route verified, UI tested manually by the repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
