### PR TITLE
feat(frontend): shareable search URLs + copy link button

### DIFF
--- a/web_interface_react/src/modules/shared/pages/search.tsx
+++ b/web_interface_react/src/modules/shared/pages/search.tsx
@@ -6,31 +6,73 @@ import { useSearch } from "../hooks/useSearch";
 import Select from "../components/Select/select";
 import { useSearchParams } from "react-router-dom";
 
+const ALLOWED_LIMITS = ["5", "10", "30", "50"];
+const DEFAULT_LIMIT = "10";
+
+const copyToClipboard = (text: string): boolean => {
+  if (navigator.clipboard && window.isSecureContext) {
+    void navigator.clipboard.writeText(text);
+    return true;
+  }
+  // Fallback dla http:// (brak secure context, np. NAS po IP)
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+};
+
 const Search = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
+  const limitParam = searchParams.get("limit") ?? DEFAULT_LIMIT;
+  const initialLimit = ALLOWED_LIMITS.includes(limitParam) ? limitParam : DEFAULT_LIMIT;
+  const initialTranslate = searchParams.get("translate") === "true";
   const [submittedQuery, setSubmittedQuery] = React.useState(initialQuery);
+  const [copied, setCopied] = React.useState(false);
   const { handleSearchSimilar, results, setResults, isLoading, message, setMessage, isError } =
       useSearch({
         callback: () => formik.resetForm(),
       });
 
   const handleClean = () => {
-    formik.resetForm();
+    formik.resetForm({ values: { search: "", searchLimit: DEFAULT_LIMIT, translate: false } });
     setResults([]);
     setMessage("");
     setSubmittedQuery("");
+    setSearchParams({});
+  };
+
+  const handleCopyLink = () => {
+    if (copyToClipboard(window.location.href)) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   const formik: any = useFormik({
     initialValues: {
       search: initialQuery,
-      searchLimit: "10",
-      translate: false
+      searchLimit: initialLimit,
+      translate: initialTranslate
     },
     onSubmit: async (data) => {
-      setSubmittedQuery(data.search.trim());
-      await handleSearchSimilar(data.search, data.searchLimit, data.translate);
+      const query = data.search.trim();
+      setSubmittedQuery(query);
+      const params: Record<string, string> = { q: query };
+      if (data.searchLimit !== DEFAULT_LIMIT) params.limit = data.searchLimit;
+      if (data.translate) params.translate = "true";
+      setSearchParams(params);
+      await handleSearchSimilar(query, data.searchLimit, data.translate);
     },
   });
 
@@ -38,9 +80,9 @@ const Search = () => {
   React.useEffect(() => {
     if (!initialSearchDone.current && initialQuery) {
       initialSearchDone.current = true;
-      void handleSearchSimilar(initialQuery, "10", false);
+      void handleSearchSimilar(initialQuery, initialLimit, initialTranslate);
     }
-  }, [handleSearchSimilar, initialQuery]);
+  }, [handleSearchSimilar, initialQuery, initialLimit, initialTranslate]);
 
   return (
       <form onSubmit={formik.handleSubmit}>
@@ -85,12 +127,24 @@ const Search = () => {
           </button>
 
           <button
+              type={"button"}
               className={"button"}
               style={{marginTop: "11px", marginLeft: "10px"}}
               onClick={() => handleClean()}
           >
             Wyczyść
           </button>
+
+          {submittedQuery && (
+            <button
+                type={"button"}
+                className={"button"}
+                style={{marginTop: "11px", marginLeft: "10px"}}
+                onClick={() => handleCopyLink()}
+            >
+              {copied ? "Skopiowano ✓" : "📋 Kopiuj link"}
+            </button>
+          )}
         </div>
 
         {isLoading && <div className={"loader"}></div>}


### PR DESCRIPTION
## Summary
- `/search` syncs `q`/`limit`/`translate` to URL query params on submit
- Opening a shared link restores `limit` and `translate` (not just `q`)
- New "Kopiuj link" button (execCommand fallback for http://)
- "Wyczyść" clears URL params and resets to an empty form
- Explicit `type=button` on non-submit buttons

## Test plan
- [x] Manual verification in browser (search, copy link, reload shared URL, clear)