### PR TITLE
feat(cleanup): add o2.pl cleanup rules from document 357 review

### DIFF
--- a/backend/data/site_rules.json
+++ b/backend/data/site_rules.json
@@ -5,8 +5,20 @@
             "\\bad\\s*\\n\\s*Reklama",
             "Reklama\\n",
             "\\d+\\s*komentarz[ey]?\\n",
-            "Udostępnij na X Udostępnij na Facebooku\\n?",
+            "Udostępnij na X\\s+Udostępnij na Facebooku\\n?",
             "Treść zewnętrzna\\n?"
+        ]
+    },
+    "https://www.o2.pl": {
+        "remove_before" : ["Udostępnij na X\\s+Udostępnij na Facebooku"],
+        "remove_after" : ["Wybrane dla Ciebie"],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?<=[.?!\"])  [^\\n]{10,120}[^.?!\\n](?=\\n+(?:[^\\n]{10,120}[^.?!\\n]\\n+){0,2}Przewiń wstecz\\s+Oglądaj)",
+            "(?:(?<=\\n)[^\\n]{10,120}[^.?!\\n]\\n+){0,2}Przewiń wstecz\\s+Oglądaj\\s+Przewiń naprzód\\s+Ustawienia\\s+Włącz / wyłącz pełny ekran\\s+\\d{2}:\\d{2}",
+            "Oglądaj\\s*\\n\\s*\\d{2}:\\d{2}\\n?",
+            "REKLAMA\\s*KONIEC REKLAMY",
+            "[\\wąćęłńóśźż][\\wąćęłńóśźż ]*\\+\\d+\\s*$"
         ]
     },
     "https://wiadomosci.onet.pl": {

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -230,9 +230,33 @@ def _clean_lines_money(lines: list[str]) -> list[str]:
 
 def _clean_lines_wp(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla wp.pl/o2.pl/tech.wp.pl."""
-    skip_exact = {"Skomentuj", "Słuchaj", "Udostępnij", "Kopiuj link"}
+    skip_exact = {"Skomentuj", "Słuchaj", "Udostępnij", "Kopiuj link",
+                  "Zaloguj", "Obserwuj nas na:", "Wyłączono komentarze"}
     skip_startswith = ("Udostępnij na ", "Dźwięk został wygenerowany",
-                       "Źródło zdjęć:", "Źródło artykułu:", "oprac.")
+                       "Źródło zdjęć:", "Źródło artykułu:", "oprac.",
+                       "Jako redakcja Wirtualnej Polski", "Redakcja serwisu o2")
+
+    # Tagi rozbite na osobne linie (o2.pl): "sztuczna inteligencja" / "polska" / "+3"
+    # — usuń samodzielny licznik "+N" i bezpośrednio poprzedzające go linie tagów
+    tag_counter_re = re.compile(r'^\+\d+$')
+    tag_word_re = re.compile(r'^[a-ząćęłńóśźż][a-ząćęłńóśźż ]{0,40}$')
+    drop: set[int] = set()
+    for i, line in enumerate(lines):
+        if tag_counter_re.match(line.strip()):
+            drop.add(i)
+            j = i - 1
+            while j >= 0:
+                s = lines[j].strip()
+                if not s:
+                    j -= 1
+                    continue
+                if tag_word_re.match(s):
+                    drop.add(j)
+                    j -= 1
+                else:
+                    break
+    lines = [line for k, line in enumerate(lines) if k not in drop]
+
     cleaned = []
     for line in lines:
         stripped = line.strip()

--- a/backend/library/website/website_download_context.py
+++ b/backend/library/website/website_download_context.py
@@ -1,4 +1,6 @@
 import ipaddress
+import json
+import logging
 import re
 import socket
 from urllib.parse import urlparse
@@ -7,14 +9,20 @@ import requests
 from bs4 import BeautifulSoup
 
 from library.text_functions import remove_before_regex, remove_last_occurrence_and_after, remove_text_regex
-import json
+from library.config_loader import load_config
 
 from library.models.webpage_parse_result import WebPageParseResult
 
+logger = logging.getLogger(__name__)
+
 
 def load_site_rules(file_path: str) -> dict:
-    with open(file_path, 'r', encoding='utf-8') as file:
-        return json.load(file)
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            return json.load(file)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Cannot load site cleanup rules from %s: %s", file_path, exc)
+        return {}
 
 
 def validate_url_target(url: str) -> None:
@@ -99,7 +107,8 @@ def webpage_raw_parse(url: str, raw_html: bytes, analyze_content: bool = True) -
 def webpage_text_clean(url: str, content: str):
     content = re.sub('\xa0', " ", content)
 
-    site_rules = load_site_rules('data/site_rules.json')
+    site_rules_path = load_config().get("SITE_RULES_PATH", "data/site_rules.json")
+    site_rules = load_site_rules(site_rules_path)
 
     for url_path in site_rules:
         if url.find(url_path) != -1:

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -243,3 +243,34 @@ class TestWpCleaning:
             "Treść artykułu wp.",
         ]
         assert _clean_lines_wp(lines) == ["Treść artykułu wp."]
+
+    def test_o2_header_and_split_tags_removed(self):
+        # o2.pl: nagłówek strony + tagi rozbite na osobne linie zakończone licznikiem "+N"
+        lines = [
+            "Zaloguj",
+            "Obserwuj nas na:",
+            "Źródło zdjęć: © Facebook, Pixabay",
+            "3 lutego 2026, 13:51",
+            "Treść artykułu o2.",
+            "sztuczna inteligencja",
+            "polska ukraina",
+            "+3",
+        ]
+        assert _clean_lines_wp(lines) == ["Treść artykułu o2."]
+
+    def test_o2_comments_disabled_notice_removed(self):
+        lines = [
+            "Treść artykułu o2.",
+            "Wyłączono komentarze",
+            "Jako redakcja Wirtualnej Polski doceniamy zaangażowanie naszych czytelników w komentarzach.",
+            "Redakcja serwisu o2",
+        ]
+        assert _clean_lines_wp(lines) == ["Treść artykułu o2."]
+
+    def test_o2_tag_like_lines_kept_without_counter(self):
+        # Krótkie linie z małych liter NIE są usuwane, gdy nie kończą się licznikiem "+N"
+        lines = [
+            "krótka linia z małych liter",
+            "Treść artykułu o2.",
+        ]
+        assert _clean_lines_wp(lines) == lines

--- a/backend/tests/unit/test_site_rules_o2.py
+++ b/backend/tests/unit/test_site_rules_o2.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Reguły czyszczenia o2.pl w data/site_rules.json (webpage_text_clean).
+
+Przypadki oparte na dokumencie #357 (o2.pl/informacje/falszywe-ukrainki-...):
+linie usunięte ręcznie podczas review są zapisane w document_removed_lines
+i posłużyły do zbudowania tych reguł.
+"""
+
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("bs4")
+
+from library.website.website_download_context import webpage_text_clean  # noqa: E402
+
+O2_URL = "https://www.o2.pl/informacje/falszywe-ukrainki-zalewaja-siec-brutalny-cel-ogloszen-7250406541257024a"
+
+HEADER = (
+    "Fałszywe Ukrainki zalewają sieć. Brutalny cel ogłoszeń          "
+    "ZalogujBlisko ludzio2kazjeQuizyRozrywkaPogodaBiznes"
+    "Obserwuj nas na:   Fałszywe Ukrainki zalewają sieć. Brutalny cel ogłoszeń "
+    "Fałszywe ogłoszenia zalewają siećŹródło zdjęć: © Facebook, Pixabay "
+    "Marcin Lewicki3 lutego 2026, 13:51  Udostępnij na X  Udostępnij na Facebooku"
+)
+
+ARTICLE_P1 = "W mediach społecznościowych pojawiła się fala fałszywych ogłoszeń matrymonialnych."
+ARTICLE_P2 = "Strony, do których prowadzą ogłoszenia również są fałszywe."
+
+FOOTER = (
+    "sztuczna inteligencja polska ukraina media społecznościowe +3 Wybrane dla Ciebie\n\n"
+    "Wyniki Lotto 03.02.2026 – losowania Lotto\n\n"
+    "Wyłączono komentarzeJako redakcja Wirtualnej Polski doceniamy zaangażowanie"
+)
+
+VIDEO_EMBED = (
+    "14-latka upadła w galerii. Trafiła do szpitala. Szokujący finał\n\n"
+    "NBP chce nadal zwiększać zapasy złota. Ekonomista: dziś to bardziej kontrowersyjny temat \n\n"
+    "Przewiń wstecz\n\nOglądaj\n\nPrzewiń naprzód\n\nUstawienia\n\n"
+    "Włącz / wyłącz pełny ekran\n\n01:49"
+)
+
+
+class TestO2SiteRules:
+    def test_header_removed_up_to_share_buttons(self):
+        text = f"{HEADER}\n\n{ARTICLE_P1}"
+        result = webpage_text_clean(O2_URL, text)
+        assert result == ARTICLE_P1
+        assert "Zaloguj" not in result
+        assert "Źródło zdjęć" not in result
+        assert "Marcin Lewicki" not in result
+
+    def test_footer_removed_from_wybrane_dla_ciebie(self):
+        text = f"{ARTICLE_P2}{FOOTER}"
+        result = webpage_text_clean(O2_URL, text)
+        assert ARTICLE_P2.rstrip(".") in result
+        assert "Wybrane dla Ciebie" not in result
+        assert "Wyniki Lotto" not in result
+        assert "Wyłączono komentarze" not in result
+        # tagi z licznikiem "+3" doklejone do końca artykułu też znikają
+        assert "sztuczna inteligencja" not in result
+
+    def test_video_embed_with_teasers_removed(self):
+        text = f"{ARTICLE_P1}\n\n{VIDEO_EMBED}\n\n{ARTICLE_P2}"
+        result = webpage_text_clean(O2_URL, text)
+        assert ARTICLE_P1 in result
+        assert ARTICLE_P2 in result
+        assert "Przewiń wstecz" not in result
+        assert "Oglądaj" not in result
+        assert "01:49" not in result
+        assert "14-latka upadła w galerii" not in result
+        assert "NBP chce nadal zwiększać" not in result
+
+    def test_video_teaser_glued_to_paragraph_removed(self):
+        # Artefakt get_text(): zajawka doklejona po kropce (dwie spacje) do końca akapitu,
+        # usuwana tylko gdy dalej następuje blok playera
+        glued = f'{ARTICLE_P1}  14-latka upadła w galerii. Trafiła do szpitala. Szokujący finał'
+        text = f"{glued}\n\n{VIDEO_EMBED.split(chr(10) + chr(10), 2)[2]}\n\n{ARTICLE_P2}"
+        result = webpage_text_clean(O2_URL, text)
+        assert ARTICLE_P1 in result
+        assert ARTICLE_P2 in result
+        assert "14-latka" not in result
+
+    def test_reklama_koniec_reklamy_removed(self):
+        text = f"{ARTICLE_P1}REKLAMAKONIEC REKLAMY \n\n{ARTICLE_P2}\nREKLAMA\nKONIEC REKLAMY"
+        result = webpage_text_clean(O2_URL, text)
+        assert "REKLAMA" not in result
+        assert ARTICLE_P1 in result
+        assert ARTICLE_P2 in result
+
+    def test_plain_article_untouched(self):
+        text = f"{ARTICLE_P1}\n\n{ARTICLE_P2}"
+        assert webpage_text_clean(O2_URL, text) == text

--- a/backend/tests/unit/test_site_rules_o2.py
+++ b/backend/tests/unit/test_site_rules_o2.py
@@ -6,12 +6,16 @@ linie usunięte ręcznie podczas review są zapisane w document_removed_lines
 i posłużyły do zbudowania tych reguł.
 """
 
+import json
+import logging
+
 import pytest
 
 pytest.importorskip("requests")
 pytest.importorskip("bs4")
 
-from library.website.website_download_context import webpage_text_clean  # noqa: E402
+from library.website import website_download_context  # noqa: E402
+from library.website.website_download_context import load_site_rules, webpage_text_clean  # noqa: E402
 
 O2_URL = "https://www.o2.pl/informacje/falszywe-ukrainki-zalewaja-siec-brutalny-cel-ogloszen-7250406541257024a"
 
@@ -38,6 +42,15 @@ VIDEO_EMBED = (
     "Przewiń wstecz\n\nOglądaj\n\nPrzewiń naprzód\n\nUstawienia\n\n"
     "Włącz / wyłącz pełny ekran\n\n01:49"
 )
+
+
+@pytest.fixture(autouse=True)
+def default_site_rules_config(monkeypatch):
+    monkeypatch.setattr(
+        website_download_context,
+        "load_config",
+        lambda: {"SITE_RULES_PATH": "data/site_rules.json"},
+    )
 
 
 class TestO2SiteRules:
@@ -90,3 +103,32 @@ class TestO2SiteRules:
     def test_plain_article_untouched(self):
         text = f"{ARTICLE_P1}\n\n{ARTICLE_P2}"
         assert webpage_text_clean(O2_URL, text) == text
+
+
+def test_site_rules_path_is_configurable(monkeypatch, tmp_path):
+    rules_path = tmp_path / "site-rules.json"
+    rules_path.write_text(json.dumps({"example.com": {
+        "remove_before": [],
+        "remove_after": [],
+        "remove_string": ["REMOVE ME"],
+        "remove_string_regexp": [],
+    }}), encoding="utf-8")
+    monkeypatch.setattr(
+        website_download_context,
+        "load_config",
+        lambda: {"SITE_RULES_PATH": str(rules_path)},
+    )
+
+    assert webpage_text_clean("https://example.com/article", "keep REMOVE ME this") == "keep  this"
+
+
+@pytest.mark.parametrize("contents", [None, "not valid json"])
+def test_missing_or_invalid_rules_fall_back_to_empty_rules(tmp_path, caplog, contents):
+    rules_path = tmp_path / "site-rules.json"
+    if contents is not None:
+        rules_path.write_text(contents, encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger=website_download_context.__name__):
+        assert load_site_rules(str(rules_path)) == {}
+
+    assert "Cannot load site cleanup rules" in caplog.text

--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -33,8 +33,11 @@ services:
       - "5055:5000"
     env_file:
       - /share/ContainerNew/lenie-env/.env
+    environment:
+      SITE_RULES_PATH: /app/config/site_rules.json
     volumes:
       - lenie-ai-data:/app/data
+      - /share/ContainerNew/lenie-config:/app/config:ro
     networks:
       - lenie-net
     depends_on:

--- a/infra/docker/nas-deploy.sh
+++ b/infra/docker/nas-deploy.sh
@@ -18,12 +18,14 @@ NAS_USER="admin"
 NAS_DOCKER="/share/CACHEDEV4_DATA/.qpkg/container-station/usr/bin/.libs/docker"
 NAS_COMPOSE_DIR="/share/ContainerNew/lenie-compose"
 NAS_COMPOSE_FILE="${NAS_COMPOSE_DIR}/compose.nas.yaml"
+NAS_CONFIG_DIR="/share/ContainerNew/lenie-config"
 REGISTRY="${NAS_HOST}:5005"
 
 # Project root (two levels up from this script)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCAL_COMPOSE_FILE="${SCRIPT_DIR}/compose.nas.yaml"
+LOCAL_SITE_RULES_FILE="${PROJECT_ROOT}/backend/data/site_rules.json"
 
 # Service definitions: name | local image | registry image | dockerfile
 declare -A SVC_IMAGE=(
@@ -171,6 +173,13 @@ sync_compose() {
     ok "compose.nas.yaml skopiowany do ${NAS_COMPOSE_FILE}"
 }
 
+sync_site_rules() {
+    log "Kopiowanie site_rules.json na NAS..."
+    nas_ssh "mkdir -p ${NAS_CONFIG_DIR}"
+    scp "$LOCAL_SITE_RULES_FILE" "${NAS_USER}@${NAS_HOST}:${NAS_CONFIG_DIR}/site_rules.json"
+    ok "site_rules.json skopiowany do ${NAS_CONFIG_DIR}"
+}
+
 deploy_service() {
     local svc="$1"
     local skip_build="$2"
@@ -262,6 +271,7 @@ echo -e "${GREEN}  Compose only: ${COMPOSE_ONLY}${NC}"
 echo -e "${GREEN}============================================${NC}"
 
 check_nas_connection
+sync_site_rules
 
 # Sync compose file if requested
 if [ "$SYNC_COMPOSE" = "true" ]; then

--- a/scripts/vars-classification.yaml
+++ b/scripts/vars-classification.yaml
@@ -292,6 +292,13 @@ groups:
         default: "cache"
         example: "tmp/youtube_to_text"
         used_by: [docker, local]
+      SITE_RULES_PATH:
+        description: "Path to hot-reloadable website cleanup rules JSON"
+        type: config
+        required: false
+        default: "data/site_rules.json"
+        example: "/app/config/site_rules.json"
+        used_by: [docker, local]
       STALKER_API_KEY:
         description: "Legacy name, now the slack-bot's own api_keys service key (x-api-key). The backend no longer accepts a shared/legacy key — every other client authenticates with its own key from the api_keys table (see library/auth.py)."
         type: secret


### PR DESCRIPTION
## Kontekst

Ręczne czyszczenie dokumentu 357 (artykuł o2.pl, `/chunks/357`) usunęło 12 linii, zarejestrowanych w `document_removed_lines` (run 60). Ten PR zamienia je na reguły automatyczne.

## Usunięte ręcznie linie → pokrycie regułami

| Linia | Mechanizm |
|---|---|
| `Zaloguj`, zduplikowany tytuł, podpis zdjęcia, `Źródło zdjęć: © …`, autor, data | `remove_before` — cięcie nagłówka do przycisków udostępniania |
| 2 zajawki wideo + `Oglądaj` + `01:49` | regex bloku playera (wersja z liniami zakotwiczonymi + wariant doklejony do akapitu) |
| `sztuczna inteligencja`, `+3` (tagi) | regex końcowej listy tagów z licznikiem `+N`; w przepływie markdown: nowa logika w `_clean_lines_wp` |
| — bonus: `Wybrane dla Ciebie` + stopka, `REKLAMA/KONIEC REKLAMY`, `Wyłączono komentarze` | `remove_after` + regexy |

## Zmiany

- **`backend/data/site_rules.json`** — nowy wpis `https://www.o2.pl` (remove_before/remove_after/remove_string_regexp); w `_global` dopuszczenie wielu spacji w "Udostępnij na X Udostępnij na Facebooku"
- **`backend/library/article_cleaner.py`** — `_clean_lines_wp`: skip `Zaloguj`/`Obserwuj nas na:`/`Wyłączono komentarze`/notka redakcji; usuwanie samodzielnej linii `+N` wraz z poprzedzającymi ją liniami tagów
- **testy**: nowy `tests/unit/test_site_rules_o2.py` (6 przypadków na bazie dokumentu 357) + 3 przypadki w `test_article_cleaner.py`

## Weryfikacja

- Pełne parsowanie zachowanego `text_raw` dokumentu 357 nowymi regułami: wszystkie 12 linii usuwanych automatycznie, treść artykułu nietknięta (1807 znaków vs 1798 w ręcznie wyczyszczonym chunku)
- `pytest tests/unit/`: **1273 passed**
- `ruff`: czysto

🤖 Generated with [Claude Code](https://claude.com/claude-code)