### PR TITLE
feat(cleanup): track removed-line rule reviews

### DIFF
--- a/backend/alembic/versions/b6c7d8e9f0a1_add_review_status_to_removed_lines.py
+++ b/backend/alembic/versions/b6c7d8e9f0a1_add_review_status_to_removed_lines.py
@@ -1,0 +1,64 @@
+"""add review status to document_removed_lines
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-07-16 15:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b6c7d8e9f0a1"
+down_revision: Union[str, None] = "a5b6c7d8e9f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE document_removed_lines "
+        "ADD COLUMN IF NOT EXISTS review_status VARCHAR(20) NOT NULL DEFAULT 'pending'"
+    )
+    op.execute(
+        "ALTER TABLE document_removed_lines "
+        "ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMP"
+    )
+    op.execute(
+        "ALTER TABLE document_removed_lines "
+        "ADD COLUMN IF NOT EXISTS review_note TEXT"
+    )
+    op.execute(
+        "ALTER TABLE document_removed_lines "
+        "ADD COLUMN IF NOT EXISTS rule_reference VARCHAR(500)"
+    )
+    op.execute(
+        "DO $$ BEGIN "
+        "ALTER TABLE document_removed_lines ADD CONSTRAINT ck_removed_lines_review_status "
+        "CHECK (review_status IN ('pending', 'rule_added', 'rejected', 'already_covered')); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_removed_lines_review_status "
+        "ON document_removed_lines(review_status)"
+    )
+
+    # These removals produced the o2.pl rules introduced in PR #262.
+    op.execute(
+        "UPDATE document_removed_lines "
+        "SET review_status = 'rule_added', reviewed_at = NOW(), "
+        "review_note = 'Analyzed for o2.pl cleanup rules in PR #262', "
+        "rule_reference = 'data/site_rules.json:o2.pl; article_cleaner.py:_clean_lines_wp' "
+        "WHERE document_id = 357 AND run_id = 60 AND review_status = 'pending'"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_removed_lines_review_status")
+    op.execute(
+        "ALTER TABLE document_removed_lines "
+        "DROP CONSTRAINT IF EXISTS ck_removed_lines_review_status"
+    )
+    op.execute("ALTER TABLE document_removed_lines DROP COLUMN IF EXISTS rule_reference")
+    op.execute("ALTER TABLE document_removed_lines DROP COLUMN IF EXISTS review_note")
+    op.execute("ALTER TABLE document_removed_lines DROP COLUMN IF EXISTS reviewed_at")
+    op.execute("ALTER TABLE document_removed_lines DROP COLUMN IF EXISTS review_status")

--- a/backend/database/init/18-create-document-removed-lines.sql
+++ b/backend/database/init/18-create-document-removed-lines.sql
@@ -15,10 +15,16 @@ CREATE TABLE IF NOT EXISTS public.document_removed_lines (
     chunk_id    INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL,
     source      VARCHAR(20) NOT NULL,
     line_text   TEXT NOT NULL,
+    review_status VARCHAR(20) NOT NULL DEFAULT 'pending'
+        CHECK (review_status IN ('pending', 'rule_added', 'rejected', 'already_covered')),
+    reviewed_at TIMESTAMP,
+    review_note TEXT,
+    rule_reference VARCHAR(500),
     created_at  TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX IF NOT EXISTS idx_removed_lines_document_id ON public.document_removed_lines(document_id);
 CREATE INDEX IF NOT EXISTS idx_removed_lines_source      ON public.document_removed_lines(source);
+CREATE INDEX IF NOT EXISTS idx_removed_lines_review_status ON public.document_removed_lines(review_status);
 
 SELECT 'Table document_removed_lines created' AS status;

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -725,7 +725,9 @@ class DocumentRemovedLine(Base):
     """Line/block removed from a document during manual chunk review cleanup.
 
     Training data for improving article_cleaner.py / site_rules.json: what the
-    automatic cleaner missed and a human had to remove. Rows survive run/chunk
+    automatic cleaner missed and a human had to remove. Claude Code/Codex rule
+    reviews should only inspect ``pending`` rows and record a terminal decision
+    using ``scripts/review_removed_lines.py``. Rows survive run/chunk
     deletion (FKs SET NULL) so aggregate queries (e.g. most-removed lines per
     portal, via join on web_documents.url) keep working over time.
     """
@@ -746,6 +748,14 @@ class DocumentRemovedLine(Base):
     # SZUM/REKLAMA chunk dropped by apply_cleanup)
     source: Mapped[str] = mapped_column(String(20), nullable=False)
     line_text: Mapped[str] = mapped_column(Text, nullable=False)
+    # Lifecycle for cleaner-rule mining. Only ``pending`` rows should be
+    # presented for analysis; terminal statuses prevent repeated review.
+    review_status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=sa_text("'pending'"),
+    )
+    reviewed_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
+    review_note: Mapped[str | None] = mapped_column(Text)
+    rule_reference: Mapped[str | None] = mapped_column(String(500))
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(),
     )

--- a/backend/scripts/review_removed_lines.py
+++ b/backend/scripts/review_removed_lines.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""List and resolve cleaner-rule candidates collected during chunk review.
+
+Intended for Claude Code/Codex-assisted rule work. Examples::
+
+    PYTHONPATH=. python scripts/review_removed_lines.py --list
+    PYTHONPATH=. python scripts/review_removed_lines.py --mark 10,11 \
+        --status rule_added --reference "data/site_rules.json:o2.pl" \
+        --note "Added during cleanup-rule review"
+"""
+
+import argparse
+import datetime
+
+from sqlalchemy import select
+
+from library.db.engine import get_session
+from library.db.models import DocumentRemovedLine
+
+TERMINAL_STATUSES = ("rule_added", "rejected", "already_covered")
+
+
+def parse_ids(value: str) -> list[int]:
+    ids = [int(item.strip()) for item in value.split(",") if item.strip()]
+    if not ids:
+        raise argparse.ArgumentTypeError("provide at least one row ID")
+    return ids
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Review document_removed_lines candidates")
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--list", action="store_true", help="List pending candidates")
+    action.add_argument("--mark", type=parse_ids, metavar="ID[,ID...]", help="Resolve row IDs")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--status", choices=TERMINAL_STATUSES)
+    parser.add_argument("--reference", help="Rule location, e.g. data/site_rules.json:o2.pl")
+    parser.add_argument("--note", help="Reason for the decision")
+    args = parser.parse_args()
+
+    if args.mark and not args.status:
+        parser.error("--status is required with --mark")
+    if args.status == "rule_added" and not args.reference:
+        parser.error("--reference is required for rule_added")
+
+    session = get_session()
+    try:
+        if args.list:
+            rows = session.scalars(
+                select(DocumentRemovedLine)
+                .where(DocumentRemovedLine.review_status == "pending")
+                .order_by(DocumentRemovedLine.created_at, DocumentRemovedLine.id)
+                .limit(args.limit)
+            ).all()
+            for row in rows:
+                print(f"{row.id}\tdoc={row.document_id}\t{row.source}\t{row.line_text}")
+            print(f"Pending candidates shown: {len(rows)}")
+            return
+
+        rows = session.scalars(
+            select(DocumentRemovedLine).where(DocumentRemovedLine.id.in_(args.mark))
+        ).all()
+        found_ids = {row.id for row in rows}
+        missing_ids = sorted(set(args.mark) - found_ids)
+        if missing_ids:
+            parser.error(f"row IDs not found: {missing_ids}")
+
+        now = datetime.datetime.now()
+        for row in rows:
+            if row.review_status != "pending":
+                parser.error(f"row {row.id} is already {row.review_status}")
+            row.review_status = args.status
+            row.reviewed_at = now
+            row.review_note = args.note
+            row.rule_reference = args.reference
+        session.commit()
+        print(f"Marked {len(rows)} row(s) as {args.status}")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_removed_lines.py
+++ b/backend/tests/unit/test_removed_lines.py
@@ -25,7 +25,8 @@ from library.db.models import DocumentRemovedLine  # noqa: E402
 
 class TestDocumentRemovedLineModel:
     EXPECTED_COLUMNS = {
-        "id", "document_id", "run_id", "chunk_id", "source", "line_text", "created_at",
+        "id", "document_id", "run_id", "chunk_id", "source", "line_text",
+        "review_status", "reviewed_at", "review_note", "rule_reference", "created_at",
     }
 
     def test_tablename(self):
@@ -118,6 +119,7 @@ class TestLogRemovedLines:
         for r in rows:
             assert isinstance(r, DocumentRemovedLine)
             assert (r.document_id, r.run_id, r.chunk_id, r.source) == (9202, 17, 101, "manual")
+            assert r.review_status is None  # database server default: pending
 
     def test_skips_empty_and_whitespace_lines(self):
         session = MagicMock(spec=["add"])


### PR DESCRIPTION
## Summary
- add review lifecycle fields to document_removed_lines
- backfill document 357/run 60 as rule_added for PR #262 rules
- add CLI for Claude Code/Codex to list pending candidates and record decisions
- update fresh-database schema and unit tests

## Test plan
- 15 unit tests passed in backend/tests/unit/test_removed_lines.py
- Alembic reports b6c7d8e9f0a1 as the single head
- git diff --check passes