### PR TITLE
feat(cleanup): improve article review workflow

### DIFF
--- a/backend/data/site_rules.json
+++ b/backend/data/site_rules.json
@@ -4,6 +4,7 @@
             "\\*\\*Reklama\\*\\*\\s*Dzięki reklamie oglądasz za darmo\\.?",
             "\\bad\\s*\\n\\s*Reklama",
             "Reklama\\n",
+            "(?m)^REKLAMA[^\\S\\n]*\\n\\s*KONIEC REKLAMY[^\\S\\n]*$",
             "\\d+\\s*komentarz[ey]?\\n",
             "Udostępnij na X\\s+Udostępnij na Facebooku\\n?",
             "Treść zewnętrzna\\n?"
@@ -34,6 +35,67 @@
         "remove_after" : ["Oceń jakość naszego artykułu:Twoja opinia pozwala nam tworzyć lepsze treści",
           "\\*\\*Masz newsa, zdjęcie lub filmik\\? Prześlij nam przez"],
         "remove_string" : [],
-        "remove_string_regexp" : ["\\d+Podziel się:\\d+Podziel się:", "\\*Dalsza część artykułu pod materiałem wideo\\*"]
+        "remove_string_regexp" : [
+            "\\d+Podziel się:\\d+Podziel się:",
+            "\\*Dalsza część artykułu pod materiałem wideo\\*",
+            "(?m)^\\d+\\s+komentarz(?:e|y)?\\s*$",
+            "(?m)^Słuchaj\\s*$",
+            "(?m)^Udostępnij na Facebooku(?:\\s+Udostępnij na X)?(?:\\s+Udostępnij na WhatsApp)?(?:\\s+Kopiuj link)?\\s*$",
+            "(?mi)^[\\w.+-]+@grupawp\\.pl\\s*o autorze[^\\S\\n]*$"
+        ]
+    },
+    "https://tech.wp.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?ms)^PREMIUM Zapisz się na newsletter!\\s*Newsy, wywiady, śledztwa i reportaże w Twojej skrzynce co tydzień - zawsze za darmo\\.\\s*Zapisz mnie[^\\S\\n]*$"
+        ]
+    },
+    "https://www.onet.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?m)^Zapytaj o więcej Onet Czat z AI(?:\\s+\\[link\\d+\\])?\\s*$",
+            "(?m)^Więcej (?:pogłębionych treści|treści premium dla Ciebie)\\s*$",
+            "(?m)^Dalszy ciąg artykułu pod materiałem wideo\\s*$"
+        ]
+    },
+    "https://businessinsider.com.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?m)^Dalszy ciąg artykułu pod materiałem wideo\\s*$",
+            "(?m)^\\*\\*Zobacz także:\\*\\*.*$",
+            "(?m)^\\|\\s*$"
+        ]
+    },
+    "https://ithardware.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?mi)^Dalsza część artykulu pod video\\s*$",
+            "(?m)^(?:Play|ad)\\s*$"
+        ]
+    },
+    "https://wiadomosci.gazeta.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?mi)^Otwórz galerię \\(\\d+\\)[^\\S\\n]*$",
+            "(?mi)^\\[przejdź na\\]\\(https://www\\.gazeta\\.pl/0%2C0\\.html[^)]*\\)[^\\S\\n]*$"
+        ]
+    },
+    "https://wiadomosci.wp.pl": {
+        "remove_before" : [],
+        "remove_after" : [],
+        "remove_string" : [],
+        "remove_string_regexp" : [
+            "(?mi)^[\\w.+-]+@grupawp\\.pl\\s*o autorze[^\\S\\n]*$"
+        ]
     }
 }

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -12,7 +12,6 @@ i reużywalna w skryptach batch.
 import re
 
 from library.article_extractor import _detect_portal, _find_footer_line, _find_start_line
-from library.article_quality import is_photo_caption_line
 from library.lenie_markdown import links_correct, md_square_brackets_in_one_line
 
 
@@ -61,6 +60,16 @@ def _is_portal_internal_link(url: str) -> bool:
     return any(re.search(p, url) for p in _PORTAL_INTERNAL_LINK_PATTERNS)
 
 
+def _is_adjacent_tag_links_line(line: str) -> bool:
+    """Czy linia składa się wyłącznie z co najmniej dwóch linków tagowych portalu."""
+    link_re = re.compile(r'\[[^\]\n]+\]\(([^)\n]+)\)')
+    matches = link_re.findall(line)
+    if len(matches) < 2 or link_re.sub('', line).strip():
+        return False
+    urls = [match.split('"')[0].strip() for match in matches]
+    return all(_is_portal_internal_link(url) for url in urls)
+
+
 def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
     """Generyczne czyszczenie linia po linii — wspólne dla wszystkich portali."""
     cleaned = []
@@ -103,7 +112,7 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
             continue
 
         # Markdown horizontal rules (---, ***, ___) — artefakty z konwersji HTML
-        if re.match(r'^[-*_]{3,}\s*$', stripped):
+        if re.match(r'^[-*_]{3,}\s*$', stripped) or stripped == "|":
             continue
 
         # Puste nagłówki markdown (np. "####" po usunięciu obrazka z pustym URL)
@@ -116,7 +125,7 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
 
         # Frazy portalowe wspólne
         if stripped in ("Dalszy ciąg materiału pod wideo", "REKLAMAKONIEC REKLAMY",
-                        "REKLAMA", "Lubię to", "[ ]", "Rozwiń", "Zwiń"):
+                        "REKLAMA", "KONIEC REKLAMY", "Lubię to", "[ ]", "Rozwiń", "Zwiń"):
             continue
 
         # Kontrolki video playera
@@ -131,19 +140,14 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
             continue
         # Warianty "Dalsza część artykułu pod wideo" (z kursywą, dwukropkiem)
         if "dalsza część artykułu pod wideo" in stripped.lower() or \
-           "dalszy ciąg materiału pod wideo" in stripped.lower():
+           "dalszy ciąg materiału pod wideo" in stripped.lower() or \
+           "dalszy ciąg artykułu pod materiałem wideo" in stripped.lower() or \
+           "dalsza część artykulu pod video" in stripped.lower():
             continue
         # "Czytaj także:" + link na tej samej lub następnej linii
         if stripped.startswith("**Czytaj także:**") or stripped.startswith("**Czytaj również:**"):
             continue
-
-        # Podpis zdjęcia / credit fotografa ("zdjęcie ilustracyjne ... / shutterstock")
-        # — wzorce współdzielone z article_quality (tam liczone do oceny staranności)
-        if is_photo_caption_line(stripped):
-            continue
-
-        # Linia z samymi [imgN] markerami (osierocone po usunięciu kontekstu)
-        if stripped.startswith("[img") and not any(c.isalpha() for c in re.sub(r'\[img\d+[^\]]*\]', '', stripped)):
+        if stripped.startswith("**Zobacz także:**") or stripped.startswith("* **Czytaj więcej:**"):
             continue
 
         # "Zobacz też" z obrazkiem: [[imgN...] tytuł](url) lub [[imgN...] tytuł [linkN]
@@ -157,7 +161,10 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
 
 def _clean_lines_onet(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla onet.pl/fakt.pl."""
-    skip = {"Posłuchaj artykułu", "Skróć artykuł", "- x1 +", "x1", "Obserwuj"}
+    skip = {
+        "Posłuchaj artykułu", "Skróć artykuł", "- x1 +", "x1", "Obserwuj",
+        "Więcej pogłębionych treści", "Więcej treści premium dla Ciebie",
+    }
     cleaned = []
     in_top_premium = False
     for line in lines:
@@ -177,6 +184,8 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
         # Porównuj treść linii bez prefiksów nagłówkowych (#### Posłuchaj artykułu → Posłuchaj artykułu)
         stripped_content = re.sub(r'^#{1,6}\s+', '', stripped)
         if stripped_content in skip:
+            continue
+        if stripped.startswith("Zapytaj o więcej Onet Czat z AI"):
             continue
         # Przyciski prędkości audio playera: x2, x1.75, x1.5, x1.25, x0.75
         if re.match(r'^x[\d.]+$', stripped):
@@ -204,18 +213,32 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
 
 def _clean_lines_money(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla money.pl."""
-    skip_exact = {"Skomentuj", "Notowania", "Udostępnij"}
-    skip_startswith = ("Udostępnij na X", "Źródło zdjęć:", "Źródło artykułu:",
+    skip_exact = {"Skomentuj", "Notowania", "Udostępnij", "Słuchaj", "Kopiuj link"}
+    skip_startswith = ("Udostępnij na ", "Źródło zdjęć:", "Źródło artykułu:",
                        "oprac.", "Dźwięk został wygenerowany")
     cleaned = []
+    skip_source_logo = False
     for line in lines:
         stripped = line.strip()
+        if stripped.startswith("Źródło artykułu:"):
+            skip_source_logo = True
+            continue
+        if skip_source_logo:
+            if not stripped:
+                continue
+            skip_source_logo = False
+            if re.match(r'^[A-Z]$', stripped):
+                continue
         if stripped in skip_exact:
             continue
         if any(stripped.startswith(s) for s in skip_startswith):
             continue
+        if re.match(r'^[\w.+-]+@grupawp\.pl\s*o autorze$', stripped, re.IGNORECASE):
+            continue
         # Samodzielna data: "24 marca 2026, 12:26"
         if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
+            continue
+        if re.match(r'^\d+\s+komentarz', stripped):
             continue
         # Tagi: "gospodarka elektrownia atomowa rosja +1" lub z markerami [linkN]
         tag_line = re.sub(r'\[link\d+\]', '', stripped).strip()
@@ -258,11 +281,26 @@ def _clean_lines_wp(lines: list[str]) -> list[str]:
     lines = [line for k, line in enumerate(lines) if k not in drop]
 
     cleaned = []
+    in_newsletter = False
     for line in lines:
         stripped = line.strip()
+        if stripped == "PREMIUM Zapisz się na newsletter!":
+            in_newsletter = True
+            continue
+        if in_newsletter:
+            if stripped in {
+                "Newsy, wywiady, śledztwa i reportaże w Twojej skrzynce co tydzień - zawsze za darmo.",
+                "Zapisz mnie",
+            }:
+                if stripped == "Zapisz mnie":
+                    in_newsletter = False
+                continue
+            in_newsletter = False
         if stripped in skip_exact:
             continue
         if any(stripped.startswith(s) for s in skip_startswith):
+            continue
+        if re.match(r'^[\w.+-]+@grupawp\.pl\s*o autorze$', stripped, re.IGNORECASE):
             continue
         if re.match(r'^\d+\s+komentarz', stripped):
             continue
@@ -286,6 +324,11 @@ def _clean_lines_wp(lines: list[str]) -> list[str]:
     return cleaned
 
 
+def _clean_lines_ithardware(lines: list[str]) -> list[str]:
+    """Usuń kontrolki osadzonego playera ITHardware bez globalnych reguł Play/ad."""
+    return [line for line in lines if line.strip() not in {"Play", "ad"}]
+
+
 def _clean_lines_gazeta(lines: list[str]) -> list[str]:
     """Usuń śródtekstowe karty rekomendacji Gazeta.pl, zachowując dalszy artykuł."""
     cleaned = []
@@ -294,6 +337,11 @@ def _clean_lines_gazeta(lines: list[str]) -> list[str]:
     for line in lines:
         stripped = line.strip()
         stripped_no_links = re.sub(r'\s*\[link\d+\]', '', stripped).strip()
+
+        if re.match(r'^Otwórz galerię \(\d+\)$', stripped, re.IGNORECASE):
+            continue
+        if re.match(r'^przejdź na(?: \[link\d+\])?$', stripped, re.IGNORECASE):
+            continue
 
         if stripped_no_links in ("Czytaj także:", "Czytaj również:"):
             in_recommendation = True
@@ -323,6 +371,23 @@ def clean_article_text(text: str, url: str = "") -> dict:
     # 1. Napraw wieloliniowe linki i tagi markdown
     text = links_correct(text)
     text = md_square_brackets_in_one_line(text)
+
+    # Karty rekomendacji z linkowanym obrazkiem i nagłówkiem. Konwerter potrafi
+    # zwrócić kilka kart bez separatora; md_square_brackets_in_one_line najpierw
+    # odtwarza ich granice. Usuwamy teraz każdą kartę jako osobną linię, zanim
+    # prosty parser obrazków natrafi na zagnieżdżone nawiasy, np. "[ANALIZA]".
+    text = "\n".join(
+        line for line in text.splitlines()
+        if not (line.strip().startswith("[![") and "#### " in line)
+    )
+
+    # Konwertery HTML -> Markdown potrafią zwrócić blok tagów bez separatorów:
+    # [tag 1](/tag/1)[tag 2](/tag/2). Usuń wyłącznie linie złożone w całości
+    # z co najmniej dwóch linków rozpoznanych jako tagi/kategorie portalu.
+    text = "\n".join(
+        line for line in text.splitlines()
+        if not _is_adjacent_tag_links_line(line.strip())
+    )
 
     # 2. Wykryj H2+obrazek wstawki PRZED usuwaniem obrazków
     h2_ad_titles = _detect_h2_ads(text)
@@ -435,6 +500,8 @@ def clean_article_text(text: str, url: str = "") -> dict:
         lines = _clean_lines_wp(lines)
     elif portal == "gazeta":
         lines = _clean_lines_gazeta(lines)
+    elif "ithardware.pl" in url.lower():
+        lines = _clean_lines_ithardware(lines)
 
     text = "\n".join(lines)
     text = re.sub(r'\n{3,}', '\n\n', text)

--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -15,6 +15,7 @@ import datetime
 import json
 import logging
 import re
+from collections import Counter
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +37,14 @@ _CAPTION_PREFIX_RE = re.compile(
 _CAPTION_AGENCY_RE = re.compile(
     r"(?:zdj[eę]cie\s+ilustracyjne|shutterstock|getty\s*images?|east\s+news|"
     r"adobe\s+stock|istock(?:photo)?|depositphotos|123rf|unsplash|pexels|"
+    r"domena\s+publiczna|\bcc\s+by(?:-sa)?\b|creative\s+commons|archiwum\s+prywatne|©|"
     r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bForum\b\s*/|/\s*Forum\b)",
     re.IGNORECASE,
 )
 
 # Podpis bywa dłuższy niż _CAPTION_MAX_CHARS, ale linia KOŃCZĄCA SIĘ
 # "(zdjęcie ilustracyjne)" to zawsze podpis, niezależnie od długości.
-_CAPTION_SUFFIX_RE = re.compile(r"\(zdj[eę]cie\s+ilustracyjne\)\s*$", re.IGNORECASE)
+_CAPTION_SUFFIX_RE = re.compile(r"\((?:zdj[eę]cie|zdj\.)\s+ilustracyjne\)\s*$", re.IGNORECASE)
 
 _CLICKBAIT_RE = re.compile(
     r"(?:nie uwierzysz|szok(?:uj[aą]c\w*)?\b|musisz to zobaczy[ćc]|zobacz,? co|"
@@ -74,6 +76,67 @@ def count_photo_captions(text: str) -> int:
     if not text:
         return 0
     return sum(1 for line in text.splitlines() if is_photo_caption_line(line))
+
+
+def photo_caption_candidates(text: str) -> list[dict]:
+    """Wykryte podpisy wraz z kategorią — dowody dla quality i podpowiedzi UI."""
+    candidates = []
+    pending_image_alt: str | None = None
+    pending_image_lines = 0
+    for index, line in enumerate((text or "").splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[img"):
+            candidates.append({"line_index": index, "text": stripped, "category": "image_marker"})
+            marker = re.match(r'^\[img\d+(?::\s*([^\]]*))?\]\s*$', stripped)
+            pending_image_alt = (marker.group(1) or "").strip() if marker else None
+            pending_image_lines = 3 if marker else 0
+            if not marker:
+                candidates.append({"line_index": index, "text": stripped, "category": "image_description"})
+            continue
+
+        direct_caption = is_photo_caption_line(stripped)
+        normalized = re.sub(r'\s+', ' ', stripped).casefold()
+        normalized_alt = re.sub(r'\s+', ' ', pending_image_alt or '').casefold()
+        repeats_image_alt = bool(pending_image_alt and normalized == normalized_alt)
+        adjacent_description = bool(
+            pending_image_lines > 0 and not stripped.startswith("#")
+            and (len(stripped) <= 120 or (repeats_image_alt and len(stripped) <= 300))
+        )
+        if pending_image_lines > 0:
+            pending_image_lines -= 1
+            if repeats_image_alt or (not direct_caption and not adjacent_description):
+                pending_image_alt = None
+                pending_image_lines = 0
+        if not (direct_caption or adjacent_description):
+            continue
+        lowered = stripped.lower()
+        if "domena publiczna" in lowered:
+            category = "public_domain"
+        elif re.search(r'\bcc\s+by(?:-sa)?\b|creative commons', lowered):
+            category = "creative_commons"
+        elif "archiwum prywatne" in lowered:
+            category = "own_or_private_archive"
+        elif re.search(r'zdj[eę]cie\s+ilustracyjne', lowered):
+            category = "illustrative"
+        elif _CAPTION_AGENCY_RE.search(line):
+            category = "agency_or_stock"
+        elif adjacent_description:
+            category = "image_description" if repeats_image_alt else "image_credit"
+        else:
+            category = "other"
+        candidates.append({"line_index": index, "text": line.strip(), "category": category})
+    return candidates
+
+
+def remove_photo_caption_lines(text: str) -> str:
+    """Kopia tekstu bez podpisów zdjęć, przeznaczona dla embeddingów/search."""
+    candidates = {item["line_index"] for item in photo_caption_candidates(text)}
+    return "\n".join(
+        line for index, line in enumerate((text or "").splitlines())
+        if index not in candidates
+    )
 
 
 def is_clickbait_title(title: str | None) -> bool:
@@ -133,7 +196,11 @@ def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -
     total_len = len(temat_text) + noise_len
 
     full_text = "\n".join((s.get("original") or "") for s in chunk_sections)
-    captions = count_photo_captions(full_text)
+    caption_evidence = photo_caption_candidates(full_text)
+    caption_evidence_for_score = [
+        item for item in caption_evidence if item["category"] != "image_marker"
+    ]
+    captions = len(caption_evidence_for_score)
     noise_share = (noise_len / total_len) if total_len else 0.0
 
     penalties: dict[str, int] = {}
@@ -161,6 +228,8 @@ def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -
         "penalties": penalties,
         "signals": {
             "photo_captions": captions,
+            "photo_caption_categories": dict(Counter(item["category"] for item in caption_evidence_for_score)),
+            "photo_caption_lines": [item["text"] for item in caption_evidence_for_score[:20]],
             "noise_share": round(noise_share, 3),
             "temat_chars": len(temat_text),
         },

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -25,6 +25,7 @@ import json
 import logging
 import threading
 import uuid
+from collections import Counter
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request, abort
@@ -146,6 +147,9 @@ def _chunk_to_dict(c: DocumentChunk, has_embeddings: bool | None = None, lite: b
     """Serialize a chunk. lite=True drops the full texts (book-sized runs are
     lazy-loaded per section) and ships a short preview + length instead."""
     text = c.corrected_text or c.original_text or ""
+    from library.article_quality import photo_caption_candidates
+
+    caption_candidates = photo_caption_candidates(c.original_text or "") if not lite else []
     return {
         "id": c.id,
         "position": c.position,
@@ -165,6 +169,7 @@ def _chunk_to_dict(c: DocumentChunk, has_embeddings: bool | None = None, lite: b
         "split_second_type": c.split_second_type,
         "obsidian_note_paths": c.obsidian_note_paths or [],
         "has_embeddings": bool(has_embeddings) if has_embeddings is not None else None,
+        "photo_caption_line_indices": [item["line_index"] for item in caption_candidates],
     }
 
 
@@ -202,11 +207,14 @@ def analyze_document_chunks(doc_id: int):
     mode = data.get("mode", "transcript")
     split_only = bool(data.get("split_only", False))
     preclean = bool(data.get("preclean", False))
+    reclean = bool(data.get("reclean", False))
     scope_chapter = data.get("scope_chapter")
     if mode not in ANALYSIS_MODES:
         return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
     if preclean and mode != "article":
         return jsonify({"status": "error", "message": "preclean requires article mode"}), 400
+    if reclean and mode != "article":
+        return jsonify({"status": "error", "message": "reclean requires article mode"}), 400
     if scope_chapter is not None:
         try:
             scope_chapter = int(scope_chapter)
@@ -248,6 +256,7 @@ def analyze_document_chunks(doc_id: int):
                 mode=mode,
                 split_only=split_only,
                 preclean=preclean,
+                reclean=reclean,
                 scope_chapter=scope_chapter,
             )
             ad_count = sum(1 for c in run.chunks if c.type == "REKLAMA")
@@ -287,12 +296,15 @@ def split_preview(doc_id: int):
     mode = request.args.get("mode", "article")
     chunk_size = request.args.get("chunk_size", 5000, type=int)
     scope_chapter = request.args.get("scope_chapter", type=int)
+    reclean = request.args.get("reclean", "0").lower() in {"1", "true", "yes"}
     if mode not in ANALYSIS_MODES:
         return jsonify({"status": "error", "message": f"Invalid mode: {mode}"}), 400
     if not 500 <= chunk_size <= 50000:
         return jsonify({"status": "error", "message": f"chunk_size out of range: {chunk_size}"}), 400
     if scope_chapter is not None and mode != "article":
         return jsonify({"status": "error", "message": "scope_chapter requires article mode"}), 400
+    if reclean and mode != "article":
+        return jsonify({"status": "error", "message": "reclean requires article mode"}), 400
 
     session = get_scoped_session()
     doc = session.get(WebDocument, doc_id)
@@ -302,6 +314,13 @@ def split_preview(doc_id: int):
     text, field = _extract_text(doc, prefer_md=(mode == "article"))
     if not text:
         return jsonify({"status": "error", "message": "Document has no usable text"}), 400
+
+    if reclean:
+        from library.article_cleaner import clean_article_text
+
+        text = clean_article_text(text, doc.url or "")["text"]
+        if not text:
+            return jsonify({"status": "error", "message": "Document is empty after cleanup"}), 400
 
     scope_title = None
     if mode == "article":
@@ -330,11 +349,66 @@ def split_preview(doc_id: int):
         "mode": mode,
         "chunk_size": chunk_size,
         "source_field": field,
+        "reclean": reclean,
         "scope_chapter": scope_chapter,
         "scope_title": scope_title,
         "text_length": len(text),
         "chunk_count": len(parts),
         "chunk_sizes": [len(p) for p in parts],
+    })
+
+
+@bp.route("/document/<int:doc_id>/reclean_preview", methods=["POST"])
+def reclean_preview(doc_id: int):
+    """Preview current deterministic cleanup and optionally save it explicitly."""
+    from library.article_cleaner import clean_article_text
+    from library.document_analysis_service import _extract_text
+
+    data = request.get_json(silent=True) or {}
+    save = bool(data.get("save", False))
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    before, field = _extract_text(doc, prefer_md=True)
+    if not before:
+        return jsonify({"status": "error", "message": "Document has no usable text"}), 400
+    if field not in {"text", "text_md"}:
+        return jsonify({
+            "status": "error",
+            "message": f"Cleanup preview cannot analyze source field {field}",
+        }), 400
+
+    after = clean_article_text(before, doc.url or "")["text"]
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    remaining = Counter(after_lines)
+    removed = []
+    for line in before_lines:
+        if remaining[line] > 0:
+            remaining[line] -= 1
+        elif line.strip():
+            removed.append(line)
+
+    if save:
+        setattr(doc, field, after)
+        doc.document_length = len(after)
+        doc.quality = None
+        session.commit()
+
+    return jsonify({
+        "status": "success",
+        "saved": save,
+        "source_field": field,
+        "before_length": len(before),
+        "after_length": len(after),
+        "before_line_count": len(before_lines),
+        "after_line_count": len(after_lines),
+        "removed_line_count": len(removed),
+        "removed_lines_preview": removed[:20],
+        "start_preview": after[:400],
+        "end_preview": after[-700:],
     })
 
 

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -355,6 +355,7 @@ class DocumentAnalysisService:
         mode: str = "transcript",
         split_only: bool = False,
         preclean: bool = False,
+        reclean: bool = False,
         scope_chapter: int | None = None,
     ) -> DocumentAnalysisRun:
         """Create a new analysis run for an existing document and persist to DB.
@@ -399,6 +400,8 @@ class DocumentAnalysisService:
             raise ValueError("scope_chapter requires article mode")
         if preclean and is_transcript:
             raise ValueError("preclean requires article mode")
+        if reclean and is_transcript:
+            raise ValueError("reclean requires article mode")
         proposal_only = split_only or preclean
 
         def log(msg: str) -> None:
@@ -419,6 +422,15 @@ class DocumentAnalysisService:
             raise ValueError(f"Document {doc_id} has no usable text (checked: text, text_md, text_raw)")
 
         log(f"doc={doc_id} mode={mode} field={text_field} len={len(text):,}")
+
+        if reclean:
+            from library.article_cleaner import clean_article_text
+
+            original_length = len(text)
+            text = clean_article_text(text, getattr(doc, "url", "") or "")["text"]
+            if not text:
+                raise ValueError(f"Document {doc_id} is empty after deterministic cleanup")
+            log(f"reclean: {original_length:,} -> {len(text):,} chars (source unchanged)")
 
         scope: str | None = None
         author_bio = None
@@ -773,6 +785,7 @@ def generate_embeddings_from_run(
     from library.config_loader import load_config
     from library.db.models import WebsiteEmbedding
     from library.lenie_markdown import md_remove_markdown, md_split_for_emb
+    from library.article_quality import remove_photo_caption_lines
     from library.models.stalker_document_status import StalkerDocumentStatus
     from library.stalker_web_documents_db_postgresql import WebsitesDBPostgreSQL
     import library.embedding as embedding
@@ -810,7 +823,9 @@ def generate_embeddings_from_run(
     skipped_empty = 0
     for i, chunk in enumerate(eligible, 1):
         log(f"chunk {i}/{len(eligible)} (position {chunk.position})...")
-        text = (chunk.corrected_text or chunk.original_text or "").strip()
+        text = remove_photo_caption_lines(
+            chunk.corrected_text or chunk.original_text or ""
+        ).strip()
         if not text:
             skipped_empty += 1
             continue

--- a/backend/library/lenie_markdown.py
+++ b/backend/library/lenie_markdown.py
@@ -135,6 +135,12 @@ def process_markdown_and_extract_links(md_text):
 
 
 def md_square_brackets_in_one_line(text):
+    # Niektóre konwertery HTML -> Markdown sklejają sąsiednie karty z obrazkiem:
+    #   [![...](image)](article)[![...](image)](article)
+    # Bez separatora poniższa normalizacja traktuje je jak jeden blok. Odtwórz
+    # granicę kart, zanim usuniemy nowe linie znajdujące się wewnątrz nawiasów.
+    text = re.sub(r'\)(?=\[!\[)', ')\n\n', text)
+
     is_in_brackets = False
     text_new = ""
     level = 0

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -6,6 +6,8 @@ Pure-function tests on synthetic markdown fixtures, no DB/LLM/network.
 from library.article_cleaner import (
     _clean_lines_money,
     _clean_lines_onet,
+    _clean_lines_ithardware,
+    _is_adjacent_tag_links_line,
     _clean_lines_wp,
     _detect_h2_ads,
     _is_portal_internal_link,
@@ -67,6 +69,21 @@ class TestGazetaExtraction:
         assert "Polecany tekst" not in result
         assert "Źródło: PAP" not in result
 
+    def test_gallery_and_homepage_controls_removed_but_article_sentence_kept(self):
+        text = "\n\n".join([
+            "Otwórz galerię (3)",
+            "[przejdź na](https://www.gazeta.pl/0%2C0.html?utm_campaign=test)",
+            "Reporter powiedział: przejdź na drugą stronę dokumentu i otwórz galerię sztuki.",
+            LONG_PARAGRAPH,
+        ])
+
+        result = clean_article_text(text, url=self.URL)["text"]
+
+        assert "Otwórz galerię (3)" not in result
+        assert "przejdź na [link" not in result
+        assert "przejdź na drugą stronę" in result
+        assert LONG_PARAGRAPH in result
+
 
 class TestImageExtraction:
     def test_inline_image_replaced_with_marker(self):
@@ -75,12 +92,12 @@ class TestImageExtraction:
         assert result["images"] == [{"alt": "Opis zdjęcia", "url": "https://example.com/foto.jpg"}]
         assert "[img0: Opis zdjęcia]" in result["text"]
 
-    def test_standalone_image_line_removed_but_collected(self):
+    def test_standalone_image_line_preserved_for_quality_and_collected(self):
         text = f"{LONG_PARAGRAPH}\n\n![Opis zdjęcia](https://example.com/foto.jpg)\n\nDrugi akapit."
         result = clean_article_text(text)
         assert result["images"] == [{"alt": "Opis zdjęcia", "url": "https://example.com/foto.jpg"}]
-        # Linia z samym markerem [imgN] jest usuwana z tekstu
-        assert "[img0" not in result["text"]
+        # Marker pozostaje dla quality/UI; generator embeddingów filtruje jego kopię.
+        assert "[img0: Opis zdjęcia]" in result["text"]
         assert "Drugi akapit." in result["text"]
 
     def test_image_with_empty_url_removed(self):
@@ -221,6 +238,29 @@ class TestMoneyCleaning:
         ]
         assert _clean_lines_money(lines) == ["Treść artykułu money."]
 
+    def test_money_comments_audio_and_share_controls_removed(self):
+        lines = [
+            "25 komentarzy",
+            "Słuchaj",
+            "Udostępnij na Facebooku Udostępnij na X Udostępnij na WhatsApp Kopiuj link",
+            "Treść artykułu money.",
+        ]
+        assert _clean_lines_money(lines) == ["Treść artykułu money."]
+
+    def test_money_author_artifact_and_contextual_source_logo_removed(self):
+        lines = [
+            "jacek.losik@grupawp.plo autorze",
+            "Źródło artykułu:",
+            "",
+            "T",
+            "The Wall Street Journal",
+            "Litera T w treści artykułu pozostaje.",
+        ]
+        assert _clean_lines_money(lines) == [
+            "The Wall Street Journal",
+            "Litera T w treści artykułu pozostaje.",
+        ]
+
 
 class TestWpCleaning:
     def test_wp_comments_author_and_tags_removed(self):
@@ -274,3 +314,111 @@ class TestWpCleaning:
             "Treść artykułu o2.",
         ]
         assert _clean_lines_wp(lines) == lines
+
+    def test_wp_newsletter_block_removed_but_article_content_kept(self):
+        lines = [
+            "PREMIUM Zapisz się na newsletter!",
+            "Newsy, wywiady, śledztwa i reportaże w Twojej skrzynce co tydzień - zawsze za darmo.",
+            "Zapisz mnie",
+            "Zapisz mnie na liście uczestników spotkania.",
+        ]
+        assert _clean_lines_wp(lines) == ["Zapisz mnie na liście uczestników spotkania."]
+
+    def test_wp_author_email_artifact_removed_but_normal_email_kept(self):
+        lines = [
+            "Lukasz.Maziewski@grupawp.plo autorze",
+            "Kontakt do autora: autor@grupawp.pl",
+        ]
+        assert _clean_lines_wp(lines) == ["Kontakt do autora: autor@grupawp.pl"]
+
+
+class TestSafeUiArtifacts:
+    def test_ad_block_markers_removed_without_touching_surrounding_paragraphs(self):
+        before = "Akapit przed blokiem reklamowym pozostaje w artykule."
+        after = "Akapit po bloku reklamowym również pozostaje w artykule."
+        text = f"{before}\n\nREKLAMA\nKONIEC REKLAMY\n\n{after}"
+
+        result = clean_article_text(text)["text"]
+
+        assert "REKLAMA" not in result
+        assert before in result
+        assert after in result
+
+    def test_generic_recommendations_video_markers_and_separator_removed(self):
+        text = "\n".join([
+            "Dalszy ciąg artykułu pod materiałem wideo",
+            "**Zobacz także:** **Polecany materiał** [link0]",
+            "* **Czytaj więcej:** **Inny materiał** [link1]",
+            "|",
+            LONG_PARAGRAPH,
+        ])
+        result = clean_article_text(text)["text"]
+        assert result == LONG_PARAGRAPH
+
+    def test_onet_ai_and_premium_labels_removed(self):
+        lines = [
+            "Zapytaj o więcej Onet Czat z AI [link0]",
+            "Więcej pogłębionych treści",
+            "Więcej treści premium dla Ciebie",
+            "Treść artykułu.",
+        ]
+        assert _clean_lines_onet(lines) == ["Treść artykułu."]
+
+    def test_ithardware_player_controls_are_domain_scoped(self):
+        lines = ["Dalsza część artykulu pod video", "Play", "ad", "Treść artykułu."]
+        assert _clean_lines_ithardware(lines) == ["Dalsza część artykulu pod video", "Treść artykułu."]
+
+        text = "\n".join(lines)
+        result = clean_article_text(text, url="https://ithardware.pl/aktualnosci/test.html")["text"]
+        assert result == "Treść artykułu."
+
+        unrelated = clean_article_text("Play\nad\nTreść artykułu.", url="https://example.com/article")["text"]
+        assert "Play" in unrelated
+        assert "ad" in unrelated
+
+    def test_onet_adjacent_recommendation_cards_do_not_merge_or_remove_article(self):
+        cards = (
+            "Więcej treści premium dla Ciebie\n\n"
+            "[![Pierwsza rekomendacja](https://cdn.example/1.jpg)\n\n"
+            "#### Pierwsza rekomendacja](https://wiadomosci.onet.pl/a/1)"
+            "[![Druga rekomendacja](https://cdn.example/2.jpg)\n\n"
+            "#### Druga rekomendacja](https://wiadomosci.onet.pl/a/2)"
+        )
+        result = clean_article_text(
+            f"{cards}\n\n{LONG_PARAGRAPH}",
+            url="https://www.onet.pl/informacje/onetwiadomosci/test",
+        )["text"]
+
+        assert "Pierwsza rekomendacja" not in result
+        assert "Druga rekomendacja" not in result
+        assert LONG_PARAGRAPH in result
+
+
+class TestAdjacentTagLinks:
+    def test_detects_wp_and_money_tag_only_lines(self):
+        assert _is_adjacent_tag_links_line(
+            '[czołgi](/tag/czolgi)[rosja](/tag/rosja)'
+        )
+        assert _is_adjacent_tag_links_line(
+            '[afryka](https://www.money.pl/wiadomosci/afryka.html "afryka")'
+            '[rosja](https://www.money.pl/wiadomosci/rosja.html "rosja")'
+        )
+
+    def test_does_not_remove_adjacent_article_links_or_inline_sentence(self):
+        article_links = (
+            '[Pierwszy artykuł](https://example.com/1)'
+            '[Drugi artykuł](https://example.com/2)'
+        )
+        inline = 'Zobacz [tag](/tag/test) w treści zdania.'
+        assert not _is_adjacent_tag_links_line(article_links)
+        assert not _is_adjacent_tag_links_line(inline)
+
+        result = clean_article_text(f"{article_links}\n{inline}")["text"]
+        assert "Pierwszy artykuł" in result
+        assert "Drugi artykuł" in result
+        assert "w treści zdania" in result
+
+    def test_cleaner_removes_adjacent_tag_block(self):
+        tags = '[czołgi](/tag/czolgi)[rosja](/tag/rosja)[militaria](/tag/militaria)'
+        result = clean_article_text(f"{LONG_PARAGRAPH}\n{tags}", url="https://tech.wp.pl/test")["text"]
+        assert result == LONG_PARAGRAPH

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -9,6 +9,8 @@ from library.article_quality import (
     count_photo_captions,
     is_clickbait_title,
     is_photo_caption_line,
+    photo_caption_candidates,
+    remove_photo_caption_lines,
 )
 
 LONG_PARAGRAPH = (
@@ -72,6 +74,73 @@ class TestPhotoCaptionDetection:
     def test_count_empty_text(self):
         assert count_photo_captions("") == 0
 
+    def test_candidates_preserve_license_and_public_domain_evidence(self):
+        text = "\n".join([
+            LONG_PARAGRAPH,
+            "Makieta obozu (fot. Drozdp), licencja CC BY-SA 4.0",
+            "Salomon Morel, 1948 r., domena publiczna",
+            "Źródło Archiwum FUF / archiwum prywatne",
+        ])
+        candidates = photo_caption_candidates(text)
+        assert [item["line_index"] for item in candidates] == [1, 2, 3]
+        assert [item["category"] for item in candidates] == [
+            "creative_commons", "public_domain", "own_or_private_archive",
+        ]
+
+    def test_embedding_filter_removes_caption_without_mutating_source(self):
+        source = f"{LONG_PARAGRAPH}\nFot. Jan Kowalski / PAP\n{LONG_PARAGRAPH}"
+        filtered = remove_photo_caption_lines(source)
+        assert "Fot. Jan Kowalski" not in filtered
+        assert filtered.count(LONG_PARAGRAPH) == 2
+        assert "Fot. Jan Kowalski" in source
+
+    def test_image_marker_makes_following_description_a_ui_candidate(self):
+        caption = "Prezydent Turcji wita prezydenta USA w Ankarze, 7 lipca 2026 r."
+        text = "\n".join([
+            f"[img2: {caption}]",
+            caption,
+            LONG_PARAGRAPH,
+        ])
+        candidates = photo_caption_candidates(text)
+        assert [(item["line_index"], item["category"]) for item in candidates] == [
+            (0, "image_marker"), (1, "image_description"),
+        ]
+        filtered = remove_photo_caption_lines(text)
+        assert "[img2" not in filtered
+        assert "Prezydent Turcji" not in filtered
+        assert LONG_PARAGRAPH in filtered
+
+    def test_onet_marker_credit_and_repeated_alt_are_all_candidates(self):
+        caption = "Prezydent Turcji wita prezydenta USA w Ankarze, 7 lipca 2026 r."
+        text = "\n".join([
+            f"[img2: {caption}]",
+            "ABDULLAH GUCLU / AFP",
+            caption,
+            LONG_PARAGRAPH,
+        ])
+        candidates = photo_caption_candidates(text)
+        assert [item["line_index"] for item in candidates] == [0, 1, 2]
+        filtered = remove_photo_caption_lines(text)
+        assert "ABDULLAH" not in filtered
+        assert caption not in filtered
+        assert LONG_PARAGRAPH in filtered
+
+    def test_histmag_short_credit_between_marker_and_repeated_alt_is_candidate(self):
+        caption = "Makieta obozu, 2022 rok (fot. Drozdp), licencja CC BY-SA 4.0"
+        text = "\n".join([
+            f"[img3: {caption}]",
+            "Drozdp / Portal historyczny Histmag.org",
+            caption,
+            LONG_PARAGRAPH,
+        ])
+        candidates = photo_caption_candidates(text)
+        assert [item["line_index"] for item in candidates] == [0, 1, 2]
+        assert candidates[1]["category"] == "image_credit"
+
+    def test_copyright_and_abbreviated_illustrative_caption_detected(self):
+        assert is_photo_caption_line("Rosyjskie czołgi. © Twitter | Kontakt6")
+        assert is_photo_caption_line("Firma złożyła wniosek o upadłość (zdj. ilustracyjne)")
+
 
 class TestClickbaitTitle:
     def test_clickbait(self):
@@ -109,6 +178,8 @@ class TestComputeQuality:
         q = compute_quality(_Doc(author="A", title="T"), secs, model=None)
         assert q["penalties"]["photo_captions"] == 15  # cap, nie 25
         assert q["signals"]["photo_captions"] == 5
+        assert q["signals"]["photo_caption_categories"] == {"agency_or_stock": 5}
+        assert len(q["signals"]["photo_caption_lines"]) == 5
 
     def test_noise_share_penalty(self):
         secs = [

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -128,6 +128,28 @@ class TestScopeChapterRun:
         with pytest.raises(ValueError, match="out of range"):
             service.create_run(doc_id=77, model="m", mode="article", scope_chapter=42)
 
+    def test_reclean_applies_current_footer_rules_before_split(self, monkeypatch, session, book_env):
+        class WpDoc(FakeBookDoc):
+            text_md = None
+            text = ("Treść właściwa artykułu i jego dłuższy akapit testowy. " * 4
+                    + "\n\nWybrane dla Ciebie\n\nPolecany materiał")
+            url = "https://tech.wp.pl/test"
+
+        monkeypatch.setattr(
+            das.WebDocument, "get_by_id", staticmethod(lambda _s, _id: WpDoc()),
+        )
+        monkeypatch.setattr("library.entity_service.refresh_document_entities", lambda *_a, **_kw: [])
+
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=77, model="m", mode="article", split_only=True, reclean=True)
+
+        joined = "\n".join(
+            item.original_text for item in session.added if isinstance(item, DocumentChunk)
+        )
+        assert "Treść właściwa" in joined
+        assert "Wybrane dla Ciebie" not in joined
+        assert "Polecany materiał" not in joined
+
 
 # ---------------------------------------------------------------------------
 # Flask routes (mocked session)
@@ -347,6 +369,11 @@ class TestAnalyzeChunksScopeValidation:
     def test_scope_chapter_must_be_int(self, client):
         resp = client.post("/document/77/analyze_chunks",
                            json={"mode": "article", "scope_chapter": "abc"})
+        assert resp.status_code == 400
+
+    def test_reclean_requires_article_mode(self, client):
+        resp = client.post("/document/77/analyze_chunks",
+                           json={"mode": "transcript", "reclean": True})
         assert resp.status_code == 400
 
 

--- a/backend/tests/unit/test_generate_embeddings_from_run.py
+++ b/backend/tests/unit/test_generate_embeddings_from_run.py
@@ -118,6 +118,19 @@ class TestGenerateEmbeddingsFromRun:
 
         assert embedding_env["embedding_add"][0]["text"] == "Wersja poprawiona."
 
+    def test_photo_captions_are_filtered_only_from_embedding_copy(self, session, embedding_env):
+        source = "Treść przed zdjęciem.\nFot. Jan Kowalski / PAP\nTreść po zdjęciu."
+        chunks = [_chunk(1, "TEMAT", "approved", original_text=source)]
+        session.scalars.return_value.all.return_value = chunks
+
+        generate_embeddings_from_run(session, 5)
+
+        embedded = embedding_env["embedding_add"][0]["text"]
+        assert "Fot. Jan Kowalski" not in embedded
+        assert "Treść przed zdjęciem" in embedded
+        assert "Treść po zdjęciu" in embedded
+        assert chunks[0].original_text == source
+
     def test_empty_text_chunk_is_skipped(self, session, embedding_env):
         chunks = [_chunk(1, "TEMAT", "approved", original_text="   ")]
         session.scalars.return_value.all.return_value = chunks

--- a/backend/tests/unit/test_md_squre_brackets_in_one_line.py
+++ b/backend/tests/unit/test_md_squre_brackets_in_one_line.py
@@ -55,6 +55,30 @@ pra](https://test2.pl)
 
         self.assertEqual(md_square_brackets_in_one_line(text), expected)
 
+    def test_separates_adjacent_linked_image_cards_before_flattening(self):
+        text = (
+            "[![Pierwsza karta](https://img.example/1.jpg)\n\n"
+            "#### Pierwsza karta](https://example.com/1)"
+            "[![Druga karta](https://img.example/2.jpg)\n\n"
+            "#### Druga karta](https://example.com/2)"
+        )
+
+        expected = (
+            "[![Pierwsza karta](https://img.example/1.jpg) #### Pierwsza karta]"
+            "(https://example.com/1)\n\n"
+            "[![Druga karta](https://img.example/2.jpg) #### Druga karta]"
+            "(https://example.com/2)"
+        )
+
+        self.assertEqual(md_square_brackets_in_one_line(text), expected)
+
+    def test_keeps_existing_separator_between_cards(self):
+        text = (
+            "[![Pierwsza](https://img.example/1.jpg)](https://example.com/1)\n\n"
+            "[![Druga](https://img.example/2.jpg)](https://example.com/2)"
+        )
+        self.assertEqual(md_square_brackets_in_one_line(text), text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/unit/test_removed_lines.py
+++ b/backend/tests/unit/test_removed_lines.py
@@ -14,8 +14,24 @@ pytest.importorskip("flask")
 
 from sqlalchemy import inspect  # noqa: E402
 
-from library.chunk_review_routes import _log_removed_lines, _removed_lines_diff  # noqa: E402
+from library.chunk_review_routes import _chunk_to_dict, _log_removed_lines, _removed_lines_diff  # noqa: E402
 from library.db.models import DocumentRemovedLine  # noqa: E402
+
+
+def test_chunk_payload_marks_photo_caption_candidates():
+    chunk = type("Chunk", (), {
+        "id": 1, "position": 1, "type": "TEMAT", "topic": None,
+        "original_text": "Treść artykułu.\nFot. Jan Kowalski / PAP\nDalsza treść.",
+        "corrected_text": None, "summary": None, "seg_start": None, "seg_end": None,
+        "rewrite_ratio": None, "status": "pending", "split_at_seg": None,
+        "split_first_type": None, "split_second_type": None,
+        "obsidian_note_paths": [],
+    })()
+
+    payload = _chunk_to_dict(chunk)
+
+    assert payload["photo_caption_line_indices"] == [1]
+    assert "Fot. Jan Kowalski / PAP" in payload["original_text"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_site_rules_o2.py
+++ b/backend/tests/unit/test_site_rules_o2.py
@@ -122,6 +122,62 @@ def test_site_rules_path_is_configurable(monkeypatch, tmp_path):
     assert webpage_text_clean("https://example.com/article", "keep REMOVE ME this") == "keep  this"
 
 
+@pytest.mark.parametrize(
+    ("url", "artifact"),
+    [
+        ("https://www.money.pl/artykul", "25 komentarzy\nSłuchaj\nUdostępnij na Facebooku Udostępnij na X Udostępnij na WhatsApp Kopiuj link"),
+        ("https://www.onet.pl/informacje/test", "Zapytaj o więcej Onet Czat z AI [link0]\nWięcej pogłębionych treści\nWięcej treści premium dla Ciebie\nDalszy ciąg artykułu pod materiałem wideo"),
+        ("https://businessinsider.com.pl/test", "Dalszy ciąg artykułu pod materiałem wideo\n**Zobacz także:** **Polecany tekst** [link0]\n|"),
+        ("https://ithardware.pl/test", "Dalsza część artykulu pod video\nPlay\nad"),
+    ],
+)
+def test_domain_safe_ui_artifacts_removed(url, artifact):
+    article = "To jest zwykła treść artykułu, która ma pozostać bez zmian."
+    result = webpage_text_clean(url, f"{artifact}\n{article}")
+    assert result == article
+
+
+def test_tech_wp_newsletter_removed_without_matching_article_phrase():
+    newsletter = (
+        "PREMIUM Zapisz się na newsletter!\n"
+        "Newsy, wywiady, śledztwa i reportaże w Twojej skrzynce co tydzień - zawsze za darmo.\n"
+        "Zapisz mnie"
+    )
+    article = "Zapisz mnie na listę uczestników spotkania."
+    result = webpage_text_clean("https://tech.wp.pl/test", f"{newsletter}\n{article}")
+    assert result == article
+
+
+def test_gazeta_gallery_controls_removed_without_touching_article_sentence():
+    controls = (
+        "Otwórz galerię (3)\n"
+        "[przejdź na](https://www.gazeta.pl/0%2C0.html?utm_campaign=test)"
+    )
+    article = "Czytelnik może przejść na wystawę i otworzyć galerię sztuki."
+    result = webpage_text_clean(
+        "https://wiadomosci.gazeta.pl/swiat/test",
+        f"{controls}\n{article}",
+    )
+    assert result == article
+
+
+def test_global_two_line_ad_marker_removed_between_article_paragraphs():
+    before = "Akapit przed reklamą pozostaje."
+    after = "Akapit po reklamie pozostaje."
+    result = webpage_text_clean(
+        "https://example.com/article",
+        f"{before}\nREKLAMA\nKONIEC REKLAMY\n{after}",
+    )
+    assert result == f"{before}\n\n{after}"
+
+
+@pytest.mark.parametrize("url", ["https://www.money.pl/test", "https://wiadomosci.wp.pl/test"])
+def test_wp_platform_glued_author_email_removed_but_normal_email_kept(url):
+    artifact = "jan.kowalski@grupawp.plo autorze"
+    article = "Kontakt pod adresem redakcja@grupawp.pl pozostaje częścią tekstu."
+    assert webpage_text_clean(url, f"{artifact}\n{article}") == article
+
+
 @pytest.mark.parametrize("contents", [None, "not valid json"])
 def test_missing_or_invalid_rules_fall_back_to_empty_rules(tmp_path, caplog, contents):
     rules_path = tmp_path / "site-rules.json"

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -28,6 +28,7 @@ interface Chunk {
   seg_end: number | null;
   obsidian_note_paths?: string[];
   has_embeddings?: boolean | null;
+  photo_caption_line_indices?: number[];
   // lite responses (big runs): texts stripped, preview + length instead
   text_length?: number | null;
   text_preview?: string | null;
@@ -71,6 +72,19 @@ interface Chapter {
   char_start: number;
   char_end: number;
   length: number;
+}
+
+interface RecleanPreview {
+  source_field: string;
+  before_length: number;
+  after_length: number;
+  before_line_count: number;
+  after_line_count: number;
+  removed_line_count: number;
+  removed_lines_preview: string[];
+  start_preview: string;
+  end_preview: string;
+  saved: boolean;
 }
 
 interface CountryTag {
@@ -309,13 +323,14 @@ const SegmentsView: React.FC<{
 const PlainTextLines: React.FC<{
   text: string;
   markedLines: Set<number>;
+  photoCaptionLines: Set<number>;
   splitLineIdx: number | null;
   saving: boolean;
   onToggleLine: (idx: number) => void;
   onMarkSplit: (idx: number) => void;
   onSave: (removeFromDocument: boolean) => void;
   onCancel: () => void;
-}> = ({ text, markedLines, splitLineIdx, saving, onToggleLine, onMarkSplit, onSave, onCancel }) => {
+}> = ({ text, markedLines, photoCaptionLines, splitLineIdx, saving, onToggleLine, onMarkSplit, onSave, onCancel }) => {
   const [removeFromDoc, setRemoveFromDoc] = React.useState(true);
   if (!text) return <em style={{ color: "#94a3b8" }}>brak tekstu</em>;
   const lines = text.split("\n");
@@ -327,6 +342,7 @@ const PlainTextLines: React.FC<{
     <div>
       {lines.map((line, i) => {
         const marked = markedLines.has(i);
+        const isPhotoCaption = photoCaptionLines.has(i);
         const isSplitMark = splitLineIdx === i;
         return (
           <div
@@ -334,6 +350,7 @@ const PlainTextLines: React.FC<{
             style={{
               position: "relative", paddingLeft: 56, borderRadius: 2, minHeight: "1.4em",
               ...(marked ? { background: "#fee2e2", textDecoration: "line-through", color: "#991b1b" } : {}),
+              ...(!marked && isPhotoCaption ? { background: "#fefce8", borderLeft: "3px solid #eab308" } : {}),
               ...(isSplitMark ? { background: "#fff7ed", borderLeft: "3px solid #f97316" } : {}),
             }}
           >
@@ -356,6 +373,14 @@ const PlainTextLines: React.FC<{
               )}
             </span>
             <span style={{ whiteSpace: "pre-wrap" }}>{line || " "}</span>
+            {isPhotoCaption && (
+              <span
+                title="Podpis lub credit zdjęcia: zachowany dla oceny jakości, pomijany przy generowaniu embeddingów"
+                style={{ marginLeft: 8, padding: "1px 5px", borderRadius: 3, background: "#fef08a", color: "#854d0e", fontSize: "0.75em", whiteSpace: "nowrap" }}
+              >
+                📷 kandydat do usunięcia
+              </span>
+            )}
           </div>
         );
       })}
@@ -418,6 +443,9 @@ const Chunks = () => {
   const [chunkSize, setChunkSize]   = React.useState(5000);
   const [splitPreview, setSplitPreview] = React.useState<{ count: number; sizes: number[]; length: number } | null>(null);
   const [previewNonce, setPreviewNonce] = React.useState(0);
+  const [recleanPreview, setRecleanPreview] = React.useState<RecleanPreview | null>(null);
+  const [useRecleaned, setUseRecleaned] = React.useState(false);
+  const [recleaning, setRecleaning] = React.useState(false);
   const [hideAds, setHideAds]       = React.useState(false);
 
   const [showCorrected, setShowCorrected] = React.useState<Record<number, boolean>>({});
@@ -585,8 +613,9 @@ const Chunks = () => {
     const t = setTimeout(async () => {
       try {
         const scopeParam = newMode === "article" && scopeChapter !== "" ? `&scope_chapter=${scopeChapter}` : "";
+        const recleanParam = newMode === "article" && useRecleaned ? "&reclean=1" : "";
         const r = await fetch(
-          `${apiUrl}/document/${id}/split_preview?mode=${newMode}&chunk_size=${chunkSize}${scopeParam}`,
+          `${apiUrl}/document/${id}/split_preview?mode=${newMode}&chunk_size=${chunkSize}${scopeParam}${recleanParam}`,
           { headers: { "x-api-key": apiKey ?? "" } },
         );
         const data = await r.json();
@@ -598,7 +627,7 @@ const Chunks = () => {
       } catch { setSplitPreview(null); }
     }, 400);
     return () => clearTimeout(t);
-  }, [id, newMode, chunkSize, scopeChapter, apiUrl, apiKey, previewNonce]);
+  }, [id, newMode, chunkSize, scopeChapter, useRecleaned, apiUrl, apiKey, previewNonce]);
 
   // ── Job polling ──
 
@@ -629,6 +658,7 @@ const Chunks = () => {
 
   const startAnalysis = async (
     modeOverride?: string, splitOnlyOverride?: boolean, scopeChapterOverride?: number | null,
+    recleanOverride?: boolean,
   ) => {
     if (!id) return;
     setError(""); setJobStatus("starting");
@@ -645,6 +675,7 @@ const Chunks = () => {
           mode,
           split_only: splitOnlyOverride ?? splitOnly,
           preclean: mode === "article" && !(splitOnlyOverride ?? splitOnly) && preclean,
+          reclean: mode === "article" && (recleanOverride ?? useRecleaned),
           ...(scope !== null ? { scope_chapter: scope } : {}),
         }),
       });
@@ -652,6 +683,40 @@ const Chunks = () => {
       if (data.job_id) { setJobId(data.job_id); setJobStatus("running"); pollJob(data.job_id); }
       else { setError("Nie udało się uruchomić analizy"); setJobStatus(null); }
     } catch { setError("Błąd połączenia"); setJobStatus(null); }
+  };
+
+  const previewReclean = async (save = false) => {
+    if (!id) return;
+    if (save && !window.confirm("Zapisać oczyszczony tekst w dokumencie? Ta operacja nadpisze bieżące pole tekstowe.")) return;
+    setRecleaning(true); setError(""); setInfo("");
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/reclean_preview`, {
+        method: "POST", headers, body: JSON.stringify({ save }),
+      });
+      const data = await r.json();
+      if (!r.ok || data.status !== "success") throw new Error(data.message || "Nie udało się przeczyścić tekstu");
+      setRecleanPreview(data as RecleanPreview);
+      setUseRecleaned(!save);
+      setPreviewNonce(n => n + 1);
+      if (save) {
+        setInfo(`Zapisano oczyszczony tekst w polu ${data.source_field}.`);
+      } else {
+        const confirmed = window.confirm(
+          `Ponowne czyszczenie: ${data.before_length.toLocaleString("pl")} → ${data.after_length.toLocaleString("pl")} znaków, `
+          + `${data.removed_line_count} usuniętych lub zmienionych linii.\n\nUtworzyć teraz nowy run „tylko podział”?`,
+        );
+        if (confirmed) {
+          setInfo("Tworzę nowy podział z oczyszczonego tekstu…");
+          await startAnalysis("article", true, null, true);
+        } else {
+          setInfo("Podgląd gotowy. Nowy run nie został utworzony.");
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Błąd ponownego czyszczenia tekstu");
+    } finally {
+      setRecleaning(false);
+    }
   };
 
   // ── Chunk patch ──
@@ -1426,6 +1491,7 @@ const Chunks = () => {
                 <PlainTextLines
                   text={chunk.original_text ?? ""}
                   markedLines={lineEdits[chunk.id] ?? new Set()}
+                  photoCaptionLines={new Set(chunk.photo_caption_line_indices ?? [])}
                   splitLineIdx={lineSplitStates[chunk.id]?.lineIdx ?? null}
                   saving={savingLines[chunk.id] ?? false}
                   onToggleLine={idx => toggleLineMark(chunk.id, idx)}
@@ -1618,6 +1684,43 @@ const Chunks = () => {
             {jobId ? `Analiza… (${jobStatus})` : hasActiveRun ? "+ Nowa analiza" : "▶ Rozpocznij analizę"}
           </button>
         </div>
+        {newMode === "article" && (
+          <div style={{ marginTop: 10, padding: "9px 11px", background: "#fff", border: "1px solid #dbeafe", borderRadius: 6 }}>
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+              <strong style={{ fontSize: "0.84em", color: "#334155" }}>1. Podział na chunki</strong>
+              <button className="button" onClick={() => previewReclean(false)} disabled={recleaning || !!jobId}
+                title="Uruchom aktualne reguły clean_article_text, pokaż podsumowanie i utwórz nowy run tylko-podział">
+                {recleaning ? "Czyszczę…" : "Przeczyść tekst i podziel ponownie"}
+              </button>
+              {recleanPreview && (
+                <label style={{ fontSize: "0.82em", display: "flex", alignItems: "center", gap: 5 }}>
+                  <input type="checkbox" checked={useRecleaned} onChange={e => setUseRecleaned(e.target.checked)} />
+                  użyj oczyszczonego tekstu tylko do podziału
+                </label>
+              )}
+            </div>
+            {recleanPreview && (
+              <div style={{ marginTop: 8, fontSize: "0.8em", color: "#475569" }}>
+                <div>
+                  Pole <code>{recleanPreview.source_field}</code>: {recleanPreview.before_length.toLocaleString("pl")} → {recleanPreview.after_length.toLocaleString("pl")} znaków,
+                  {" "}{recleanPreview.before_line_count} → {recleanPreview.after_line_count} linii;
+                  usuniętych/zmienionych linii: <strong>{recleanPreview.removed_line_count}</strong>.
+                </div>
+                <details style={{ marginTop: 5 }}>
+                  <summary style={{ cursor: "pointer" }}>Pokaż koniec tekstu po czyszczeniu</summary>
+                  <pre style={{ whiteSpace: "pre-wrap", maxHeight: 220, overflow: "auto", background: "#f8fafc", padding: 8, borderRadius: 4 }}>
+                    {recleanPreview.end_preview}
+                  </pre>
+                </details>
+                <button onClick={() => previewReclean(true)} disabled={recleaning}
+                  style={{ marginTop: 6, padding: "3px 8px", border: "1px solid #f59e0b", background: "#fffbeb", borderRadius: 4, cursor: "pointer", color: "#92400e" }}
+                  title="Opcjonalnie nadpisuje bieżące pole text/text_md wynikiem czyszczenia">
+                  Zapisz oczyszczony tekst w dokumencie…
+                </button>
+              </div>
+            )}
+          </div>
+        )}
         <details style={{ marginTop: 9 }}>
           <summary style={{ cursor: "pointer", color: "#64748b", fontSize: "0.82em", userSelect: "none" }}>
             Ustawienia zaawansowane


### PR DESCRIPTION
## Zakres
- rozszerza deterministyczne reguły czyszczenia artykułów i naprawia sklejone karty markdown
- oznacza podpisy zdjęć jako kandydatów do usunięcia i pomija je w embeddingach
- usuwa markery reklam oraz stopki WP i innych obsługiwanych portali
- dodaje niedestrukcyjny podgląd ponownego czyszczenia
- przycisk ponownego czyszczenia automatycznie tworzy nowy run tylko-podział

## Weryfikacja
- backend: 92 testy wcześniejszego zestawu regresji oraz testy scenariusza ponownego czyszczenia WP
- frontend: npm run lint / tsc --noEmit
- test ręczny dokumentów 9178 i 9168 na NAS
- wdrożenie backendu i frontendu na NAS zakończone poprawnie