### PR TITLE
feat(quality): treat publisher-owned photo agency as own material

### DIFF
--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -16,6 +16,7 @@ import json
 import logging
 import re
 from collections import Counter
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ _CAPTION_STOCK_RE = re.compile(
 
 _CAPTION_AGENCY_SOURCE_RE = re.compile(
     r"(?:\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|"
-    r"\bForum\b\s*/|/\s*Forum\b)",
+    r"\bForum\b\s*/|/\s*Forum\b|agencj\w+\s+wyborcz\w+)",
     re.IGNORECASE,
 )
 
@@ -52,9 +53,37 @@ _CAPTION_AGENCY_RE = re.compile(
     r"(?:zdj[eę]cie\s+ilustracyjne|shutterstock|getty\s*images?|east\s+news|"
     r"adobe\s+stock|istock(?:photo)?|depositphotos|123rf|unsplash|pexels|"
     r"domena\s+publiczna|\bcc\s+by(?:-sa)?\b|creative\s+commons|archiwum\s+prywatne|©|"
-    r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bForum\b\s*/|/\s*Forum\b)",
+    r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bForum\b\s*/|/\s*Forum\b|"
+    r"agencj\w+\s+wyborcz\w+)",
     re.IGNORECASE,
 )
+
+# Zdjęcie z agencji fotograficznej należącej do wydawcy artykułu to materiał
+# własny redakcji (waga 0), nie zewnętrzna agencja — mapa: wzorzec nazwy
+# agencji w podpisie -> domeny serwisów tego wydawcy.
+PUBLISHER_OWN_AGENCIES: list[tuple[re.Pattern, tuple[str, ...]]] = [
+    # Agencja Wyborcza.pl — agencja fotograficzna Agory
+    (re.compile(r"agencj\w+\s+wyborcz\w+", re.IGNORECASE),
+     ("wyborcza.pl", "gazeta.pl", "wyborcza.biz", "wysokieobcasy.pl", "tokfm.pl")),
+]
+
+
+def _is_publisher_own_agency(line: str, url: str | None) -> bool:
+    """Czy podpis wskazuje agencję fotograficzną wydawcy serwisu z `url`?"""
+    if not url:
+        return False
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    for agency_re, domains in PUBLISHER_OWN_AGENCIES:
+        if agency_re.search(line) and any(
+            host == domain or host.endswith("." + domain) for domain in domains
+        ):
+            return True
+    return False
 
 # Punkty oznaczają jakość/oryginalność źródła, a nie fakt, że
 # podpis pozostał w tekście. Materiał własny jest najlepszy, fotografia
@@ -126,8 +155,11 @@ def count_photo_captions(text: str) -> int:
     return sum(1 for line in text.splitlines() if is_photo_caption_line(line))
 
 
-def photo_caption_candidates(text: str) -> list[dict]:
-    """Wykryte podpisy wraz z kategorią — dowody dla quality i podpowiedzi UI."""
+def photo_caption_candidates(text: str, url: str | None = None) -> list[dict]:
+    """Wykryte podpisy wraz z kategorią — dowody dla quality i podpowiedzi UI.
+
+    url: adres dokumentu; pozwala rozpoznać agencję własną wydawcy
+    (PUBLISHER_OWN_AGENCIES) i nadać jej kategorię materiału własnego."""
     candidates = []
     pending_image_alt: str | None = None
     pending_image_lines = 0
@@ -170,6 +202,8 @@ def photo_caption_candidates(text: str) -> list[dict]:
             category = "illustrative"
         elif _CAPTION_STOCK_RE.search(line):
             category = "stock"
+        elif _is_publisher_own_agency(line, url):
+            category = "own_or_private_archive"
         elif _CAPTION_AGENCY_SOURCE_RE.search(line):
             category = "agency"
         elif adjacent_description:
@@ -267,7 +301,7 @@ def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -
     full_text = "\n".join((s.get("original") or "") for s in chunk_sections)
     from library.cited_publications import extract_cited_publications
     cited_publications = extract_cited_publications(full_text)
-    caption_evidence = photo_caption_candidates(full_text)
+    caption_evidence = photo_caption_candidates(full_text, getattr(doc, "url", None))
     photo_source_evidence = [
         item for item in caption_evidence
         if item["category"] in PHOTO_SOURCE_PENALTY_WEIGHTS

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -288,13 +288,16 @@ def _parse_segments(text_raw: str | None) -> list[dict]:
 TEXT_PREVIEW_CHARS = 200
 
 
-def _chunk_to_dict(c: DocumentChunk, has_embeddings: bool | None = None, lite: bool = False) -> dict:
+def _chunk_to_dict(
+    c: DocumentChunk, has_embeddings: bool | None = None, lite: bool = False, doc_url: str | None = None,
+) -> dict:
     """Serialize a chunk. lite=True drops the full texts (book-sized runs are
-    lazy-loaded per section) and ships a short preview + length instead."""
+    lazy-loaded per section) and ships a short preview + length instead.
+    doc_url lets caption categorization recognize the publisher's own photo agency."""
     text = c.corrected_text or c.original_text or ""
     from library.article_quality import photo_caption_candidates
 
-    caption_candidates = photo_caption_candidates(c.original_text or "") if not lite else []
+    caption_candidates = photo_caption_candidates(c.original_text or "", doc_url) if not lite else []
     return {
         "id": c.id,
         "position": c.position,
@@ -1170,7 +1173,8 @@ def get_run_chunks(run_id: int):
         "offset": offset,
         "chunk_total": chunk_total,
         "chunks": [{
-            **_chunk_to_dict(c, has_embeddings=c.id in embedded_chunk_ids, lite=lite),
+            **_chunk_to_dict(c, has_embeddings=c.id in embedded_chunk_ids, lite=lite,
+                             doc_url=doc.url if doc else None),
             "cited_publications": citations_by_chunk.get(c.id, []),
         } for c in chunks],
         "topic_sections": [

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -20,9 +20,10 @@ LONG_PARAGRAPH = (
 
 
 class _Doc:
-    def __init__(self, author=None, title=None):
+    def __init__(self, author=None, title=None, url=None):
         self.author = author
         self.title = title
+        self.url = url
 
 
 class TestPhotoCaptionDetection:
@@ -141,6 +142,28 @@ class TestPhotoCaptionDetection:
         assert is_photo_caption_line("Rosyjskie czołgi. © Twitter | Kontakt6")
         assert is_photo_caption_line("Firma złożyła wniosek o upadłość (zdj. ilustracyjne)")
 
+    def test_agencja_wyborcza_detected_without_fot_prefix(self):
+        assert is_photo_caption_line("Krzysztof Gutkowski / Agencja Wyborcza.pl")
+
+    def test_publisher_own_agency_on_publisher_domain(self):
+        text = f"{LONG_PARAGRAPH}\nFot. Krzysztof Gutkowski / Agencja Wyborcza.pl"
+        for url in (
+            "https://next.gazeta.pl/next/7,151003,32847569,artykul.html",
+            "https://wyborcza.pl/7,75399,12345,artykul.html",
+        ):
+            candidates = photo_caption_candidates(text, url)
+            assert [item["category"] for item in candidates] == ["own_or_private_archive"]
+
+    def test_publisher_own_agency_on_foreign_domain_is_regular_agency(self):
+        text = f"{LONG_PARAGRAPH}\nFot. Krzysztof Gutkowski / Agencja Wyborcza.pl"
+        candidates = photo_caption_candidates(text, "https://www.onet.pl/informacje/artykul")
+        assert [item["category"] for item in candidates] == ["agency"]
+
+    def test_publisher_own_agency_without_url_is_regular_agency(self):
+        text = f"{LONG_PARAGRAPH}\nFot. Krzysztof Gutkowski / Agencja Wyborcza.pl"
+        candidates = photo_caption_candidates(text)
+        assert [item["category"] for item in candidates] == ["agency"]
+
 
 class TestClickbaitTitle:
     def test_clickbait(self):
@@ -211,6 +234,27 @@ class TestComputeQuality:
 
         assert "photo_sources" not in q["penalties"]
         assert q["signals"]["photo_caption_categories"] == {"own_or_private_archive": 1}
+
+    def test_publisher_own_agency_photo_is_not_penalized(self):
+        secs = self._sections() + [{
+            "type": "TEMAT", "original": "Fot. Krzysztof Gutkowski / Agencja Wyborcza.pl",
+        }]
+        doc = _Doc(author="Oliwia Ziółkowska", title="T",
+                   url="https://next.gazeta.pl/next/7,151003,32847569,artykul.html")
+        q = compute_quality(doc, secs, model=None)
+
+        assert "photo_sources" not in q["penalties"]
+        assert q["signals"]["photo_caption_categories"] == {"own_or_private_archive": 1}
+
+    def test_publisher_agency_photo_on_foreign_portal_penalized_as_agency(self):
+        secs = self._sections() + [{
+            "type": "TEMAT", "original": "Fot. Krzysztof Gutkowski / Agencja Wyborcza.pl",
+        }]
+        doc = _Doc(author="A", title="T", url="https://www.onet.pl/informacje/artykul")
+        q = compute_quality(doc, secs, model=None)
+
+        assert q["penalties"]["photo_sources"] == 1
+        assert q["signals"]["photo_caption_categories"] == {"agency": 1}
 
     def test_image_description_is_not_treated_as_a_photo_source(self):
         secs = self._sections() + [{


### PR DESCRIPTION
## Problem
Dokument 9146 (next.gazeta.pl) dostawał karę `photo_sources: 2` za podpis **"Fot. Krzysztof Gutkowski / Agencja Wyborcza.pl"** — regex agencji znał tylko PAP/EPA/AFP/Reuters/Forum, więc podpis wpadał do kategorii `other` (waga 2), mimo że Agencja Wyborcza.pl to agencja fotograficzna wydawcy tego portalu (Agora).

## Zmiany
- `Agencja Wyborcza.pl` rozpoznawana jako agencja we wszystkich regexach podpisów (waga 1 na obcych portalach, wykrywanie także bez prefiksu "Fot."),
- nowa mapa `PUBLISHER_OWN_AGENCIES` (wzorzec nazwy agencji → domeny wydawcy): na portalach Agory (wyborcza.pl, gazeta.pl, wyborcza.biz, wysokieobcasy.pl, tokfm.pl) podpis dostaje kategorię `own_or_private_archive` (waga 0),
- `photo_caption_candidates()` przyjmuje opcjonalny `url` dokumentu; przekazują go `compute_quality()` i serializer chunków w widoku runa (`_chunk_to_dict`),
- kategorie treściowe (illustrative/stock) nadal wygrywają z agencją własną.

## Testy
- 7 nowych testów (kategoryzacja per domena, brak kary w `compute_quality`, wykrywanie bez prefiksu),
- pełna suita unit: **1325 passed**, ruff czysty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)