### PR TITLE
feat(quality): detect glued photo credits and Bloomberg agency captions

### DIFF
--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -44,7 +44,7 @@ _CAPTION_STOCK_RE = re.compile(
 )
 
 _CAPTION_AGENCY_SOURCE_RE = re.compile(
-    r"(?:\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|"
+    r"(?:\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bBloomberg\b|"
     r"\bForum\b\s*/|/\s*Forum\b|agencj\w+\s+wyborcz\w+)",
     re.IGNORECASE,
 )
@@ -53,10 +53,24 @@ _CAPTION_AGENCY_RE = re.compile(
     r"(?:zdj[eę]cie\s+ilustracyjne|shutterstock|getty\s*images?|east\s+news|"
     r"adobe\s+stock|istock(?:photo)?|depositphotos|123rf|unsplash|pexels|"
     r"domena\s+publiczna|\bcc\s+by(?:-sa)?\b|creative\s+commons|archiwum\s+prywatne|©|"
-    r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bForum\b\s*/|/\s*Forum\b|"
-    r"agencj\w+\s+wyborcz\w+)",
+    r"\bPAP\s*/|/\s*PAP\b|\bEPA\b|\bAFP\b|\bReuters\b|\bBloomberg\b|"
+    r"\bForum\b\s*/|/\s*Forum\b|agencj\w+\s+wyborcz\w+)",
     re.IGNORECASE,
 )
+
+# Ekstrakcja Interii skleja podpis, fotografa i agencję bez separatora
+# ("...dronowychBloombergBloomberg", "...wojskaTHOMAS SAMSONAFP"), przez co
+# \b we wzorcach agencji nie znajduje granicy słowa. Rozklejenie: spacja na
+# granicy mała→wielka litera oraz przed akronimem agencji doklejonym do
+# wersalikowego nazwiska (min. 3 wielkie litery przed akronimem, żeby nie
+# rozcinać zwykłych słów w stylu "RZEPA").
+_GLUED_LOWER_UPPER_RE = re.compile(r"(?<=[a-ząćęłńóśźż])(?=[A-ZĄĆĘŁŃÓŚŹŻ])")
+_GLUED_ACRONYM_RE = re.compile(r"(?<=[A-ZĄĆĘŁŃÓŚŹŻ]{3})(?=(?:AFP|EPA|PAP)\s*$)")
+
+
+def _deglue_credits(line: str) -> str:
+    """Kopia linii z przywróconymi granicami słów w sklejonym credicie."""
+    return _GLUED_ACRONYM_RE.sub(" ", _GLUED_LOWER_UPPER_RE.sub(" ", line))
 
 # Zdjęcie z agencji fotograficznej należącej do wydawcy artykułu to materiał
 # własny redakcji (waga 0), nie zewnętrzna agencja — mapa: wzorzec nazwy
@@ -145,7 +159,10 @@ def is_photo_caption_line(line: str) -> bool:
     bare = re.sub(r"\[img\d+(?::[^\]]*)?\]", "", stripped).strip()
     if not bare:
         return False
-    return bool(_CAPTION_PREFIX_RE.match(bare) or _CAPTION_AGENCY_RE.search(bare))
+    if _CAPTION_PREFIX_RE.match(bare) or _CAPTION_AGENCY_RE.search(bare):
+        return True
+    deglued = _deglue_credits(bare)
+    return deglued != bare and bool(_CAPTION_AGENCY_RE.search(deglued))
 
 
 def count_photo_captions(text: str) -> int:
@@ -191,7 +208,8 @@ def photo_caption_candidates(text: str, url: str | None = None) -> list[dict]:
                 pending_image_lines = 0
         if not (direct_caption or adjacent_description):
             continue
-        lowered = stripped.lower()
+        deglued = _deglue_credits(stripped)
+        lowered = deglued.lower()
         if "domena publiczna" in lowered:
             category = "public_domain"
         elif re.search(r'\bcc\s+by(?:-sa)?\b|creative commons', lowered):
@@ -200,11 +218,11 @@ def photo_caption_candidates(text: str, url: str | None = None) -> list[dict]:
             category = "own_or_private_archive"
         elif re.search(r'zdj[eę]cie\s+ilustracyjne', lowered):
             category = "illustrative"
-        elif _CAPTION_STOCK_RE.search(line):
+        elif _CAPTION_STOCK_RE.search(deglued):
             category = "stock"
-        elif _is_publisher_own_agency(line, url):
+        elif _is_publisher_own_agency(deglued, url):
             category = "own_or_private_archive"
-        elif _CAPTION_AGENCY_SOURCE_RE.search(line):
+        elif _CAPTION_AGENCY_SOURCE_RE.search(deglued):
             category = "agency"
         elif adjacent_description:
             category = "image_description" if repeats_image_alt else "image_credit"

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -145,6 +145,38 @@ class TestPhotoCaptionDetection:
     def test_agencja_wyborcza_detected_without_fot_prefix(self):
         assert is_photo_caption_line("Krzysztof Gutkowski / Agencja Wyborcza.pl")
 
+    def test_bloomberg_credit_line(self):
+        assert is_photo_caption_line("Bloomberg")
+
+    def test_interia_glued_caption_with_doubled_agency(self):
+        # Prawdziwy podpis z interia.pl (dok. 9145) — ekstrakcja skleiła
+        # podpis z podwojonym creditem agencji bez spacji.
+        line = (
+            "Mapy stworzone za pomocą Pokémon GO zasilają systemy "
+            "nawigacyjne wojskowych dronowychBloombergBloomberg"
+        )
+        assert is_photo_caption_line(line)
+
+    def test_interia_glued_uppercase_photographer_and_acronym(self):
+        # Wersalikowe nazwisko fotografa sklejone z akronimem agencji.
+        line = (
+            "W Pokemon Go gracze skanowali masę znanych obiektów, "
+            "tworząc nieświadomie mapy dla wojskaTHOMAS SAMSONAFP"
+        )
+        assert is_photo_caption_line(line)
+
+    def test_glued_agency_credit_categorized_as_agency(self):
+        text = "\n".join([
+            LONG_PARAGRAPH,
+            "Mapy stworzone za pomocą Pokémon GO zasilają systemy "
+            "nawigacyjne wojskowych dronowychBloombergBloomberg",
+        ])
+        candidates = photo_caption_candidates(text)
+        assert [item["category"] for item in candidates] == ["agency"]
+
+    def test_allcaps_word_ending_like_acronym_is_not_split(self):
+        assert not is_photo_caption_line("NA OBIAD BYŁA RZEPA")
+
     def test_publisher_own_agency_on_publisher_domain(self):
         text = f"{LONG_PARAGRAPH}\nFot. Krzysztof Gutkowski / Agencja Wyborcza.pl"
         for url in (


### PR DESCRIPTION
## Problem

Photo-caption detection missed real caption lines from interia.pl (document 9145):

- `Mapy stworzone za pomocą Pokémon GO zasilają systemy nawigacyjne wojskowych dronowychBloombergBloomberg`
- `W Pokemon Go gracze skanowali masę znanych obiektów, tworząc nieświadomie mapy dla wojskaTHOMAS SAMSONAFP`

Two independent causes:
1. **Bloomberg was missing** from both agency patterns (`_CAPTION_AGENCY_RE`, `_CAPTION_AGENCY_SOURCE_RE`) — even a clean `Bloomberg` credit line was never flagged.
2. **Interia glues caption + photographer + agency without separators**, so `\b` word boundaries never match (e.g. `AFP` inside `SAMSONAFP`, even though AFP is on the list).

## Changes

- Add `Bloomberg` to both agency patterns (detection + `agency` categorization).
- New `_deglue_credits()` helper: inserts spaces at lowercase→uppercase boundaries and before an agency acronym (AFP/EPA/PAP) appended to an all-caps surname (min. 3 uppercase letters before the acronym, so words like `RZEPA` are not split). Used as a fallback in `is_photo_caption_line()` and for categorization in `photo_caption_candidates()`.

## Tests

- 5 new unit tests, including the two real lines from document 9145 and a negative case for the acronym splitter.
- Full unit suite: 1330 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)