### PR TITLE
feat(reader): collapsible provenance section + chunk type-cycle order

### DIFF
--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -209,7 +209,7 @@ const MODELS = [
 ];
 
 const STATUS_CYCLE = ["pending", "approved", "needs_reanalysis"] as const;
-const TYPE_CYCLE: ChunkType[] = ["TEMAT", "ZRODLA", "SZUM", "REKLAMA"];
+const TYPE_CYCLE: ChunkType[] = ["TEMAT", "SZUM", "ZRODLA", "REKLAMA"];
 
 // Speaker self-introductions are expected near the start of a transcript, so the
 // per-chunk "detect speakers from just this chunk" button only appears on the

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -1031,11 +1031,13 @@ const Read: React.FC = () => {
               </div>
             ) : <>
             {informationSources.length > 0 && (
-              <div style={{
+              <details open style={{
                 background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
                 padding: 10, marginTop: 12,
               }}>
-                <strong style={{ fontSize: "0.85em", display: "block", marginBottom: 8 }}>📰 Pochodzenie</strong>
+                <summary style={{ cursor: "pointer", fontSize: "0.85em", fontWeight: 600 }}>
+                  📰 Pochodzenie ({informationSources.length})
+                </summary>
                 {informationSources.map(source => (
                   <div key={source.id} style={{ marginTop: 7 }}>
                     <div style={{ fontSize: "0.75em", color: "#64748b" }}>
@@ -1052,7 +1054,7 @@ const Read: React.FC = () => {
                     )}
                   </div>
                 ))}
-              </div>
+              </details>
             )}
             {citedPublications.length > 0 && (
               <div style={{ background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8, padding: 10, marginTop: 12 }}>


### PR DESCRIPTION
Dwie drobne zmiany UI, które działały na NAS (deploy z roboczej kopii), ale nigdy nie trafiły do gita:

- **/read**: sekcja „📰 Pochodzenie" jest zwijana (`<details>`, domyślnie otwarta) z licznikiem pozycji w nagłówku — długie listy źródeł można schować z sidebara.
- **/chunks**: kolejność cyklu typu chunka pod przyciskiem zmiany typu: `TEMAT → SZUM → ZRODLA → REKLAMA` (SZUM przesunięty przed ZRODLA — częściej używana korekta jest bliżej).

tsc czysty. Zmiany są już wdrożone na NAS — ten PR tylko domyka stan repo do stanu wdrożenia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)