### PR TITLE
fix(timeline): accept nominative months and 'lata X — Y' ranges from the LLM

### DIFF
--- a/backend/library/timeline_events.py
+++ b/backend/library/timeline_events.py
@@ -21,31 +21,45 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMELINE_MODEL = "Bielik-11B-v3.0-Instruct"
 MAX_FRAGMENT_CHARS = 10_000
 
+# Genitive/locative forms come from the article text ("w lutym 2024 r."); the
+# nominative ones from the LLM, which often normalizes date_text to "luty 2024 r.".
 _MONTHS = {
     "stycznia": 1,
     "styczniu": 1,
+    "styczen": 1,
     "lutego": 2,
     "lutym": 2,
+    "luty": 2,
     "marca": 3,
     "marcu": 3,
+    "marzec": 3,
     "kwietnia": 4,
     "kwietniu": 4,
+    "kwiecien": 4,
     "maja": 5,
     "maju": 5,
+    "maj": 5,
     "czerwca": 6,
     "czerwcu": 6,
+    "czerwiec": 6,
     "lipca": 7,
     "lipcu": 7,
+    "lipiec": 7,
     "sierpnia": 8,
     "sierpniu": 8,
+    "sierpien": 8,
     "wrzesnia": 9,
     "wrzesniu": 9,
+    "wrzesien": 9,
     "pazdziernika": 10,
     "pazdzierniku": 10,
+    "pazdziernik": 10,
     "listopada": 11,
     "listopadzie": 11,
+    "listopad": 11,
     "grudnia": 12,
     "grudniu": 12,
+    "grudzien": 12,
 }
 _MONTH_PATTERN = "|".join(sorted(_MONTHS, key=len, reverse=True))
 _DECADE_WORDS = {
@@ -66,7 +80,9 @@ _ERA_PATTERNS = (
     (re.compile(r"\b(?:w\s+)?okresie\s+prl\b", re.IGNORECASE), 1945),
     (re.compile(r"\b(?:podczas|w\s+czasie)\s+zimnej\s+wojny\b", re.IGNORECASE), 1947),
 )
-_YEAR_RANGE_RE = re.compile(r"(?:w\s+latach\s+)?(\d{3,4})\s*[-‐‑‒–—−]\s*(\d{3,4})")
+# The dash class needs a + because unidecode turns an em dash into "--";
+# the prefix covers "w latach"/"latach"/"lata" spellings of a year range.
+_YEAR_RANGE_RE = re.compile(r"(?:(?:w\s+)?lat(?:ach|a)\s+)?(\d{3,4})\s*[-‐‑‒–—−]+\s*(\d{3,4})")
 _TYPOGRAPHY_TRANSLATION = str.maketrans({
     **dict.fromkeys("‐‑‒–—−", "-"),
     **dict.fromkeys("“”„‟«»", '"'),

--- a/backend/tests/unit/test_timeline_events.py
+++ b/backend/tests/unit/test_timeline_events.py
@@ -146,6 +146,10 @@ def test_quote_outside_fragment_is_rejected(monkeypatch):
         ("XIX wieku", "century", datetime.date(1801, 1, 1), 1850),
         ("1918-1939", "year", datetime.date(1918, 1, 1), 1918),
         ("w latach 1918–1939", "year", datetime.date(1918, 1, 1), 1918),
+        ("lata 1988 — 1998", "year", datetime.date(1988, 1, 1), 1988),
+        ("luty 2024 r.", "month", datetime.date(2024, 2, 1), 2024),
+        ("styczeń 2024 r.", "month", datetime.date(2024, 1, 1), 2024),
+        ("sierpień 2023 r.", "month", datetime.date(2023, 8, 1), 2023),
     ],
 )
 def test_polish_date_normalization(date_text, precision, event_date, sort_year):


### PR DESCRIPTION
Oś czasu dokumentu 9144 gubiła 4 z 8 wydarzeń znalezionych przez Bielika — nie przez LLM, tylko przez luki w `normalize_date_text()`:

1. **Mianownik miesięcy**: Bielik normalizuje `date_text` do mianownika ("luty 2024 r.", "styczeń 2024 r.", "sierpień 2023 r."), a słownik `_MONTHS` znał tylko formy z tekstu artykułu ("lutego"/"lutym"). Dodane formy mianownikowe wszystkich 12 miesięcy.
2. **Zakres "lata 1988 — 1998"** (wojna domowa na Bougainville) padał podwójnie: regex zakresu wymagał prefiksu "w latach" (gołe "lata" nie przechodziło), a pauza em po unidecode staje się `--`, czego jednoznakowa klasa myślników nie łapała. Prefiks rozszerzony o "lata"/"latach", klasa myślników z `+`.

Po poprawce ponowna ekstrakcja 9144: **7 wydarzeń, rejected_without_date=0** (jedyny odrzucony kandydat to zasadny brak dosłownego cytatu). 4 nowe przypadki w testach parametryzowanych; 30 testów timeline przechodzi, ruff czysty.

Zmiana dotyczy tylko ekstrakcji uruchamianej lokalnie (`imports/extract_events.py`) — dane 9144 już przeliczone na NAS; obraz backendu na NAS nie wymaga pilnego redeployu (endpoint `GET /events` tylko czyta tabelę).

🤖 Generated with [Claude Code](https://claude.com/claude-code)