### PR TITLE
feat(reader,search): show publication date, added date and original link

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -698,6 +698,8 @@ def document_chapters(doc_id: int):
         "thematic_tags": thematic_tags,
         "synthesis": doc_run.synthesis if doc_run else None,
         "quality": getattr(doc, "quality", None),
+        "date_from": doc.date_from.isoformat() if doc.date_from else None,
+        "created_at": doc.created_at.isoformat() if doc.created_at else None,
     })
 
 

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -266,6 +266,8 @@ class WebsitesDBPostgreSQL:
                 WebDocument.title,
                 WebDocument.document_type,
                 WebDocument.project,
+                WebDocument.date_from,
+                WebDocument.created_at,
                 WebsiteEmbedding.chunk_id,
                 DocumentChunk.obsidian_note_paths,
             )
@@ -300,6 +302,8 @@ class WebsitesDBPostgreSQL:
                 "title": r.title,
                 "document_type": r.document_type,
                 "project": r.project,
+                "date_from": r.date_from.isoformat() if r.date_from else None,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
                 "chunk_id": r.chunk_id,
                 "obsidian_note_paths": r.obsidian_note_paths or [],
             }
@@ -369,6 +373,8 @@ class WebsitesDBPostgreSQL:
                 "title": doc.title,
                 "document_type": doc.document_type,
                 "project": doc.project,
+                "date_from": doc.date_from.isoformat() if doc.date_from else None,
+                "created_at": doc.created_at.isoformat() if doc.created_at else None,
                 "chunk_id": None,
                 "obsidian_note_paths": doc.obsidian_note_paths or [],
                 "tags": doc.tags,

--- a/backend/tests/unit/test_similarity_search_orm.py
+++ b/backend/tests/unit/test_similarity_search_orm.py
@@ -14,12 +14,13 @@ sa = pytest.importorskip("sqlalchemy")
 EXPECTED_KEYS = {
     "website_id", "text", "similarity", "id", "url", "language",
     "text_original", "websites_text_length", "embeddings_text_length",
-    "title", "document_type", "project", "chunk_id", "obsidian_note_paths",
+    "title", "document_type", "project", "date_from", "created_at",
+    "chunk_id", "obsidian_note_paths",
 }
 
 
 def _make_row(**overrides):
-    """Create a mock result row with all 14 expected attributes."""
+    """Create a mock result row with all 16 expected attributes."""
     defaults = {
         "website_id": 1,
         "text": "chunk text",
@@ -33,6 +34,8 @@ def _make_row(**overrides):
         "title": "Test Doc",
         "document_type": "webpage",
         "project": "lenie",
+        "date_from": None,
+        "created_at": None,
         "chunk_id": None,
         "obsidian_note_paths": None,
     }

--- a/web_interface_react/src/modules/shared/pages/read.tsx
+++ b/web_interface_react/src/modules/shared/pages/read.tsx
@@ -382,6 +382,9 @@ const Read: React.FC = () => {
   const [informationSources, setInformationSources] = React.useState<InformationSourceLink[]>([]);
   const [citedPublications, setCitedPublications] = React.useState<CitedPublicationLink[]>([]);
   const [docQuality, setDocQuality] = React.useState<DocQuality | null>(null);
+  const [docUrl, setDocUrl] = React.useState<string | null>(null);
+  const [docDateFrom, setDocDateFrom] = React.useState<string | null>(null);
+  const [docCreatedAt, setDocCreatedAt] = React.useState<string | null>(null);
   const [content, setContent] = React.useState<ChapterContent | null>(null);
   // sidebar scope: current chapter (default) vs whole document
   const [scopeChapter, setScopeChapter] = React.useState(true);
@@ -450,6 +453,9 @@ const Read: React.FC = () => {
         setThematicTags(data.thematic_tags ?? []);
         setSynthesis(data.synthesis ?? null);
         setDocQuality(data.quality ?? null);
+        setDocUrl(data.url ?? null);
+        setDocDateFrom(data.date_from ?? null);
+        setDocCreatedAt(data.created_at ?? null);
       } catch (e) {
         setError(String(e));
       }
@@ -839,6 +845,18 @@ const Read: React.FC = () => {
         <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         <div style={{ marginLeft: "auto" }}><ReaderIdentityBadge identity={identity} /></div>
       </div>
+
+      {(docDateFrom || docCreatedAt || docUrl) && (
+        <div style={{ fontSize: "0.82em", color: "#64748b", marginBottom: 10, display: "flex", gap: 14, flexWrap: "wrap" }}>
+          {docDateFrom && <span>📅 Opublikowano: {new Date(docDateFrom).toLocaleDateString("pl-PL")}</span>}
+          {docCreatedAt && <span>Dodano do Lenie: {new Date(docCreatedAt).toLocaleDateString("pl-PL")}</span>}
+          {docUrl && (
+            <a href={docUrl} target="_blank" rel="noreferrer" style={{ color: "#0369a1", wordBreak: "break-all" }}>
+              🔗 Oryginał ↗
+            </a>
+          )}
+        </div>
+      )}
 
       {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
 

--- a/web_interface_react/src/utils.tsx
+++ b/web_interface_react/src/utils.tsx
@@ -14,10 +14,15 @@ interface ListItemSearchSimilarProps {
     document_type?: string | null;
     website_id: number;
     url: string;
+    date_from?: string | null;
+    created_at?: string | null;
     chunk_id?: number | null;
     obsidian_note_paths?: string[];
   };
 }
+
+const formatDocDate = (value?: string | null) =>
+  value ? new Date(value).toLocaleDateString("pl-PL") : null;
 
 const meaningfulTerms = (query: string) =>
   Array.from(new Set(query.trim().split(/\s+/).filter(term => term.length >= 3)))
@@ -76,6 +81,10 @@ const ListItemSearchSimilar = ({ item, query }: ListItemSearchSimilarProps) => {
               {MATCH_LABELS[match]}
             </span>
             {item.document_type && <span>{item.document_type}</span>}
+            {formatDocDate(item.date_from) && <span title="Data publikacji">📅 {formatDocDate(item.date_from)}</span>}
+            {!item.date_from && formatDocDate(item.created_at) && (
+              <span title="Data dodania do Lenie (brak daty publikacji)">📅 dodano {formatDocDate(item.created_at)}</span>
+            )}
             <span>ID {item.website_id}</span>
             {item.chunk_id != null && <span>chunk #{item.chunk_id}</span>}
           </div>


### PR DESCRIPTION
Czytnik i wyniki wyszukiwania nie pokazywały, z kiedy jest artykuł — mimo że `date_from` (data publikacji, wypełniana przez importy feedów) istnieje dla ~74% dokumentów.

- **`GET /document/<id>/chapters`** zwraca teraz `date_from` i `created_at`; nagłówek czytnika pokazuje „📅 Opublikowano: …", „Dodano do Lenie: …" oraz **🔗 link do oryginału**.
- **Kandydaci wyszukiwania** (`search_text`/`get_similar`) niosą te same pola; karta wyniku w `/search` pokazuje datę publikacji, a gdy jej brak — oznaczoną datę dodania („📅 dodano …").
- Testy kluczy słownika `get_similar` zaktualizowane (16 pól); tsc i ruff czyste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)