### PR TITLE
perf(embeddings): batch provider calls and checkpoint-commit per batch

### DIFF
--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -777,6 +777,9 @@ class DocumentAnalysisService:
         return run
 
 
+EMBEDDING_BATCH_SIZE = 32
+
+
 def generate_embeddings_from_run(
     session, run_id: int, progress_fn: Callable[[str], None] | None = None,
 ) -> dict:
@@ -788,6 +791,12 @@ def generate_embeddings_from_run(
     webdocument_md_decode.py), strips markdown syntax, and stores one
     WebsiteEmbedding row per piece with chunk_id set. REKLAMA/SZUM chunks and
     non-approved TEMAT chunks are skipped.
+
+    Pieces are embedded in batches of EMBEDDING_BATCH_SIZE (one provider API
+    call per batch where the provider supports it — a 400-chunk book used to
+    take ~5 h as one HTTP round-trip per piece) and the session is committed
+    after every batch, so a crash mid-run keeps the embeddings finished so far
+    instead of discarding hours of work.
 
     Re-running deletes this run's previously chunk-linked embeddings first, so
     it is safe to call again after a chunk is re-approved or edited.
@@ -831,10 +840,9 @@ def generate_embeddings_from_run(
     if not doc.language:
         doc.language = "pl"
 
-    created = 0
     skipped_empty = 0
-    for i, chunk in enumerate(eligible, 1):
-        log(f"chunk {i}/{len(eligible)} (position {chunk.position})...")
+    pieces: list[tuple[DocumentChunk, str]] = []
+    for chunk in eligible:
         text = remove_photo_caption_lines(
             chunk.corrected_text or chunk.original_text or ""
         ).strip()
@@ -843,13 +851,22 @@ def generate_embeddings_from_run(
             continue
         for part in md_split_for_emb(text):
             cleaned = md_remove_markdown(part).strip()
-            if not cleaned:
-                continue
-            result = embedding.get_embedding(model=model, text=cleaned)
+            if cleaned:
+                pieces.append((chunk, cleaned))
+
+    created = 0
+    failed = 0
+    total_batches = (len(pieces) + EMBEDDING_BATCH_SIZE - 1) // EMBEDDING_BATCH_SIZE
+    for batch_number, start in enumerate(range(0, len(pieces), EMBEDDING_BATCH_SIZE), 1):
+        batch = pieces[start:start + EMBEDDING_BATCH_SIZE]
+        log(f"batch {batch_number}/{total_batches} ({len(batch)} fragments, {created} embeddings stored)...")
+        results = embedding.get_embeddings(model, [piece_text for _, piece_text in batch])
+        for (chunk, cleaned), result in zip(batch, results):
             if result.status != "success" or not result.embedding:
+                failed += 1
                 logger.warning(
                     "Embedding generation failed for chunk %d (run %d): %s",
-                    chunk.id, run_id, result.status,
+                    chunk.id, run_id, result.error_message or result.status,
                 )
                 continue
             websites.embedding_add(
@@ -862,6 +879,7 @@ def generate_embeddings_from_run(
                 chunk_id=chunk.id,
             )
             created += 1
+        session.commit()
 
     if created:
         doc.document_state = StalkerDocumentStatus.EMBEDDING_EXIST.name
@@ -876,4 +894,5 @@ def generate_embeddings_from_run(
         "chunks_considered": len(eligible),
         "chunks_skipped_empty": skipped_empty,
         "embeddings_created": created,
+        "embeddings_failed": failed,
     }

--- a/backend/library/embedding.py
+++ b/backend/library/embedding.py
@@ -6,6 +6,51 @@ embedding_models = {"amazon.titan-embed-text-v1", "amazon.titan-embed-text-v2:0"
                     "dunzhang/stella_en_1.5B_v5", "BAAI/bge-m3"}
 
 
+_SHERLOCK_MODELS = {"BAAI/bge-multilingual-gemma2", "intfloat/e5-mistral-7b-instruct", "dunzhang/stella_en_1.5B_v5"}
+
+
+def get_embeddings(model: str, texts: list[str]) -> list[EmbeddingResult]:
+    """Batch variant of get_embedding — one API call where the provider supports it.
+
+    CloudFerro Sherlock embeds the whole list in a single request; other
+    providers fall back to one get_embedding call per text (which also
+    validates the model name). Always returns one EmbeddingResult per input
+    text, in input order.
+    """
+    if not texts:
+        return []
+
+    if model in _SHERLOCK_MODELS:
+        from library.api.cloudferro.sherlock.sherlock_embedding import sherlock_create_embeddings
+
+        response = sherlock_create_embeddings(texts, model)
+        if response.status_code != 200 or not response.embedding:
+            error = getattr(response, "error", None) or response.error_message or f"HTTP {response.status_code}"
+            return [
+                EmbeddingResult(text=text, model_id=model, status="error", error_message=str(error))
+                for text in texts
+            ]
+        vectors: list = [None] * len(texts)
+        for position, item in enumerate(response.embedding):
+            index = item.get("index", position) if isinstance(item, dict) else position
+            if isinstance(index, int) and 0 <= index < len(vectors):
+                vectors[index] = item["embedding"] if isinstance(item, dict) else item
+        results = []
+        for text, vector in zip(texts, vectors):
+            if vector is None:
+                results.append(EmbeddingResult(
+                    text=text, model_id=response.model_id, status="error",
+                    error_message="missing embedding in batch response",
+                ))
+            else:
+                result = EmbeddingResult(text=text, model_id=response.model_id, embedding=vector, status="success")
+                result.status_code = 200
+                results.append(result)
+        return results
+
+    return [get_embedding(model, text) for text in texts]
+
+
 def get_embedding(model: str, text: str) -> EmbeddingResult:
     if model not in embedding_models:
         raise Exception(f"DEBUG: Error, no model info for text {model}")

--- a/backend/tests/unit/test_document_analysis_book_mode.py
+++ b/backend/tests/unit/test_document_analysis_book_mode.py
@@ -41,6 +41,8 @@ class FakeBookDoc:
     document_type = "text"
     url = None
     quality = None
+    date_from = None
+    created_at = None
 
 
 # ---------------------------------------------------------------------------
@@ -475,6 +477,8 @@ class FakeTranscriptDoc:
     document_type = "youtube"
     tags = None
     url = None
+    date_from = None
+    created_at = None
 
 
 @pytest.fixture

--- a/backend/tests/unit/test_embedding_batch.py
+++ b/backend/tests/unit/test_embedding_batch.py
@@ -1,0 +1,181 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+import library.embedding as embedding_module  # noqa: E402
+from library.models.embedding_results import EmbeddingResults  # noqa: E402
+
+
+def _batch_response(texts, status_code=200, model="BAAI/bge-multilingual-gemma2"):
+    response = EmbeddingResults(text=texts)
+    response.status_code = status_code
+    response.model_id = model
+    if status_code == 200:
+        response.embedding = [{"index": i, "embedding": [float(i)]} for i in range(len(texts))]
+    else:
+        response.error = "boom"
+    return response
+
+
+class TestGetEmbeddings:
+    def test_sherlock_model_uses_one_batch_call(self, monkeypatch):
+        calls = []
+
+        def fake_batch(texts, model):
+            calls.append(list(texts))
+            return _batch_response(texts, model=model)
+
+        monkeypatch.setattr(
+            "library.api.cloudferro.sherlock.sherlock_embedding.sherlock_create_embeddings", fake_batch,
+        )
+
+        results = embedding_module.get_embeddings("BAAI/bge-multilingual-gemma2", ["a", "b", "c"])
+
+        assert calls == [["a", "b", "c"]]
+        assert [r.embedding for r in results] == [[0.0], [1.0], [2.0]]
+        assert all(r.status == "success" for r in results)
+
+    def test_batch_failure_marks_every_text_failed(self, monkeypatch):
+        monkeypatch.setattr(
+            "library.api.cloudferro.sherlock.sherlock_embedding.sherlock_create_embeddings",
+            lambda texts, model: _batch_response(texts, status_code=500),
+        )
+
+        results = embedding_module.get_embeddings("BAAI/bge-multilingual-gemma2", ["a", "b"])
+
+        assert len(results) == 2
+        assert all(r.status == "error" and r.embedding is None for r in results)
+        assert results[0].error_message == "boom"
+
+    def test_out_of_order_batch_items_map_by_index(self, monkeypatch):
+        def fake_batch(texts, model):
+            response = _batch_response(texts, model=model)
+            response.embedding = list(reversed(response.embedding))
+            return response
+
+        monkeypatch.setattr(
+            "library.api.cloudferro.sherlock.sherlock_embedding.sherlock_create_embeddings", fake_batch,
+        )
+
+        results = embedding_module.get_embeddings("BAAI/bge-multilingual-gemma2", ["a", "b", "c"])
+
+        assert [r.embedding for r in results] == [[0.0], [1.0], [2.0]]
+
+    def test_non_batch_provider_falls_back_to_per_text_calls(self, monkeypatch):
+        calls = []
+
+        def fake_single(model, text):
+            calls.append(text)
+            return SimpleNamespace(text=text, status="success", embedding=[1.0])
+
+        monkeypatch.setattr(embedding_module, "get_embedding", fake_single)
+
+        results = embedding_module.get_embeddings("text-embedding-ada-002", ["a", "b"])
+
+        assert calls == ["a", "b"]
+        assert len(results) == 2
+
+    def test_empty_input_returns_empty_list(self):
+        assert embedding_module.get_embeddings("BAAI/bge-multilingual-gemma2", []) == []
+
+    def test_unknown_model_raises(self):
+        with pytest.raises(Exception, match="no model info"):
+            embedding_module.get_embeddings("nieznany-model", ["a"])
+
+
+class TestGenerateEmbeddingsBatching:
+    def _run(self, monkeypatch, chunk_count=5, batch_size=2):
+        from library import document_analysis_service as das
+        from library.models.embedding_result import EmbeddingResult
+
+        run = SimpleNamespace(id=21, document_id=9204)
+        doc = SimpleNamespace(id=9204, language="pl", document_state="DOCUMENT_INTO_DATABASE")
+        chunks = [
+            SimpleNamespace(
+                id=100 + i, type="TEMAT", status="approved",
+                corrected_text=None, original_text=f"Tekst rozdziału numer {i}.", position=i,
+            )
+            for i in range(1, chunk_count + 1)
+        ]
+
+        session = MagicMock()
+        session.get.side_effect = lambda _cls, key: {21: run, 9204: doc}[key]
+        session.scalars.return_value.all.return_value = chunks
+
+        added = []
+
+        class FakeRepo:
+            def __init__(self, _session):
+                pass
+
+            def embedding_add(self, **kwargs):
+                added.append(kwargs)
+
+        monkeypatch.setattr("library.stalker_web_documents_db_postgresql.WebsitesDBPostgreSQL", FakeRepo)
+        cfg = MagicMock()
+        cfg.require.return_value = "BAAI/bge-multilingual-gemma2"
+        monkeypatch.setattr("library.config_loader.load_config", lambda: cfg)
+
+        batch_calls = []
+
+        def fake_get_embeddings(model, texts):
+            batch_calls.append(len(texts))
+            return [EmbeddingResult(text=text, embedding=[0.1], status="success") for text in texts]
+
+        monkeypatch.setattr("library.embedding.get_embeddings", fake_get_embeddings)
+        monkeypatch.setattr(das, "EMBEDDING_BATCH_SIZE", batch_size)
+
+        result = das.generate_embeddings_from_run(session, 21)
+        return result, session, added, batch_calls, doc
+
+    def test_batches_pieces_and_commits_per_batch(self, monkeypatch):
+        result, session, added, batch_calls, doc = self._run(monkeypatch, chunk_count=5, batch_size=2)
+
+        assert result["embeddings_created"] == 5
+        assert result["embeddings_failed"] == 0
+        assert len(added) == 5
+        # 5 pieces in batches of 2 -> 3 API calls
+        assert batch_calls == [2, 2, 1]
+        # commits: 1 after the delete + 1 per batch (3) + 1 final
+        assert session.commit.call_count == 5
+        assert doc.document_state == "EMBEDDING_EXIST"
+
+    def test_failed_batch_items_are_counted_not_stored(self, monkeypatch):
+        from library.models.embedding_result import EmbeddingResult
+
+        def failing_get_embeddings(model, texts):
+            return [EmbeddingResult(text=text, status="error", error_message="boom") for text in texts]
+
+        monkeypatch.setattr("library.embedding.get_embeddings", failing_get_embeddings)
+        # _run would override the patch, so patch again inside via a plain call path
+        from library import document_analysis_service as das
+        from unittest.mock import MagicMock as MM
+
+        run = SimpleNamespace(id=21, document_id=9204)
+        doc = SimpleNamespace(id=9204, language="pl", document_state="DOCUMENT_INTO_DATABASE")
+        chunks = [SimpleNamespace(id=101, type="TEMAT", status="approved",
+                                  corrected_text=None, original_text="Tekst.", position=1)]
+        session = MM()
+        session.get.side_effect = lambda _cls, key: {21: run, 9204: doc}[key]
+        session.scalars.return_value.all.return_value = chunks
+
+        class FakeRepo:
+            def __init__(self, _session):
+                pass
+
+            def embedding_add(self, **kwargs):
+                raise AssertionError("failed embeddings must not be stored")
+
+        monkeypatch.setattr("library.stalker_web_documents_db_postgresql.WebsitesDBPostgreSQL", FakeRepo)
+        cfg = MM()
+        cfg.require.return_value = "BAAI/bge-multilingual-gemma2"
+        monkeypatch.setattr("library.config_loader.load_config", lambda: cfg)
+
+        result = das.generate_embeddings_from_run(session, 21)
+
+        assert result["embeddings_created"] == 0
+        assert result["embeddings_failed"] == 1
+        assert doc.document_state == "DOCUMENT_INTO_DATABASE"


### PR DESCRIPTION
Wnioski z dzisiejszego 5-godzinnego jobu embeddingów książki 9204 (por. dyskusja o równoległości):

- **Batchowanie**: `generate_embeddings_from_run()` robił jedno wywołanie HTTP na każdy fragment (~1000+ round-tripów po 2-3 s). Nowe `embedding.get_embeddings(model, texts)` wysyła do CloudFerro Sherlock **jedną paczkę 32 fragmentów na wywołanie** (funkcja `sherlock_create_embeddings` istniała w repo, ale ta ścieżka jej nie używała); pozostali providerzy dostają fallback per tekst. Oczekiwany zysk ~20-30× (5 h → kilkanaście minut).
- **Commit co batch zamiast jednego na końcu**: awaria w trakcie nie wyrzuca już godzin pracy, postęp widać w bazie na bieżąco (`SELECT COUNT(*)...`), a restart backendu w trakcie jobu przestaje być katastrofą.
- Mapowanie odpowiedzi batcha po polu `index` (odporne na kolejność), błędy per fragment liczone w nowym polu `embeddings_failed` raportu.
- Przy okazji: uzupełnione atrapy dokumentów w testach endpointu `/chapters` o `date_from`/`created_at` — przeoczenie z #276, przez które pełna suita miała 7 czerwonych testów.

**Weryfikacja**: 8 nowych testów (batchowanie per provider, mapowanie po index, awarie batcha, kadencja commitów, licznik błędów) + pełna suita unit **1382 passed**; ruff czysty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)