### PR TITLE
feat(chunks): bankier.pl cleanup rules, config-health warnings, publication-date editing

### DIFF
--- a/backend/alembic/versions/b1c2d3e4f5a6_add_date_from_source_to_web_documents.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_add_date_from_source_to_web_documents.py
@@ -1,0 +1,27 @@
+"""add date_from_source to web_documents
+
+Revision ID: b1c2d3e4f5a6
+Revises: f0a1b2c3d4e5
+Create Date: 2026-07-18 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "f0a1b2c3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS date_from_source VARCHAR(10)")
+    op.execute("""
+        ALTER TABLE web_documents ADD CONSTRAINT ck_web_documents_date_from_source
+        CHECK (date_from_source IS NULL OR date_from_source IN ('manual', 'llm'))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE web_documents DROP CONSTRAINT IF EXISTS ck_web_documents_date_from_source")
+    op.execute("ALTER TABLE web_documents DROP COLUMN IF EXISTS date_from_source")

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -74,6 +74,7 @@ Main document storage. Each row represents a collected web resource (article, vi
 | `note` | `text` | User notes |
 | `paywall` | `boolean` | Whether content is behind a paywall (default: false) |
 | `date_from` | `date` | Publication date |
+| `date_from_source` | `varchar(10)` | How `date_from` was set: `manual` (reviewer typed it on `/chunks`) or `llm` (`extract_publication_date`); `NULL` for legacy/import-set values. CHECK constraint `ck_web_documents_date_from_source` |
 | `created_at` | `timestamp` | Row creation timestamp |
 | `document_length` | `integer` | Text length in characters |
 | `chapter_list` | `text` | Chapter/section list (for videos/transcripts) |

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -3,7 +3,7 @@
 Główne wejście: clean_article_text(text, url) — zwraca dict {text, links, images}.
 Obrazki i linki są zamieniane na markery [imgN] / [linkN], a ich metadane
 trafiają do osobnych list. Reguły czyszczenia: generyczne (wspólne dla
-wszystkich portali) + specyficzne per portal (onet, money, wp).
+wszystkich portali) + specyficzne per portal (onet, money, wp, gazeta, bankier).
 
 Wydzielone z imports/article_browser.py, aby logika była testowalna
 i reużywalna w skryptach batch.
@@ -329,6 +329,56 @@ def _clean_lines_ithardware(lines: list[str]) -> list[str]:
     return [line for line in lines if line.strip() not in {"Play", "ad"}]
 
 
+def _clean_lines_bankier(lines: list[str]) -> list[str]:
+    """Czyszczenie specyficzne dla bankier.pl.
+
+    Breadcrumb i podmenu sekcji różnią się treścią per kategoria artykułu
+    (Giełda/Gospodarka/Podatki/...), więc zamiast dopasowania po dokładnym
+    tekście rozpoznajemy je po kształcie: krótki wiersz zaczynający się od
+    "Bankier.pl" (breadcrumb sklejony bez spacji) albo wiersz zawierający
+    kilka charakterystycznych nazw sekcji podmenu naraz.
+    """
+    subnav_keywords = ("Notowania", "Kalendarium", "Dywidendy", "Narzędzia", "Portfel", "Forum")
+    cleaned = []
+    skip_source_value = False
+    in_tags = False
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped == "Źródło:":
+            skip_source_value = True
+            continue
+        if skip_source_value:
+            if not stripped:
+                continue
+            skip_source_value = False
+            continue
+
+        if stripped == "tematy":
+            in_tags = True
+            continue
+        if in_tags:
+            if not stripped:
+                in_tags = False
+                continue
+            if len(stripped) < 60:
+                continue
+            in_tags = False
+
+        if stripped in ("publikacja", "ad"):
+            continue
+        if stripped.startswith("Bankier.pl") and len(stripped) < 80:
+            continue
+        if sum(kw in stripped for kw in subnav_keywords) >= 3:
+            continue
+        # Samodzielna data publikacji: "2026-02-25 08:10"
+        if re.match(r'^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}$', stripped):
+            continue
+
+        cleaned.append(line)
+    return cleaned
+
+
 def _clean_lines_gazeta(lines: list[str]) -> list[str]:
     """Usuń śródtekstowe karty rekomendacji Gazeta.pl, zachowując dalszy artykuł."""
     cleaned = []
@@ -500,6 +550,8 @@ def clean_article_text(text: str, url: str = "") -> dict:
         lines = _clean_lines_wp(lines)
     elif portal == "gazeta":
         lines = _clean_lines_gazeta(lines)
+    elif portal == "bankier":
+        lines = _clean_lines_bankier(lines)
     elif "ithardware.pl" in url.lower():
         lines = _clean_lines_ithardware(lines)
 
@@ -510,4 +562,5 @@ def clean_article_text(text: str, url: str = "") -> dict:
         "text": text.strip(),
         "links": extracted_links,
         "images": extracted_images,
+        "portal": portal,
     }

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -88,6 +88,8 @@ def _detect_portal(url: str) -> str | None:
         return "natgeo"
     if "gazeta.pl" in url_lower:
         return "gazeta"
+    if "bankier.pl" in url_lower:
+        return "bankier"
     return None
 
 
@@ -141,6 +143,11 @@ PORTAL_FOOTER_MARKERS = {
         "Dziękujemy za przeczytanie",
         "#### Obserwuj nas",
     ],
+    # Komentarze rozpoczynają blok "Komentarze (N)" — za nim leży widget notowań,
+    # rekomendacje ("Powiązane"/"Najpopularniejsze"/"Polecane") i stopka-sitemapa.
+    "bankier": [
+        "Komentarze (",
+    ],
 }
 
 # Markery końca nawigacji/początku artykułu per portal.
@@ -151,6 +158,12 @@ PORTAL_START_AFTER_MARKERS: dict[str, list[str]] = {
     "wp": [
         "Prawdziwe dziennikarstwo. Niezależna redakcja. ZA DARMO.",
         "ZAPISZUDOSTĘPNIJ",
+    ],
+    # Ostatnia linia głównego menu nagłówka bankier.pl (obecna na każdej stronie
+    # niezależnie od kategorii artykułu) — za nią leży breadcrumb, podmenu sekcji
+    # i dopiero potem właściwy tytuł/treść.
+    "bankier": [
+        "Zaloguj się / Zarejestruj",
     ],
 }
 
@@ -220,7 +233,7 @@ def _find_footer_line(text: str, portal: str | None) -> int | None:
 
     lines = text.splitlines()
     for i, line in enumerate(lines):
-        stripped = line.strip()
+        stripped = line.strip().replace('\xa0', ' ')
         for marker in markers:
             if stripped.startswith(marker):
                 return i
@@ -242,7 +255,7 @@ def _find_start_line(text: str, portal: str | None) -> int | None:
 
     lines = text.splitlines()
     for i, line in enumerate(lines):
-        stripped = line.strip()
+        stripped = line.strip().replace('\xa0', ' ')
         for marker in PORTAL_START_AFTER_MARKERS[portal]:
             if marker in stripped:
                 return i
@@ -260,7 +273,7 @@ def _cut_at_footer(text: str, portal: str | None) -> str:
 
     lines = text.splitlines()
     for i, line in enumerate(lines):
-        stripped = line.strip()
+        stripped = line.strip().replace('\xa0', ' ')
         for marker in markers:
             if stripped.startswith(marker):
                 logger.debug(f"Footer marker found at line {i}: {marker}")

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -168,6 +168,37 @@ Fragment artykułu:
     return None
 
 
+def extract_publication_date_info(text: str, model: str) -> str | None:
+    """Ask LLM to identify the article's publication date from a text excerpt.
+
+    Returns an ISO date string (YYYY-MM-DD), or None if extraction fails,
+    the date is ambiguous, or no date is found. The caller is responsible
+    for validating the returned string is a real calendar date.
+    """
+    prompt = f"""Z poniższego fragmentu artykułu spróbuj ustalić datę jego publikacji.
+Zwróć TYLKO obiekt JSON bez żadnego dodatkowego tekstu, w formacie:
+{{"date": "RRRR-MM-DD"}}
+
+Jeśli nie możesz jednoznacznie ustalić daty publikacji (np. widzisz tylko datę wydarzenia
+opisywanego w artykule, a nie datę jego napisania/publikacji), zwróć: {{"date": null}}
+
+Fragment artykułu:
+{text}"""
+
+    logger.info("extract_publication_date_info: len=%d", len(text))
+    response_text, _ = call_model(prompt, model, max_tokens=100)
+    try:
+        match = re.search(r'\{.*\}', response_text, re.DOTALL)
+        if match:
+            result = json.loads(match.group())
+            date_str = result.get("date")
+            if isinstance(date_str, str) and date_str.strip():
+                return date_str.strip()
+    except Exception:
+        logger.warning("extract_publication_date_info: failed to parse JSON response")
+    return None
+
+
 def assign_speakers(text: str, speaker1: str, speaker2: str) -> str:
     """Parse >> speaker-change markers from YouTube auto-transcript and label each turn.
 

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -26,7 +26,7 @@ import logging
 import threading
 import uuid
 from collections import Counter
-from datetime import datetime
+from datetime import date, datetime
 
 from flask import Blueprint, jsonify, request, abort
 from sqlalchemy import func, or_, select, text as sa_text, update as sa_update
@@ -512,6 +512,33 @@ def next_document_for_analysis(doc_id: int):
     })
 
 
+def _site_rules_file_status() -> dict:
+    """Check whether data/site_rules.json is actually present and non-empty
+    on THIS runtime — distinct from the per-portal rules baked into
+    article_cleaner.py/article_extractor.py, which reclean_preview's
+    ``portal`` field already covers.
+
+    site_rules.json is read fresh on every webpage_text_clean() call (no
+    cache), so a missing/empty file at download time silently produces no
+    cleanup — the rules exist in the repo/image but a runtime volume mount
+    can shadow data/ and hide them (this happened on the NAS deployment:
+    the named volume on /app/data pre-dated the file and was never
+    refreshed with it). Surfacing this here turns a silent "cleaning did
+    nothing" into an actionable configuration diagnostic.
+    """
+    import os
+
+    from library.config_loader import load_config
+    from library.website.website_download_context import load_site_rules
+
+    path = load_config().get("SITE_RULES_PATH", "data/site_rules.json")
+    if not os.path.isfile(path):
+        return {"ok": False, "path": path, "reason": "missing"}
+    if not load_site_rules(path):
+        return {"ok": False, "path": path, "reason": "empty_or_invalid"}
+    return {"ok": True, "path": path, "reason": None}
+
+
 @bp.route("/document/<int:doc_id>/reclean_preview", methods=["POST"])
 def reclean_preview(doc_id: int):
     """Preview current deterministic cleanup and optionally save it explicitly."""
@@ -534,7 +561,8 @@ def reclean_preview(doc_id: int):
             "message": f"Cleanup preview cannot analyze source field {field}",
         }), 400
 
-    after = clean_article_text(before, doc.url or "")["text"]
+    cleaned = clean_article_text(before, doc.url or "")
+    after = cleaned["text"]
     before_lines = before.splitlines()
     after_lines = after.splitlines()
     remaining = Counter(after_lines)
@@ -555,6 +583,8 @@ def reclean_preview(doc_id: int):
         "status": "success",
         "saved": save,
         "source_field": field,
+        "portal": cleaned["portal"],
+        "site_rules_file": _site_rules_file_status(),
         "before_length": len(before),
         "after_length": len(after),
         "before_line_count": len(before_lines),
@@ -1242,6 +1272,7 @@ def get_run_chunks(run_id: int):
             "countries": doc_countries,
             "thematic_tags": doc_thematic_tags,
             "quality": getattr(doc, "quality", None) if doc else None,
+            "date_from": doc.date_from.isoformat() if doc and doc.date_from else None,
         },
         "segments": segments,
         "lite": lite,
@@ -1643,6 +1674,128 @@ def extract_author(run_id: int):
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
     return jsonify({"status": "success", "author": author})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /analysis_run/<run_id>/extract_publication_date
+# ---------------------------------------------------------------------------
+
+@bp.route("/analysis_run/<int:run_id>/extract_publication_date", methods=["POST"])
+def extract_publication_date(run_id: int):
+    """Extract the article's publication date using LLM.
+
+    Pass chunk_ids (JSON body) to use specific chunk(s) instead — e.g. a
+    chunk containing the dateline the reviewer identified. Without chunk_ids,
+    uses the head+tail of the whole document's text (a publication date
+    usually appears near the byline at the start, or in a source line at the
+    end). Saves the result directly to the document's date_from field,
+    always overwriting any existing value — this is a reviewer-triggered
+    manual action, mirroring extract_author above.
+    """
+    session = get_scoped_session()
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        abort(404, f"Run {run_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    chunk_ids = data.get("chunk_ids")
+    context_text = data.get("context_text")
+
+    if context_text is not None:
+        if not isinstance(context_text, str):
+            return jsonify({"status": "error", "message": "context_text must be a string"}), 400
+        source_text = context_text.strip()[:12000]
+    elif chunk_ids:
+        if not isinstance(chunk_ids, list) or not all(isinstance(i, int) for i in chunk_ids):
+            return jsonify({"status": "error", "message": "chunk_ids must be a list of integers"}), 400
+        chunks = session.scalars(
+            select(DocumentChunk)
+            .where(DocumentChunk.run_id == run_id, DocumentChunk.id.in_(chunk_ids))
+            .order_by(DocumentChunk.position)
+        ).all()
+        if len(chunks) != len(set(chunk_ids)):
+            return jsonify({"status": "error", "message": "One or more chunk_ids not found in this run"}), 400
+        source_text = "\n\n".join(
+            c.corrected_text or c.original_text or "" for c in chunks
+        ).strip()
+    else:
+        doc = session.get(WebDocument, run.document_id)
+        if doc is None:
+            abort(404, f"Document {run.document_id} not found")
+        from library.chunk_llm_analysis import head_tail_excerpt
+        source_text = head_tail_excerpt(doc.text_md or doc.text or "")
+
+    if not source_text:
+        return jsonify({"status": "error", "message": "No text available for date extraction"}), 400
+
+    try:
+        from library.chunk_llm_analysis import extract_publication_date_info
+        date_str = extract_publication_date_info(source_text, run.model)
+    except Exception:
+        logger.exception("extract_publication_date_info failed for run %d", run_id)
+        return jsonify({"status": "error", "message": "LLM call failed"}), 500
+
+    if not date_str:
+        return jsonify({"status": "success", "date_from": None})
+
+    try:
+        parsed_date = date.fromisoformat(date_str)
+    except ValueError:
+        logger.warning("extract_publication_date_info: unparseable date %r for run %d", date_str, run_id)
+        return jsonify({"status": "success", "date_from": None})
+
+    doc = session.get(WebDocument, run.document_id)
+    if doc is None:
+        abort(404, f"Document {run.document_id} not found")
+    doc.date_from = parsed_date
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for run %d date_from", run_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "date_from": parsed_date.isoformat()})
+
+
+# ---------------------------------------------------------------------------
+# API: POST /document/<doc_id>/date_from
+# ---------------------------------------------------------------------------
+
+@bp.route("/document/<int:doc_id>/date_from", methods=["POST"])
+def set_date_from(doc_id: int):
+    """Manually set (or clear) the document's publication date.
+
+    Companion to extract_publication_date above — this is the reviewer typing
+    a date directly (e.g. from the original page's calendar picker) instead
+    of asking the LLM to find one.
+    """
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    date_str = data.get("date_from")
+
+    if date_str is None:
+        doc.date_from = None
+    else:
+        if not isinstance(date_str, str):
+            return jsonify({"status": "error", "message": "date_from must be a string or null"}), 400
+        try:
+            doc.date_from = date.fromisoformat(date_str)
+        except ValueError:
+            return jsonify({"status": "error", "message": f"Invalid date {date_str!r}, expected YYYY-MM-DD"}), 400
+
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for document %d date_from", doc_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({"status": "success", "date_from": doc.date_from.isoformat() if doc.date_from else None})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1273,6 +1273,7 @@ def get_run_chunks(run_id: int):
             "thematic_tags": doc_thematic_tags,
             "quality": getattr(doc, "quality", None) if doc else None,
             "date_from": doc.date_from.isoformat() if doc and doc.date_from else None,
+            "date_from_source": getattr(doc, "date_from_source", None) if doc else None,
         },
         "segments": segments,
         "lite": lite,
@@ -1748,6 +1749,7 @@ def extract_publication_date(run_id: int):
     if doc is None:
         abort(404, f"Document {run.document_id} not found")
     doc.date_from = parsed_date
+    doc.date_from_source = "llm"
     try:
         session.commit()
     except Exception:
@@ -1755,7 +1757,7 @@ def extract_publication_date(run_id: int):
         logger.exception("DB save failed for run %d date_from", run_id)
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
-    return jsonify({"status": "success", "date_from": parsed_date.isoformat()})
+    return jsonify({"status": "success", "date_from": parsed_date.isoformat(), "date_from_source": "llm"})
 
 
 # ---------------------------------------------------------------------------
@@ -1780,6 +1782,7 @@ def set_date_from(doc_id: int):
 
     if date_str is None:
         doc.date_from = None
+        doc.date_from_source = None
     else:
         if not isinstance(date_str, str):
             return jsonify({"status": "error", "message": "date_from must be a string or null"}), 400
@@ -1787,6 +1790,7 @@ def set_date_from(doc_id: int):
             doc.date_from = date.fromisoformat(date_str)
         except ValueError:
             return jsonify({"status": "error", "message": f"Invalid date {date_str!r}, expected YYYY-MM-DD"}), 400
+        doc.date_from_source = "manual"
 
     try:
         session.commit()
@@ -1795,7 +1799,11 @@ def set_date_from(doc_id: int):
         logger.exception("DB save failed for document %d date_from", doc_id)
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
-    return jsonify({"status": "success", "date_from": doc.date_from.isoformat() if doc.date_from else None})
+    return jsonify({
+        "status": "success",
+        "date_from": doc.date_from.isoformat() if doc.date_from else None,
+        "date_from_source": doc.date_from_source,
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -218,6 +218,12 @@ class WebDocument(Base):
     # before_flush hook at the bottom of this module.
     source: Mapped[str | None] = mapped_column(Text, ForeignKey("sources.name"))
     date_from: Mapped[datetime.date | None] = mapped_column(Date)
+    # How date_from was set — "manual" (reviewer typed it on /chunks) or "llm"
+    # (extract_publication_date). NULL for legacy/import-set values (unknown
+    # provenance). Lets a future pass find documents where the automatic
+    # pipeline never found a date, to build deterministic per-portal rules —
+    # the same workflow document_removed_lines already does for cleanup rules.
+    date_from_source: Mapped[str | None] = mapped_column(String(10))
     original_id: Mapped[str | None] = mapped_column(Text)
     document_length: Mapped[int | None] = mapped_column(Integer)
     chapter_list: Mapped[str | None] = mapped_column(Text)
@@ -417,6 +423,7 @@ class WebDocument(Base):
             "document_type": self.document_type,
             "source": self.source,
             "date_from": self.date_from,
+            "date_from_source": self.date_from_source,
             "original_id": self.original_id,
             "document_length": self.document_length,
             "chapter_list": self.chapter_list,

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -422,3 +422,84 @@ class TestAdjacentTagLinks:
         tags = '[czołgi](/tag/czolgi)[rosja](/tag/rosja)[militaria](/tag/militaria)'
         result = clean_article_text(f"{LONG_PARAGRAPH}\n{tags}", url="https://tech.wp.pl/test")["text"]
         assert result == LONG_PARAGRAPH
+
+
+class TestBankierExtraction:
+    URL = "https://www.bankier.pl/wiadomosc/Jakis-artykul-1234567.html"
+
+    # Kształt zdjęty z realnego dokumentu (bankier.pl, 2026-02) — menu nagłówka
+    # skrócone do reprezentatywnej próbki markerów.
+    RAW_PAGE = "\n".join([
+        "GIEŁDATytuł strony w tagu <title>",
+        "Podziel się",
+        "Skomentuj",
+        "21",
+        "Newsletter",
+        "Rynki",
+        "Giełda",
+        "Waluty",
+        "Zaloguj się / Zarejestruj",
+        "REKLAMA",
+        "Bankier.plRynkiGiełdaWiadomości",
+        "InneNotowania GPWESPI/EBIGiełdy światoweRekomendacjeKalendariumDywidendyNarzędziaPortfelForum",
+        "Ważny krok ws. budowy małych reaktorów jądrowych nad Wisłą",
+        "publikacja",
+        "2026-02-25 08:10",
+        "",
+        LONG_PARAGRAPH,
+        "",
+        "mcb/ osz/",
+        "",
+        "Źródło:",
+        "PAP Biznes",
+        "tematy",
+        "pknorlen",
+        "Polska elektrownia jądrowa",
+        "Komentarze\xa0(21)",  # bankier.pl łączy oba słowa twardą spacją
+        "dodaj komentarz",
+        "miketheripper2026-02-25 15:28",
+        "0",
+        "1",
+        "\"Nad Wisłą\" - będą lewitować czy wisieć?",
+        "Powiązane: pknorlen",
+        "Paweł Wojtunik wchodzi do zarządu Orlenu",
+        "Notowania",
+        "PKNORLEN",
+        "114,56-0,47%",
+        "Bankier.pl na skróty",
+        "Giełda",
+        "WIG30",
+    ])
+
+    def test_detects_bankier_portal(self):
+        assert _detect_portal(self.URL) == "bankier"
+
+    def test_cleaner_strips_nav_metadata_comments_and_footer_but_keeps_article(self):
+        result = clean_article_text(self.RAW_PAGE, url=self.URL)["text"]
+
+        assert LONG_PARAGRAPH in result
+
+        # Górne menu nagłówka i breadcrumb/podmenu
+        assert "Podziel się" not in result
+        assert "Newsletter" not in result
+        assert "Zaloguj się / Zarejestruj" not in result
+        assert "Bankier.plRynkiGiełdaWiadomości" not in result
+        assert "InneNotowania" not in result
+
+        # Metadane publikacji nad artykułem
+        assert "publikacja" not in result
+        assert "2026-02-25 08:10" not in result
+
+        # Źródło i tagi po artykule
+        assert "Źródło:" not in result
+        assert "PAP Biznes" not in result
+        assert "pknorlen" not in result
+
+        # Komentarze, powiązane artykuły, widget notowań, stopka-sitemapa
+        assert "Komentarze (21)" not in result
+        assert "będą lewitować" not in result
+        assert "Powiązane: pknorlen" not in result
+        assert "Paweł Wojtunik" not in result
+        assert "PKNORLEN" not in result
+        assert "Bankier.pl na skróty" not in result
+        assert "WIG30" not in result

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -155,7 +155,7 @@ class TestWebDocumentColumns:
     EXPECTED_COLUMNS = {
         "id", "summary", "url", "language", "tags", "text",
         "paywall", "title", "created_at", "document_type",
-        "source", "date_from", "original_id", "document_length",
+        "source", "date_from", "date_from_source", "original_id", "document_length",
         "chapter_list", "document_state", "document_state_error",
         "text_raw", "transcript_job_id", "ai_summary_needed",
         "author", "note", "uuid", "project", "text_md",
@@ -165,7 +165,7 @@ class TestWebDocumentColumns:
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebDocument)) == 32
+        assert len(_column_names(WebDocument)) == 33
 
     def test_all_column_names(self):
         assert _column_names(WebDocument) == self.EXPECTED_COLUMNS
@@ -497,14 +497,14 @@ class TestValidate:
 # ---------------------------------------------------------------------------
 
 class TestDict:
-    def test_dict_has_34_keys(self):
+    def test_dict_has_35_keys(self):
         doc = _make_doc(
             title="Test",
             document_state_error="NONE",
         )
         doc.created_at = datetime.datetime(2025, 1, 15, 10, 30, 0)
         result = doc.dict()
-        assert len(result) == 34
+        assert len(result) == 35
 
     def test_dict_keys(self):
         doc = _make_doc(
@@ -516,7 +516,7 @@ class TestDict:
         expected_keys = {
             "id", "next_id", "next_type", "previous_id", "previous_type",
             "summary", "url", "language", "tags", "text", "paywall", "title",
-            "created_at", "document_type", "source", "date_from", "original_id",
+            "created_at", "document_type", "source", "date_from", "date_from_source", "original_id",
             "document_length", "chapter_list", "document_state",
             "document_state_error", "text_raw", "transcript_job_id",
             "ai_summary_needed", "author", "note", "uuid", "project",

--- a/backend/tests/unit/test_orm_crud.py
+++ b/backend/tests/unit/test_orm_crud.py
@@ -424,7 +424,7 @@ class TestDictCompatibility:
         expected_keys = {
             "id", "next_id", "next_type", "previous_id", "previous_type",
             "summary", "url", "language", "tags", "text", "paywall", "title",
-            "created_at", "document_type", "source", "date_from", "original_id",
+            "created_at", "document_type", "source", "date_from", "date_from_source", "original_id",
             "document_length", "chapter_list", "document_state", "document_state_error",
             "text_raw", "transcript_job_id", "ai_summary_needed", "author",
             "note", "uuid", "project", "text_md", "transcript_needed",

--- a/docs/security/secrets-management.md
+++ b/docs/security/secrets-management.md
@@ -34,6 +34,9 @@ Variables are split into two categories:
 
 Bootstrap variables: `SECRETS_BACKEND`, `SECRETS_ENV`, `PROJECT_CODE`, `VAULT_ADDR`, `VAULT_TOKEN`, `ENV_DATA`, `AWS_REGION`. Additionally, `VAULT_ENV` is recognized as a deprecated fallback for `SECRETS_ENV` (use `SECRETS_ENV` for new deployments).
 
+> **Pitfall — `docker-compose environment:` is silently ignored for non-bootstrap variables under `vault`/`aws` backends.**
+> `VaultBackend.load()` and `AWSSSMBackend.load()` build the `Config` dict from ONLY two sources: the bootstrap variables listed above (read from `os.environ`) and whatever is stored in the remote secret store. Any other key set under a service's `environment:` block in a compose file (e.g. `compose.nas.yaml`) is never read by `load_config()` — it sits in the container's `os.environ` but `Config.get()`/`Config.require()` never look there. This looks like it should work (Docker's normal env-var story) and fails silently: no error, just the code's hardcoded default. If you add a new `type: config` variable to `scripts/vars-classification.yaml` and it needs a different value on a `vault`/`aws` deployment than the code default, you MUST push it with `env_to_vault.py vault set --env <env> KEY=value` (see [Adding New Variables](#adding-new-variables)) — setting it in the compose file's `environment:` does nothing there. (Discovered 2026-07-18: `SITE_RULES_PATH` was set in `compose.nas.yaml`'s `environment:` but never in Vault, so `webpage_text_clean()` kept resolving the hardcoded default path instead.)
+
 ### Config Loader Flow
 
 ```
@@ -119,6 +122,12 @@ python scripts/env_to_vault.py vault set --env dev OPENAI_API_KEY=<your-openai-a
 # List all keys in Vault
 python scripts/env_to_vault.py vault list --env dev
 ```
+
+> **Windows/Git Bash pitfall**: if the value starts with `/` (a container path like `/app/config/site_rules.json`), Git Bash's MSYS layer silently rewrites it to a Windows path (e.g. `C:/Program Files/Git/app/config/site_rules.json`) before Python ever sees it — `vault get` will then show the mangled value with no error. Prefix the command with `MSYS_NO_PATHCONV=1` whenever a value starts with `/`:
+> ```bash
+> MSYS_NO_PATHCONV=1 python scripts/env_to_vault.py vault set --env dev SITE_RULES_PATH=/app/config/site_rules.json
+> ```
+> Always `vault get --env dev KEY` afterwards to confirm the stored value matches what you intended — this affects any `/`-prefixed value, not just paths.
 
 ## AWS SSM Parameter Store Setup
 
@@ -268,6 +277,19 @@ The Vault or SSM endpoint is not reachable. Check:
 - Network connectivity (VPN if accessing NAS Vault remotely)
 - Vault server is running and unsealed
 - For SSM: AWS region matches where parameters are stored
+
+### Variable Set in Docker Compose but the App Still Uses the Default
+
+Symptom: you added `KEY: value` under a service's `environment:` in a compose file (e.g. `compose.nas.yaml`), the container has it in `env` (`docker exec <container> env | grep KEY` shows it), but `cfg.get("KEY")` in the app returns `None` / the code's hardcoded default, and behavior doesn't change.
+
+Cause: on `vault`/`aws` backends, `load_config()` never reads arbitrary `os.environ` keys — only the bootstrap variables and whatever is in the remote secret store (see the pitfall note under [Bootstrap vs Application Variables](#bootstrap-vs-application-variables)). This is `docker-compose environment:`'s most common footgun in this project.
+
+Fix: push the value to the actual backend in use, then restart the container so it re-reads config at startup (the `Config` singleton is loaded once per process):
+```bash
+python scripts/env_to_vault.py vault set --env dev KEY=value   # or: ssm set
+# then restart the container so the new Vault/SSM value is picked up
+```
+Verify end-to-end: `vault get --env dev KEY` shows the intended value, then `docker exec <container> python -c "from library.config_loader import load_config; print(load_config().get('KEY'))"` after the restart.
 
 ### Unknown SECRETS_BACKEND Value
 

--- a/infra/docker/compose.nas.yaml
+++ b/infra/docker/compose.nas.yaml
@@ -33,6 +33,13 @@ services:
       - "5055:5000"
     env_file:
       - /share/ContainerNew/lenie-env/.env
+    # NOTE: this backend runs with SECRETS_BACKEND=vault, so entries here are
+    # NOT read by the app's config_loader (only bootstrap vars + Vault KV are)
+    # — kept only so `env`-backend/local runs of this compose file still work.
+    # The value that actually matters is in Vault: secret/lenie/dev SITE_RULES_PATH.
+    # To change it: MSYS_NO_PATHCONV=1 python scripts/env_to_vault.py vault set
+    # --env dev SITE_RULES_PATH=/app/config/site_rules.json, then restart the
+    # container. See docs/security/secrets-management.md#adding-new-variables.
     environment:
       SITE_RULES_PATH: /app/config/site_rules.json
     volumes:

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -524,6 +524,7 @@ const Chunks = () => {
   const [authorPersonId, setAuthorPersonId] = React.useState<number | null>(null);
   const [authorDescription, setAuthorDescription] = React.useState("");
   const [docDateFrom, setDocDateFrom] = React.useState<string | null>(null);
+  const [docDateFromSource, setDocDateFromSource] = React.useState<string | null>(null);
   const [extractingDateFor, setExtractingDateFor] = React.useState<number | null>(null);
   const [dateInput, setDateInput] = React.useState("");
   const [savingDate, setSavingDate] = React.useState(false);
@@ -658,6 +659,7 @@ const Chunks = () => {
       setAuthorPersonId(data.document?.author_person_id ?? null);
       setAuthorDescription(data.document?.author_description ?? "");
       setDocDateFrom(data.document?.date_from ?? null);
+      setDocDateFromSource(data.document?.date_from_source ?? null);
       setDateInput(data.document?.date_from ?? "");
       setDocQuality(data.document?.quality ?? null);
       setDocCountries(data.document?.countries ?? []);
@@ -1374,6 +1376,7 @@ const Chunks = () => {
       const data = await r.json();
       if (data.status === "success" && data.date_from) {
         setDocDateFrom(data.date_from);
+        setDocDateFromSource(data.date_from_source ?? "llm");
         setDateInput(data.date_from);
         setInfo(`Ustawiono datę publikacji: ${data.date_from}`);
       }
@@ -1396,6 +1399,7 @@ const Chunks = () => {
       const data = await r.json();
       if (data.status === "success") {
         setDocDateFrom(data.date_from);
+        setDocDateFromSource(data.date_from_source ?? "manual");
         setInfo(`Ustawiono datę publikacji: ${data.date_from}`);
       } else setError("Błąd zapisu daty publikacji: " + (data.message ?? ""));
     } catch { setError("Błąd połączenia przy zapisie daty publikacji"); }
@@ -1988,6 +1992,16 @@ const Chunks = () => {
         {runMode === "article" && (
           <span style={{ fontSize: "0.88em", padding: "3px 9px", borderRadius: 4, background: docDateFrom ? "#f3e8ff" : "#f1f5f9", color: docDateFrom ? "#6b21a8" : "#64748b", display: "inline-flex", alignItems: "center", gap: 6 }}>
             Data publikacji: <strong>{docDateFrom || "nie wykryto"}</strong>
+            {docDateFrom && docDateFromSource && (
+              <span
+                title={docDateFromSource === "manual"
+                  ? "Wpisana ręcznie przez recenzenta — automatyka jej nie znalazła"
+                  : "Wykryta przez LLM z treści chunka"}
+                style={{ fontSize: "0.85em", opacity: 0.75 }}
+              >
+                {docDateFromSource === "manual" ? "✍️" : "🤖"}
+              </span>
+            )}
             <input
               type="date"
               value={dateInput}

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -85,8 +85,16 @@ interface Chapter {
   length: number;
 }
 
+interface SiteRulesFileStatus {
+  ok: boolean;
+  path: string;
+  reason: "missing" | "empty_or_invalid" | null;
+}
+
 interface RecleanPreview {
   source_field: string;
+  portal: string | null;
+  site_rules_file: SiteRulesFileStatus;
   before_length: number;
   after_length: number;
   before_line_count: number;
@@ -515,6 +523,10 @@ const Chunks = () => {
   const [docAuthor, setDocAuthor]   = React.useState("");
   const [authorPersonId, setAuthorPersonId] = React.useState<number | null>(null);
   const [authorDescription, setAuthorDescription] = React.useState("");
+  const [docDateFrom, setDocDateFrom] = React.useState<string | null>(null);
+  const [extractingDateFor, setExtractingDateFor] = React.useState<number | null>(null);
+  const [dateInput, setDateInput] = React.useState("");
+  const [savingDate, setSavingDate] = React.useState(false);
   const [docUrl, setDocUrl]         = React.useState("");
   const [docQuality, setDocQuality] = React.useState<DocQuality | null>(null);
   const [computingQuality, setComputingQuality] = React.useState(false);
@@ -645,6 +657,8 @@ const Chunks = () => {
       setDocAuthor(data.document?.author ?? "");
       setAuthorPersonId(data.document?.author_person_id ?? null);
       setAuthorDescription(data.document?.author_description ?? "");
+      setDocDateFrom(data.document?.date_from ?? null);
+      setDateInput(data.document?.date_from ?? "");
       setDocQuality(data.document?.quality ?? null);
       setDocCountries(data.document?.countries ?? []);
       setDocThematicTags(data.document?.thematic_tags ?? []);
@@ -688,6 +702,7 @@ const Chunks = () => {
         if (data.title) setDocTitle(data.title);
         if (data.url) setDocUrl(data.url);
         if (data.author) setDocAuthor(data.author);
+        if (data.date_from) { setDocDateFrom(data.date_from); setDateInput(data.date_from); }
         if (data.quality) setDocQuality(data.quality);
       } catch { /* analysis can still be configured manually */ }
     })();
@@ -1346,6 +1361,47 @@ const Chunks = () => {
     finally { setExtractingAuthorFor(null); }
   };
 
+  // Detect the publication date from one specific chunk. Mirrors extractAuthorFromChunk —
+  // no position limit, saves directly to doc.date_from (backend commits it).
+  const extractDateFromChunk = async (chunkId: number) => {
+    if (!selectedRun) return;
+    setExtractingDateFor(chunkId);
+    try {
+      const r = await fetch(`${apiUrl}/analysis_run/${selectedRun}/extract_publication_date`, {
+        method: "POST", headers,
+        body: JSON.stringify({ chunk_ids: [chunkId] }),
+      });
+      const data = await r.json();
+      if (data.status === "success" && data.date_from) {
+        setDocDateFrom(data.date_from);
+        setDateInput(data.date_from);
+        setInfo(`Ustawiono datę publikacji: ${data.date_from}`);
+      }
+      else if (data.status === "success") setError("Nie udało się rozpoznać daty publikacji w tym chunku");
+      else setError("Błąd wykrywania daty publikacji: " + (data.message ?? ""));
+    } catch { setError("Błąd połączenia przy wykrywaniu daty publikacji"); }
+    finally { setExtractingDateFor(null); }
+  };
+
+  // Manually save the date typed into the calendar input next to the "Data
+  // publikacji" badge — the reviewer copying a date off the original page,
+  // as opposed to extractDateFromChunk's LLM-based detection above.
+  const saveDateFrom = async () => {
+    if (!id || !dateInput) return;
+    setSavingDate(true);
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/date_from`, {
+        method: "POST", headers, body: JSON.stringify({ date_from: dateInput }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        setDocDateFrom(data.date_from);
+        setInfo(`Ustawiono datę publikacji: ${data.date_from}`);
+      } else setError("Błąd zapisu daty publikacji: " + (data.message ?? ""));
+    } catch { setError("Błąd połączenia przy zapisie daty publikacji"); }
+    finally { setSavingDate(false); }
+  };
+
   const extractAuthorFromLine = async (chunk: Chunk, lineIdx: number) => {
     if (!selectedRun) return;
     const lines = (chunk.original_text ?? "").split("\n");
@@ -1706,6 +1762,16 @@ const Chunks = () => {
               )}
               {runMode === "article" && (
                 <button
+                  onClick={() => extractDateFromChunk(chunk.id)}
+                  disabled={extractingDateFor === chunk.id}
+                  title="Wykryj datę publikacji artykułu z tego chunka i zapisz ją w dokumencie"
+                  style={{ padding: "2px 8px", border: "1px solid #cbd5e1", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: "0.82em", color: "#64748b" }}
+                >
+                  {extractingDateFor === chunk.id ? "📅 Wykrywam…" : "📅 Data"}
+                </button>
+              )}
+              {runMode === "article" && (
+                <button
                   onClick={() => refreshCitedPublications(chunk)}
                   disabled={refreshingCitationsFor !== null}
                   title="Odczytaj PMID, PMCID i DOI tylko z tego chunka; publikacje zostaną przypisane do całego dokumentu"
@@ -1919,6 +1985,26 @@ const Chunks = () => {
               : <strong>{docAuthor || "nie wykryto"}</strong>}
           </span>
         )}
+        {runMode === "article" && (
+          <span style={{ fontSize: "0.88em", padding: "3px 9px", borderRadius: 4, background: docDateFrom ? "#f3e8ff" : "#f1f5f9", color: docDateFrom ? "#6b21a8" : "#64748b", display: "inline-flex", alignItems: "center", gap: 6 }}>
+            Data publikacji: <strong>{docDateFrom || "nie wykryto"}</strong>
+            <input
+              type="date"
+              value={dateInput}
+              onChange={e => setDateInput(e.target.value)}
+              title="Wpisz datę publikacji ręcznie, np. z kalendarza na oryginalnej stronie"
+              style={{ fontSize: "0.9em", padding: "1px 3px", border: "1px solid #cbd5e1", borderRadius: 3 }}
+            />
+            <button
+              onClick={saveDateFrom}
+              disabled={!dateInput || savingDate}
+              title="Zapisz wpisaną datę jako datę publikacji dokumentu"
+              style={{ padding: "1px 7px", border: "1px solid #cbd5e1", borderRadius: 3, background: "#fff", cursor: "pointer", fontSize: "0.9em", color: "#64748b" }}
+            >
+              {savingDate ? "…" : "💾"}
+            </button>
+          </span>
+        )}
         {EDITOR_TYPES.includes(docType) ? (
           <NavLink to={`/${docType}/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>← Edytuj dokument</NavLink>
         ) : (
@@ -2006,6 +2092,26 @@ const Chunks = () => {
                 background: useRecleaned ? "#dbeafe" : cleanupNeeded ? "#fef3c7" : "#dcfce7",
               }}>{useRecleaned ? "widok po czyszczeniu — użyty do podziału" : cleanupNeeded ? "wykryto elementy do czyszczenia" : "tekst nie wymaga ponownego czyszczenia"}</span>}
             </div>
+            {recleanPreview && !recleanPreview.portal && (
+              <div style={{
+                marginTop: 8, fontSize: "0.8em", padding: "6px 9px", borderRadius: 6,
+                color: "#92400e", background: "#fef3c7", border: "1px solid #fde68a",
+              }}>
+                ⚠ Brak reguł czyszczenia dla tego portalu — działa tylko czyszczenie generyczne,
+                nawigacja, komentarze, notowania czy sekcje rekomendacji mogą zostać w tekście.
+              </div>
+            )}
+            {recleanPreview && recleanPreview.site_rules_file && !recleanPreview.site_rules_file.ok && (
+              <div style={{
+                marginTop: 8, fontSize: "0.8em", padding: "6px 9px", borderRadius: 6,
+                color: "#991b1b", background: "#fee2e2", border: "1px solid #fecaca",
+              }}>
+                ⚠ Błąd konfiguracji środowiska: plik reguł czyszczenia (<code>{recleanPreview.site_rules_file.path}</code>)
+                {recleanPreview.site_rules_file.reason === "missing" ? " nie istnieje na tym serwerze" : " jest pusty lub uszkodzony na tym serwerze"} —
+                jest w repozytorium/GitHub, ale nie w działającym środowisku. Czyszczenie przy pobieraniu dokumentu
+                mogło nic nie usunąć niezależnie od reguł per-portal powyżej.
+              </div>
+            )}
             {recleanPreview && (
               <div style={{ marginTop: 8, fontSize: "0.8em", color: "#475569" }}>
                 <div>


### PR DESCRIPTION
## Summary
- Register bankier.pl as a recognized cleanup portal (`article_extractor.py`/`article_cleaner.py`) and fix a `\xa0`-vs-space bug in footer/start marker matching that affected all portals on real scraped HTML.
- `/chunks` now warns when the current document's portal has no cleanup rules, and separately when `site_rules.json` is missing/empty on the running backend (distinct from being present in the repo) — the latter caught a real Vault config bug on NAS (`SITE_RULES_PATH` was set in `compose.nas.yaml`'s `environment:`, which is a no-op under `SECRETS_BACKEND=vault`; fixed by pushing the value to Vault instead).
- Publication-date support on `/chunks`: LLM extraction (mirrors the existing author extraction), plus a manual calendar input for the reviewer, plus a `date_from_source` column (`manual`/`llm`/`NULL`) so documents where the pipeline never found a date can be found later to build deterministic rules — same idea as `document_removed_lines` for cleanup rules.
- Documentation: filled in the `docker-compose environment:` vault/aws pitfall and the Git Bash/MSYS path-mangling gotcha in `docs/security/secrets-management.md`, plus a warning comment in `compose.nas.yaml`.

## Test plan
- [x] `cd backend && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -q` — 1397 passed
- [x] `cd web_interface_react && npm run lint` (tsc --noEmit) — clean
- [x] `uvx ruff check` on all changed backend files — clean
- [x] Verified bankier.pl cleanup against the real document text that prompted this (10438 → 1522 chars)
- [x] Alembic migration applied and verified against the NAS database
- [x] Deployed backend+frontend to NAS and manually verified `/healthz`, `site_rules.json` loading, and Vault config end-to-end