### PR TITLE
feat(authors): structured multi-author support and HTML refresh

### DIFF
--- a/backend/alembic/versions/c2d3e4f5a6b7_add_author_source_to_web_documents.py
+++ b/backend/alembic/versions/c2d3e4f5a6b7_add_author_source_to_web_documents.py
@@ -18,7 +18,7 @@ def upgrade() -> None:
     op.execute("ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS author_source VARCHAR(10)")
     op.execute("""
         ALTER TABLE web_documents ADD CONSTRAINT ck_web_documents_author_source
-        CHECK (author_source IS NULL OR author_source IN ('manual', 'llm'))
+        CHECK (author_source IS NULL OR author_source IN ('manual', 'llm', 'html'))
     """)
 
 

--- a/backend/alembic/versions/c2d3e4f5a6b7_add_author_source_to_web_documents.py
+++ b/backend/alembic/versions/c2d3e4f5a6b7_add_author_source_to_web_documents.py
@@ -1,0 +1,27 @@
+"""add author_source to web_documents
+
+Revision ID: c2d3e4f5a6b7
+Revises: b1c2d3e4f5a6
+Create Date: 2026-07-18 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c2d3e4f5a6b7"
+down_revision: Union[str, None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE web_documents ADD COLUMN IF NOT EXISTS author_source VARCHAR(10)")
+    op.execute("""
+        ALTER TABLE web_documents ADD CONSTRAINT ck_web_documents_author_source
+        CHECK (author_source IS NULL OR author_source IN ('manual', 'llm'))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE web_documents DROP CONSTRAINT IF EXISTS ck_web_documents_author_source")
+    op.execute("ALTER TABLE web_documents DROP COLUMN IF EXISTS author_source")

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -183,6 +183,41 @@ def save_cache_files(doc_id: int, text_content: str | None, html_content: str | 
         print(f"  Cache: saved {path} ({len(text_content)} chars)")
 
 
+def refresh_existing_document(session, item: dict, text_content: str | None,
+                              html_content: str | None, cache_dir: str) -> int:
+    """Apply an extension-captured source revision to an existing document.
+
+    The previous S3 object remains untouched. The DynamoDB create event retains
+    its UUID, while this refresh event points the document at the new object.
+    Only deterministic author metadata is refreshed here; article analysis,
+    chunks and embeddings are deliberately left intact.
+    """
+    target_id = int(item["target_document_id"])
+    doc = session.get(WebDocument, target_id)
+    if doc is None:
+        raise ValueError(f"refresh target document {target_id} does not exist")
+    if doc.url != item.get("url"):
+        raise ValueError(f"refresh URL does not match document {target_id}")
+    if not html_content:
+        raise ValueError("refresh HTML is missing from S3")
+
+    new_uuid = item.get("uuid") or item.get("s3_uuid")
+    if not new_uuid:
+        raise ValueError("refresh S3 UUID is missing")
+
+    doc.uuid = new_uuid
+    doc.text_raw = html_content
+    save_cache_files(doc.id, text_content, html_content, cache_dir)
+
+    from library.article_metadata import extract_article_authors
+    from library.author_service import set_document_authors
+
+    authors = extract_article_authors(html_content, doc.url)
+    set_document_authors(session, doc, authors, source="html")
+    session.commit()
+    print(f"  REFRESHED (id={doc.id}, authors={authors or 'none'})")
+    return doc.id
+
 def process_article_content(doc_id: int, cache_base_dir: str,
                              session, skip_llm: bool = False) -> tuple[bool, bool]:
     """Convert HTML to markdown and optionally run LLM article extraction.
@@ -437,6 +472,7 @@ def main():
 
     # Sync items
     added = 0
+    refreshed = 0
     skipped = 0
     errors = 0
     md_converted = 0
@@ -470,10 +506,35 @@ def main():
                 text_content = None
                 html_content = None
 
+                if item.get("operation", "create") == "refresh":
+                    if args.dry_run:
+                        print(f"  WOULD REFRESH document id={item.get('target_document_id')}")
+                        refreshed += 1
+                        continue
+                    if args.skip_s3:
+                        print("  ERROR: refresh requires S3 download")
+                        errors += 1
+                        continue
+                    doc_uuid = item.get("uuid") or item.get("s3_uuid")
+                    text_content, html_content = fetch_s3_content(s3_client, bucket, doc_uuid)
+                    try:
+                        refresh_existing_document(session, item, text_content, html_content, args.data_dir)
+                        refreshed += 1
+                    except Exception as e:
+                        session.rollback()
+                        print(f"  ERROR refreshing: {e}")
+                        errors += 1
+                    continue
+
                 if not args.dry_run:
                     try:
                         existing = WebDocument.get_by_url(session, item.get("url", ""))
                     except Exception as e:
+                        # Any PostgreSQL statement error aborts the whole
+                        # transaction until rollback. Without this, one bad
+                        # item makes every later URL check fail with
+                        # InFailedSqlTransaction.
+                        session.rollback()
                         print(f"  ERROR checking URL: {e}")
                         errors += 1
                         continue
@@ -525,6 +586,7 @@ def main():
     print("\n=== Summary ===")
     print(f"Total processed: {len(items)}")
     print(f"Added: {added}")
+    print(f"Refreshed: {refreshed}")
     print(f"Skipped (already exist): {skipped}")
     print(f"Errors: {errors}")
     if md_converted or llm_extracted:

--- a/backend/library/article_metadata.py
+++ b/backend/library/article_metadata.py
@@ -12,6 +12,75 @@ def _is_wp_url(url: str) -> bool:
     return host == "wp.pl" or host.endswith(".wp.pl") or host == "o2.pl" or host.endswith(".o2.pl")
 
 
+def _is_onet_url(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host == "onet.pl" or host.endswith(".onet.pl")
+
+
+def _as_types(value) -> set[str]:
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, list):
+        return {item for item in value if isinstance(item, str)}
+    return set()
+
+
+def _author_names(value) -> list[str]:
+    values = value if isinstance(value, list) else [value]
+    names: list[str] = []
+    for item in values:
+        name = item.get("name") if isinstance(item, dict) else item if isinstance(item, str) else None
+        if name and name.strip() and name.strip().casefold() not in {n.casefold() for n in names}:
+            names.append(name.strip())
+    return names
+
+
+def _extract_onet_authors(html: str) -> list[str]:
+    """Read the byline from the Article object, never every Person in @graph."""
+    soup = BeautifulSoup(html, "html.parser")
+    article_types = {"Article", "NewsArticle", "ReportageNewsArticle", "AnalysisNewsArticle"}
+    for script in soup.select('script[type="application/ld+json"]'):
+        try:
+            payload = json.loads(script.string or script.get_text())
+        except (json.JSONDecodeError, TypeError):
+            continue
+        roots = payload if isinstance(payload, list) else [payload]
+        for root in roots:
+            if not isinstance(root, dict):
+                continue
+            objects = root.get("@graph", [root])
+            if not isinstance(objects, list):
+                objects = [objects]
+            for obj in objects:
+                if isinstance(obj, dict) and _as_types(obj.get("@type")) & article_types:
+                    names = _author_names(obj.get("author"))
+                    if names:
+                        return names
+
+    # Portal-specific fallback: only the compact byline immediately associated
+    # with the story. Profile cards later on the page repeat the same people.
+    names: list[str] = []
+    for link in soup.select('a[href*="/autorzy/"]'):
+        if link.find_parent(class_=lambda c: c and "author-xl" in " ".join(c if isinstance(c, list) else [c])):
+            continue
+        name = link.get_text(" ", strip=True)
+        if name and name.casefold() not in {n.casefold() for n in names}:
+            names.append(name)
+        if len(names) >= 10:
+            break
+    return names
+
+
+def extract_article_authors(html: str | None, url: str = "") -> list[str]:
+    """Extract all deterministic portal byline authors from raw HTML."""
+    if not html:
+        return []
+    if _is_onet_url(url):
+        return _extract_onet_authors(html)
+    author = extract_article_author(html, url)
+    return [author] if author else []
+
+
 def extract_article_author(html: str | None, url: str = "") -> str | None:
     """Extract a content author's name from raw HTML.
 

--- a/backend/library/author_service.py
+++ b/backend/library/author_service.py
@@ -1,0 +1,143 @@
+"""Structured document authorship — document_persons links with role="author".
+
+web_documents.author stays the comma-separated display cache; the source of
+truth for "who wrote this" is document_persons (role="author"), one row per
+co-author, resolved through the person registry so the same journalist links
+to one Person row across documents. Portal journalists usually have no
+Wikidata entry — they become local Person rows (wikidata_qid NULL), exactly
+like person_registry's cascade step 5.
+
+Confidence semantics on the author links:
+- manual entry (reviewer typed the byline)  -> manual_confirmed
+- LLM extraction, name already in registry  -> alias_matched
+- LLM extraction, new/unknown name          -> manual_review (queued on
+  /persons-review like any other unverified person)
+"""
+
+import logging
+import re
+
+from sqlalchemy import select
+
+from library.db.models import DocumentPerson, Person
+from library.person_registry import (
+    CONFIDENCE_ALIAS,
+    CONFIDENCE_MANUAL_CONFIRMED,
+    CONFIDENCE_MANUAL_REVIEW,
+    _delete_person_if_orphaned,
+    find_by_alias,
+)
+
+logger = logging.getLogger(__name__)
+
+# Portal bylines separate co-authors with commas, semicolons, slashes,
+# newlines (multi-line copy-paste) or the Polish conjunctions "i"/"oraz"
+# ("Michał Rogalski i Piotr Gruszka").
+_AUTHOR_SEPARATORS = re.compile(r"\s*(?:[,;/\n]|\bi\b|\boraz\b)\s*", re.IGNORECASE)
+
+# Portal UI junk that survives a byline copy-paste ("Michał Rogalski\nObserwuj").
+_AUTHOR_STOPWORDS = {"obserwuj", "autor", "autorzy", "autorka", "red.", "redakcja", "opracowanie"}
+
+
+def split_author_names(raw: str) -> list[str]:
+    """Split a byline string into individual author names, deduplicated.
+
+    Copy-pasting from a portal often duplicates each name ("Michał Rogalski
+    Michał Rogalski") — dedup is case-insensitive, first occurrence wins.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for part in _AUTHOR_SEPARATORS.split(raw or ""):
+        name = part.strip()
+        if not name or name.lower() in seen or name.lower() in _AUTHOR_STOPWORDS:
+            continue
+        seen.add(name.lower())
+        names.append(name)
+    return names
+
+
+def set_document_authors(session, doc, names: list[str], source: str) -> list[dict]:
+    """Set the document's authors: display cache + document_persons links.
+
+    source: "manual" (reviewer typed the byline) or "llm" (byline extraction).
+    Queues changes on the session without committing (caller owns the
+    transaction). Returns the author list in get_document_authors() shape.
+
+    Author links not in the new set are deleted (the main use case is fixing
+    an LLM misfire); if the person is genuinely mentioned in the text, the
+    next entity refresh re-links them as role="mentioned". Persons orphaned
+    by the deletion are removed from the registry.
+    """
+    names = [n.strip() for n in names if n and n.strip()]
+    doc.author = ", ".join(names) or None
+    doc.author_source = source if names else None
+
+    existing = session.execute(
+        select(DocumentPerson).where(
+            DocumentPerson.document_id == doc.id,
+            DocumentPerson.role == "author",
+        )
+    ).scalars().all()
+    existing_by_person = {link.person_id: link for link in existing}
+
+    kept_person_ids: set[int] = set()
+    for name in names:
+        person = find_by_alias(session, name)
+        if person is None:
+            person = Person(canonical_name=name)
+            session.add(person)
+            session.flush()
+            confidence = CONFIDENCE_MANUAL_CONFIRMED if source == "manual" else CONFIDENCE_MANUAL_REVIEW
+        else:
+            confidence = CONFIDENCE_MANUAL_CONFIRMED if source == "manual" else CONFIDENCE_ALIAS
+        kept_person_ids.add(person.id)
+
+        link = existing_by_person.get(person.id) or session.execute(
+            select(DocumentPerson).where(
+                DocumentPerson.document_id == doc.id,
+                DocumentPerson.person_id == person.id,
+            )
+        ).scalars().first()
+        if link is None:
+            session.add(DocumentPerson(
+                document_id=doc.id, person_id=person.id, raw_mention=name,
+                confidence=confidence, role="author",
+            ))
+        else:
+            # Promote a "mentioned" link (or refresh an author one). A manual
+            # confirmation upgrades confidence; never downgrade an existing
+            # manual_confirmed/wikidata_matched link to manual_review.
+            link.role = "author"
+            if source == "manual":
+                link.confidence = CONFIDENCE_MANUAL_CONFIRMED
+
+    for link in existing:
+        if link.person_id not in kept_person_ids:
+            person_id = link.person_id
+            session.delete(link)
+            session.flush()
+            _delete_person_if_orphaned(session, person_id)
+
+    session.flush()
+    return get_document_authors(session, doc.id)
+
+
+def get_document_authors(session, document_id: int) -> list[dict]:
+    """The document's authors (role="author" links), oldest link first."""
+    rows = session.execute(
+        select(DocumentPerson, Person)
+        .join(Person, DocumentPerson.person_id == Person.id)
+        .where(
+            DocumentPerson.document_id == document_id,
+            DocumentPerson.role == "author",
+        )
+        .order_by(DocumentPerson.id)
+    ).all()
+    return [{
+        "person_id": person.id,
+        "link_id": link.id,
+        "name": person.canonical_name,
+        "description": person.description,
+        "confidence": link.confidence,
+        "wikidata_qid": person.wikidata_qid,
+    } for link, person in rows]

--- a/backend/library/author_service.py
+++ b/backend/library/author_service.py
@@ -33,7 +33,10 @@ logger = logging.getLogger(__name__)
 # Portal bylines separate co-authors with commas, semicolons, slashes,
 # newlines (multi-line copy-paste) or the Polish conjunctions "i"/"oraz"
 # ("Michał Rogalski i Piotr Gruszka").
-_AUTHOR_SEPARATORS = re.compile(r"\s*(?:[,;/\n]|\bi\b|\boraz\b)\s*", re.IGNORECASE)
+# Do not wrap the alternatives in ``\s*``: adjacent unbounded whitespace
+# matches can backtrack polynomially on an untrusted pasted byline. Each split
+# part is stripped below, so whitespace consumption here is unnecessary.
+_AUTHOR_SEPARATORS = re.compile(r"[,;/\n]|\bi\b|\boraz\b", re.IGNORECASE)
 
 # Portal UI junk that survives a byline copy-paste ("Michał Rogalski\nObserwuj").
 _AUTHOR_STOPWORDS = {"obserwuj", "autor", "autorzy", "autorka", "red.", "redakcja", "opracowanie"}

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -140,29 +140,38 @@ def head_tail_excerpt(text: str, chars: int = 1500) -> str:
     return text[:chars] + "\n...\n" + text[-chars:]
 
 
-def extract_author_info(text: str, model: str) -> str | None:
-    """Ask LLM to identify the article's author (byline) from a text excerpt.
+def extract_author_info(text: str, model: str) -> list[str] | None:
+    """Ask LLM to identify the article's author(s) (byline) from a text excerpt.
 
-    Returns the author's name, or None if extraction fails or no author found.
+    Returns the list of author names (an article can have co-authors), or
+    None if extraction fails or no author found.
     """
-    prompt = f"""Z poniższego fragmentu artykułu spróbuj ustalić imię i nazwisko autora (dziennikarza, publicysty).
+    prompt = f"""Z poniższego fragmentu artykułu spróbuj ustalić imiona i nazwiska autorów (dziennikarzy, publicystów).
+Artykuł może mieć jednego autora lub kilku współautorów — wypisz wszystkich podpisanych pod artykułem.
 Zwróć TYLKO obiekt JSON bez żadnego dodatkowego tekstu, w formacie:
-{{"author": "Imię Nazwisko"}}
+{{"authors": ["Imię Nazwisko", "Imię Nazwisko"]}}
 
-Jeśli nie możesz jednoznacznie zidentyfikować autora, zwróć: {{"author": null}}
+Jeśli nie możesz jednoznacznie zidentyfikować żadnego autora, zwróć: {{"authors": null}}
 
 Fragment artykułu:
 {text}"""
 
     logger.info("extract_author_info: len=%d", len(text))
-    response_text, _ = call_model(prompt, model, max_tokens=100)
+    response_text, _ = call_model(prompt, model, max_tokens=200)
     try:
         match = re.search(r'\{.*\}', response_text, re.DOTALL)
         if match:
             result = json.loads(match.group())
-            author = result.get("author")
-            if isinstance(author, str) and author.strip():
-                return author.strip()
+            authors = result.get("authors")
+            # Tolerate a model answering with the older single-author shape.
+            if authors is None:
+                authors = result.get("author")
+            if isinstance(authors, str):
+                authors = [authors]
+            if isinstance(authors, list):
+                cleaned = [a.strip() for a in authors if isinstance(a, str) and a.strip()]
+                if cleaned:
+                    return cleaned
     except Exception:
         logger.warning("extract_author_info: failed to parse JSON response")
     return None

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -34,7 +34,7 @@ from sqlalchemy import func, or_, select, text as sa_text, update as sa_update
 from library.db.engine import get_scoped_session
 from library.db.models import (
     CitedPublication, DocumentAnalysisJob, DocumentAnalysisRun, DocumentChunk, DocumentCitedPublication,
-    DocumentPerson, DocumentRemovedLine, DocumentTopicSection, Person,
+    DocumentRemovedLine, DocumentTopicSection,
     WebDocument, WebsiteEmbedding,
 )
 
@@ -1164,16 +1164,10 @@ def get_run_chunks(run_id: int):
         abort(404, f"Run {run_id} not found")
 
     doc = session.get(WebDocument, run.document_id)
-    author_person = None
+    author_persons = []
     if isinstance(doc, WebDocument):
-        author_person = session.execute(
-            select(Person.id, Person.description)
-            .join(DocumentPerson, DocumentPerson.person_id == Person.id)
-            .where(
-                DocumentPerson.document_id == run.document_id,
-                DocumentPerson.role == "author",
-            ).limit(1)
-        ).first()
+        from library.author_service import get_document_authors
+        author_persons = get_document_authors(session, run.document_id)
     segments = [] if lite else _parse_segments(doc.text_raw if doc else None)
 
     topic_sections = session.scalars(
@@ -1267,8 +1261,8 @@ def get_run_chunks(run_id: int):
             "original_id": doc.original_id if doc else "",
             "document_type": doc.document_type if doc else "",
             "author": getattr(doc, "author", "") if doc else "",
-            "author_person_id": author_person.id if author_person else None,
-            "author_description": author_person.description if author_person else None,
+            "author_source": getattr(doc, "author_source", None) if doc else None,
+            "author_persons": author_persons,
             "countries": doc_countries,
             "thematic_tags": doc_thematic_tags,
             "quality": getattr(doc, "quality", None) if doc else None,
@@ -1655,18 +1649,19 @@ def extract_author(run_id: int):
 
     try:
         from library.chunk_llm_analysis import extract_author_info
-        author = extract_author_info(source_text, run.model)
+        author_names = extract_author_info(source_text, run.model)
     except Exception:
         logger.exception("extract_author_info failed for run %d", run_id)
         return jsonify({"status": "error", "message": "LLM call failed"}), 500
 
-    if not author:
+    if not author_names:
         return jsonify({"status": "success", "author": None})
 
     doc = session.get(WebDocument, run.document_id)
     if doc is None:
         abort(404, f"Document {run.document_id} not found")
-    doc.author = author
+    from library.author_service import set_document_authors
+    author_persons = set_document_authors(session, doc, author_names, source="llm")
     try:
         session.commit()
     except Exception:
@@ -1674,7 +1669,12 @@ def extract_author(run_id: int):
         logger.exception("DB save failed for run %d author", run_id)
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
-    return jsonify({"status": "success", "author": author})
+    return jsonify({
+        "status": "success",
+        "author": doc.author,
+        "author_source": doc.author_source,
+        "author_persons": author_persons,
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -1803,6 +1803,50 @@ def set_date_from(doc_id: int):
         "status": "success",
         "date_from": doc.date_from.isoformat() if doc.date_from else None,
         "date_from_source": doc.date_from_source,
+    })
+
+
+# ---------------------------------------------------------------------------
+# API: POST /document/<doc_id>/author
+# ---------------------------------------------------------------------------
+
+@bp.route("/document/<int:doc_id>/author", methods=["POST"])
+def set_author(doc_id: int):
+    """Manually set (or clear) the document's author(s).
+
+    Companion to extract_author above — the reviewer pastes the byline from
+    the original page instead of asking the LLM. Accepts co-authors in one
+    string ("Michał Rogalski, Piotr Gruszka" — also "i"/"oraz"/";" work as
+    separators) and links each of them in document_persons (role="author",
+    confidence=manual_confirmed). null clears the author and its links.
+    """
+    from library.author_service import set_document_authors, split_author_names
+
+    session = get_scoped_session()
+    doc = session.get(WebDocument, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    author_str = data.get("author")
+    if author_str is not None and not isinstance(author_str, str):
+        return jsonify({"status": "error", "message": "author must be a string or null"}), 400
+
+    names = split_author_names(author_str or "")
+    author_persons = set_document_authors(session, doc, names, source="manual")
+
+    try:
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.exception("DB save failed for document %d author", doc_id)
+        return jsonify({"status": "error", "message": "DB save failed"}), 500
+
+    return jsonify({
+        "status": "success",
+        "author": doc.author,
+        "author_source": doc.author_source,
+        "author_persons": author_persons,
     })
 
 

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -241,7 +241,14 @@ class WebDocument(Base):
     transcript_job_id: Mapped[str | None] = mapped_column(Text)
     ai_summary_needed: Mapped[bool | None] = mapped_column(Boolean, server_default=sa_text("false"))
     # Content creator: YouTube channel name, article author, etc. — metadata about who made it.
+    # Multiple authors are stored comma-separated; the structured links live in
+    # document_persons (role="author"), this column is the display cache.
     author: Mapped[str | None] = mapped_column(Text)
+    # How author was set — "manual" (reviewer typed it on /chunks) or "llm"
+    # (extract_author / pipeline step 11b2). NULL for legacy/import-set values.
+    # Mirrors date_from_source: lets a future pass find documents where the
+    # byline extraction failed and a human had to fix it.
+    author_source: Mapped[str | None] = mapped_column(String(10))
     note: Mapped[str | None] = mapped_column(Text)
     uuid: Mapped[str] = mapped_column(
         String(100), nullable=False, unique=True,
@@ -434,6 +441,7 @@ class WebDocument(Base):
             "transcript_job_id": self.transcript_job_id,
             "ai_summary_needed": self.ai_summary_needed,
             "author": self.author,
+            "author_source": self.author_source,
             "note": self.note,
             "uuid": self.uuid,
             "project": self.project,

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -630,12 +630,13 @@ class DocumentAnalysisService:
             #       single chapter excerpt is not a reliable place to look for a byline.
             if not is_transcript and scope is None and not (getattr(doc, "author", None) or "").strip():
                 try:
+                    from library.author_service import set_document_authors
                     from library.chunk_llm_analysis import extract_author_info, head_tail_excerpt
 
-                    author_name = extract_author_info(head_tail_excerpt(text), model)
-                    if author_name:
-                        doc.author = author_name
-                        log(f"author detected: {author_name}")
+                    author_names = extract_author_info(head_tail_excerpt(text), model)
+                    if author_names:
+                        set_document_authors(self.session, doc, author_names, source="llm")
+                        log(f"author detected: {', '.join(author_names)}")
                 except Exception:
                     logger.exception("author extraction failed, continuing without author")
 

--- a/backend/library/document_service.py
+++ b/backend/library/document_service.py
@@ -131,6 +131,39 @@ class DocumentService:
     # save_document — extracted from /website_save
     # ------------------------------------------------------------------
 
+    def refresh_document_source(self, document_id: int, url: str, html: str,
+                                text: str = "") -> WebDocument:
+        """Store a new captured source revision and re-extract deterministic authors."""
+        try:
+            document_id = int(document_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Refresh requires target_document_id") from exc
+        doc = WebDocument.get_by_id(self.session, document_id)
+        if doc is None:
+            raise ValueError("Refresh target document does not exist")
+        if doc.url != url:
+            raise ValueError("Refresh URL does not match target document")
+        if doc.document_type != "webpage" or not html:
+            raise ValueError("Refresh requires a webpage with HTML")
+
+        cfg = load_config()
+        bucket_name = cfg.get("AWS_S3_WEBSITE_CONTENT")
+        use_s3 = bucket_name is not None
+        s3_client = __import__("boto3").client("s3") if use_s3 else None
+        new_uuid = str(uuid.uuid4())
+        if text:
+            self._store_file(new_uuid, "txt", text, use_s3, s3_client, bucket_name)
+        self._store_file(new_uuid, "html", html, use_s3, s3_client, bucket_name)
+
+        doc.uuid = new_uuid
+        doc.text_raw = html
+        from library.article_metadata import extract_article_authors
+        from library.author_service import set_document_authors
+
+        set_document_authors(self.session, doc, extract_article_authors(html, url), source="html")
+        self.session.commit()
+        return doc
+
     def save_document(
         self,
         url: str,

--- a/backend/server.py
+++ b/backend/server.py
@@ -216,19 +216,27 @@ def url_add():
 
         session = get_scoped_session()
         service = DocumentService(session)
-        doc = service.create_document(
-            url=url_data.get("url", ""),
-            url_type=url_data.get("type", ""),
-            text=url_data.get("text", ""),
-            html=url_data.get("html", ""),
-            title=url_data.get("title", ""),
-            language=url_data.get("language", ""),
-            note=url_data.get("note", "default_note"),
-            paywall=url_data.get("paywall", False),
-            source=url_data.get("source", "own"),
-            ai_summary=url_data.get("ai_summary", False),
-            chapter_list=url_data.get("chapter_list", False),
-        )
+        if url_data.get("operation", "create") == "refresh":
+            doc = service.refresh_document_source(
+                document_id=url_data.get("target_document_id"),
+                url=url_data.get("url", ""),
+                html=url_data.get("html", ""),
+                text=url_data.get("text", ""),
+            )
+        else:
+            doc = service.create_document(
+                url=url_data.get("url", ""),
+                url_type=url_data.get("type", ""),
+                text=url_data.get("text", ""),
+                html=url_data.get("html", ""),
+                title=url_data.get("title", ""),
+                language=url_data.get("language", ""),
+                note=url_data.get("note", "default_note"),
+                paywall=url_data.get("paywall", False),
+                source=url_data.get("source", "own"),
+                ai_summary=url_data.get("ai_summary", False),
+                chapter_list=url_data.get("chapter_list", False),
+            )
         return {
             'status': 'success',
             'message': f'Successfully saved document with ID: {doc.id}',

--- a/backend/tests/unit/test_article_metadata.py
+++ b/backend/tests/unit/test_article_metadata.py
@@ -1,6 +1,6 @@
 """Tests for deterministic portal metadata extraction."""
 
-from library.article_metadata import extract_article_author
+from library.article_metadata import extract_article_author, extract_article_authors
 
 
 def test_wp_author_prefers_cauthor_over_publisher_meta():
@@ -30,3 +30,30 @@ def test_publisher_meta_is_not_used_as_wp_author():
 def test_wp_rule_does_not_apply_to_other_domains():
     html = '<script>window.page={"cauthor":"Jan Kowalski"};</script>'
     assert extract_article_author(html, "https://example.com/artykul") is None
+
+
+def test_onet_extracts_multiple_authors_from_article_json_ld():
+    html = '''<script type="application/ld+json">{
+      "@context": "https://schema.org", "@graph": [
+        {"@type": "Person", "name": "Osoba z rekomendacji"},
+        {"@type": "NewsArticle", "author": [
+          {"@type": "Person", "name": "Michał Rogalski"},
+          {"@type": "Person", "name": "Piotr Gruszka"}
+        ]}
+      ]
+    }</script>'''
+
+    assert extract_article_authors(html, "https://wiadomosci.onet.pl/artykul") == [
+        "Michał Rogalski", "Piotr Gruszka",
+    ]
+
+
+def test_onet_does_not_collect_unrelated_people_from_json_ld_graph():
+    html = '''<script type="application/ld+json">{
+      "@graph": [
+        {"@type": "NewsArticle", "author": {"@type": "Person", "name": "Autor Tekstu"}},
+        {"@type": "Person", "name": "Autor Polecanego Tekstu"}
+      ]
+    }</script>'''
+
+    assert extract_article_authors(html, "https://www.onet.pl/informacje/test") == ["Autor Tekstu"]

--- a/backend/tests/unit/test_author_service.py
+++ b/backend/tests/unit/test_author_service.py
@@ -1,0 +1,188 @@
+"""Unit tests for library/author_service.py — structured document authorship."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+import library.author_service as auth_svc  # noqa: E402
+from library.author_service import split_author_names, set_document_authors  # noqa: E402
+from library.db.models import DocumentPerson, Person  # noqa: E402
+
+
+class TestSplitAuthorNames:
+    def test_single_author(self):
+        assert split_author_names("Michał Rogalski") == ["Michał Rogalski"]
+
+    @pytest.mark.parametrize("raw", [
+        "Michał Rogalski, Piotr Gruszka",
+        "Michał Rogalski i Piotr Gruszka",
+        "Michał Rogalski oraz Piotr Gruszka",
+        "Michał Rogalski; Piotr Gruszka",
+        "Michał Rogalski / Piotr Gruszka",
+        "Michał Rogalski\nPiotr Gruszka",
+    ])
+    def test_separators(self, raw):
+        assert split_author_names(raw) == ["Michał Rogalski", "Piotr Gruszka"]
+
+    def test_portal_paste_with_duplicates_and_junk(self):
+        # Copy-paste from a portal duplicates each name (avatar alt + link
+        # text) and drags UI junk like the "Obserwuj" button label along
+        raw = "Michał Rogalski\nMichał Rogalski\n\nObserwuj\nPiotr Gruszka\nPiotr Gruszka\n\nObserwuj"
+        assert split_author_names(raw) == ["Michał Rogalski", "Piotr Gruszka"]
+
+    def test_dedup_is_case_insensitive(self):
+        assert split_author_names("Jan Kowalski, jan kowalski") == ["Jan Kowalski"]
+
+    def test_empty_input(self):
+        assert split_author_names("") == []
+        assert split_author_names("  ,  ") == []
+
+    def test_conjunction_inside_name_is_not_split(self):
+        # "i"/"oraz" only split as standalone words
+        assert split_author_names("Iga Nowak") == ["Iga Nowak"]
+
+
+def _doc(doc_id=421):
+    doc = MagicMock()
+    doc.id = doc_id
+    return doc
+
+
+def _session(existing_author_links=()):
+    """MagicMock session: first execute -> existing author links, later
+    executes (per-name link lookup) -> no link found."""
+    session = MagicMock()
+    author_links_result = MagicMock()
+    author_links_result.scalars.return_value.all.return_value = list(existing_author_links)
+    no_link_result = MagicMock()
+    no_link_result.scalars.return_value.first.return_value = None
+    session.execute.side_effect = [author_links_result] + [no_link_result] * 20
+    return session
+
+
+class TestSetDocumentAuthors:
+    def test_manual_entry_creates_persons_and_author_links(self):
+        doc = _doc()
+        session = _session()
+
+        with patch.object(auth_svc, "find_by_alias", return_value=None), \
+                patch.object(auth_svc, "get_document_authors", return_value=[]):
+            set_document_authors(session, doc, ["Michał Rogalski", "Piotr Gruszka"], source="manual")
+
+        assert doc.author == "Michał Rogalski, Piotr Gruszka"
+        assert doc.author_source == "manual"
+        added = [c.args[0] for c in session.add.call_args_list]
+        persons = [a for a in added if isinstance(a, Person)]
+        links = [a for a in added if isinstance(a, DocumentPerson)]
+        assert [p.canonical_name for p in persons] == ["Michał Rogalski", "Piotr Gruszka"]
+        assert all(link.role == "author" for link in links)
+        assert all(link.confidence == "manual_confirmed" for link in links)
+
+    def test_llm_new_person_is_queued_for_review(self):
+        doc = _doc()
+        session = _session()
+
+        with patch.object(auth_svc, "find_by_alias", return_value=None), \
+                patch.object(auth_svc, "get_document_authors", return_value=[]):
+            set_document_authors(session, doc, ["Weronika Jaworska"], source="llm")
+
+        assert doc.author_source == "llm"
+        links = [c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], DocumentPerson)]
+        assert len(links) == 1
+        assert links[0].confidence == "manual_review"
+
+    def test_llm_known_person_links_as_alias_matched(self):
+        doc = _doc()
+        session = _session()
+        known = MagicMock(spec=Person)
+        known.id = 7
+
+        with patch.object(auth_svc, "find_by_alias", return_value=known), \
+                patch.object(auth_svc, "get_document_authors", return_value=[]):
+            set_document_authors(session, doc, ["Jacek Losik"], source="llm")
+
+        links = [c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], DocumentPerson)]
+        assert len(links) == 1
+        assert links[0].person_id == 7
+        assert links[0].confidence == "alias_matched"
+
+    def test_stale_author_link_is_deleted_and_orphan_cleaned(self):
+        doc = _doc()
+        stale = MagicMock(spec=DocumentPerson)
+        stale.person_id = 99
+        session = _session(existing_author_links=[stale])
+
+        with patch.object(auth_svc, "find_by_alias", return_value=None), \
+                patch.object(auth_svc, "get_document_authors", return_value=[]), \
+                patch.object(auth_svc, "_delete_person_if_orphaned") as orphan:
+            set_document_authors(session, doc, ["Nowy Autor"], source="manual")
+
+        session.delete.assert_called_once_with(stale)
+        orphan.assert_called_once_with(session, 99)
+
+    def test_existing_mentioned_link_is_promoted_to_author(self):
+        doc = _doc()
+        known = MagicMock(spec=Person)
+        known.id = 7
+        mentioned_link = MagicMock(spec=DocumentPerson)
+        mentioned_link.person_id = 7
+        mentioned_link.role = "mentioned"
+        mentioned_link.confidence = "wikidata_matched"
+
+        session = MagicMock()
+        author_links_result = MagicMock()
+        author_links_result.scalars.return_value.all.return_value = []
+        link_result = MagicMock()
+        link_result.scalars.return_value.first.return_value = mentioned_link
+        session.execute.side_effect = [author_links_result, link_result]
+
+        with patch.object(auth_svc, "find_by_alias", return_value=known), \
+                patch.object(auth_svc, "get_document_authors", return_value=[]):
+            set_document_authors(session, doc, ["Donald Tusk"], source="llm")
+
+        assert mentioned_link.role == "author"
+        # LLM extraction must not downgrade an existing confidence
+        assert mentioned_link.confidence == "wikidata_matched"
+        session.add.assert_not_called()
+
+    def test_empty_names_clear_author(self):
+        doc = _doc()
+        stale = MagicMock(spec=DocumentPerson)
+        stale.person_id = 99
+        session = _session(existing_author_links=[stale])
+
+        with patch.object(auth_svc, "get_document_authors", return_value=[]), \
+                patch.object(auth_svc, "_delete_person_if_orphaned"):
+            set_document_authors(session, doc, [], source="manual")
+
+        assert doc.author is None
+        assert doc.author_source is None
+        session.delete.assert_called_once_with(stale)
+
+
+class TestExtractAuthorInfoParsing:
+    def _extract(self, monkeypatch, response):
+        import library.chunk_llm_analysis as llm
+        monkeypatch.setattr(llm, "call_model", lambda *a, **kw: (response, 10))
+        return llm.extract_author_info("tekst artykułu", "m")
+
+    def test_multiple_authors(self, monkeypatch):
+        result = self._extract(monkeypatch, '{"authors": ["Michał Rogalski", "Piotr Gruszka"]}')
+        assert result == ["Michał Rogalski", "Piotr Gruszka"]
+
+    def test_single_author_list(self, monkeypatch):
+        assert self._extract(monkeypatch, '{"authors": ["Jan Kowalski"]}') == ["Jan Kowalski"]
+
+    def test_legacy_single_author_shape(self, monkeypatch):
+        assert self._extract(monkeypatch, '{"author": "Jan Kowalski"}') == ["Jan Kowalski"]
+
+    def test_null_authors(self, monkeypatch):
+        assert self._extract(monkeypatch, '{"authors": null}') is None
+
+    def test_garbage_response(self, monkeypatch):
+        assert self._extract(monkeypatch, "nie wiem") is None
+
+    def test_empty_strings_filtered(self, monkeypatch):
+        assert self._extract(monkeypatch, '{"authors": ["", "  "]}') is None

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -158,14 +158,14 @@ class TestWebDocumentColumns:
         "source", "date_from", "date_from_source", "original_id", "document_length",
         "chapter_list", "document_state", "document_state_error",
         "text_raw", "transcript_job_id", "ai_summary_needed",
-        "author", "note", "uuid", "project", "text_md",
+        "author", "author_source", "note", "uuid", "project", "text_md",
         "text_extracted", "transcript_needed", "reviewed_at",
         "obsidian_note_paths", "video_description", "ner_unavailable_at",
         "quality",
     }
 
     def test_column_count(self):
-        assert len(_column_names(WebDocument)) == 33
+        assert len(_column_names(WebDocument)) == 34
 
     def test_all_column_names(self):
         assert _column_names(WebDocument) == self.EXPECTED_COLUMNS
@@ -497,14 +497,14 @@ class TestValidate:
 # ---------------------------------------------------------------------------
 
 class TestDict:
-    def test_dict_has_35_keys(self):
+    def test_dict_has_36_keys(self):
         doc = _make_doc(
             title="Test",
             document_state_error="NONE",
         )
         doc.created_at = datetime.datetime(2025, 1, 15, 10, 30, 0)
         result = doc.dict()
-        assert len(result) == 35
+        assert len(result) == 36
 
     def test_dict_keys(self):
         doc = _make_doc(
@@ -519,7 +519,7 @@ class TestDict:
             "created_at", "document_type", "source", "date_from", "date_from_source", "original_id",
             "document_length", "chapter_list", "document_state",
             "document_state_error", "text_raw", "transcript_job_id",
-            "ai_summary_needed", "author", "note", "uuid", "project",
+            "ai_summary_needed", "author", "author_source", "note", "uuid", "project",
             "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
             "quality",

--- a/backend/tests/unit/test_orm_crud.py
+++ b/backend/tests/unit/test_orm_crud.py
@@ -427,7 +427,7 @@ class TestDictCompatibility:
             "created_at", "document_type", "source", "date_from", "date_from_source", "original_id",
             "document_length", "chapter_list", "document_state", "document_state_error",
             "text_raw", "transcript_job_id", "ai_summary_needed", "author",
-            "note", "uuid", "project", "text_md", "transcript_needed",
+            "author_source", "note", "uuid", "project", "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
             "quality",
         }

--- a/infra/aws/serverless/lambdas/url-add/lambda_function.py
+++ b/infra/aws/serverless/lambdas/url-add/lambda_function.py
@@ -54,9 +54,20 @@ def lambda_handler(event, context):
     paywall = url_data.get("paywall", False)
     source = url_data.get("source", "own")
     chapter_list = url_data.get("chapter_list", False)
+    operation = url_data.get("operation", "create")
+    target_document_id = url_data.get("target_document_id")
 
     if not target_url or not url_type:
         return _error_response("Missing required parameter(s): 'url' or 'type'")
+    if operation not in {"create", "refresh"}:
+        return _error_response("Invalid operation", 400)
+    if operation == "refresh":
+        try:
+            target_document_id = int(target_document_id)
+        except (TypeError, ValueError):
+            return _error_response("Refresh requires target_document_id", 400)
+        if target_document_id <= 0 or url_type != "webpage" or not html:
+            return _error_response("Refresh requires a webpage with HTML", 400)
 
     # Generuj unikalny identyfikator i timestamp
     uid = str(uuid.uuid4())
@@ -99,7 +110,11 @@ def lambda_handler(event, context):
             'chapter_list': chapter_list,
             'created_at': timestamp,
             'created_date': created_date,
+            'operation': operation,
         }
+
+        if operation == "refresh":
+            dynamodb_item['target_document_id'] = target_document_id
 
         # Dodaj s3_uuid tylko dla webpage
         if url_type == 'webpage':

--- a/web_chrome_extension/CHANGELOG.md
+++ b/web_chrome_extension/CHANGELOG.md
@@ -4,6 +4,10 @@ Wszystkie istotne zmiany w tym projekcie będą udokumentowane w tym pliku.
 
 Format zgodny z [Keep a Changelog](https://keepachangelog.com/) i semantycznym wersjonowaniem [Semantic Versioning](https://semver.org/).
 
+## [1.0.25] - 2026-07-18
+### Dodane
+- Tryb „Odśwież istniejący dokument” wysyłający aktualny, wyrenderowany HTML strony wraz z ID dokumentu Lenie.
+
 ## [1.0.24] - 2026-07-14
 ### Dodane
 - Lista źródeł (Source) pobierana dynamicznie z backendu (`GET /sources?active=1`) zamiast 4 zaszytych opcji; zaszyte opcje pozostają jako fallback offline (dodatkowo cache w `chrome.storage.local`)
@@ -45,4 +49,3 @@ Format zgodny z [Keep a Changelog](https://keepachangelog.com/) i semantycznym w
 ## [1.0.16] - 2025-01-19
 ### Dodano
 - Dodano obsługę automatycznego wykrywania języka strony.
-

--- a/web_chrome_extension/manifest.json
+++ b/web_chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lenie AI assistant",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Wtyczka do komunikacji z API lenie-ai.eu",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "content_security_policy": {
@@ -17,4 +17,3 @@
     }
   }
 }
-

--- a/web_chrome_extension/popup.html
+++ b/web_chrome_extension/popup.html
@@ -98,6 +98,16 @@
         </div>
       </div>
 
+      <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" id="refreshExisting">
+        <label class="form-check-label" for="refreshExisting">Odśwież istniejący dokument</label>
+      </div>
+      <div class="form-group" id="refreshDocumentIdContainer" style="display: none;">
+        <label for="refreshDocumentId">ID dokumentu Lenie</label>
+        <input type="number" min="1" id="refreshDocumentId" class="form-control" placeholder="np. 421">
+        <small class="form-text text-muted">Zapisze nową kopię HTML i zaktualizuje wskazany dokument po synchronizacji.</small>
+      </div>
+
       <button id="sendButton" class="btn btn-primary btn-block">Wyślij</button>
     </div>
   </div>
@@ -126,7 +136,7 @@
   </div>
 
   <div class="mt-3">
-    Wersja <a href="https://github.com/ziutus/ai_assistant_lenie/blob/main/web_chrome_extension/CHANGELOG.md" target="_blank">1.0.24</a>
+    Wersja <a href="https://github.com/ziutus/ai_assistant_lenie/blob/main/web_chrome_extension/CHANGELOG.md" target="_blank">1.0.25</a>
   </div>
 </div>
 <script src="popup.js"></script>

--- a/web_chrome_extension/popup.js
+++ b/web_chrome_extension/popup.js
@@ -34,6 +34,13 @@ document.addEventListener('DOMContentLoaded', function () {
   const newSourceContainer = document.getElementById('newSourceContainer');
   const newSourceNameInput = document.getElementById('newSourceName');
   const addSourceButton = document.getElementById('addSourceButton');
+  const refreshExisting = document.getElementById('refreshExisting');
+  const refreshDocumentId = document.getElementById('refreshDocumentId');
+  const refreshDocumentIdContainer = document.getElementById('refreshDocumentIdContainer');
+
+  refreshExisting.addEventListener('change', () => {
+    refreshDocumentIdContainer.style.display = refreshExisting.checked ? 'block' : 'none';
+  });
 
   const ADD_NEW_SOURCE = '__add_new__';
   let previousSourceValue = sourceSelect.value;
@@ -260,6 +267,15 @@ document.addEventListener('DOMContentLoaded', function () {
     sendButton.disabled = true;
     sendButton.textContent = 'Wysyłam...';
 
+    const targetDocumentId = Number.parseInt(refreshDocumentId.value, 10);
+    if (refreshExisting.checked && (!Number.isInteger(targetDocumentId) || targetDocumentId <= 0)) {
+      alert('Podaj prawidłowe ID istniejącego dokumentu.');
+      sendButton.style.backgroundColor = '';
+      sendButton.disabled = false;
+      sendButton.textContent = 'Wyślij';
+      return;
+    }
+
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       const pageUrl = tabs[0]?.url || '';
       chrome.scripting.executeScript({
@@ -283,6 +299,10 @@ document.addEventListener('DOMContentLoaded', function () {
             source: sourceSelect.value,
             chapter_list: chapter_list.value
           };
+          if (refreshExisting.checked) {
+            data.operation = 'refresh';
+            data.target_document_id = targetDocumentId;
+          }
 
           return fetch(serverUrl, {
             method: 'POST',

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -113,6 +113,15 @@ interface CountryTag {
   name_pl: string;
 }
 
+interface AuthorPerson {
+  person_id: number;
+  link_id: number;
+  name: string;
+  description: string | null;
+  confidence: string;
+  wikidata_qid: string | null;
+}
+
 interface DocQuality {
   score: number;
   penalties: Record<string, number>;
@@ -521,8 +530,10 @@ const Chunks = () => {
   const [docType, setDocType]       = React.useState(initialDocType);
   const [docTitle, setDocTitle]     = React.useState("");
   const [docAuthor, setDocAuthor]   = React.useState("");
-  const [authorPersonId, setAuthorPersonId] = React.useState<number | null>(null);
-  const [authorDescription, setAuthorDescription] = React.useState("");
+  const [docAuthorSource, setDocAuthorSource] = React.useState<string | null>(null);
+  const [authorPersons, setAuthorPersons] = React.useState<AuthorPerson[]>([]);
+  const [authorInput, setAuthorInput] = React.useState("");
+  const [savingAuthor, setSavingAuthor] = React.useState(false);
   const [docDateFrom, setDocDateFrom] = React.useState<string | null>(null);
   const [docDateFromSource, setDocDateFromSource] = React.useState<string | null>(null);
   const [extractingDateFor, setExtractingDateFor] = React.useState<number | null>(null);
@@ -656,8 +667,9 @@ const Chunks = () => {
       setDocType(data.document?.document_type ?? "");
       setDocUrl(data.document?.url ?? "");
       setDocAuthor(data.document?.author ?? "");
-      setAuthorPersonId(data.document?.author_person_id ?? null);
-      setAuthorDescription(data.document?.author_description ?? "");
+      setDocAuthorSource(data.document?.author_source ?? null);
+      setAuthorPersons(data.document?.author_persons ?? []);
+      setAuthorInput(data.document?.author ?? "");
       setDocDateFrom(data.document?.date_from ?? null);
       setDocDateFromSource(data.document?.date_from_source ?? null);
       setDateInput(data.document?.date_from ?? "");
@@ -703,7 +715,8 @@ const Chunks = () => {
         if (data.document_type) setDocType(data.document_type);
         if (data.title) setDocTitle(data.title);
         if (data.url) setDocUrl(data.url);
-        if (data.author) setDocAuthor(data.author);
+        if (data.author) { setDocAuthor(data.author); setAuthorInput(data.author); }
+        if (data.author_source) setDocAuthorSource(data.author_source);
         if (data.date_from) { setDocDateFrom(data.date_from); setDateInput(data.date_from); }
         if (data.quality) setDocQuality(data.quality);
       } catch { /* analysis can still be configured manually */ }
@@ -1344,6 +1357,13 @@ const Chunks = () => {
   // Detect the article author (byline) from one specific chunk. Unlike speaker
   // detection, no position limit — a byline can appear at either the start or
   // the end of an article. Saves directly to doc.author (backend commits it).
+  const applyAuthorResponse = (data: { author: string; author_source?: string; author_persons?: AuthorPerson[] }) => {
+    setDocAuthor(data.author);
+    setAuthorInput(data.author);
+    setDocAuthorSource(data.author_source ?? "llm");
+    setAuthorPersons(data.author_persons ?? []);
+  };
+
   const extractAuthorFromChunk = async (chunkId: number) => {
     if (!selectedRun) return;
     setExtractingAuthorFor(chunkId);
@@ -1354,7 +1374,7 @@ const Chunks = () => {
       });
       const data = await r.json();
       if (data.status === "success" && data.author) {
-        setDocAuthor(data.author);
+        applyAuthorResponse(data);
         setInfo(`Ustawiono autora: ${data.author}`);
       }
       else if (data.status === "success") setError("Nie udało się rozpoznać autora w tym chunku");
@@ -1406,6 +1426,25 @@ const Chunks = () => {
     finally { setSavingDate(false); }
   };
 
+  // Manually save the byline typed/pasted into the input next to the "Autor"
+  // badge — the reviewer copying the byline off the original page (co-authors
+  // separated by commas or "i"/"oraz"), as opposed to the LLM detection above.
+  const saveAuthor = async () => {
+    if (!id || !authorInput.trim()) return;
+    setSavingAuthor(true);
+    try {
+      const r = await fetch(`${apiUrl}/document/${id}/author`, {
+        method: "POST", headers, body: JSON.stringify({ author: authorInput }),
+      });
+      const data = await r.json();
+      if (data.status === "success") {
+        applyAuthorResponse({ ...data, author_source: data.author_source ?? "manual" });
+        setInfo(`Ustawiono autora: ${data.author}`);
+      } else setError("Błąd zapisu autora: " + (data.message ?? ""));
+    } catch { setError("Błąd połączenia przy zapisie autora"); }
+    finally { setSavingAuthor(false); }
+  };
+
   const extractAuthorFromLine = async (chunk: Chunk, lineIdx: number) => {
     if (!selectedRun) return;
     const lines = (chunk.original_text ?? "").split("\n");
@@ -1418,7 +1457,7 @@ const Chunks = () => {
       });
       const data = await r.json();
       if (data.status === "success" && data.author) {
-        setDocAuthor(data.author);
+        applyAuthorResponse(data);
         setInfo(`Ustawiono autora: ${data.author}. Linię autora możesz teraz oznaczyć × i usunąć.`);
       } else if (data.status === "success") setError("Nie udało się rozpoznać autora w tym kontekście");
       else setError("Błąd wykrywania autora: " + (data.message ?? ""));
@@ -1981,12 +2020,44 @@ const Chunks = () => {
           {docType && <span style={{ fontWeight: 400, color: "#64748b", fontSize: "0.7em" }}> ({DOC_TYPE_LABELS[docType] ?? docType}, #{id})</span>}
         </h2>
         {runMode === "article" && (
-          <span style={{ fontSize: "0.88em", padding: "3px 9px", borderRadius: 4, background: docAuthor ? "#f3e8ff" : "#f1f5f9", color: docAuthor ? "#6b21a8" : "#64748b" }}>
-            Autor: {docAuthor && authorPersonId
-              ? <NavLink to={`/persons/${authorPersonId}`} target="_blank" rel="noreferrer"
-                  title={authorDescription || "Podsumowanie autora i jego artykuły — otwórz w nowej karcie"}
-                  style={{ color: "inherit", fontWeight: 700 }}>{docAuthor}</NavLink>
+          <span style={{ fontSize: "0.88em", padding: "3px 9px", borderRadius: 4, background: docAuthor ? "#f3e8ff" : "#f1f5f9", color: docAuthor ? "#6b21a8" : "#64748b", display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+            Autor:{" "}
+            {authorPersons.length > 0
+              ? authorPersons.map((p, i) => (
+                  <React.Fragment key={p.person_id}>
+                    {i > 0 && <span>, </span>}
+                    <NavLink to={`/persons/${p.person_id}`} target="_blank" rel="noreferrer"
+                      title={p.description || "Podsumowanie autora i jego artykuły — otwórz w nowej karcie"}
+                      style={{ color: "inherit", fontWeight: 700 }}>{p.name}</NavLink>
+                  </React.Fragment>
+                ))
               : <strong>{docAuthor || "nie wykryto"}</strong>}
+            {docAuthor && docAuthorSource && (
+              <span
+                title={docAuthorSource === "manual"
+                  ? "Wpisany ręcznie przez recenzenta — automatyka go nie znalazła"
+                  : "Wykryty przez LLM z treści dokumentu"}
+                style={{ fontSize: "0.85em", opacity: 0.75 }}
+              >
+                {docAuthorSource === "manual" ? "✍️" : "🤖"}
+              </span>
+            )}
+            <input
+              type="text"
+              value={authorInput}
+              onChange={e => setAuthorInput(e.target.value)}
+              placeholder="Imię Nazwisko, Imię Nazwisko"
+              title="Wpisz lub wklej autorów z oryginalnej strony — współautorów oddziel przecinkiem lub „i”"
+              style={{ fontSize: "0.9em", padding: "1px 3px", border: "1px solid #cbd5e1", borderRadius: 3, width: 180 }}
+            />
+            <button
+              onClick={saveAuthor}
+              disabled={!authorInput.trim() || savingAuthor}
+              title="Zapisz wpisanych autorów (utworzy też powiązania z rejestrem osób)"
+              style={{ padding: "1px 7px", border: "1px solid #cbd5e1", borderRadius: 3, background: "#fff", cursor: "pointer", fontSize: "0.9em", color: "#64748b" }}
+            >
+              {savingAuthor ? "…" : "💾"}
+            </button>
           </span>
         )}
         {runMode === "article" && (


### PR DESCRIPTION
## Summary
- store article co-authors as structured document-person links
- add manual and LLM author review flow
- extract deterministic Onet bylines from JSON-LD
- allow the browser extension to refresh captured HTML for an existing document
- process refresh events through Lambda, DynamoDB/S3 sync, and preserve previous S3 objects
- prevent one PostgreSQL error from poisoning the remaining sync transaction

## Verification
- 1422 backend unit tests passed
- tsc --noEmit passed
- targeted metadata tests passed after the final cache-write correction
- Python compilation and git diff checks passed
- gitleaks and TruffleHog hooks passed

## Operational verification
- lenie-dev-url-add Lambda deployed successfully
- migration c2d3e4f5a6b7 applied to the local database
- document 421 refreshed from captured HTML with Michał Rogalski and Piotr Gruszka