### PR TITLE
feat(search): stage 1 - validated search domain types

### DIFF
--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -36,6 +36,8 @@ library/
 ├── place_verification.py    # NER place candidates → geocoder (geocode_cache) → LLM → miejsce-* tags
 ├── wikidata_client.py       # Wikidata person search (humans only, P31=Q5) for disambiguation
 ├── person_registry.py       # NER person mentions → alias/Wikidata+LLM/fuzzy → document_persons links
+├── search/           # Typed search domain models (stage 1 of docs/search-rebuild-implementation-plan.md)
+│   └── types.py      # ParsedSearchQuery, SearchFilters, SearchRequest, SearchFeedback + enums; frozen dataclasses validated at construction (SearchQueryValidationError), target domain names (published_on, subject_period_*), normalize_*_range() helpers for the future parser
 ├── stalker_web_documents_db_postgresql.py  # Query layer (ORM, list, search, similarity)
 ├── text_functions.py        # Text processing & splitting utilities
 ├── text_detect_language.py  # Language detection abstraction

--- a/backend/library/search/__init__.py
+++ b/backend/library/search/__init__.py
@@ -1,0 +1,42 @@
+"""Search domain types (stage 1 of docs/search-rebuild-implementation-plan.md).
+
+Public surface of the new search subsystem. Types use the target domain
+vocabulary (document_id, published_on, subject_period_*, discovery_source,
+collection) from day one, regardless of the legacy SQL column names.
+"""
+
+from library.search.types import (
+    MAX_SEARCH_LIMIT,
+    MAX_SUBJECT_YEAR,
+    MIN_SUBJECT_YEAR,
+    FeedbackVerdict,
+    InterpretationStatus,
+    ModelConfidence,
+    ParsedSearchQuery,
+    SearchFeedback,
+    SearchFilters,
+    SearchQueryValidationError,
+    SearchRequest,
+    SearchSort,
+    normalize_date_range,
+    normalize_datetime_range,
+    normalize_year_range,
+)
+
+__all__ = [
+    "MAX_SEARCH_LIMIT",
+    "MAX_SUBJECT_YEAR",
+    "MIN_SUBJECT_YEAR",
+    "FeedbackVerdict",
+    "InterpretationStatus",
+    "ModelConfidence",
+    "ParsedSearchQuery",
+    "SearchFeedback",
+    "SearchFilters",
+    "SearchQueryValidationError",
+    "SearchRequest",
+    "SearchSort",
+    "normalize_date_range",
+    "normalize_datetime_range",
+    "normalize_year_range",
+]

--- a/backend/library/search/types.py
+++ b/backend/library/search/types.py
@@ -1,0 +1,383 @@
+"""Typed search domain models with construction-time validation.
+
+Stage 1 of docs/search-rebuild-implementation-plan.md: an invalid object
+cannot exist, so an invalid object can never reach SearchService. All
+dataclasses are frozen; every field is validated in __post_init__ and a
+violation raises SearchQueryValidationError naming the offending field.
+
+Reversed ranges are an error at construction time. The parser/normalizer
+(stage 4/5) repairs LLM output *before* construction with the
+normalize_*_range() helpers, which swap the bounds and return the Polish
+warning expected by the evaluation fixture (edge-04/edge-05 in
+tests/fixtures/search_query_cases.json).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, fields
+from datetime import date, datetime
+from enum import Enum
+
+from library.models.stalker_document_type import StalkerDocumentType
+
+MIN_SUBJECT_YEAR = -10000
+MAX_SUBJECT_YEAR = 3000
+MAX_SEARCH_LIMIT = 100
+MAX_QUERY_LENGTH = 1000
+MAX_NAME_LENGTH = 300
+MAX_TEXT_LENGTH = 1000
+MAX_COMMENT_LENGTH = 2000
+
+_LANGUAGE_RE = re.compile(r"^[a-z]{2,3}$")
+_DOMAIN_RE = re.compile(r"^(?=.{4,253}$)([a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$")
+
+VALID_DOCUMENT_TYPES = frozenset(member.name for member in StalkerDocumentType)
+
+
+class SearchQueryValidationError(ValueError):
+    """Invalid value for a search domain object; `field` names the culprit."""
+
+    def __init__(self, field_name: str, message: str):
+        self.field = field_name
+        super().__init__(f"{field_name}: {message}")
+
+
+class SearchSort(str, Enum):
+    RELEVANCE = "relevance"
+    PUBLISHED_DESC = "published_desc"
+    PUBLISHED_ASC = "published_asc"
+    INGESTED_DESC = "ingested_desc"
+
+
+class InterpretationStatus(str, Enum):
+    PARSED = "parsed"
+    AMBIGUOUS = "ambiguous"
+    INVALID_JSON = "invalid_json"
+    VALIDATION_ERROR = "validation_error"
+    LLM_ERROR = "llm_error"
+    FALLBACK = "fallback"
+
+
+class FeedbackVerdict(str, Enum):
+    CORRECT = "correct"
+    PARTIALLY_CORRECT = "partially_correct"
+    INCORRECT = "incorrect"
+
+
+class ModelConfidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+# --- field validators -------------------------------------------------------
+# Shared by SearchFilters, ParsedSearchQuery and SearchRequest so each rule
+# lives in exactly one place. Validators return the canonical value to store.
+
+
+def _opt_text(name: str, value, max_length: int = MAX_NAME_LENGTH) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SearchQueryValidationError(name, f"expected str or None, got {type(value).__name__}")
+    stripped = value.strip()
+    if not stripped:
+        raise SearchQueryValidationError(name, "must not be empty; use None instead")
+    if len(stripped) > max_length:
+        raise SearchQueryValidationError(name, f"longer than {max_length} characters")
+    return stripped
+
+
+def _required_text(name: str, value, max_length: int = MAX_TEXT_LENGTH) -> str:
+    text = _opt_text(name, value, max_length)
+    if text is None:
+        raise SearchQueryValidationError(name, "is required")
+    return text
+
+
+def _opt_date(name: str, value) -> date | None:
+    if value is None:
+        return None
+    # datetime is a subclass of date -- a published_on bound must be a plain date.
+    if isinstance(value, datetime) or not isinstance(value, date):
+        raise SearchQueryValidationError(name, f"expected datetime.date or None, got {type(value).__name__}")
+    return value
+
+
+def _opt_datetime(name: str, value) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        raise SearchQueryValidationError(name, f"expected datetime.datetime or None, got {type(value).__name__}")
+    return value
+
+
+def _opt_year(name: str, value) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SearchQueryValidationError(name, f"expected int or None, got {type(value).__name__}")
+    if not MIN_SUBJECT_YEAR <= value <= MAX_SUBJECT_YEAR:
+        raise SearchQueryValidationError(name, f"must be within [{MIN_SUBJECT_YEAR}, {MAX_SUBJECT_YEAR}]")
+    return value
+
+
+def _int_in_range(name: str, value, minimum: int, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SearchQueryValidationError(name, f"expected int, got {type(value).__name__}")
+    if value < minimum or (maximum is not None and value > maximum):
+        bound = f">= {minimum}" if maximum is None else f"within [{minimum}, {maximum}]"
+        raise SearchQueryValidationError(name, f"must be {bound}")
+    return value
+
+
+def _bool(name: str, value) -> bool:
+    if not isinstance(value, bool):
+        raise SearchQueryValidationError(name, f"expected bool, got {type(value).__name__}")
+    return value
+
+
+def _str_tuple(name: str, value, max_item_length: int = MAX_TEXT_LENGTH) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise SearchQueryValidationError(name, f"expected a list of str, got {type(value).__name__}")
+    items = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise SearchQueryValidationError(name, "every item must be a non-empty str")
+        if len(item) > max_item_length:
+            raise SearchQueryValidationError(name, f"item longer than {max_item_length} characters")
+        items.append(item.strip())
+    return tuple(items)
+
+
+def _document_types(name: str, value) -> tuple[str, ...]:
+    items = _str_tuple(name, value)
+    for item in items:
+        if item not in VALID_DOCUMENT_TYPES:
+            allowed = ", ".join(sorted(VALID_DOCUMENT_TYPES))
+            raise SearchQueryValidationError(name, f"unknown document type {item!r}; allowed: {allowed}")
+    return items
+
+
+def _languages(name: str, value) -> tuple[str, ...]:
+    items = tuple(item.lower() for item in _str_tuple(name, value))
+    for item in items:
+        if not _LANGUAGE_RE.match(item):
+            raise SearchQueryValidationError(name, f"invalid language code {item!r} (expected e.g. 'pl', 'en')")
+    return items
+
+
+def _opt_domain(name: str, value) -> str | None:
+    text = _opt_text(name, value)
+    if text is None:
+        return None
+    text = text.lower()
+    if not _DOMAIN_RE.match(text):
+        raise SearchQueryValidationError(name, f"invalid domain {text!r}")
+    return text
+
+
+def _enum(name: str, value, enum_cls):
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, str):
+        try:
+            return enum_cls(value)
+        except ValueError:
+            pass
+    allowed = ", ".join(member.value for member in enum_cls)
+    raise SearchQueryValidationError(name, f"expected one of: {allowed}")
+
+
+def _ordered(name_from: str, value_from, value_to) -> None:
+    if value_from is not None and value_to is not None and value_from > value_to:
+        raise SearchQueryValidationError(
+            name_from, f"reversed range: {value_from} > {value_to} (normalize before constructing)"
+        )
+
+
+# --- range normalization (for the stage 4/5 parser, before construction) ----
+
+
+def normalize_year_range(start: int | None, end: int | None) -> tuple[int | None, int | None, str | None]:
+    """Swap a reversed year range; the warning is None when nothing changed."""
+    if start is not None and end is not None and start > end:
+        return end, start, f"Odwrócony zakres lat: zamieniono {start} i {end}."
+    return start, end, None
+
+
+def normalize_date_range(
+    date_from: date | None, date_to: date | None
+) -> tuple[date | None, date | None, str | None]:
+    """Swap a reversed publication-date range; warning is None when unchanged."""
+    if date_from is not None and date_to is not None and date_from > date_to:
+        return date_to, date_from, f"Odwrócony zakres dat: zamieniono {date_from.isoformat()} i {date_to.isoformat()}."
+    return date_from, date_to, None
+
+
+def normalize_datetime_range(
+    dt_from: datetime | None, dt_to: datetime | None
+) -> tuple[datetime | None, datetime | None, str | None]:
+    """Swap a reversed ingested-at range; warning is None when unchanged."""
+    if dt_from is not None and dt_to is not None and dt_from > dt_to:
+        return dt_to, dt_from, f"Odwrócony zakres dat: zamieniono {dt_from.isoformat()} i {dt_to.isoformat()}."
+    return dt_from, dt_to, None
+
+
+# --- domain objects ---------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    """Explicit, already-validated search constraints (no LLM involved)."""
+
+    author_name: str | None = None
+    publisher_name: str | None = None
+    publisher_domain: str | None = None
+    discovery_source_name: str | None = None
+    collection_name: str | None = None
+    published_on_from: date | None = None
+    published_on_to: date | None = None
+    ingested_at_from: datetime | None = None
+    ingested_at_to: datetime | None = None
+    subject_period_start_year: int | None = None
+    subject_period_end_year: int | None = None
+    document_types: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        set_ = object.__setattr__
+        set_(self, "author_name", _opt_text("author_name", self.author_name))
+        set_(self, "publisher_name", _opt_text("publisher_name", self.publisher_name))
+        set_(self, "publisher_domain", _opt_domain("publisher_domain", self.publisher_domain))
+        set_(self, "discovery_source_name", _opt_text("discovery_source_name", self.discovery_source_name))
+        set_(self, "collection_name", _opt_text("collection_name", self.collection_name))
+        set_(self, "published_on_from", _opt_date("published_on_from", self.published_on_from))
+        set_(self, "published_on_to", _opt_date("published_on_to", self.published_on_to))
+        set_(self, "ingested_at_from", _opt_datetime("ingested_at_from", self.ingested_at_from))
+        set_(self, "ingested_at_to", _opt_datetime("ingested_at_to", self.ingested_at_to))
+        set_(self, "subject_period_start_year", _opt_year("subject_period_start_year", self.subject_period_start_year))
+        set_(self, "subject_period_end_year", _opt_year("subject_period_end_year", self.subject_period_end_year))
+        set_(self, "document_types", _document_types("document_types", self.document_types))
+        set_(self, "languages", _languages("languages", self.languages))
+        _ordered("published_on_from", self.published_on_from, self.published_on_to)
+        _ordered("ingested_at_from", self.ingested_at_from, self.ingested_at_to)
+        _ordered("subject_period_start_year", self.subject_period_start_year, self.subject_period_end_year)
+
+    def is_empty(self) -> bool:
+        return all(getattr(self, f.name) in (None, ()) for f in fields(self))
+
+
+@dataclass(frozen=True)
+class ParsedSearchQuery:
+    """Validated interpretation of a natural-language query (plan section 5).
+
+    Flat on purpose -- it mirrors the JSON contract the LLM produces.
+    interpretation_summary is always required (the frontend shows it); apart
+    from that, an object with no query, no filters and no clarification is
+    legal and means "list everything".
+    """
+
+    query: str | None = None
+    author_name: str | None = None
+    publisher_name: str | None = None
+    publisher_domain: str | None = None
+    discovery_source_name: str | None = None
+    collection_name: str | None = None
+    published_on_from: date | None = None
+    published_on_to: date | None = None
+    ingested_at_from: datetime | None = None
+    ingested_at_to: datetime | None = None
+    subject_period_start_year: int | None = None
+    subject_period_end_year: int | None = None
+    temporal_expression: str | None = None
+    document_types: tuple[str, ...] = ()
+    languages: tuple[str, ...] = ()
+    sort: SearchSort = SearchSort.RELEVANCE
+    interpretation_summary: str = ""
+    warnings: tuple[str, ...] = ()
+    clarification_required: bool = False
+    clarification_question: str | None = None
+    model_confidence: ModelConfidence = ModelConfidence.MEDIUM
+
+    def __post_init__(self):
+        set_ = object.__setattr__
+        set_(self, "query", _opt_text("query", self.query, MAX_QUERY_LENGTH))
+        # Reuse SearchFilters for every shared constraint field: same rules,
+        # same error messages, single source of truth.
+        filters = self.to_filters()
+        for f in fields(SearchFilters):
+            set_(self, f.name, getattr(filters, f.name))
+        set_(self, "temporal_expression", _opt_text("temporal_expression", self.temporal_expression, MAX_TEXT_LENGTH))
+        set_(self, "sort", _enum("sort", self.sort, SearchSort))
+        set_(self, "interpretation_summary", _required_text("interpretation_summary", self.interpretation_summary))
+        set_(self, "warnings", _str_tuple("warnings", self.warnings))
+        set_(self, "clarification_required", _bool("clarification_required", self.clarification_required))
+        set_(self, "clarification_question",
+             _opt_text("clarification_question", self.clarification_question, MAX_TEXT_LENGTH))
+        set_(self, "model_confidence", _enum("model_confidence", self.model_confidence, ModelConfidence))
+        if self.clarification_question is not None and not self.clarification_required:
+            raise SearchQueryValidationError(
+                "clarification_question", "set while clarification_required is False"
+            )
+
+    def to_filters(self) -> SearchFilters:
+        return SearchFilters(**{f.name: getattr(self, f.name) for f in fields(SearchFilters)})
+
+
+@dataclass(frozen=True)
+class SearchRequest:
+    """One of two variants (plan section 4): natural language or explicit.
+
+    Either `natural_query` alone (the LLM will interpret it), or an explicit
+    `query`/`filters` combination that skips the LLM entirely. Mixing the two
+    or providing neither is an error; an all-empty request must never reach
+    the LLM (fixture case edge-06).
+    """
+
+    natural_query: str | None = None
+    query: str | None = None
+    filters: SearchFilters = field(default_factory=SearchFilters)
+    limit: int = 10
+    offset: int = 0
+    sort: SearchSort = SearchSort.RELEVANCE
+
+    def __post_init__(self):
+        set_ = object.__setattr__
+        set_(self, "natural_query", _opt_text("natural_query", self.natural_query, MAX_QUERY_LENGTH))
+        set_(self, "query", _opt_text("query", self.query, MAX_QUERY_LENGTH))
+        if not isinstance(self.filters, SearchFilters):
+            raise SearchQueryValidationError("filters", f"expected SearchFilters, got {type(self.filters).__name__}")
+        set_(self, "limit", _int_in_range("limit", self.limit, 1, MAX_SEARCH_LIMIT))
+        set_(self, "offset", _int_in_range("offset", self.offset, 0))
+        set_(self, "sort", _enum("sort", self.sort, SearchSort))
+        explicit = self.query is not None or not self.filters.is_empty()
+        if self.natural_query is not None and explicit:
+            raise SearchQueryValidationError(
+                "natural_query", "provide either natural_query or explicit query/filters, not both"
+            )
+        if self.natural_query is None and not explicit:
+            raise SearchQueryValidationError("natural_query", "empty request: no query and no filters")
+
+    @property
+    def is_natural(self) -> bool:
+        return self.natural_query is not None
+
+
+@dataclass(frozen=True)
+class SearchFeedback:
+    """User verdict on an interpretation (POST /search/{id}/feedback)."""
+
+    verdict: FeedbackVerdict
+    comment: str | None = None
+    corrected_query: ParsedSearchQuery | None = None
+
+    def __post_init__(self):
+        set_ = object.__setattr__
+        set_(self, "verdict", _enum("verdict", self.verdict, FeedbackVerdict))
+        set_(self, "comment", _opt_text("comment", self.comment, MAX_COMMENT_LENGTH))
+        if self.corrected_query is not None and not isinstance(self.corrected_query, ParsedSearchQuery):
+            raise SearchQueryValidationError(
+                "corrected_query", f"expected ParsedSearchQuery, got {type(self.corrected_query).__name__}"
+            )

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -46,6 +46,7 @@ Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. The
 |------|--------|
 | `test_document_service.py` | `DocumentService` (create/import document) |
 | `test_search_service.py` | `SearchService` (embeddings, similarity) |
+| `test_search_types.py` | `library/search/types.py` — frozen search domain models: per-field validation, boundaries, reversed ranges, request variants |
 | `test_flask_endpoints_orm.py` | ORM-backed endpoints; error responses use generic messages (details logged, not leaked) |
 | `test_flask_endpoints_document_states.py` | `GET /document_states` |
 | `test_website_get_validation.py` | `/website_get` input validation |

--- a/backend/tests/unit/test_search_types.py
+++ b/backend/tests/unit/test_search_types.py
@@ -1,0 +1,365 @@
+"""Unit tests for the search domain types (stage 1 of the search rebuild).
+
+Every field is exercised with a valid value, a wrong type and its boundary;
+the stage's exit condition is that an invalid object cannot be constructed,
+so it can never reach SearchService.
+"""
+
+import dataclasses
+from datetime import date, datetime
+
+import pytest
+
+from library.search import (
+    MAX_SEARCH_LIMIT,
+    MAX_SUBJECT_YEAR,
+    MIN_SUBJECT_YEAR,
+    FeedbackVerdict,
+    InterpretationStatus,
+    ModelConfidence,
+    ParsedSearchQuery,
+    SearchFeedback,
+    SearchFilters,
+    SearchQueryValidationError,
+    SearchRequest,
+    SearchSort,
+    normalize_date_range,
+    normalize_datetime_range,
+    normalize_year_range,
+)
+
+
+def parsed_query(**overrides) -> ParsedSearchQuery:
+    kwargs = {"interpretation_summary": "testowa interpretacja"}
+    kwargs.update(overrides)
+    return ParsedSearchQuery(**kwargs)
+
+
+class TestEnums:
+    def test_sort_values(self):
+        assert [m.value for m in SearchSort] == [
+            "relevance", "published_desc", "published_asc", "ingested_desc",
+        ]
+
+    def test_interpretation_status_values(self):
+        assert [m.value for m in InterpretationStatus] == [
+            "parsed", "ambiguous", "invalid_json", "validation_error", "llm_error", "fallback",
+        ]
+
+    def test_feedback_verdict_values(self):
+        assert [m.value for m in FeedbackVerdict] == ["correct", "partially_correct", "incorrect"]
+
+    def test_model_confidence_values(self):
+        assert [m.value for m in ModelConfidence] == ["high", "medium", "low"]
+
+    def test_enums_construct_from_string(self):
+        assert SearchSort("published_desc") is SearchSort.PUBLISHED_DESC
+        assert InterpretationStatus("fallback") is InterpretationStatus.FALLBACK
+
+
+class TestSearchFilters:
+    def test_full_valid_object(self):
+        filters = SearchFilters(
+            author_name="Jan Kowalski",
+            publisher_name="Onet",
+            publisher_domain="onet.pl",
+            discovery_source_name="unknow.news",
+            collection_name="historia",
+            published_on_from=date(2020, 1, 1),
+            published_on_to=date(2025, 12, 31),
+            ingested_at_from=datetime(2024, 1, 1, 12, 0),
+            ingested_at_to=datetime(2024, 6, 1, 12, 0),
+            subject_period_start_year=-3100,
+            subject_period_end_year=-30,
+            document_types=["webpage", "youtube"],
+            languages=["pl", "EN"],
+        )
+        assert filters.document_types == ("webpage", "youtube")
+        assert filters.languages == ("pl", "en")
+        assert not filters.is_empty()
+
+    def test_empty_by_default(self):
+        assert SearchFilters().is_empty()
+
+    @pytest.mark.parametrize("field_name", [
+        "author_name", "publisher_name", "discovery_source_name", "collection_name",
+    ])
+    @pytest.mark.parametrize("bad", ["", "   ", 123, ["x"]])
+    def test_text_fields_reject_empty_and_wrong_types(self, field_name, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(**{field_name: bad})
+        assert exc.value.field == field_name
+
+    def test_text_fields_are_stripped(self):
+        assert SearchFilters(author_name="  Jan  ").author_name == "Jan"
+
+    @pytest.mark.parametrize("bad", ["onet", "http://onet.pl", "o net.pl", "-bad-.pl", 5])
+    def test_publisher_domain_rejects_invalid(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(publisher_domain=bad)
+        assert exc.value.field == "publisher_domain"
+
+    def test_publisher_domain_is_lowercased(self):
+        assert SearchFilters(publisher_domain="Onet.PL").publisher_domain == "onet.pl"
+
+    @pytest.mark.parametrize("field_name", ["published_on_from", "published_on_to"])
+    @pytest.mark.parametrize("bad", ["2024-01-01", datetime(2024, 1, 1), 20240101])
+    def test_published_on_requires_plain_date(self, field_name, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(**{field_name: bad})
+        assert exc.value.field == field_name
+
+    @pytest.mark.parametrize("field_name", ["ingested_at_from", "ingested_at_to"])
+    @pytest.mark.parametrize("bad", ["2024-01-01T00:00:00", date(2024, 1, 1), 0])
+    def test_ingested_at_requires_datetime(self, field_name, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(**{field_name: bad})
+        assert exc.value.field == field_name
+
+    @pytest.mark.parametrize("field_name", ["subject_period_start_year", "subject_period_end_year"])
+    @pytest.mark.parametrize("bad", ["1945", 1945.0, True, MIN_SUBJECT_YEAR - 1, MAX_SUBJECT_YEAR + 1])
+    def test_years_reject_wrong_types_and_bounds(self, field_name, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(**{field_name: bad})
+        assert exc.value.field == field_name
+
+    def test_years_accept_boundaries(self):
+        filters = SearchFilters(
+            subject_period_start_year=MIN_SUBJECT_YEAR,
+            subject_period_end_year=MAX_SUBJECT_YEAR,
+        )
+        assert filters.subject_period_start_year == MIN_SUBJECT_YEAR
+        assert filters.subject_period_end_year == MAX_SUBJECT_YEAR
+
+    @pytest.mark.parametrize("bad", ["webpage", [1], ["nosuchtype"], [""], [None]])
+    def test_document_types_reject_invalid(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(document_types=bad)
+        assert exc.value.field == "document_types"
+
+    @pytest.mark.parametrize("bad", [["polski"], ["p"], ["pl-PL"], "pl", [1]])
+    def test_languages_reject_invalid(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(languages=bad)
+        assert exc.value.field == "languages"
+
+    def test_reversed_year_range_rejected(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(subject_period_start_year=1800, subject_period_end_year=1700)
+        assert exc.value.field == "subject_period_start_year"
+
+    def test_reversed_published_on_range_rejected(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(published_on_from=date(2025, 1, 1), published_on_to=date(2020, 1, 1))
+        assert exc.value.field == "published_on_from"
+
+    def test_reversed_ingested_at_range_rejected(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFilters(
+                ingested_at_from=datetime(2025, 1, 1),
+                ingested_at_to=datetime(2020, 1, 1),
+            )
+        assert exc.value.field == "ingested_at_from"
+
+    def test_open_ended_ranges_allowed(self):
+        assert SearchFilters(subject_period_start_year=1945).subject_period_end_year is None
+        assert SearchFilters(published_on_to=date(2025, 1, 1)).published_on_from is None
+
+    def test_frozen(self):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            SearchFilters().author_name = "x"
+
+
+class TestParsedSearchQuery:
+    def test_canonical_plan_example(self):
+        parsed = ParsedSearchQuery(
+            query="niewolnictwo w Afryce",
+            subject_period_start_year=1945,
+            subject_period_end_year=None,
+            temporal_expression="od końca II wojny światowej",
+            interpretation_summary="Niewolnictwo w Afryce od zakończenia II wojny światowej",
+            warnings=["Nie podano końca okresu."],
+        )
+        assert parsed.query == "niewolnictwo w Afryce"
+        assert parsed.subject_period_start_year == 1945
+        assert parsed.warnings == ("Nie podano końca okresu.",)
+        assert parsed.sort is SearchSort.RELEVANCE
+        assert parsed.model_confidence is ModelConfidence.MEDIUM
+        assert not parsed.clarification_required
+
+    def test_interpretation_summary_is_required(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            ParsedSearchQuery(query="cokolwiek")
+        assert exc.value.field == "interpretation_summary"
+
+    def test_shared_filter_fields_are_validated(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            parsed_query(subject_period_start_year=1800, subject_period_end_year=1700)
+        assert exc.value.field == "subject_period_start_year"
+        with pytest.raises(SearchQueryValidationError):
+            parsed_query(document_types=["nosuchtype"])
+
+    def test_query_length_limit(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            parsed_query(query="x" * 1001)
+        assert exc.value.field == "query"
+
+    def test_sort_and_confidence_accept_strings(self):
+        parsed = parsed_query(sort="published_desc", model_confidence="high")
+        assert parsed.sort is SearchSort.PUBLISHED_DESC
+        assert parsed.model_confidence is ModelConfidence.HIGH
+
+    @pytest.mark.parametrize("field_name,bad", [
+        ("sort", "newest"),
+        ("model_confidence", "certain"),
+        ("warnings", "warning"),
+        ("clarification_required", 1),
+        ("temporal_expression", ""),
+    ])
+    def test_invalid_values_rejected(self, field_name, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            parsed_query(**{field_name: bad})
+        assert exc.value.field == field_name
+
+    def test_clarification_question_requires_flag(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            parsed_query(clarification_question="Doprecyzuj temat?")
+        assert exc.value.field == "clarification_question"
+        parsed = parsed_query(clarification_required=True, clarification_question="Doprecyzuj temat?")
+        assert parsed.clarification_question == "Doprecyzuj temat?"
+
+    def test_empty_query_with_summary_means_list_everything(self):
+        parsed = parsed_query()
+        assert parsed.query is None
+        assert parsed.to_filters().is_empty()
+
+    def test_to_filters_round_trip(self):
+        parsed = parsed_query(
+            publisher_domain="onet.pl",
+            published_on_from=date(2024, 1, 1),
+            document_types=["webpage"],
+            languages=["pl"],
+        )
+        filters = parsed.to_filters()
+        assert filters == SearchFilters(
+            publisher_domain="onet.pl",
+            published_on_from=date(2024, 1, 1),
+            document_types=("webpage",),
+            languages=("pl",),
+        )
+
+    def test_frozen(self):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            parsed_query().query = "zmiana"
+
+
+class TestNormalizeRanges:
+    def test_year_swap_with_warning(self):
+        start, end, warning = normalize_year_range(1800, 1700)
+        assert (start, end) == (1700, 1800)
+        assert "1800" in warning and "1700" in warning
+
+    def test_year_noop(self):
+        assert normalize_year_range(1700, 1800) == (1700, 1800, None)
+        assert normalize_year_range(None, 1800) == (None, 1800, None)
+        assert normalize_year_range(1700, None) == (1700, None, None)
+
+    def test_date_swap_with_warning(self):
+        d_from, d_to, warning = normalize_date_range(date(2025, 12, 31), date(2020, 1, 1))
+        assert (d_from, d_to) == (date(2020, 1, 1), date(2025, 12, 31))
+        assert "2025-12-31" in warning
+
+    def test_datetime_swap_with_warning(self):
+        dt_from, dt_to, warning = normalize_datetime_range(datetime(2025, 1, 1), datetime(2020, 1, 1))
+        assert (dt_from, dt_to) == (datetime(2020, 1, 1), datetime(2025, 1, 1))
+        assert warning is not None
+
+    def test_normalized_values_construct_cleanly(self):
+        start, end, warning = normalize_year_range(1800, 1700)
+        filters = SearchFilters(subject_period_start_year=start, subject_period_end_year=end)
+        assert filters.subject_period_start_year == 1700
+        assert warning is not None
+
+
+class TestSearchRequest:
+    def test_natural_variant(self):
+        request = SearchRequest(natural_query="niewolnictwo w Afryce po 1945")
+        assert request.is_natural
+        assert request.limit == 10
+        assert request.offset == 0
+        assert request.sort is SearchSort.RELEVANCE
+
+    def test_explicit_variant_query_only(self):
+        request = SearchRequest(query="niewolnictwo w Afryce", limit=20)
+        assert not request.is_natural
+
+    def test_explicit_variant_filters_only(self):
+        request = SearchRequest(filters=SearchFilters(languages=["pl"]))
+        assert not request.is_natural
+
+    def test_both_variants_rejected(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchRequest(natural_query="temat", query="temat")
+        assert exc.value.field == "natural_query"
+        with pytest.raises(SearchQueryValidationError):
+            SearchRequest(natural_query="temat", filters=SearchFilters(languages=["pl"]))
+
+    @pytest.mark.parametrize("kwargs", [{}, {"natural_query": None}, {"query": None}])
+    def test_empty_request_rejected(self, kwargs):
+        with pytest.raises(SearchQueryValidationError):
+            SearchRequest(**kwargs)
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    def test_blank_natural_query_rejected(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchRequest(natural_query=bad)
+        assert exc.value.field == "natural_query"
+
+    @pytest.mark.parametrize("bad", [0, -1, MAX_SEARCH_LIMIT + 1, True, 10.0, "10"])
+    def test_limit_bounds_and_types(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchRequest(natural_query="temat", limit=bad)
+        assert exc.value.field == "limit"
+
+    def test_limit_boundaries_accepted(self):
+        assert SearchRequest(natural_query="temat", limit=1).limit == 1
+        assert SearchRequest(natural_query="temat", limit=MAX_SEARCH_LIMIT).limit == MAX_SEARCH_LIMIT
+
+    @pytest.mark.parametrize("bad", [-1, True, "0"])
+    def test_offset_rejects_invalid(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchRequest(natural_query="temat", offset=bad)
+        assert exc.value.field == "offset"
+
+    def test_filters_must_be_typed(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchRequest(query="temat", filters={"languages": ["pl"]})
+        assert exc.value.field == "filters"
+
+    def test_sort_from_string(self):
+        request = SearchRequest(natural_query="temat", sort="ingested_desc")
+        assert request.sort is SearchSort.INGESTED_DESC
+
+
+class TestSearchFeedback:
+    def test_verdict_from_string(self):
+        feedback = SearchFeedback(verdict="partially_correct", comment="prawie dobrze")
+        assert feedback.verdict is FeedbackVerdict.PARTIALLY_CORRECT
+
+    def test_invalid_verdict_rejected(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFeedback(verdict="maybe")
+        assert exc.value.field == "verdict"
+
+    def test_corrected_query_must_be_typed(self):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFeedback(verdict="incorrect", corrected_query={"query": "temat"})
+        assert exc.value.field == "corrected_query"
+        feedback = SearchFeedback(verdict="incorrect", corrected_query=parsed_query(query="temat"))
+        assert feedback.corrected_query.query == "temat"
+
+    @pytest.mark.parametrize("bad", ["", 42])
+    def test_comment_rejects_invalid(self, bad):
+        with pytest.raises(SearchQueryValidationError) as exc:
+            SearchFeedback(verdict="correct", comment=bad)
+        assert exc.value.field == "comment"

--- a/docs/search-rebuild-progress.md
+++ b/docs/search-rebuild-progress.md
@@ -5,6 +5,49 @@ Nowe wpisy dopisywać NA GÓRZE.
 
 ---
 
+## 2026-07-18 — Etap 1 (typy domenowe wyszukiwania) — UKOŃCZONY
+
+**Zakres wykonany:**
+
+- Nowy pakiet `backend/library/search/` (`types.py`): zamrożone dataclass walidowane w `__post_init__` —
+  niepoprawnego obiektu nie da się skonstruować (`SearchQueryValidationError` z nazwą pola).
+  - `ParsedSearchQuery` — pełny model z sekcji 5 planu (nowe nazwy domenowe: `published_on_*`,
+    `ingested_at_*`, `subject_period_*_year`, `publisher_*`, `discovery_source_name`, `collection_name`);
+    `interpretation_summary` wymagane; `clarification_question` tylko przy `clarification_required=True`;
+    `to_filters()` produkuje `SearchFilters`.
+  - `SearchFilters` — jedyne źródło reguł walidacji pól filtrów (współdzielone przez `ParsedSearchQuery`);
+    `published_on_*` wymaga czystego `date` (odrzuca `datetime`), lata p.n.e. jako ujemne
+    w zakresie [-10000, 3000], `document_types` walidowane wobec `StalkerDocumentType`,
+    języki `^[a-z]{2,3}$`, domena wydawcy regex + lowercase, odwrócone zakresy = błąd konstrukcji.
+  - `SearchRequest` — dwa warianty z sekcji 4 planu (naturalne zdanie XOR jawne query/filtry),
+    pusty request odrzucany (fixture edge-06), `limit` 1–100, `offset` ≥ 0, odrzucanie `bool` jako int.
+  - `SearchFeedback` + enumy: `SearchSort`, `InterpretationStatus`, `FeedbackVerdict`, `ModelConfidence`.
+  - `normalize_year_range`/`normalize_date_range`/`normalize_datetime_range` — swap odwróconego zakresu
+    + polski warning (semantyka fixture edge-04/edge-05); do użycia przez parser w etapie 4/5
+    PRZED konstrukcją obiektu.
+- Bez zmian w LLM, bazie, `SearchService` i frontendzie (zgodnie z zakresem etapu).
+- Dokumentacja: wpisy w `backend/library/CLAUDE.md` i `backend/tests/CLAUDE.md`.
+
+**Testy uruchomione:**
+
+- `tests/unit/test_search_types.py`: 113 passed (każde pole: wartość poprawna, zły typ, granice;
+  odwrócone zakresy; warianty requestu; frozen).
+- Pełna suita `tests/unit/`: **1544 passed**; `uvx ruff check backend/`: czysty.
+
+**Otwarte ryzyka:**
+
+- Limity długości (`MAX_QUERY_LENGTH=1000`, `MAX_NAME_LENGTH=300`, `MAX_COMMENT_LENGTH=2000`) przyjęte
+  arbitralnie — zsynchronizować z kontrolą długości `raw_query` w etapie 2 (tabela audytu).
+- `SearchRequest` bez `natural_query` wymaga query LUB niepustych filtrów — wariant „lista wszystkiego"
+  świadomie niedostępny z poziomu requestu (dostępny w `ParsedSearchQuery`); do rewizji przy etapie 8,
+  jeśli endpoint ma wspierać przeglądanie bez kryteriów.
+- Ryzyka z etapu 0 bez zmian (structured output Sherlocka, pokrycie `document_persons.role='author'`).
+
+**Następny krok:** Etap 2 — audyt wyszukiwania i użycie LLM (migracje Alembic:
+`search_interpretation_logs` + `llm_usage_logs`, ORM + repozytorium, retencja `expires_at` 90 dni
+wg ADR-017, seed cennika CloudFerro, koszty wyłącznie `NUMERIC`/`Decimal`). Etap `M` — podzielić
+na dwie sesje; migracje testować na bazie NAS.
+
 ## 2026-07-18 — Etap 0 (decyzje i baseline) — UKOŃCZONY
 
 **Zakres wykonany:**


### PR DESCRIPTION
Stage 1 of [docs/search-rebuild-implementation-plan.md](https://github.com/ziutus/ai_assistant_lenie/blob/feat/search-etap-1-typy-domenowe/docs/search-rebuild-implementation-plan.md) — typed search domain models.

**Stacked on #282** (stage 0); base is `feat/search-etap-0-baseline`, GitHub will retarget to `main` after #282 merges.

## Scope

- New `backend/library/search/` package: frozen dataclasses validated in `__post_init__` — an invalid object cannot be constructed, so it can never reach `SearchService` (stage exit condition).
- `ParsedSearchQuery` (plan section 5), `SearchFilters` (single source of filter validation rules), `SearchRequest` (natural XOR explicit variant, empty request rejected), `SearchFeedback`; enums `SearchSort`, `InterpretationStatus`, `FeedbackVerdict`, `ModelConfidence`.
- Target domain names from day one: `published_on_*`, `ingested_at_*`, `subject_period_*_year`, `publisher_*`, `discovery_source_name`, `collection_name`.
- Validation: types, emptiness, bounds (years [-10000, 3000], BCE negative; limit 1–100; offset ≥ 0; `bool` rejected as int), `document_types` against `StalkerDocumentType`, language codes, publisher domain; reversed ranges are a construction error.
- `normalize_*_range()` helpers (swap + Polish warning) for the stage 4/5 parser — matches fixture cases edge-04/edge-05.
- No changes to LLM calls, database, `SearchService` or frontend.

## Tests

- `tests/unit/test_search_types.py`: 113 passed (every field: valid value, wrong type, boundary; reversed ranges; request variants; frozen).
- Full unit suite: 1544 passed; `uvx ruff check backend/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)