### PR TITLE
feat(search): stage 2 - search audit and central LLM usage accounting

### DIFF
--- a/backend/alembic/versions/d3e4f5a6b7c8_create_search_interpretation_logs.py
+++ b/backend/alembic/versions/d3e4f5a6b7c8_create_search_interpretation_logs.py
@@ -1,0 +1,58 @@
+"""create search interpretation audit log
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-07-18 18:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE search_interpretation_logs (
+            id SERIAL PRIMARY KEY,
+            raw_query TEXT NOT NULL,
+            model VARCHAR(100),
+            parser_version VARCHAR(50),
+            prompt_version VARCHAR(50),
+            raw_response TEXT,
+            parsed_query JSONB,
+            status VARCHAR(20) NOT NULL,
+            error_code VARCHAR(50),
+            error_message TEXT,
+            fallback_used BOOLEAN NOT NULL DEFAULT FALSE,
+            llm_latency_ms INTEGER,
+            search_latency_ms INTEGER,
+            result_count INTEGER,
+            feedback_verdict VARCHAR(20),
+            feedback_comment TEXT,
+            corrected_query JSONB,
+            feedback_at TIMESTAMP,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            expires_at TIMESTAMP NOT NULL DEFAULT (NOW() + INTERVAL '90 days'),
+            CONSTRAINT ck_search_interpretation_logs_status CHECK (
+                status IN ('parsed', 'ambiguous', 'invalid_json',
+                           'validation_error', 'llm_error', 'fallback')
+            ),
+            CONSTRAINT ck_search_interpretation_logs_feedback CHECK (
+                feedback_verdict IS NULL
+                OR feedback_verdict IN ('correct', 'partially_correct', 'incorrect')
+            )
+        )
+    """)
+    op.execute("CREATE INDEX idx_search_interpretation_logs_created ON search_interpretation_logs(created_at)")
+    op.execute(
+        "CREATE INDEX idx_search_interpretation_logs_status_created ON search_interpretation_logs(status, created_at)"
+    )
+    op.execute("CREATE INDEX idx_search_interpretation_logs_expires ON search_interpretation_logs(expires_at)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS search_interpretation_logs")

--- a/backend/alembic/versions/e4f5a6b7c8d9_create_llm_pricing_and_usage_logs.py
+++ b/backend/alembic/versions/e4f5a6b7c8d9_create_llm_pricing_and_usage_logs.py
@@ -1,0 +1,106 @@
+"""create versioned llm pricing and provider-agnostic usage logs
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-07-18 18:10:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "e4f5a6b7c8d9"
+down_revision: Union[str, None] = "d3e4f5a6b7c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE llm_pricing (
+            id SERIAL PRIMARY KEY,
+            pricing_version VARCHAR(64) NOT NULL UNIQUE,
+            provider VARCHAR(50) NOT NULL,
+            model VARCHAR(100) NOT NULL,
+            pricing_mode VARCHAR(20) NOT NULL,
+            input_price_per_million NUMERIC(12, 6),
+            output_price_per_million NUMERIC(12, 6),
+            currency VARCHAR(3) NOT NULL,
+            effective_from DATE NOT NULL,
+            effective_to DATE,
+            notes TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            CONSTRAINT ck_llm_pricing_mode CHECK (
+                pricing_mode IN ('per_token', 'per_request', 'credits',
+                                 'subscription', 'free', 'unknown')
+            )
+        )
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX uq_llm_pricing_active_model
+        ON llm_pricing(provider, model)
+        WHERE effective_to IS NULL
+    """)
+    op.execute("""
+        INSERT INTO llm_pricing (pricing_version, provider, model, pricing_mode,
+                                 input_price_per_million, output_price_per_million,
+                                 currency, effective_from, notes)
+        VALUES
+            ('cloudferro-bielik-2026-07-18', 'cloudferro', 'Bielik-11B-v3.0-Instruct',
+             'per_token', 0.56, 0.56, 'EUR', '2026-07-18', NULL),
+            ('cloudferro-bge-2026-07-18', 'cloudferro', 'BAAI/bge-multilingual-gemma2',
+             'per_token', 0.50, 0.50, 'PLN', '2026-07-18',
+             'kwota netto, bez VAT; embedding rozlicza tylko tokeny wejsciowe')
+    """)
+    op.execute("""
+        CREATE TABLE llm_usage_logs (
+            id BIGSERIAL PRIMARY KEY,
+            request_id VARCHAR(64),
+            search_interpretation_log_id INTEGER
+                REFERENCES search_interpretation_logs(id) ON DELETE SET NULL,
+            operation VARCHAR(50) NOT NULL,
+            provider VARCHAR(50) NOT NULL,
+            model VARCHAR(100) NOT NULL,
+            endpoint VARCHAR(200),
+            prompt_tokens INTEGER,
+            completion_tokens INTEGER,
+            total_tokens INTEGER,
+            credits_used NUMERIC(18, 6),
+            pricing_mode VARCHAR(20) NOT NULL DEFAULT 'unknown',
+            pricing_version VARCHAR(64) REFERENCES llm_pricing(pricing_version),
+            input_price_per_million NUMERIC(12, 6),
+            output_price_per_million NUMERIC(12, 6),
+            cost_amount NUMERIC(18, 10),
+            cost_currency VARCHAR(3),
+            cost_status VARCHAR(20) NOT NULL DEFAULT 'unknown',
+            success BOOLEAN NOT NULL DEFAULT TRUE,
+            error_code VARCHAR(100),
+            called_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            latency_ms INTEGER,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            CONSTRAINT ck_llm_usage_logs_pricing_mode CHECK (
+                pricing_mode IN ('per_token', 'per_request', 'credits',
+                                 'subscription', 'free', 'unknown')
+            ),
+            CONSTRAINT ck_llm_usage_logs_cost_status CHECK (
+                cost_status IN ('reported', 'estimated', 'allocated', 'unknown')
+            ),
+            CONSTRAINT ck_llm_usage_logs_tokens_nonneg CHECK (
+                (prompt_tokens IS NULL OR prompt_tokens >= 0)
+                AND (completion_tokens IS NULL OR completion_tokens >= 0)
+                AND (total_tokens IS NULL OR total_tokens >= 0)
+            )
+        )
+    """)
+    op.execute("CREATE INDEX idx_llm_usage_logs_called ON llm_usage_logs(called_at)")
+    op.execute("CREATE INDEX idx_llm_usage_logs_operation_called ON llm_usage_logs(operation, called_at)")
+    op.execute("CREATE INDEX idx_llm_usage_logs_provider_model_called ON llm_usage_logs(provider, model, called_at)")
+    op.execute("""
+        CREATE INDEX idx_llm_usage_logs_interpretation
+        ON llm_usage_logs(search_interpretation_log_id)
+        WHERE search_interpretation_log_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS llm_usage_logs")
+    op.execute("DROP TABLE IF EXISTS llm_pricing")

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -342,6 +342,14 @@ Discovery-source lookup — how the user found a document (`own`, a newsletter, 
 | `url` | `text` | Optional source website |
 | `is_active` | `boolean NOT NULL DEFAULT TRUE` | Inactive sources stay valid on existing documents but disappear from pickers (`GET /sources?active=1`) |
 
+### Tables: `public.search_interpretation_logs`, `public.llm_pricing`, `public.llm_usage_logs`
+
+Search audit and LLM usage accounting (stage 2 of [docs/search-rebuild-implementation-plan.md](../../docs/search-rebuild-implementation-plan.md); Alembic only, no init scripts — migrations `d3e4f5a6b7c8`, `e4f5a6b7c8d9`; ORM in `library/db/models.py`).
+
+- **`search_interpretation_logs`** — one row per attempt to interpret a natural-language search query: `raw_query`, model/parser/prompt versions, raw LLM response, normalised `parsed_query` JSONB, `status` (CHECK: `parsed`/`ambiguous`/`invalid_json`/`validation_error`/`llm_error`/`fallback`), safe error code/message, latencies, result count, user feedback (`feedback_verdict` CHECK: `correct`/`partially_correct`/`incorrect`, comment, `corrected_query` JSONB). Retention per [ADR-017](../../docs/adr/adr-017-search-rebuild-scope-decisions.md): `expires_at NOT NULL DEFAULT now() + 90 days` (indexed; cleanup job to be added later).
+- **`llm_pricing`** — versioned price list, provider-agnostic. Rows are immutable facts: a price change is a NEW row with a new `pricing_version`, never an UPDATE. Partial unique index allows at most one open-ended (`effective_to IS NULL`) row per provider/model. Seeded with confirmed CloudFerro rates: `cloudferro-bielik-2026-07-18` (0.56 EUR/1M in and out) and `cloudferro-bge-2026-07-18` (0.50 PLN net/1M).
+- **`llm_usage_logs`** — one row per LLM/embedding call regardless of provider: correlation ids (optional FK to `search_interpretation_logs`, `ON DELETE SET NULL`), `operation`/`provider`/`model`, token counts (facts, stored even without a price), `credits_used`, denormalised pricing snapshot (`pricing_mode`, `pricing_version` FK, per-million rates), `cost_amount NUMERIC(18,10)` + `cost_currency` + `cost_status` (CHECK: `reported`/`estimated`/`allocated`/`unknown`), success/error, `called_at`, `latency_ms`. Money is NUMERIC/Decimal only — never float. Currencies differ per row (EUR/PLN/USD); aggregates must not sum across currencies without explicit conversion. Cost math lives exclusively in `library/llm_usage/pricing.py`.
+
 Reader identity and API key tables (`users`, `user_reading_progress`, `user_document_notes`, `api_keys` — init scripts 19-20) are out of scope for this section; see `library/reader_routes.py`, `library/auth.py` and `library/db/models.py` for their definitions.
 
 ## Document Processing States

--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -38,6 +38,8 @@ library/
 ├── person_registry.py       # NER person mentions → alias/Wikidata+LLM/fuzzy → document_persons links
 ├── search/           # Typed search domain models (stage 1 of docs/search-rebuild-implementation-plan.md)
 │   └── types.py      # ParsedSearchQuery, SearchFilters, SearchRequest, SearchFeedback + enums; frozen dataclasses validated at construction (SearchQueryValidationError), target domain names (published_on, subject_period_*), normalize_*_range() helpers for the future parser
+├── llm_usage/        # Central LLM usage & cost accounting (stage 2 of the search-rebuild plan)
+│   └── pricing.py    # estimate_cost() — Decimal-only per-token cost math (float money raises PricingError), PricingMode/CostStatus enums, UNKNOWN_COST sentinel; the ONLY place allowed to compute LLM call costs; backing tables: search_interpretation_logs, llm_pricing, llm_usage_logs (db/models.py)
 ├── stalker_web_documents_db_postgresql.py  # Query layer (ORM, list, search, similarity)
 ├── text_functions.py        # Text processing & splitting utilities
 ├── text_detect_language.py  # Language detection abstraction

--- a/backend/library/CLAUDE.md
+++ b/backend/library/CLAUDE.md
@@ -36,10 +36,12 @@ library/
 ├── place_verification.py    # NER place candidates → geocoder (geocode_cache) → LLM → miejsce-* tags
 ├── wikidata_client.py       # Wikidata person search (humans only, P31=Q5) for disambiguation
 ├── person_registry.py       # NER person mentions → alias/Wikidata+LLM/fuzzy → document_persons links
-├── search/           # Typed search domain models (stage 1 of docs/search-rebuild-implementation-plan.md)
-│   └── types.py      # ParsedSearchQuery, SearchFilters, SearchRequest, SearchFeedback + enums; frozen dataclasses validated at construction (SearchQueryValidationError), target domain names (published_on, subject_period_*), normalize_*_range() helpers for the future parser
+├── search/           # Typed search domain models (stages 1-2 of docs/search-rebuild-implementation-plan.md)
+│   ├── types.py      # ParsedSearchQuery, SearchFilters, SearchRequest, SearchFeedback + enums; frozen dataclasses validated at construction (SearchQueryValidationError), target domain names (published_on, subject_period_*), normalize_*_range() helpers for the future parser
+│   └── audit_repository.py  # record_interpretation()/record_feedback() write search_interpretation_logs in their OWN session (a failed audit write is swallowed, never breaks the search path); field-length caps applied here (raw_query→MAX_QUERY_LENGTH, raw_response→20k, error_message→500, visible TRUNCATION_SUFFIX); parsed_query_to_dict() serializes ParsedSearchQuery to JSONB; delete_expired_interpretations() = 90-day retention sweep (ADR-017, errors propagate — maintenance path)
 ├── llm_usage/        # Central LLM usage & cost accounting (stage 2 of the search-rebuild plan)
-│   └── pricing.py    # estimate_cost() — Decimal-only per-token cost math (float money raises PricingError), PricingMode/CostStatus enums, UNKNOWN_COST sentinel; the ONLY place allowed to compute LLM call costs; backing tables: search_interpretation_logs, llm_pricing, llm_usage_logs (db/models.py)
+│   ├── pricing.py    # estimate_cost() — Decimal-only per-token cost math (float money raises PricingError), PricingMode/CostStatus enums, UNKNOWN_COST sentinel; the ONLY place allowed to compute LLM call costs; backing tables: search_interpretation_logs, llm_pricing, llm_usage_logs (db/models.py)
+│   └── recorder.py   # record_llm_usage() — the SINGLE write path for llm_usage_logs (exactly one row per LLM call); snapshots the active llm_pricing row, reported cost (Decimal + currency) beats the local estimate, missing price → cost_status='unknown' (never an error, never 0); own session, DB failures swallowed (usage_log_id=None); stage 3 wires this into ai.py
 ├── stalker_web_documents_db_postgresql.py  # Query layer (ORM, list, search, similarity)
 ├── text_functions.py        # Text processing & splitting utilities
 ├── text_detect_language.py  # Language detection abstraction

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -9,9 +9,11 @@ Provides:
 """
 
 import datetime
+import decimal
 import logging
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     CheckConstraint,
     Date,
@@ -1457,6 +1459,200 @@ class ApiKey(Base):
 
     def __repr__(self) -> str:
         return f"ApiKey(id={self.id!r}, kind={self.kind!r}, name={self.name!r}, active={self.active!r})"
+
+
+# ---------------------------------------------------------------------------
+# Search audit and LLM usage (docs/search-rebuild-implementation-plan.md, stage 2)
+# ---------------------------------------------------------------------------
+
+
+class SearchInterpretationLog(Base):
+    """Audit record of one attempt to interpret a natural-language search query.
+
+    Stores the raw user query, the raw LLM response, the parsed/normalised
+    interpretation and the outcome status (see InterpretationStatus in
+    library/search/types.py). User feedback and a corrected interpretation are
+    attached to the same row. Rows expire after the retention window
+    (ADR-017: 90 days) via expires_at; raw queries may contain private data.
+    """
+
+    __tablename__ = "search_interpretation_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    raw_query: Mapped[str] = mapped_column(Text, nullable=False)
+    model: Mapped[str | None] = mapped_column(String(100))
+    parser_version: Mapped[str | None] = mapped_column(String(50))
+    prompt_version: Mapped[str | None] = mapped_column(String(50))
+    raw_response: Mapped[str | None] = mapped_column(Text)
+    parsed_query: Mapped[dict | None] = mapped_column(JSONB)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    error_code: Mapped[str | None] = mapped_column(String(50))
+    error_message: Mapped[str | None] = mapped_column(Text)
+    fallback_used: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=sa_text("FALSE"))
+    llm_latency_ms: Mapped[int | None] = mapped_column(Integer)
+    search_latency_ms: Mapped[int | None] = mapped_column(Integer)
+    result_count: Mapped[int | None] = mapped_column(Integer)
+    feedback_verdict: Mapped[str | None] = mapped_column(String(20))
+    feedback_comment: Mapped[str | None] = mapped_column(Text)
+    corrected_query: Mapped[dict | None] = mapped_column(JSONB)
+    feedback_at: Mapped[datetime.datetime | None] = mapped_column(DateTime)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    expires_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=sa_text("NOW() + INTERVAL '90 days'"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('parsed', 'ambiguous', 'invalid_json', 'validation_error', 'llm_error', 'fallback')",
+            name="ck_search_interpretation_logs_status",
+        ),
+        CheckConstraint(
+            "feedback_verdict IS NULL OR feedback_verdict IN ('correct', 'partially_correct', 'incorrect')",
+            name="ck_search_interpretation_logs_feedback",
+        ),
+        Index("idx_search_interpretation_logs_created", "created_at"),
+        Index("idx_search_interpretation_logs_status_created", "status", "created_at"),
+        Index("idx_search_interpretation_logs_expires", "expires_at"),
+    )
+
+    usage_logs: Mapped[list["LlmUsageLog"]] = relationship(back_populates="search_interpretation_log")
+
+    def __repr__(self) -> str:
+        return (
+            f"SearchInterpretationLog(id={self.id!r}, status={self.status!r}, "
+            f"fallback_used={self.fallback_used!r}, created_at={self.created_at!r})"
+        )
+
+
+class LlmPricing(Base):
+    """Versioned price list entry for one provider/model.
+
+    Rows are immutable facts: a price change is a new row with a new
+    pricing_version and effective_from, never an UPDATE — historical usage
+    records must keep pointing at the rates that were valid when they were
+    written. At most one open-ended (effective_to IS NULL) row per
+    provider/model is allowed (partial unique index).
+    """
+
+    __tablename__ = "llm_pricing"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    pricing_version: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    pricing_mode: Mapped[str] = mapped_column(String(20), nullable=False)
+    input_price_per_million: Mapped[decimal.Decimal | None] = mapped_column(Numeric(12, 6))
+    output_price_per_million: Mapped[decimal.Decimal | None] = mapped_column(Numeric(12, 6))
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    effective_from: Mapped[datetime.date] = mapped_column(Date, nullable=False)
+    effective_to: Mapped[datetime.date | None] = mapped_column(Date)
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "pricing_mode IN ('per_token', 'per_request', 'credits', 'subscription', 'free', 'unknown')",
+            name="ck_llm_pricing_mode",
+        ),
+        Index(
+            "uq_llm_pricing_active_model",
+            "provider",
+            "model",
+            unique=True,
+            postgresql_where=sa_text("effective_to IS NULL"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"LlmPricing(id={self.id!r}, pricing_version={self.pricing_version!r}, "
+            f"provider={self.provider!r}, model={self.model!r})"
+        )
+
+
+class LlmUsageLog(Base):
+    """One record per LLM/embedding call, independent of provider and model.
+
+    Token counts are measured facts and are stored even when no price is
+    known. Rates and currency are a denormalised snapshot of the pricing row
+    used at write time, so later price changes never alter history. Money is
+    NUMERIC/Decimal only; cost_status says how cost_amount was obtained
+    (reported/estimated/allocated) or 'unknown' when it could not be.
+    """
+
+    __tablename__ = "llm_usage_logs"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    request_id: Mapped[str | None] = mapped_column(String(64))
+    search_interpretation_log_id: Mapped[int | None] = mapped_column(
+        ForeignKey("search_interpretation_logs.id", ondelete="SET NULL"),
+    )
+    operation: Mapped[str] = mapped_column(String(50), nullable=False)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    endpoint: Mapped[str | None] = mapped_column(String(200))
+    prompt_tokens: Mapped[int | None] = mapped_column(Integer)
+    completion_tokens: Mapped[int | None] = mapped_column(Integer)
+    total_tokens: Mapped[int | None] = mapped_column(Integer)
+    credits_used: Mapped[decimal.Decimal | None] = mapped_column(Numeric(18, 6))
+    pricing_mode: Mapped[str] = mapped_column(String(20), nullable=False, server_default=sa_text("'unknown'"))
+    pricing_version: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("llm_pricing.pricing_version"),
+    )
+    input_price_per_million: Mapped[decimal.Decimal | None] = mapped_column(Numeric(12, 6))
+    output_price_per_million: Mapped[decimal.Decimal | None] = mapped_column(Numeric(12, 6))
+    cost_amount: Mapped[decimal.Decimal | None] = mapped_column(Numeric(18, 10))
+    cost_currency: Mapped[str | None] = mapped_column(String(3))
+    cost_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default=sa_text("'unknown'"))
+    success: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=sa_text("TRUE"))
+    error_code: Mapped[str | None] = mapped_column(String(100))
+    called_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+    latency_ms: Mapped[int | None] = mapped_column(Integer)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "pricing_mode IN ('per_token', 'per_request', 'credits', 'subscription', 'free', 'unknown')",
+            name="ck_llm_usage_logs_pricing_mode",
+        ),
+        CheckConstraint(
+            "cost_status IN ('reported', 'estimated', 'allocated', 'unknown')",
+            name="ck_llm_usage_logs_cost_status",
+        ),
+        CheckConstraint(
+            "(prompt_tokens IS NULL OR prompt_tokens >= 0)"
+            " AND (completion_tokens IS NULL OR completion_tokens >= 0)"
+            " AND (total_tokens IS NULL OR total_tokens >= 0)",
+            name="ck_llm_usage_logs_tokens_nonneg",
+        ),
+        Index("idx_llm_usage_logs_called", "called_at"),
+        Index("idx_llm_usage_logs_operation_called", "operation", "called_at"),
+        Index("idx_llm_usage_logs_provider_model_called", "provider", "model", "called_at"),
+        Index(
+            "idx_llm_usage_logs_interpretation",
+            "search_interpretation_log_id",
+            postgresql_where=sa_text("search_interpretation_log_id IS NOT NULL"),
+        ),
+    )
+
+    search_interpretation_log: Mapped["SearchInterpretationLog | None"] = relationship(
+        back_populates="usage_logs",
+    )
+    pricing: Mapped["LlmPricing | None"] = relationship(foreign_keys=[pricing_version])
+
+    def __repr__(self) -> str:
+        return (
+            f"LlmUsageLog(id={self.id!r}, operation={self.operation!r}, provider={self.provider!r}, "
+            f"model={self.model!r}, cost_status={self.cost_status!r})"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/library/llm_usage/__init__.py
+++ b/backend/library/llm_usage/__init__.py
@@ -1,11 +1,13 @@
 """Central LLM usage and cost accounting (search-rebuild plan, stages 2-3).
 
-Stage 2 ships the pricing math (`pricing.py`) and the audit tables
+Stage 2 ships the pricing math (`pricing.py`), the audit tables
 (search_interpretation_logs, llm_pricing, llm_usage_logs — see
-library/db/models.py). Stage 3 adds the service that writes one
-llm_usage_logs record per LLM call; domain modules must never compute
-costs themselves.
+library/db/models.py) and the central recorder (`recorder.py`) that writes
+exactly one llm_usage_logs record per LLM call. Stage 3 wires the recorder
+into ai.py; domain modules must never compute costs themselves.
 """
+
+import importlib
 
 from library.llm_usage.pricing import (
     UNKNOWN_COST,
@@ -22,5 +24,17 @@ __all__ = [
     "CostStatus",
     "PricingError",
     "PricingMode",
+    "UsageRecord",
     "estimate_cost",
+    "record_llm_usage",
 ]
+
+# recorder needs sqlalchemy; lazy re-export keeps `library.llm_usage`
+# importable in the lightweight (uvx) test environment without it.
+_RECORDER_EXPORTS = frozenset({"UsageRecord", "record_llm_usage"})
+
+
+def __getattr__(name):
+    if name in _RECORDER_EXPORTS:
+        return getattr(importlib.import_module("library.llm_usage.recorder"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/library/llm_usage/__init__.py
+++ b/backend/library/llm_usage/__init__.py
@@ -1,0 +1,26 @@
+"""Central LLM usage and cost accounting (search-rebuild plan, stages 2-3).
+
+Stage 2 ships the pricing math (`pricing.py`) and the audit tables
+(search_interpretation_logs, llm_pricing, llm_usage_logs — see
+library/db/models.py). Stage 3 adds the service that writes one
+llm_usage_logs record per LLM call; domain modules must never compute
+costs themselves.
+"""
+
+from library.llm_usage.pricing import (
+    UNKNOWN_COST,
+    CostEstimate,
+    CostStatus,
+    PricingError,
+    PricingMode,
+    estimate_cost,
+)
+
+__all__ = [
+    "UNKNOWN_COST",
+    "CostEstimate",
+    "CostStatus",
+    "PricingError",
+    "PricingMode",
+    "estimate_cost",
+]

--- a/backend/library/llm_usage/pricing.py
+++ b/backend/library/llm_usage/pricing.py
@@ -1,0 +1,118 @@
+"""Provider-agnostic LLM cost estimation (search-rebuild plan, stage 2).
+
+This module is the only place allowed to compute an LLM call cost from a
+price list. Money is Decimal end to end: passing a float for any rate is a
+programming error and raises immediately, because binary floats cannot
+represent prices like 0.56 exactly.
+
+Input and output components are computed separately even when the rates are
+currently equal (CloudFerro Bielik: 0.56 EUR both ways), so a future change
+of a single rate needs no data-model rework. Results are quantized to
+10 decimal places — the scale of llm_usage_logs.cost_amount (NUMERIC(18, 10)).
+"""
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from enum import Enum
+
+TOKENS_PER_MILLION = Decimal(1_000_000)
+COST_SCALE = Decimal("1E-10")
+
+
+class PricingMode(str, Enum):
+    PER_TOKEN = "per_token"
+    PER_REQUEST = "per_request"
+    CREDITS = "credits"
+    SUBSCRIPTION = "subscription"
+    FREE = "free"
+    UNKNOWN = "unknown"
+
+
+class CostStatus(str, Enum):
+    REPORTED = "reported"
+    ESTIMATED = "estimated"
+    ALLOCATED = "allocated"
+    UNKNOWN = "unknown"
+
+
+class PricingError(ValueError):
+    """Raised for invalid pricing inputs (float money, negative tokens/rates)."""
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Cost of a single LLM call, split into components.
+
+    When the cost cannot be computed (non-token pricing, missing rates),
+    ``status`` is UNKNOWN and every money field is None — a missing price
+    must never turn into a zero cost or an exception in a business path.
+    """
+
+    input_cost: Decimal | None
+    output_cost: Decimal | None
+    total_cost: Decimal | None
+    currency: str | None
+    status: CostStatus
+
+
+UNKNOWN_COST = CostEstimate(
+    input_cost=None, output_cost=None, total_cost=None, currency=None, status=CostStatus.UNKNOWN,
+)
+
+
+def _decimal_rate(name: str, value) -> Decimal:
+    if isinstance(value, float):
+        raise PricingError(f"{name} must be Decimal, not float (money is never float)")
+    if isinstance(value, int):
+        value = Decimal(value)
+    if not isinstance(value, Decimal):
+        raise PricingError(f"{name} must be Decimal, got {type(value).__name__}")
+    if value < 0:
+        raise PricingError(f"{name} must not be negative")
+    return value
+
+
+def _token_count(name: str, value) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PricingError(f"{name} must be an int, got {type(value).__name__}")
+    if value < 0:
+        raise PricingError(f"{name} must not be negative")
+    return value
+
+
+def estimate_cost(
+    *,
+    pricing_mode: PricingMode | str,
+    input_price_per_million: Decimal | int | None,
+    output_price_per_million: Decimal | int | None,
+    currency: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> CostEstimate:
+    """Estimate the cost of one call from a versioned price list entry.
+
+    Only per-token pricing is computable locally; every other mode returns
+    UNKNOWN_COST (subscription allocation is a reporting concern, stage 12).
+    """
+    mode = PricingMode(pricing_mode)
+    prompt = _token_count("prompt_tokens", prompt_tokens)
+    completion = _token_count("completion_tokens", completion_tokens)
+
+    if mode is not PricingMode.PER_TOKEN:
+        return UNKNOWN_COST
+    if input_price_per_million is None or output_price_per_million is None or not currency:
+        return UNKNOWN_COST
+
+    input_rate = _decimal_rate("input_price_per_million", input_price_per_million)
+    output_rate = _decimal_rate("output_price_per_million", output_price_per_million)
+
+    input_cost = (Decimal(prompt) * input_rate / TOKENS_PER_MILLION).quantize(COST_SCALE, rounding=ROUND_HALF_UP)
+    output_cost = (Decimal(completion) * output_rate / TOKENS_PER_MILLION).quantize(COST_SCALE, rounding=ROUND_HALF_UP)
+
+    return CostEstimate(
+        input_cost=input_cost,
+        output_cost=output_cost,
+        total_cost=input_cost + output_cost,
+        currency=currency,
+        status=CostStatus.ESTIMATED,
+    )

--- a/backend/library/llm_usage/recorder.py
+++ b/backend/library/llm_usage/recorder.py
@@ -1,0 +1,217 @@
+"""Central recorder of LLM/embedding usage (search-rebuild plan, stage 2B).
+
+This is the single write path for llm_usage_logs: one call to
+``record_llm_usage()`` per LLM call leaves exactly one row. Domain modules
+never compute costs themselves — they receive the returned ``UsageRecord``
+summary (stage 3 wires this into ``ai.py``).
+
+Writes use their own short-lived session, independent of any business
+transaction: a database failure is logged and swallowed, because usage
+accounting must never break the operation that triggered the LLM call.
+Provider-reported data (token counts) is sanitized, not validated — a
+malformed value from the API becomes NULL with a warning. Money arguments
+built by our own code (``reported_cost``, ``credits_used``) are validated
+strictly: a float raises ``PricingError``.
+"""
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from library.db.engine import get_session
+from library.db.models import LlmPricing, LlmUsageLog
+from library.llm_usage.pricing import (
+    UNKNOWN_COST,
+    CostEstimate,
+    CostStatus,
+    PricingError,
+    PricingMode,
+    estimate_cost,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    """Summary handed back to the caller of ``record_llm_usage()``.
+
+    ``usage_log_id`` is None when the database write failed (the call
+    itself must not fail because of that). ``cost`` carries the resolved
+    cost with its status (reported/estimated/unknown) and currency.
+    """
+
+    usage_log_id: int | None
+    cost: CostEstimate
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+    pricing_version: str | None
+
+
+def _decimal_money(name: str, value) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, float):
+        raise PricingError(f"{name} must be Decimal, not float (money is never float)")
+    if isinstance(value, int):
+        value = Decimal(value)
+    if not isinstance(value, Decimal):
+        raise PricingError(f"{name} must be Decimal, got {type(value).__name__}")
+    if value < 0:
+        raise PricingError(f"{name} must not be negative")
+    return value
+
+
+def _sanitize_tokens(name: str, value) -> int | None:
+    """Token counts are provider-reported facts: drop bad values, never raise."""
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        logger.warning("Ignoring invalid %s reported by provider: %r", name, value)
+        return None
+    return value
+
+
+def _active_pricing(session, provider: str, model: str) -> LlmPricing | None:
+    stmt = select(LlmPricing).where(
+        LlmPricing.provider == provider,
+        LlmPricing.model == model,
+        LlmPricing.effective_to.is_(None),
+    )
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def _resolve_cost(
+    pricing: LlmPricing | None,
+    reported_cost: Decimal | None,
+    reported_cost_currency: str | None,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+) -> CostEstimate:
+    if reported_cost is not None:
+        # A provider-reported cost always wins over the local estimate.
+        return CostEstimate(
+            input_cost=None,
+            output_cost=None,
+            total_cost=reported_cost,
+            currency=reported_cost_currency,
+            status=CostStatus.REPORTED,
+        )
+    if pricing is None or prompt_tokens is None or completion_tokens is None:
+        return UNKNOWN_COST
+    return estimate_cost(
+        pricing_mode=pricing.pricing_mode,
+        input_price_per_million=pricing.input_price_per_million,
+        output_price_per_million=pricing.output_price_per_million,
+        currency=pricing.currency,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+
+
+def record_llm_usage(
+    *,
+    operation: str,
+    provider: str,
+    model: str,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    total_tokens: int | None = None,
+    endpoint: str | None = None,
+    request_id: str | None = None,
+    search_interpretation_log_id: int | None = None,
+    credits_used: Decimal | None = None,
+    reported_cost: Decimal | None = None,
+    reported_cost_currency: str | None = None,
+    success: bool = True,
+    error_code: str | None = None,
+    latency_ms: int | None = None,
+    session_factory=get_session,
+) -> UsageRecord:
+    """Persist exactly one llm_usage_logs row for one LLM/embedding call.
+
+    Token counts are stored even when no price is known; a missing price
+    yields ``cost_status='unknown'``, never an exception or a zero cost.
+    ``reported_cost`` (Decimal + ``reported_cost_currency``) takes priority
+    over the local estimate. Rates and currency of the matched price-list
+    row are snapshotted onto the usage row, so later price changes never
+    alter history.
+    """
+    reported = _decimal_money("reported_cost", reported_cost)
+    if reported is not None and not reported_cost_currency:
+        raise PricingError("reported_cost requires reported_cost_currency")
+    credits = _decimal_money("credits_used", credits_used)
+
+    prompt = _sanitize_tokens("prompt_tokens", prompt_tokens)
+    completion = _sanitize_tokens("completion_tokens", completion_tokens)
+    total = _sanitize_tokens("total_tokens", total_tokens)
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+
+    session = None
+    try:
+        session = session_factory()
+        pricing = _active_pricing(session, provider, model)
+        cost = _resolve_cost(pricing, reported, reported_cost_currency, prompt, completion)
+
+        log = LlmUsageLog(
+            request_id=request_id,
+            search_interpretation_log_id=search_interpretation_log_id,
+            operation=operation,
+            provider=provider,
+            model=model,
+            endpoint=endpoint,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=total,
+            credits_used=credits,
+            pricing_mode=pricing.pricing_mode if pricing else PricingMode.UNKNOWN.value,
+            pricing_version=pricing.pricing_version if pricing else None,
+            input_price_per_million=pricing.input_price_per_million if pricing else None,
+            output_price_per_million=pricing.output_price_per_million if pricing else None,
+            cost_amount=cost.total_cost,
+            cost_currency=cost.currency,
+            cost_status=cost.status.value,
+            success=success,
+            error_code=error_code,
+            latency_ms=latency_ms,
+        )
+        session.add(log)
+        session.commit()
+        return UsageRecord(
+            usage_log_id=log.id,
+            cost=cost,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=total,
+            pricing_version=pricing.pricing_version if pricing else None,
+        )
+    except Exception:
+        # Usage accounting must never break the business call that used the
+        # LLM — but a lost record violates the one-record-per-call guarantee,
+        # so log loudly with the full context.
+        logger.exception(
+            "Failed to record LLM usage (operation=%s, provider=%s, model=%s)", operation, provider, model
+        )
+        if session is not None:
+            try:
+                session.rollback()
+            except Exception:
+                logger.exception("Rollback after failed usage write also failed")
+        return UsageRecord(
+            usage_log_id=None,
+            cost=UNKNOWN_COST,
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=total,
+            pricing_version=None,
+        )
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                logger.exception("Closing usage-recorder session failed")

--- a/backend/library/search/__init__.py
+++ b/backend/library/search/__init__.py
@@ -5,6 +5,8 @@ vocabulary (document_id, published_on, subject_period_*, discovery_source,
 collection) from day one, regardless of the legacy SQL column names.
 """
 
+import importlib
+
 from library.search.types import (
     MAX_SEARCH_LIMIT,
     MAX_SUBJECT_YEAR,
@@ -36,7 +38,23 @@ __all__ = [
     "SearchQueryValidationError",
     "SearchRequest",
     "SearchSort",
+    "delete_expired_interpretations",
     "normalize_date_range",
     "normalize_datetime_range",
     "normalize_year_range",
+    "parsed_query_to_dict",
+    "record_feedback",
+    "record_interpretation",
 ]
+
+# audit_repository needs sqlalchemy; lazy re-export keeps `library.search`
+# importable in the lightweight (uvx) test environment without it.
+_AUDIT_EXPORTS = frozenset(
+    {"record_interpretation", "record_feedback", "delete_expired_interpretations", "parsed_query_to_dict"}
+)
+
+
+def __getattr__(name):
+    if name in _AUDIT_EXPORTS:
+        return getattr(importlib.import_module("library.search.audit_repository"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/library/search/audit_repository.py
+++ b/backend/library/search/audit_repository.py
@@ -1,0 +1,191 @@
+"""Audit persistence for search interpretations (search-rebuild, stage 2B).
+
+Every write opens its own short-lived session, so audit rows commit
+independently of the search transaction: a failed audit write is logged and
+swallowed, never raised into the search path (plan rule: awaria zapisu logów
+nie może wywalić wyszukiwania). The one exception is
+``delete_expired_interpretations()`` — a maintenance operation run from a
+job/CLI, where a failure must surface to the operator.
+
+The audit columns are TEXT; length caps live here in the write layer:
+``raw_query`` reuses MAX_QUERY_LENGTH from the domain types, raw responses
+and error messages use module-level caps. Truncation is visible in the
+stored value via TRUNCATION_SUFFIX.
+"""
+
+import logging
+from dataclasses import fields
+from datetime import date, datetime
+from enum import Enum
+
+from sqlalchemy import delete, func
+
+from library.db.engine import get_session
+from library.db.models import SearchInterpretationLog
+from library.search.types import (
+    MAX_COMMENT_LENGTH,
+    MAX_QUERY_LENGTH,
+    InterpretationStatus,
+    ParsedSearchQuery,
+    SearchFeedback,
+)
+
+logger = logging.getLogger(__name__)
+
+TRUNCATION_SUFFIX = "… [truncated]"
+MAX_RAW_RESPONSE_LENGTH = 20_000
+MAX_ERROR_MESSAGE_LENGTH = 500
+
+
+def _truncate(value: str | None, limit: int) -> str | None:
+    if value is None or len(value) <= limit:
+        return value
+    return value[: limit - len(TRUNCATION_SUFFIX)] + TRUNCATION_SUFFIX
+
+
+def parsed_query_to_dict(parsed: ParsedSearchQuery) -> dict:
+    """JSON-safe dict for the parsed_query/corrected_query JSONB columns."""
+
+    def convert(value):
+        if isinstance(value, Enum):
+            return value.value
+        # datetime is a subclass of date — check it first.
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if isinstance(value, tuple):
+            return [convert(item) for item in value]
+        return value
+
+    return {f.name: convert(getattr(parsed, f.name)) for f in fields(parsed)}
+
+
+def _as_json_dict(value: ParsedSearchQuery | dict | None) -> dict | None:
+    if value is None or isinstance(value, dict):
+        return value
+    return parsed_query_to_dict(value)
+
+
+def record_interpretation(
+    *,
+    raw_query: str,
+    status: InterpretationStatus | str,
+    model: str | None = None,
+    parser_version: str | None = None,
+    prompt_version: str | None = None,
+    raw_response: str | None = None,
+    parsed_query: ParsedSearchQuery | dict | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+    fallback_used: bool = False,
+    llm_latency_ms: int | None = None,
+    search_latency_ms: int | None = None,
+    result_count: int | None = None,
+    session_factory=get_session,
+) -> int | None:
+    """Persist one interpretation attempt; return the row id, or None.
+
+    An invalid ``status`` raises ValueError eagerly (programmer error — the
+    parser only produces InterpretationStatus values). Database failures are
+    swallowed and yield None: the search request keeps working without its
+    audit row.
+    """
+    status_value = InterpretationStatus(status)
+    session = None
+    try:
+        session = session_factory()
+        log = SearchInterpretationLog(
+            raw_query=_truncate(raw_query, MAX_QUERY_LENGTH),
+            model=model,
+            parser_version=parser_version,
+            prompt_version=prompt_version,
+            raw_response=_truncate(raw_response, MAX_RAW_RESPONSE_LENGTH),
+            parsed_query=_as_json_dict(parsed_query),
+            status=status_value.value,
+            error_code=error_code,
+            error_message=_truncate(error_message, MAX_ERROR_MESSAGE_LENGTH),
+            fallback_used=fallback_used or status_value is InterpretationStatus.FALLBACK,
+            llm_latency_ms=llm_latency_ms,
+            search_latency_ms=search_latency_ms,
+            result_count=result_count,
+        )
+        session.add(log)
+        session.commit()
+        return log.id
+    except Exception:
+        logger.exception("Failed to record search interpretation (status=%s)", status_value.value)
+        if session is not None:
+            try:
+                session.rollback()
+            except Exception:
+                logger.exception("Rollback after failed interpretation write also failed")
+        return None
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                logger.exception("Closing audit session failed")
+
+
+def record_feedback(
+    interpretation_log_id: int,
+    feedback: SearchFeedback,
+    *,
+    session_factory=get_session,
+) -> bool:
+    """Attach (or update) user feedback on an interpretation row.
+
+    Repeated calls overwrite the previous verdict/comment/correction —
+    the user may change their mind. Returns False when the row does not
+    exist (e.g. already expired) or the write failed.
+    """
+    session = None
+    try:
+        session = session_factory()
+        log = session.get(SearchInterpretationLog, interpretation_log_id)
+        if log is None:
+            logger.warning("Feedback for unknown interpretation log id=%s", interpretation_log_id)
+            return False
+        log.feedback_verdict = feedback.verdict.value
+        log.feedback_comment = _truncate(feedback.comment, MAX_COMMENT_LENGTH)
+        log.corrected_query = _as_json_dict(feedback.corrected_query)
+        log.feedback_at = func.now()
+        session.commit()
+        return True
+    except Exception:
+        logger.exception("Failed to record search feedback (log id=%s)", interpretation_log_id)
+        if session is not None:
+            try:
+                session.rollback()
+            except Exception:
+                logger.exception("Rollback after failed feedback write also failed")
+        return False
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                logger.exception("Closing audit session failed")
+
+
+def delete_expired_interpretations(*, session_factory=get_session) -> int:
+    """Retention sweep (ADR-017: 90 days): delete rows past expires_at.
+
+    Linked llm_usage_logs rows survive with search_interpretation_log_id
+    set to NULL (ON DELETE SET NULL) — cost history is never lost.
+    Maintenance path: database errors propagate to the caller.
+    """
+    session = session_factory()
+    try:
+        result = session.execute(
+            delete(SearchInterpretationLog).where(SearchInterpretationLog.expires_at < func.now())
+        )
+        session.commit()
+        deleted = result.rowcount or 0
+        if deleted:
+            logger.info("Deleted %d expired search interpretation logs", deleted)
+        return deleted
+    finally:
+        session.close()

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -47,6 +47,8 @@ Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. The
 | `test_document_service.py` | `DocumentService` (create/import document) |
 | `test_search_service.py` | `SearchService` (embeddings, similarity) |
 | `test_search_types.py` | `library/search/types.py` — frozen search domain models: per-field validation, boundaries, reversed ranges, request variants |
+| `test_llm_usage_pricing.py` | `library/llm_usage/pricing.py` — exact Decimal Bielik/embedding cost math, UNKNOWN for non-token pricing, float money rejected |
+| `test_search_audit_models.py` | ORM metadata for `search_interpretation_logs`/`llm_pricing`/`llm_usage_logs` pinned to the stage-2 migrations |
 | `test_flask_endpoints_orm.py` | ORM-backed endpoints; error responses use generic messages (details logged, not leaked) |
 | `test_flask_endpoints_document_states.py` | `GET /document_states` |
 | `test_website_get_validation.py` | `/website_get` input validation |

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -49,6 +49,8 @@ Configuration in `backend/pyproject.toml` under `[tool.pytest.ini_options]`. The
 | `test_search_types.py` | `library/search/types.py` — frozen search domain models: per-field validation, boundaries, reversed ranges, request variants |
 | `test_llm_usage_pricing.py` | `library/llm_usage/pricing.py` — exact Decimal Bielik/embedding cost math, UNKNOWN for non-token pricing, float money rejected |
 | `test_search_audit_models.py` | ORM metadata for `search_interpretation_logs`/`llm_pricing`/`llm_usage_logs` pinned to the stage-2 migrations |
+| `test_search_audit_repository.py` | `library/search/audit_repository.py` — all interpretation statuses, field truncation, JSONB serialization, feedback write/update, retention sweep, DB failures swallowed (fake sessions) |
+| `test_llm_usage_recorder.py` | `library/llm_usage/recorder.py` — exactly one row per call, pricing snapshot + Decimal estimate, reported cost priority, unknown/credits/subscription modes, float money rejected, DB failures swallowed |
 | `test_flask_endpoints_orm.py` | ORM-backed endpoints; error responses use generic messages (details logged, not leaked) |
 | `test_flask_endpoints_document_states.py` | `GET /document_states` |
 | `test_website_get_validation.py` | `/website_get` input validation |

--- a/backend/tests/unit/test_llm_usage_pricing.py
+++ b/backend/tests/unit/test_llm_usage_pricing.py
@@ -1,0 +1,181 @@
+"""Tests for library/llm_usage/pricing.py — Decimal-only LLM cost estimation.
+
+Covers the stage-2 requirements from docs/search-rebuild-implementation-plan.md:
+exact Bielik arithmetic for various input/output token counts, separate
+input/output components, UNKNOWN for non-token pricing, and a hard ban on
+float money.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from library.llm_usage import (
+    UNKNOWN_COST,
+    CostStatus,
+    PricingError,
+    PricingMode,
+    estimate_cost,
+)
+
+BIELIK_RATE = Decimal("0.56")
+BGE_RATE = Decimal("0.50")
+
+
+def bielik_cost(prompt_tokens: int, completion_tokens: int):
+    return estimate_cost(
+        pricing_mode=PricingMode.PER_TOKEN,
+        input_price_per_million=BIELIK_RATE,
+        output_price_per_million=BIELIK_RATE,
+        currency="EUR",
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+
+
+class TestBielikArithmetic:
+    def test_example_from_plan(self):
+        estimate = bielik_cost(1000, 500)
+        assert estimate.input_cost == Decimal("0.00056")
+        assert estimate.output_cost == Decimal("0.00028")
+        assert estimate.total_cost == Decimal("0.00084")
+        assert estimate.currency == "EUR"
+        assert estimate.status is CostStatus.ESTIMATED
+
+    def test_single_token(self):
+        estimate = bielik_cost(1, 0)
+        assert estimate.input_cost == Decimal("0.00000056")
+        assert estimate.output_cost == Decimal("0")
+        assert estimate.total_cost == Decimal("0.00000056")
+
+    def test_zero_tokens_is_zero_cost_not_unknown(self):
+        estimate = bielik_cost(0, 0)
+        assert estimate.total_cost == Decimal("0")
+        assert estimate.status is CostStatus.ESTIMATED
+
+    def test_one_million_tokens_each_way(self):
+        estimate = bielik_cost(1_000_000, 1_000_000)
+        assert estimate.input_cost == BIELIK_RATE
+        assert estimate.output_cost == BIELIK_RATE
+        assert estimate.total_cost == Decimal("1.12")
+
+    def test_components_add_up_for_asymmetric_counts(self):
+        estimate = bielik_cost(123_456, 7_891)
+        assert estimate.input_cost == Decimal("123456") * BIELIK_RATE / Decimal(1_000_000)
+        assert estimate.output_cost == Decimal("7891") * BIELIK_RATE / Decimal(1_000_000)
+        assert estimate.total_cost == estimate.input_cost + estimate.output_cost
+
+    def test_no_float_artifacts(self):
+        # 0.56 is not representable in binary floating point; Decimal math
+        # must give the exact product for an awkward token count.
+        estimate = bielik_cost(3, 0)
+        assert estimate.input_cost == Decimal("0.00000168")
+
+    def test_result_scale_matches_cost_amount_column(self):
+        estimate = bielik_cost(1, 1)
+        assert estimate.input_cost.as_tuple().exponent == -10
+        assert estimate.output_cost.as_tuple().exponent == -10
+
+
+class TestEmbeddingPricing:
+    def test_embedding_charges_input_only(self):
+        estimate = estimate_cost(
+            pricing_mode="per_token",
+            input_price_per_million=BGE_RATE,
+            output_price_per_million=BGE_RATE,
+            currency="PLN",
+            prompt_tokens=2000,
+            completion_tokens=0,
+        )
+        assert estimate.input_cost == Decimal("0.001")
+        assert estimate.output_cost == Decimal("0")
+        assert estimate.total_cost == Decimal("0.001")
+        assert estimate.currency == "PLN"
+
+
+class TestUnknownCost:
+    @pytest.mark.parametrize(
+        "mode",
+        [PricingMode.PER_REQUEST, PricingMode.CREDITS, PricingMode.SUBSCRIPTION, PricingMode.FREE, PricingMode.UNKNOWN],
+    )
+    def test_non_token_modes_are_unknown(self, mode):
+        estimate = estimate_cost(
+            pricing_mode=mode,
+            input_price_per_million=BIELIK_RATE,
+            output_price_per_million=BIELIK_RATE,
+            currency="EUR",
+            prompt_tokens=100,
+            completion_tokens=100,
+        )
+        assert estimate is UNKNOWN_COST
+        assert estimate.total_cost is None
+        assert estimate.status is CostStatus.UNKNOWN
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"input_price_per_million": None},
+            {"output_price_per_million": None},
+            {"currency": None},
+            {"currency": ""},
+        ],
+    )
+    def test_missing_rate_or_currency_is_unknown_not_error(self, kwargs):
+        args = {
+            "pricing_mode": PricingMode.PER_TOKEN,
+            "input_price_per_million": BIELIK_RATE,
+            "output_price_per_million": BIELIK_RATE,
+            "currency": "EUR",
+            "prompt_tokens": 10,
+            "completion_tokens": 10,
+        }
+        args.update(kwargs)
+        assert estimate_cost(**args) is UNKNOWN_COST
+
+
+class TestInputValidation:
+    def test_float_rate_is_rejected(self):
+        with pytest.raises(PricingError, match="float"):
+            bielik_cost_with_rate(0.56)
+
+    def test_int_rate_is_accepted(self):
+        estimate = estimate_cost(
+            pricing_mode=PricingMode.PER_TOKEN,
+            input_price_per_million=1,
+            output_price_per_million=1,
+            currency="EUR",
+            prompt_tokens=1_000_000,
+            completion_tokens=0,
+        )
+        assert estimate.input_cost == Decimal("1")
+
+    def test_negative_rate_is_rejected(self):
+        with pytest.raises(PricingError, match="negative"):
+            bielik_cost_with_rate(Decimal("-0.56"))
+
+    @pytest.mark.parametrize("tokens", [-1, 1.5, "10", None, True])
+    def test_bad_token_counts_are_rejected(self, tokens):
+        with pytest.raises(PricingError):
+            bielik_cost(tokens, 0)
+
+    def test_invalid_mode_string_is_rejected(self):
+        with pytest.raises(ValueError):
+            estimate_cost(
+                pricing_mode="per_word",
+                input_price_per_million=BIELIK_RATE,
+                output_price_per_million=BIELIK_RATE,
+                currency="EUR",
+                prompt_tokens=1,
+                completion_tokens=1,
+            )
+
+
+def bielik_cost_with_rate(rate):
+    return estimate_cost(
+        pricing_mode=PricingMode.PER_TOKEN,
+        input_price_per_million=rate,
+        output_price_per_million=rate,
+        currency="EUR",
+        prompt_tokens=100,
+        completion_tokens=100,
+    )

--- a/backend/tests/unit/test_llm_usage_recorder.py
+++ b/backend/tests/unit/test_llm_usage_recorder.py
@@ -1,0 +1,362 @@
+"""Tests for library/llm_usage/recorder.py (stage 2B of the search rebuild).
+
+No database: the session factory is faked. The fake mimics the two calls
+the recorder makes (pricing lookup via execute().scalar_one_or_none() and
+the add/commit of exactly one LlmUsageLog row) and assigns ids on commit.
+"""
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from library.db.models import LlmPricing, LlmUsageLog  # noqa: E402
+from library.llm_usage.pricing import CostStatus, PricingError  # noqa: E402
+from library.llm_usage.recorder import record_llm_usage  # noqa: E402
+
+BIELIK_PRICING = dict(
+    pricing_version="cloudferro-bielik-2026-07-18",
+    provider="cloudferro",
+    model="Bielik-11B-v3.0-Instruct",
+    pricing_mode="per_token",
+    input_price_per_million=Decimal("0.56"),
+    output_price_per_million=Decimal("0.56"),
+    currency="EUR",
+    effective_from=date(2026, 7, 18),
+)
+
+
+class FakeSessionFactory:
+    """One reusable fake Session; records added objects, assigns ids on commit."""
+
+    def __init__(self, pricing: LlmPricing | None = None, fail: str | None = None):
+        self.added: list = []
+        self.session = MagicMock()
+        self.session.add.side_effect = self.added.append
+        if fail == "execute":
+            self.session.execute.side_effect = RuntimeError("db down")
+        else:
+            self.session.execute.return_value.scalar_one_or_none.return_value = pricing
+        if fail == "commit":
+            self.session.commit.side_effect = RuntimeError("db down")
+        else:
+            self.session.commit.side_effect = self._assign_ids
+
+    def _assign_ids(self):
+        for i, obj in enumerate(self.added, start=1):
+            if getattr(obj, "id", None) is None:
+                obj.id = i
+
+    def __call__(self):
+        return self.session
+
+
+def bielik_factory(**kwargs) -> FakeSessionFactory:
+    return FakeSessionFactory(pricing=LlmPricing(**BIELIK_PRICING), **kwargs)
+
+
+class TestEstimatedCost:
+    def test_per_token_pricing_writes_estimated_cost(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=1000,
+            completion_tokens=500,
+            latency_ms=1234,
+            session_factory=factory,
+        )
+        assert len(factory.added) == 1
+        log = factory.added[0]
+        assert isinstance(log, LlmUsageLog)
+        # 1000 * 0.56 / 1e6 = 0.00056; 500 * 0.56 / 1e6 = 0.00028
+        assert log.cost_amount == Decimal("0.0008400000")
+        assert log.cost_currency == "EUR"
+        assert log.cost_status == "estimated"
+        assert log.pricing_mode == "per_token"
+        assert log.pricing_version == "cloudferro-bielik-2026-07-18"
+        assert log.input_price_per_million == Decimal("0.56")
+        assert log.output_price_per_million == Decimal("0.56")
+        assert log.latency_ms == 1234
+        assert record.usage_log_id == 1
+        assert record.cost.status is CostStatus.ESTIMATED
+        assert record.cost.total_cost == Decimal("0.0008400000")
+
+    def test_total_tokens_autofilled_from_components(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=100,
+            completion_tokens=25,
+            session_factory=factory,
+        )
+        assert factory.added[0].total_tokens == 125
+        assert record.total_tokens == 125
+
+    def test_explicit_total_tokens_kept(self):
+        factory = bielik_factory()
+        record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=100,
+            completion_tokens=25,
+            total_tokens=130,
+            session_factory=factory,
+        )
+        assert factory.added[0].total_tokens == 130
+
+    def test_embedding_call_output_tokens_zero(self):
+        factory = FakeSessionFactory(
+            pricing=LlmPricing(
+                pricing_version="cloudferro-bge-2026-07-18",
+                provider="cloudferro",
+                model="BAAI/bge-multilingual-gemma2",
+                pricing_mode="per_token",
+                input_price_per_million=Decimal("0.50"),
+                output_price_per_million=Decimal("0.50"),
+                currency="PLN",
+                effective_from=date(2026, 7, 18),
+            )
+        )
+        record = record_llm_usage(
+            operation="embedding_generation",
+            provider="cloudferro",
+            model="BAAI/bge-multilingual-gemma2",
+            prompt_tokens=2_000_000,
+            completion_tokens=0,
+            session_factory=factory,
+        )
+        assert factory.added[0].cost_amount == Decimal("1.0000000000")
+        assert factory.added[0].cost_currency == "PLN"
+        assert record.cost.output_cost == Decimal("0")
+
+
+class TestReportedCost:
+    def test_reported_cost_wins_over_estimate(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=1000,
+            completion_tokens=500,
+            reported_cost=Decimal("0.001"),
+            reported_cost_currency="EUR",
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.cost_amount == Decimal("0.001")
+        assert log.cost_status == "reported"
+        # Pricing snapshot is still recorded for the audit trail.
+        assert log.pricing_version == "cloudferro-bielik-2026-07-18"
+        assert record.cost.status is CostStatus.REPORTED
+
+    def test_reported_cost_as_float_raises(self):
+        with pytest.raises(PricingError, match="float"):
+            record_llm_usage(
+                operation="search_query_parse",
+                provider="cloudferro",
+                model="Bielik-11B-v3.0-Instruct",
+                reported_cost=0.001,
+                reported_cost_currency="EUR",
+                session_factory=bielik_factory(),
+            )
+
+    def test_reported_cost_requires_currency(self):
+        with pytest.raises(PricingError, match="currency"):
+            record_llm_usage(
+                operation="search_query_parse",
+                provider="cloudferro",
+                model="Bielik-11B-v3.0-Instruct",
+                reported_cost=Decimal("0.001"),
+                session_factory=bielik_factory(),
+            )
+
+    def test_negative_reported_cost_raises(self):
+        with pytest.raises(PricingError, match="negative"):
+            record_llm_usage(
+                operation="search_query_parse",
+                provider="cloudferro",
+                model="Bielik-11B-v3.0-Instruct",
+                reported_cost=Decimal("-1"),
+                reported_cost_currency="EUR",
+                session_factory=bielik_factory(),
+            )
+
+
+class TestUnknownCost:
+    def test_no_pricing_row_stores_tokens_with_unknown_cost(self):
+        factory = FakeSessionFactory(pricing=None)
+        record = record_llm_usage(
+            operation="document_analysis",
+            provider="openai",
+            model="gpt-4o-mini",
+            prompt_tokens=1000,
+            completion_tokens=200,
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.prompt_tokens == 1000
+        assert log.completion_tokens == 200
+        assert log.cost_amount is None
+        assert log.cost_currency is None
+        assert log.cost_status == "unknown"
+        assert log.pricing_mode == "unknown"
+        assert log.pricing_version is None
+        assert record.cost.status is CostStatus.UNKNOWN
+
+    def test_subscription_pricing_snapshot_kept_cost_unknown(self):
+        factory = FakeSessionFactory(
+            pricing=LlmPricing(
+                pricing_version="acme-flat-2026-01-01",
+                provider="acme",
+                model="acme-large",
+                pricing_mode="subscription",
+                input_price_per_million=None,
+                output_price_per_million=None,
+                currency="EUR",
+                effective_from=date(2026, 1, 1),
+            )
+        )
+        record = record_llm_usage(
+            operation="document_analysis",
+            provider="acme",
+            model="acme-large",
+            prompt_tokens=10,
+            completion_tokens=10,
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.pricing_mode == "subscription"
+        assert log.pricing_version == "acme-flat-2026-01-01"
+        assert log.cost_status == "unknown"
+        assert record.cost.status is CostStatus.UNKNOWN
+
+    def test_credits_mode_stores_credits_used(self):
+        factory = FakeSessionFactory(
+            pricing=LlmPricing(
+                pricing_version="acme-credits-2026-01-01",
+                provider="acme",
+                model="acme-credits",
+                pricing_mode="credits",
+                input_price_per_million=None,
+                output_price_per_million=None,
+                currency="USD",
+                effective_from=date(2026, 1, 1),
+            )
+        )
+        record_llm_usage(
+            operation="document_analysis",
+            provider="acme",
+            model="acme-credits",
+            credits_used=Decimal("3.5"),
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.credits_used == Decimal("3.5")
+        assert log.cost_status == "unknown"
+
+    def test_credits_as_float_raises(self):
+        with pytest.raises(PricingError, match="float"):
+            record_llm_usage(
+                operation="document_analysis",
+                provider="acme",
+                model="acme-credits",
+                credits_used=3.5,
+                session_factory=FakeSessionFactory(),
+            )
+
+    def test_missing_tokens_never_estimate(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=None,
+            completion_tokens=None,
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.total_tokens is None
+        assert log.cost_status == "unknown"
+        assert record.cost.total_cost is None
+
+
+class TestFailurePaths:
+    def test_llm_error_call_still_writes_one_row(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            success=False,
+            error_code="timeout",
+            session_factory=factory,
+        )
+        assert len(factory.added) == 1
+        log = factory.added[0]
+        assert log.success is False
+        assert log.error_code == "timeout"
+        assert record.usage_log_id == 1
+
+    def test_invalid_provider_tokens_dropped_not_raised(self):
+        factory = bielik_factory()
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=-5,
+            completion_tokens="oops",
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.prompt_tokens is None
+        assert log.completion_tokens is None
+        assert record.cost.status is CostStatus.UNKNOWN
+
+    def test_db_failure_swallowed_returns_no_id(self):
+        factory = bielik_factory(fail="commit")
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=10,
+            completion_tokens=10,
+            session_factory=factory,
+        )
+        assert record.usage_log_id is None
+        assert record.cost.status is CostStatus.UNKNOWN
+        assert record.prompt_tokens == 10
+        factory.session.rollback.assert_called_once()
+        factory.session.close.assert_called_once()
+
+    def test_pricing_lookup_failure_swallowed(self):
+        factory = FakeSessionFactory(fail="execute")
+        record = record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=10,
+            completion_tokens=10,
+            session_factory=factory,
+        )
+        assert record.usage_log_id is None
+
+    def test_session_closed_on_success(self):
+        factory = bielik_factory()
+        record_llm_usage(
+            operation="search_query_parse",
+            provider="cloudferro",
+            model="Bielik-11B-v3.0-Instruct",
+            prompt_tokens=1,
+            completion_tokens=1,
+            session_factory=factory,
+        )
+        factory.session.close.assert_called_once()

--- a/backend/tests/unit/test_search_audit_models.py
+++ b/backend/tests/unit/test_search_audit_models.py
@@ -1,0 +1,95 @@
+"""Metadata tests for the stage-2 audit models (search-rebuild plan).
+
+The tables are created by raw-SQL Alembic migrations (d3e4f5a6b7c8,
+e4f5a6b7c8d9); these tests pin the ORM mapping to the same shape so a drift
+between models.py and the migrations is caught without a database.
+"""
+
+import sqlalchemy as sa
+
+from library.db.models import LlmPricing, LlmUsageLog, SearchInterpretationLog
+
+
+def check_constraint_names(table):
+    return {c.name for c in table.constraints if isinstance(c, sa.CheckConstraint)}
+
+
+def index_names(table):
+    return {i.name for i in table.indexes}
+
+
+class TestSearchInterpretationLog:
+    def test_required_columns(self):
+        table = SearchInterpretationLog.__table__
+        assert table.name == "search_interpretation_logs"
+        for column in ("raw_query", "status", "created_at", "expires_at"):
+            assert not table.c[column].nullable
+
+    def test_feedback_and_audit_columns_exist(self):
+        columns = set(SearchInterpretationLog.__table__.c.keys())
+        assert {
+            "model", "parser_version", "prompt_version", "raw_response", "parsed_query",
+            "error_code", "error_message", "fallback_used", "llm_latency_ms",
+            "search_latency_ms", "result_count", "feedback_verdict", "feedback_comment",
+            "corrected_query", "feedback_at",
+        } <= columns
+
+    def test_status_and_feedback_checks(self):
+        names = check_constraint_names(SearchInterpretationLog.__table__)
+        assert "ck_search_interpretation_logs_status" in names
+        assert "ck_search_interpretation_logs_feedback" in names
+
+    def test_retention_index_present(self):
+        assert "idx_search_interpretation_logs_expires" in index_names(SearchInterpretationLog.__table__)
+
+
+class TestLlmPricing:
+    def test_pricing_version_unique(self):
+        assert LlmPricing.__table__.c.pricing_version.unique
+
+    def test_money_columns_are_numeric(self):
+        table = LlmPricing.__table__
+        for column in ("input_price_per_million", "output_price_per_million"):
+            column_type = table.c[column].type
+            assert isinstance(column_type, sa.Numeric)
+            assert (column_type.precision, column_type.scale) == (12, 6)
+
+    def test_single_active_row_per_model_index(self):
+        index = next(i for i in LlmPricing.__table__.indexes if i.name == "uq_llm_pricing_active_model")
+        assert index.unique
+
+
+class TestLlmUsageLog:
+    def test_cost_amount_precision_matches_migration(self):
+        column_type = LlmUsageLog.__table__.c.cost_amount.type
+        assert isinstance(column_type, sa.Numeric)
+        assert (column_type.precision, column_type.scale) == (18, 10)
+
+    def test_interpretation_fk_survives_log_deletion(self):
+        fk = next(iter(LlmUsageLog.__table__.c.search_interpretation_log_id.foreign_keys))
+        assert fk.column.table.name == "search_interpretation_logs"
+        assert fk.ondelete == "SET NULL"
+
+    def test_pricing_snapshot_columns_exist(self):
+        columns = set(LlmUsageLog.__table__.c.keys())
+        assert {
+            "pricing_mode", "pricing_version", "input_price_per_million",
+            "output_price_per_million", "cost_amount", "cost_currency", "cost_status",
+            "prompt_tokens", "completion_tokens", "total_tokens", "credits_used",
+            "operation", "provider", "model", "latency_ms", "success", "error_code",
+        } <= columns
+
+    def test_cost_status_and_tokens_checks(self):
+        names = check_constraint_names(LlmUsageLog.__table__)
+        assert "ck_llm_usage_logs_cost_status" in names
+        assert "ck_llm_usage_logs_pricing_mode" in names
+        assert "ck_llm_usage_logs_tokens_nonneg" in names
+
+    def test_aggregation_indexes_present(self):
+        names = index_names(LlmUsageLog.__table__)
+        assert {
+            "idx_llm_usage_logs_called",
+            "idx_llm_usage_logs_operation_called",
+            "idx_llm_usage_logs_provider_model_called",
+            "idx_llm_usage_logs_interpretation",
+        } <= names

--- a/backend/tests/unit/test_search_audit_repository.py
+++ b/backend/tests/unit/test_search_audit_repository.py
@@ -1,0 +1,273 @@
+"""Tests for library/search/audit_repository.py (stage 2B of the search rebuild).
+
+No database: sessions are faked. What matters is the shape of the row the
+repository builds (statuses, truncation, JSONB serialization), that the
+write commits in its own session, and that a database failure is swallowed
+instead of breaking the search path.
+"""
+
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from library.db.models import SearchInterpretationLog  # noqa: E402
+from library.search.audit_repository import (  # noqa: E402
+    MAX_ERROR_MESSAGE_LENGTH,
+    MAX_RAW_RESPONSE_LENGTH,
+    TRUNCATION_SUFFIX,
+    delete_expired_interpretations,
+    parsed_query_to_dict,
+    record_feedback,
+    record_interpretation,
+)
+from library.search.types import (  # noqa: E402
+    MAX_QUERY_LENGTH,
+    FeedbackVerdict,
+    InterpretationStatus,
+    ParsedSearchQuery,
+    SearchFeedback,
+)
+
+
+class FakeSessionFactory:
+    def __init__(self, existing_log: SearchInterpretationLog | None = None, fail_on_commit: bool = False):
+        self.added: list = []
+        self.session = MagicMock()
+        self.session.add.side_effect = self.added.append
+        self.session.get.return_value = existing_log
+        if fail_on_commit:
+            self.session.commit.side_effect = RuntimeError("db down")
+        else:
+            self.session.commit.side_effect = self._assign_ids
+
+    def _assign_ids(self):
+        for i, obj in enumerate(self.added, start=1):
+            if getattr(obj, "id", None) is None:
+                obj.id = i
+
+    def __call__(self):
+        return self.session
+
+
+def parsed_query() -> ParsedSearchQuery:
+    return ParsedSearchQuery(
+        query="niewolnictwo w Afryce",
+        subject_period_start_year=1945,
+        published_on_from=date(2020, 1, 1),
+        ingested_at_to=datetime(2026, 7, 18, 12, 30),
+        document_types=("text",),
+        interpretation_summary="Niewolnictwo w Afryce od 1945 roku",
+        warnings=("Nie podano końca okresu.",),
+    )
+
+
+class TestRecordInterpretation:
+    def test_parsed_success_row(self):
+        factory = FakeSessionFactory()
+        log_id = record_interpretation(
+            raw_query="niewolnictwo w afryce po ii wojnie",
+            status=InterpretationStatus.PARSED,
+            model="Bielik-11B-v3.0-Instruct",
+            parser_version="1",
+            prompt_version="1",
+            raw_response='{"query": "niewolnictwo w Afryce"}',
+            parsed_query=parsed_query(),
+            llm_latency_ms=900,
+            search_latency_ms=150,
+            result_count=7,
+            session_factory=factory,
+        )
+        assert log_id == 1
+        assert len(factory.added) == 1
+        log = factory.added[0]
+        assert log.status == "parsed"
+        assert log.fallback_used is False
+        assert log.parsed_query["query"] == "niewolnictwo w Afryce"
+        assert log.result_count == 7
+        factory.session.commit.assert_called_once()
+        factory.session.close.assert_called_once()
+
+    @pytest.mark.parametrize("status", list(InterpretationStatus))
+    def test_every_status_is_writable(self, status):
+        factory = FakeSessionFactory()
+        assert record_interpretation(raw_query="q", status=status, session_factory=factory) == 1
+        assert factory.added[0].status == status.value
+
+    def test_llm_error_row(self):
+        factory = FakeSessionFactory()
+        record_interpretation(
+            raw_query="cokolwiek",
+            status="llm_error",
+            error_code="timeout",
+            error_message="Sherlock request timed out",
+            fallback_used=True,
+            session_factory=factory,
+        )
+        log = factory.added[0]
+        assert log.status == "llm_error"
+        assert log.error_code == "timeout"
+        assert log.fallback_used is True
+
+    def test_fallback_status_forces_fallback_flag(self):
+        factory = FakeSessionFactory()
+        record_interpretation(raw_query="q", status=InterpretationStatus.FALLBACK, session_factory=factory)
+        assert factory.added[0].fallback_used is True
+
+    def test_invalid_status_raises_before_any_write(self):
+        factory = FakeSessionFactory()
+        with pytest.raises(ValueError):
+            record_interpretation(raw_query="q", status="nonsense", session_factory=factory)
+        assert factory.added == []
+
+    def test_parsed_query_accepts_plain_dict(self):
+        factory = FakeSessionFactory()
+        record_interpretation(
+            raw_query="q",
+            status=InterpretationStatus.PARSED,
+            parsed_query={"query": "x"},
+            session_factory=factory,
+        )
+        assert factory.added[0].parsed_query == {"query": "x"}
+
+    def test_db_failure_swallowed_returns_none(self):
+        factory = FakeSessionFactory(fail_on_commit=True)
+        log_id = record_interpretation(raw_query="q", status="parsed", session_factory=factory)
+        assert log_id is None
+        factory.session.rollback.assert_called_once()
+        factory.session.close.assert_called_once()
+
+
+class TestTruncation:
+    def test_raw_query_capped_at_query_limit(self):
+        factory = FakeSessionFactory()
+        record_interpretation(raw_query="x" * (MAX_QUERY_LENGTH + 500), status="parsed", session_factory=factory)
+        stored = factory.added[0].raw_query
+        assert len(stored) == MAX_QUERY_LENGTH
+        assert stored.endswith(TRUNCATION_SUFFIX)
+
+    def test_raw_response_capped(self):
+        factory = FakeSessionFactory()
+        record_interpretation(
+            raw_query="q",
+            status="invalid_json",
+            raw_response="y" * (MAX_RAW_RESPONSE_LENGTH * 2),
+            session_factory=factory,
+        )
+        stored = factory.added[0].raw_response
+        assert len(stored) == MAX_RAW_RESPONSE_LENGTH
+        assert stored.endswith(TRUNCATION_SUFFIX)
+
+    def test_error_message_capped(self):
+        factory = FakeSessionFactory()
+        record_interpretation(
+            raw_query="q",
+            status="llm_error",
+            error_message="e" * (MAX_ERROR_MESSAGE_LENGTH + 1),
+            session_factory=factory,
+        )
+        stored = factory.added[0].error_message
+        assert len(stored) == MAX_ERROR_MESSAGE_LENGTH
+        assert stored.endswith(TRUNCATION_SUFFIX)
+
+    def test_short_values_untouched(self):
+        factory = FakeSessionFactory()
+        record_interpretation(
+            raw_query="krótkie zapytanie",
+            status="parsed",
+            raw_response="{}",
+            session_factory=factory,
+        )
+        assert factory.added[0].raw_query == "krótkie zapytanie"
+        assert factory.added[0].raw_response == "{}"
+
+
+class TestParsedQuerySerialization:
+    def test_json_safe_values(self):
+        data = parsed_query_to_dict(parsed_query())
+        assert data["query"] == "niewolnictwo w Afryce"
+        assert data["subject_period_start_year"] == 1945
+        assert data["published_on_from"] == "2020-01-01"
+        assert data["ingested_at_to"] == "2026-07-18T12:30:00"
+        assert data["document_types"] == ["text"]
+        assert data["warnings"] == ["Nie podano końca okresu."]
+        assert data["sort"] == "relevance"
+        assert data["model_confidence"] == "medium"
+        assert data["clarification_question"] is None
+
+    def test_only_json_types(self):
+        def check(value):
+            if isinstance(value, list):
+                for item in value:
+                    check(item)
+            else:
+                assert value is None or isinstance(value, (str, int, float, bool))
+
+        for value in parsed_query_to_dict(parsed_query()).values():
+            check(value)
+
+
+class TestRecordFeedback:
+    def test_feedback_written_to_existing_row(self):
+        log = SearchInterpretationLog(raw_query="q", status="parsed")
+        factory = FakeSessionFactory(existing_log=log)
+        ok = record_feedback(
+            5,
+            SearchFeedback(
+                verdict=FeedbackVerdict.PARTIALLY_CORRECT,
+                comment="Okres OK, ale zły portal",
+                corrected_query=parsed_query(),
+            ),
+            session_factory=factory,
+        )
+        assert ok is True
+        assert log.feedback_verdict == "partially_correct"
+        assert log.feedback_comment == "Okres OK, ale zły portal"
+        assert log.corrected_query["query"] == "niewolnictwo w Afryce"
+        assert log.feedback_at is not None
+        factory.session.commit.assert_called_once()
+
+    def test_feedback_update_overwrites_previous(self):
+        log = SearchInterpretationLog(raw_query="q", status="parsed")
+        log.feedback_verdict = "incorrect"
+        log.feedback_comment = "stary komentarz"
+        factory = FakeSessionFactory(existing_log=log)
+        ok = record_feedback(5, SearchFeedback(verdict="correct"), session_factory=factory)
+        assert ok is True
+        assert log.feedback_verdict == "correct"
+        assert log.feedback_comment is None
+        assert log.corrected_query is None
+
+    def test_missing_row_returns_false(self):
+        factory = FakeSessionFactory(existing_log=None)
+        ok = record_feedback(999, SearchFeedback(verdict="correct"), session_factory=factory)
+        assert ok is False
+        factory.session.commit.assert_not_called()
+
+    def test_db_failure_swallowed(self):
+        log = SearchInterpretationLog(raw_query="q", status="parsed")
+        factory = FakeSessionFactory(existing_log=log, fail_on_commit=True)
+        ok = record_feedback(5, SearchFeedback(verdict="correct"), session_factory=factory)
+        assert ok is False
+        factory.session.rollback.assert_called_once()
+        factory.session.close.assert_called_once()
+
+
+class TestRetention:
+    def test_delete_expired_returns_rowcount(self):
+        factory = FakeSessionFactory()
+        factory.session.execute.return_value.rowcount = 3
+        assert delete_expired_interpretations(session_factory=factory) == 3
+        statement = factory.session.execute.call_args.args[0]
+        assert "expires_at" in str(statement)
+        factory.session.commit.assert_called_once()
+        factory.session.close.assert_called_once()
+
+    def test_delete_expired_propagates_db_errors(self):
+        factory = FakeSessionFactory()
+        factory.session.execute.side_effect = RuntimeError("db down")
+        with pytest.raises(RuntimeError):
+            delete_expired_interpretations(session_factory=factory)
+        factory.session.close.assert_called_once()

--- a/docs/search-rebuild-progress.md
+++ b/docs/search-rebuild-progress.md
@@ -5,6 +5,57 @@ Nowe wpisy dopisywać NA GÓRZE.
 
 ---
 
+## 2026-07-18 — Etap 2, sesja B (repozytorium audytu + recorder usage) — ETAP 2 UKOŃCZONY
+
+**Zakres wykonany:**
+
+- `library/llm_usage/recorder.py` — `record_llm_usage()`: JEDYNA ścieżka zapisu do `llm_usage_logs`
+  (dokładnie jeden rekord na wywołanie LLM). Snapshot aktywnego wiersza `llm_pricing`
+  (stawki + waluta + `pricing_version` FK), koszt przez `estimate_cost()`; koszt raportowany
+  przez providera (Decimal + wymagana waluta) ma pierwszeństwo przed estymacją; brak ceny →
+  `cost_status='unknown'` (nigdy błąd, nigdy 0). Tokeny od providera sanityzowane (złe wartości →
+  NULL + warning, bez wyjątku); float dla pieniędzy (`reported_cost`, `credits_used`) →
+  `PricingError` (błąd programisty). Własna sesja; awaria DB połknięta (`usage_log_id=None`,
+  głośny log) — accounting nie może wywalić operacji biznesowej.
+- `library/search/audit_repository.py` — `record_interpretation()` (wszystkie statusy
+  `InterpretationStatus`; status `fallback` wymusza `fallback_used=True`; niepoprawny status →
+  ValueError eager, przed sesją), `record_feedback()` (zapis i nadpisanie werdyktu/komentarza/
+  `corrected_query`; brak wiersza → False), `delete_expired_interpretations()` (retencja 90 dni;
+  jako operacja utrzymaniowa PROPAGUJE błędy DB), `parsed_query_to_dict()` (ParsedSearchQuery →
+  JSON-safe dict dla JSONB: daty→ISO, enumy→value, tuple→list). Kontrola długości w warstwie
+  zapisu: `raw_query`→`MAX_QUERY_LENGTH` (1000), `raw_response`→20 000, `error_message`→500,
+  z widocznym `TRUNCATION_SUFFIX`. Zapisy we własnej sesji — awaria zapisu audytu nie psuje
+  wyszukiwania (zwraca None/False).
+- `__init__.py` obu pakietów: leniwe re-eksporty (PEP 562) — `library.search`/`library.llm_usage`
+  importują się nadal bez sqlalchemy w lekkim środowisku uvx.
+- Dokumentacja: `backend/library/CLAUDE.md`, `backend/tests/CLAUDE.md`.
+
+**Testy uruchomione:**
+
+- `tests/unit/test_llm_usage_recorder.py` (17) + `tests/unit/test_search_audit_repository.py` (25):
+  42 passed (mockowane sesje, bez DB — konwencja repo).
+- Pełna suita `tests/unit/`: **1624 passed**; `uvx ruff check backend/`: czysty.
+- E2E na bazie NAS (192.168.200.7:5434): pełny cykl `record_interpretation` → `record_feedback` →
+  `record_llm_usage` (1000+500 tokenów → 0.0008400000 EUR `estimated` z seedu
+  `cloudferro-bielik-2026-07-18`) → `delete_expired_interpretations` (0) → DELETE interpretacji
+  potwierdza `ON DELETE SET NULL` na usage → cleanup; tabele po teście puste (0/0).
+
+**Otwarte ryzyka:**
+
+- `delete_expired_interpretations()` nie jest nigdzie wywoływane cyklicznie — podpiąć w etapie 12
+  (job/cron) albo wywoływać przy okazji zapytań.
+- `feedback_at` ustawiane przez `func.now()` (zegar DB) — spójne z `created_at`, ale wartość
+  w obiekcie ORM przed odświeżeniem to wyrażenie SQL, nie datetime.
+- Alokacja kosztu abonamentowego (`allocated`) i sumowanie między walutami (EUR/PLN/USD) —
+  bez zmian, świadomie odłożone do etapu 12 (raporty).
+- Warunek zakończenia etapu 2 spełniony: błędy zapisywane bez wpływu na transakcję wyszukiwania,
+  jedno wywołanie LLM = jeden rekord usage.
+
+**Następny krok:** Etap 3 — poprawa abstrakcji LLM (`ai_ask()` z osobnym `system_prompt`,
+rola systemowa w Sherlocku, temperatura 0 dla parsera, structured output jeśli wspierany,
+po każdym callu zapis usage przez `record_llm_usage()`, `response.usage` bez atrybutów
+`cost_usd`/`cost`/`credits_used` na `AiResponse`). Etap `S` — jedna sesja.
+
 ## 2026-07-18 — Etap 2, sesja A (migracje audytu + cennik + koszty Decimal) — POŁOWA ETAPU
 
 **Zakres wykonany:**

--- a/docs/search-rebuild-progress.md
+++ b/docs/search-rebuild-progress.md
@@ -5,6 +5,54 @@ Nowe wpisy dopisywać NA GÓRZE.
 
 ---
 
+## 2026-07-18 — Etap 2, sesja A (migracje audytu + cennik + koszty Decimal) — POŁOWA ETAPU
+
+**Zakres wykonany:**
+
+- Migracja `d3e4f5a6b7c8` — `search_interpretation_logs`: raw_query, wersje modelu/parsera/promptu,
+  surowa odpowiedź, `parsed_query` JSONB, `status` (CHECK zgodny z `InterpretationStatus`),
+  bezpieczny kod/opis błędu, latencje, feedback (`feedback_verdict` CHECK, komentarz,
+  `corrected_query`), `expires_at NOT NULL DEFAULT now() + 90 dni` (ADR-017) + indeksy
+  (created_at, status+created_at, expires_at).
+- Migracja `e4f5a6b7c8d9` — `llm_pricing` (wersjonowany cennik, wiersze niemutowalne, częściowy
+  unikalny indeks „jeden otwarty cennik na provider/model", seed CloudFerro:
+  `cloudferro-bielik-2026-07-18` 0,56 EUR/1M we/wy, `cloudferro-bge-2026-07-18` 0,50 PLN netto/1M)
+  oraz `llm_usage_logs` (operation/provider/model, tokeny jako fakt pomiarowy, `credits_used`,
+  zdenormalizowany snapshot stawek + FK `pricing_version`, `cost_amount NUMERIC(18,10)`,
+  `cost_currency`, `cost_status` CHECK reported/estimated/allocated/unknown, opcjonalne FK
+  do interpretacji `ON DELETE SET NULL`, indeksy agregacyjne).
+- ORM: `SearchInterpretationLog`, `LlmPricing`, `LlmUsageLog` w `library/db/models.py`
+  (pieniądze jako `Decimal`/`Numeric`, nie float).
+- Nowy pakiet `library/llm_usage/` (`pricing.py`): `estimate_cost()` — koszt liczony wyłącznie
+  na `Decimal` (float dla stawki = `PricingError`), osobno składnik wejścia i wyjścia,
+  kwantyzacja do 10 miejsc (skala kolumny), tryby nie-tokenowe → `UNKNOWN_COST`
+  (brak ceny nigdy nie jest błędem biznesowym ani kosztem 0).
+- Dokumentacja: `backend/database/CLAUDE.md` (sekcja 3 nowych tabel), `backend/library/CLAUDE.md`,
+  `backend/tests/CLAUDE.md`.
+
+**Testy uruchomione:**
+
+- `tests/unit/test_llm_usage_pricing.py` (25) + `tests/unit/test_search_audit_models.py` (13): 38 passed.
+- Pełna suita `tests/unit/`: **1582 passed**; `uvx ruff check backend/`: czysty.
+- Migracje na bazie NAS (192.168.200.7:5434): `upgrade head` → weryfikacja psql (schemat + seed) →
+  `downgrade c2d3e4f5a6b7` (tabele znikają) → `upgrade head`; head = `e4f5a6b7c8d9`.
+- ORM round-trip na NAS (insert interpretacji + usage z kosztem 0.0008400000 EUR `estimated`,
+  `expires_at` = created_at + 90 dni) zakończony rollbackiem — nic nie zostało w bazie.
+
+**Otwarte ryzyka:**
+
+- Retencja 90 dni to na razie tylko `expires_at` + indeks — brak joba czyszczącego (do etapu 12
+  lub prostego DELETE w sesji B).
+- Kontrola długości `raw_query`/odpowiedzi/komunikatu błędu odłożona do repozytorium (sesja B) —
+  kolumny są TEXT, limity z `library/search/types.py` (`MAX_QUERY_LENGTH=1000`) zastosuje warstwa zapisu.
+- Alokacja kosztu abonamentowego (`allocated`) świadomie niezaimplementowana — `estimate_cost()`
+  zwraca `UNKNOWN_COST` dla trybów nie-tokenowych; alokacja to raport (etap 12).
+- Waluty per rekord (EUR/PLN/USD) — agregaty nie mogą sumować między walutami bez przeliczenia.
+
+**Następny krok:** Etap 2, sesja B — repozytorium audytu (zapis sukcesu/błędu/fallbacku poza
+transakcją wyszukiwania, kontrola długości pól, zapis i aktualizacja feedbacku, gwarancja
+dokładnie jednego rekordu usage na wywołanie LLM) + testy zapisu wszystkich statusów.
+
 ## 2026-07-18 — Etap 1 (typy domenowe wyszukiwania) — UKOŃCZONY
 
 **Zakres wykonany:**


### PR DESCRIPTION
## Zakres (etap 2 planu przebudowy wyszukiwania)

Sesja A (migracje + koszty Decimal):
- Migracja `d3e4f5a6b7c8` — `search_interpretation_logs` (surowe zapytanie, wersje modelu/parsera/promptu, surowa odpowiedź, `parsed_query` JSONB, statusy, feedback, retencja `expires_at` = 90 dni wg ADR-017).
- Migracja `e4f5a6b7c8d9` — `llm_pricing` (wersjonowany cennik, wiersze niemutowalne, seed CloudFerro: Bielik 0,56 EUR/1M we/wy, embedding bge 0,50 PLN netto/1M) + `llm_usage_logs` (tokeny jako fakt pomiarowy, zdenormalizowany snapshot stawek, `cost_amount NUMERIC(18,10)`, `cost_status` reported/estimated/allocated/unknown).
- `library/llm_usage/pricing.py` — `estimate_cost()` wyłącznie na `Decimal` (float dla pieniędzy = `PricingError`), osobne składniki wejścia i wyjścia.

Sesja B (repozytorium audytu + recorder):
- `library/search/audit_repository.py` — zapis interpretacji i feedbacku we własnej sesji (awaria zapisu audytu nie psuje wyszukiwania), kontrola długości pól w warstwie zapisu, retencja `delete_expired_interpretations()`.
- `library/llm_usage/recorder.py` — `record_llm_usage()`: jedyna ścieżka zapisu do `llm_usage_logs`, dokładnie jeden rekord na wywołanie LLM; koszt raportowany > estymowany > unknown; snapshot cennika chroni historię przed zmianą cen.
- Leniwe re-eksporty pakietów (kompatybilność z lekkim środowiskiem uvx bez sqlalchemy).

## Testy
- Pełna suita unit: **1624 passed**; `uvx ruff check backend/`: czysty.
- Migracje przetestowane na bazie NAS: `upgrade head` → `downgrade` → `upgrade`.
- E2E na NAS: pełny cykl interpretacja → feedback → usage (0,0008400000 EUR estimated z seedu cennika) → retencja → `ON DELETE SET NULL`; tabele po teście puste.

Warunek zakończenia etapu 2 spełniony: błędy zapisywane bez wpływu na transakcję wyszukiwania, jedno wywołanie LLM = jeden rekord usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)