### PR TITLE
Etap 11b: rename author → byline + author_source → byline_method

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -149,14 +149,14 @@ pre-commit run         # Pre-commit hooks (includes TruffleHog secret detection)
 
 Tool config in `pyproject.toml`: ruff line-length=120, excludes `.git`, `__pycache__`, `venv`, `node_modules`.
 
-## Key Field Semantics: `source` vs `author`
+## Key Field Semantics: `source` vs `byline`
 
 These two fields on `web_documents` serve distinct purposes:
 
 - **`source`** — How the user *discovered* the content: `"own"` (found it themselves), `"unknow.news"` (from unknow.news newsletter), `"friend"` (personal recommendation), etc. This enables evaluating recommendation source quality over time (e.g. "links from source X tend to be low quality").
-- **`author`** — Who *created* the content: YouTube channel name, article author, blog name, etc. This is content metadata, not a discovery channel.
+- **`byline`** (renamed from `author` in stage 11b of the search rebuild) — Who *created* the content: YouTube channel name, article author, blog name, etc. This is content metadata, not a discovery channel. The comma-separated display cache; structured author links live in `document_persons` (role=`author`).
 
-Example: A YouTube video by "Good Times Bad Times Polska" found via unknow.news newsletter → `source="unknow.news"`, `author="Good Times Bad Times Polska"`.
+Example: A YouTube video by "Good Times Bad Times Polska" found via unknow.news newsletter → `source="unknow.news"`, `byline="Good Times Bad Times Polska"`.
 
 ## Subdirectory Documentation
 

--- a/backend/alembic/versions/b3c4d5e6f7a8_rename_author_to_byline.py
+++ b/backend/alembic/versions/b3c4d5e6f7a8_rename_author_to_byline.py
@@ -1,0 +1,37 @@
+"""rename author to byline and author_source to byline_method
+
+Stage 11b of docs/search-rebuild-implementation-plan.md: physical column rename
+only — types, values and CHECK semantics stay identical. The relational author
+model (document_persons role='author') and ner_exclusions.author are untouched;
+byline is the presentational display cache on the document row.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-07-19 02:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b3c4d5e6f7a8"
+down_revision: Union[str, None] = "a2b3c4d5e6f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE web_documents RENAME COLUMN author TO byline")
+    op.execute("ALTER TABLE web_documents RENAME COLUMN author_source TO byline_method")
+    op.execute(
+        "ALTER TABLE web_documents RENAME CONSTRAINT ck_web_documents_author_source"
+        " TO ck_web_documents_byline_method"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE web_documents RENAME CONSTRAINT ck_web_documents_byline_method"
+        " TO ck_web_documents_author_source"
+    )
+    op.execute("ALTER TABLE web_documents RENAME COLUMN byline_method TO author_source")
+    op.execute("ALTER TABLE web_documents RENAME COLUMN byline TO author")

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -70,7 +70,8 @@ Main document storage. Each row represents a collected web resource (article, vi
 | `language` | `varchar(10)` | Detected language code |
 | `tags` | `text` | Comma-separated tags |
 | `source` | `text` | Discovery source (how the user found the document) — FK → `sources.name` (`fk_source`, `ON UPDATE CASCADE`); unknown values are auto-created by the ORM `before_flush` hook |
-| `author` | `text` | Document author |
+| `byline` | `text` | Document author(s) display cache (comma-separated); structured links in `document_persons` (role=`author`) |
+| `byline_method` | `varchar(10)` | How `byline` was set: `manual`, `llm` or `html`; `NULL` for legacy/import-set values. CHECK constraint `ck_web_documents_byline_method` |
 | `note` | `text` | User notes |
 | `paywall` | `boolean` | Whether content is behind a paywall (default: false) |
 | `published_on` | `date` | Publication date |
@@ -323,7 +324,7 @@ NER false-positive suppression dictionary, applied in `library/entity_service.py
 | `id` | `serial PK` | Auto-incrementing primary key |
 | `entity_text` | `text NOT NULL` | Matched case-insensitively against the aggregated entity base form |
 | `entity_type` | `varchar(20) NOT NULL DEFAULT '*'` | `persName` / `geogName` / `placeName` / `*` (all types) |
-| `scope` | `varchar(10) NOT NULL DEFAULT 'global'` | `global` (every document) or `author` (only documents whose `web_documents.author` matches) |
+| `scope` | `varchar(10) NOT NULL DEFAULT 'global'` | `global` (every document) or `author` (only documents whose `web_documents.byline` matches) |
 | `author` | `text` | Author the rule is limited to (required when `scope='author'`, CHECK constraint) |
 | `note` | `text` | Optional human note (why excluded) |
 | `created_at` | `timestamp` | Row creation timestamp |

--- a/backend/database/init/03-create-table.sql
+++ b/backend/database/init/03-create-table.sql
@@ -28,7 +28,7 @@ create table web_documents
     text_raw             text,
     transcript_job_id    text,
     ai_summary_needed    boolean     default false,
-    author               text,
+    byline               text,
     note                 text,
     uuid                 varchar(100) NOT NULL DEFAULT gen_random_uuid(),
     project              varchar(100),

--- a/backend/email_import.py
+++ b/backend/email_import.py
@@ -347,7 +347,7 @@ def main():
         doc = WebDocument(url=url)
         doc.document_type = StalkerDocumentType.email.name
         doc.title = subject
-        doc.author = author
+        doc.byline = author
         doc.text = text
         doc.text_raw = text_raw
         doc.source = args.source

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -591,13 +591,13 @@ def action_save_to_db(doc, article: dict, session) -> bool:
     # Zapisz autora z LLM markers jeśli dostępny
     import glob as glob_mod
     markers_files = glob_mod.glob(os.path.join(CACHE_DIR_BASE, str(doc.id), "*_llm_markers.json"))
-    if markers_files and not doc.author:
+    if markers_files and not doc.byline:
         import json
         with open(markers_files[0], "r", encoding="utf-8") as f:
             markers_data = json.load(f)
         author = markers_data.get("markers", {}).get("author")
         if author:
-            doc.author = author
+            doc.byline = author
             print(f"    Autor: {author}")
 
     try:
@@ -889,7 +889,7 @@ def cmd_meta(session, article_id: Optional[int] = None):
         "document_type": doc.document_type,
         "language": doc.language,
         "source": doc.source,
-        "author": doc.author,
+        "byline": doc.byline,
         "note": doc.note,
         "summary": doc.summary,
         "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,
@@ -937,7 +937,7 @@ def cmd_dump(session, article_id: Optional[int] = None, use_md: bool = False):
         "document_type": doc.document_type,
         "language": doc.language,
         "source": doc.source,
-        "author": doc.author,
+        "byline": doc.byline,
         "note": doc.note,
         "summary": doc.summary,
         "reviewed_at": doc.reviewed_at.isoformat() if doc.reviewed_at else None,

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -213,7 +213,7 @@ def refresh_existing_document(session, item: dict, text_content: str | None,
     from library.author_service import set_document_authors
 
     authors = extract_article_authors(html_content, doc.url)
-    set_document_authors(session, doc, authors, source="html")
+    set_document_authors(session, doc, authors, method="html")
     session.commit()
     print(f"  REFRESHED (id={doc.id}, authors={authors or 'none'})")
     return doc.id
@@ -260,9 +260,9 @@ def process_article_content(doc_id: int, cache_base_dir: str,
         cleaned = clean_article_text(article, doc.url)
         doc.text_extracted = article
         doc.text_md = cleaned["text"]
-        if not doc.author:
+        if not doc.byline:
             with open(html_file, encoding="utf-8") as f:
-                doc.author = extract_article_author(f.read(), doc.url)
+                doc.byline = extract_article_author(f.read(), doc.url)
         try:
             session.commit()
             print(f"  Process: saved text_extracted/text_md ({len(cleaned['text'])} chars cleaned)")

--- a/backend/imports/refresh_entities.py
+++ b/backend/imports/refresh_entities.py
@@ -95,7 +95,7 @@ def _filtered_groups(session, doc, raw: list[dict]) -> dict:
     exclusions = list(session.scalars(select(NerExclusion)).all())
     for key, group in list(groups.items()):
         raw_terms = [*group.get("raw_lemmas", []), *group.get("variants", [])]
-        if is_excluded(exclusions, key[0], key[1], doc.author, raw_terms=raw_terms):
+        if is_excluded(exclusions, key[0], key[1], doc.byline, raw_terms=raw_terms):
             del groups[key]
     return groups
 

--- a/backend/imports/youtube_backfill_author.py
+++ b/backend/imports/youtube_backfill_author.py
@@ -58,7 +58,7 @@ def fetch_author(url: str, proxies: dict[str, str] | None) -> str | None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Backfill the 'author' (YouTube channel name) field for existing videos missing it."
+        description="Backfill the 'byline' (YouTube channel name) field for existing videos missing it."
     )
     parser.add_argument("--dry-run", action="store_true", help="Preview only, no DB writes")
     parser.add_argument("--limit", type=int, help="Max number of videos to process")
@@ -87,13 +87,13 @@ def main():
     try:
         query = session.query(WebDocument).filter(
             WebDocument.document_type == "youtube",
-            WebDocument.author.is_(None),
+            WebDocument.byline.is_(None),
         ).order_by(WebDocument.id)
         if args.limit:
             query = query.limit(args.limit)
         docs = query.all()
 
-        logging.info(f"Found {len(docs)} YouTube documents missing 'author'")
+        logging.info(f"Found {len(docs)} YouTube documents missing 'byline'")
 
         updated, failed = 0, 0
         for i, doc in enumerate(docs, start=1):
@@ -108,7 +108,7 @@ def main():
 
             logging.info(f"  author: {author}")
             if not args.dry_run:
-                doc.author = author
+                doc.byline = author
                 session.commit()
             updated += 1
             time.sleep(args.delay)

--- a/backend/imports/youtube_batch_analyze.py
+++ b/backend/imports/youtube_batch_analyze.py
@@ -88,8 +88,8 @@ def main():
 
         print(f"Tytuł  : {doc.title}")
         print(f"Typ    : {doc.document_type} | Stan: {doc.document_state}")
-        if doc.author:
-            print(f"Autor  : {doc.author}")
+        if doc.byline:
+            print(f"Autor  : {doc.byline}")
 
         segments = _load_segments(getattr(doc, "text_raw", "") or "")
         if segments:

--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -391,7 +391,7 @@ def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -
     photo_source_penalty = min(15, sum(photo_source_penalty_details.values()))
     if photo_source_penalty:
         penalties["photo_sources"] = photo_source_penalty
-    if not (getattr(doc, "author", None) or "").strip():
+    if not (getattr(doc, "byline", None) or "").strip():
         penalties["missing_author"] = 10
     if noise_share > 0:
         penalties["noise_share"] = min(20, round(noise_share * 50))

--- a/backend/library/author_biography.py
+++ b/backend/library/author_biography.py
@@ -112,7 +112,7 @@ def process_author_biography(session, doc, excerpt: str, model: str) -> dict:
     """Attach an author biography to its person and evaluate it with the LLM."""
     from library.person_registry import find_by_alias
 
-    author = (doc.author or "").strip()
+    author = (doc.byline or "").strip()
     person = find_by_alias(session, author)
     if person is None:
         person = Person(canonical_name=author)

--- a/backend/library/author_service.py
+++ b/backend/library/author_service.py
@@ -1,6 +1,6 @@
 """Structured document authorship — document_persons links with role="author".
 
-web_documents.author stays the comma-separated display cache; the source of
+web_documents.byline stays the comma-separated display cache; the source of
 truth for "who wrote this" is document_persons (role="author"), one row per
 co-author, resolved through the person registry so the same journalist links
 to one Person row across documents. Portal journalists usually have no
@@ -59,10 +59,11 @@ def split_author_names(raw: str) -> list[str]:
     return names
 
 
-def set_document_authors(session, doc, names: list[str], source: str) -> list[dict]:
-    """Set the document's authors: display cache + document_persons links.
+def set_document_authors(session, doc, names: list[str], method: str) -> list[dict]:
+    """Set the document's authors: display cache (byline) + document_persons links.
 
-    source: "manual" (reviewer typed the byline) or "llm" (byline extraction).
+    method: "manual" (reviewer typed the byline), "llm" (byline extraction)
+    or "html" (deterministic metadata extraction).
     Queues changes on the session without committing (caller owns the
     transaction). Returns the author list in get_document_authors() shape.
 
@@ -72,8 +73,8 @@ def set_document_authors(session, doc, names: list[str], source: str) -> list[di
     by the deletion are removed from the registry.
     """
     names = [n.strip() for n in names if n and n.strip()]
-    doc.author = ", ".join(names) or None
-    doc.author_source = source if names else None
+    doc.byline = ", ".join(names) or None
+    doc.byline_method = method if names else None
 
     existing = session.execute(
         select(DocumentPerson).where(
@@ -90,9 +91,9 @@ def set_document_authors(session, doc, names: list[str], source: str) -> list[di
             person = Person(canonical_name=name)
             session.add(person)
             session.flush()
-            confidence = CONFIDENCE_MANUAL_CONFIRMED if source == "manual" else CONFIDENCE_MANUAL_REVIEW
+            confidence = CONFIDENCE_MANUAL_CONFIRMED if method == "manual" else CONFIDENCE_MANUAL_REVIEW
         else:
-            confidence = CONFIDENCE_MANUAL_CONFIRMED if source == "manual" else CONFIDENCE_ALIAS
+            confidence = CONFIDENCE_MANUAL_CONFIRMED if method == "manual" else CONFIDENCE_ALIAS
         kept_person_ids.add(person.id)
 
         link = existing_by_person.get(person.id) or session.execute(
@@ -111,7 +112,7 @@ def set_document_authors(session, doc, names: list[str], source: str) -> list[di
             # confirmation upgrades confidence; never downgrade an existing
             # manual_confirmed/wikidata_matched link to manual_review.
             link.role = "author"
-            if source == "manual":
+            if method == "manual":
                 link.confidence = CONFIDENCE_MANUAL_CONFIRMED
 
     for link in existing:

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1260,8 +1260,8 @@ def get_run_chunks(run_id: int):
             "url": doc.url if doc else "",
             "original_id": doc.original_id if doc else "",
             "document_type": doc.document_type if doc else "",
-            "author": getattr(doc, "author", "") if doc else "",
-            "author_source": getattr(doc, "author_source", None) if doc else None,
+            "byline": getattr(doc, "byline", "") if doc else "",
+            "byline_method": getattr(doc, "byline_method", None) if doc else None,
             "author_persons": author_persons,
             "countries": doc_countries,
             "thematic_tags": doc_thematic_tags,
@@ -1605,7 +1605,7 @@ def extract_author(run_id: int):
     chunk containing the byline the reviewer identified. Without chunk_ids,
     uses the head+tail of the whole document's text (a byline can appear at
     the start or the end of an article). Saves the result directly to the
-    document's author field, always overwriting any existing value — this is
+    document's byline field, always overwriting any existing value — this is
     a reviewer-triggered manual action, unlike the automatic pipeline step in
     document_analysis_service.create_run() which never overwrites.
     """
@@ -1655,13 +1655,13 @@ def extract_author(run_id: int):
         return jsonify({"status": "error", "message": "LLM call failed"}), 500
 
     if not author_names:
-        return jsonify({"status": "success", "author": None})
+        return jsonify({"status": "success", "byline": None})
 
     doc = session.get(WebDocument, run.document_id)
     if doc is None:
         abort(404, f"Document {run.document_id} not found")
     from library.author_service import set_document_authors
-    author_persons = set_document_authors(session, doc, author_names, source="llm")
+    author_persons = set_document_authors(session, doc, author_names, method="llm")
     try:
         session.commit()
     except Exception:
@@ -1671,8 +1671,8 @@ def extract_author(run_id: int):
 
     return jsonify({
         "status": "success",
-        "author": doc.author,
-        "author_source": doc.author_source,
+        "byline": doc.byline,
+        "byline_method": doc.byline_method,
         "author_persons": author_persons,
     })
 
@@ -1807,12 +1807,12 @@ def set_published_on(doc_id: int):
 
 
 # ---------------------------------------------------------------------------
-# API: POST /document/<doc_id>/author
+# API: POST /document/<doc_id>/byline
 # ---------------------------------------------------------------------------
 
-@bp.route("/document/<int:doc_id>/author", methods=["POST"])
-def set_author(doc_id: int):
-    """Manually set (or clear) the document's author(s).
+@bp.route("/document/<int:doc_id>/byline", methods=["POST"])
+def set_byline(doc_id: int):
+    """Manually set (or clear) the document's author(s) (byline).
 
     Companion to extract_author above — the reviewer pastes the byline from
     the original page instead of asking the LLM. Accepts co-authors in one
@@ -1828,24 +1828,24 @@ def set_author(doc_id: int):
         abort(404, f"Document {doc_id} not found")
 
     data = request.get_json(silent=True) or {}
-    author_str = data.get("author")
+    author_str = data.get("byline")
     if author_str is not None and not isinstance(author_str, str):
-        return jsonify({"status": "error", "message": "author must be a string or null"}), 400
+        return jsonify({"status": "error", "message": "byline must be a string or null"}), 400
 
     names = split_author_names(author_str or "")
-    author_persons = set_document_authors(session, doc, names, source="manual")
+    author_persons = set_document_authors(session, doc, names, method="manual")
 
     try:
         session.commit()
     except Exception:
         session.rollback()
-        logger.exception("DB save failed for document %d author", doc_id)
+        logger.exception("DB save failed for document %d byline", doc_id)
         return jsonify({"status": "error", "message": "DB save failed"}), 500
 
     return jsonify({
         "status": "success",
-        "author": doc.author,
-        "author_source": doc.author_source,
+        "byline": doc.byline,
+        "byline_method": doc.byline_method,
         "author_persons": author_persons,
     })
 

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -276,12 +276,13 @@ class WebDocument(Base):
     # Content creator: YouTube channel name, article author, etc. — metadata about who made it.
     # Multiple authors are stored comma-separated; the structured links live in
     # document_persons (role="author"), this column is the display cache.
-    author: Mapped[str | None] = mapped_column(Text)
-    # How author was set — "manual" (reviewer typed it on /chunks) or "llm"
-    # (extract_author / pipeline step 11b2). NULL for legacy/import-set values.
+    byline: Mapped[str | None] = mapped_column(Text)
+    # How byline was set — "manual" (reviewer typed it on /chunks), "llm"
+    # (extract_author / pipeline step 11b2) or "html" (deterministic metadata
+    # extraction). NULL for legacy/import-set values.
     # Mirrors published_on_method: lets a future pass find documents where the
     # byline extraction failed and a human had to fix it.
-    author_source: Mapped[str | None] = mapped_column(String(10))
+    byline_method: Mapped[str | None] = mapped_column(String(10))
     note: Mapped[str | None] = mapped_column(Text)
     uuid: Mapped[str] = mapped_column(
         String(100), nullable=False, unique=True,
@@ -473,8 +474,8 @@ class WebDocument(Base):
             "text_raw": self.text_raw,
             "transcript_job_id": self.transcript_job_id,
             "ai_summary_needed": self.ai_summary_needed,
-            "author": self.author,
-            "author_source": self.author_source,
+            "byline": self.byline,
+            "byline_method": self.byline_method,
             "note": self.note,
             "uuid": self.uuid,
             "project": self.project,

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -488,7 +488,7 @@ class DocumentAnalysisService:
                 log(f'scope: chapter {scope_chapter} "{scope}" ({len(text):,} chars)')
             from library.author_biography import extract_trailing_author_biography
 
-            article_body, author_bio = extract_trailing_author_biography(text, getattr(doc, "author", None))
+            article_body, author_bio = extract_trailing_author_biography(text, getattr(doc, "byline", None))
             preclean_meta: list[tuple[str, str | None]] = []
             if preclean:
                 log("preclean: detecting ads and noisy line ranges before final split...")
@@ -625,17 +625,17 @@ class DocumentAnalysisService:
 
             # 11b2. Article author fallback (LLM) — article_metadata.extract_article_author()
             #       (deterministic, WP.pl only) already ran at import time; this is a
-            #       fallback for everything else. Never overwrites an existing doc.author
+            #       fallback for everything else. Never overwrites an existing doc.byline
             #       (deterministic or manually entered). Whole-document runs only — a
             #       single chapter excerpt is not a reliable place to look for a byline.
-            if not is_transcript and scope is None and not (getattr(doc, "author", None) or "").strip():
+            if not is_transcript and scope is None and not (getattr(doc, "byline", None) or "").strip():
                 try:
                     from library.author_service import set_document_authors
                     from library.chunk_llm_analysis import extract_author_info, head_tail_excerpt
 
                     author_names = extract_author_info(head_tail_excerpt(text), model)
                     if author_names:
-                        set_document_authors(self.session, doc, author_names, source="llm")
+                        set_document_authors(self.session, doc, author_names, method="llm")
                         log(f"author detected: {', '.join(author_names)}")
                 except Exception:
                     logger.exception("author extraction failed, continuing without author")

--- a/backend/library/document_service.py
+++ b/backend/library/document_service.py
@@ -160,7 +160,7 @@ class DocumentService:
         from library.article_metadata import extract_article_authors
         from library.author_service import set_document_authors
 
-        set_document_authors(self.session, doc, extract_article_authors(html, url), source="html")
+        set_document_authors(self.session, doc, extract_article_authors(html, url), method="html")
         self.session.commit()
         return doc
 
@@ -174,7 +174,7 @@ class DocumentService:
     ) -> WebDocument:
         """Look up or create a document, apply attribute updates, and commit.
 
-        Accepted keyword attrs: text, title, language, tags, summary, source, author, note.
+        Accepted keyword attrs: text, title, language, tags, summary, source, byline, note.
         Raises ValueError for invalid document_type.
         Returns the saved WebDocument.
         """
@@ -193,7 +193,7 @@ class DocumentService:
         if document_state is not None:
             doc.set_document_state(document_state)
 
-        for attr in ("text", "title", "language", "tags", "summary", "source", "author", "note"):
+        for attr in ("text", "title", "language", "tags", "summary", "source", "byline", "note"):
             value = attrs.get(attr)
             if value is not None:
                 setattr(doc, attr, value)

--- a/backend/library/entity_service.py
+++ b/backend/library/entity_service.py
@@ -104,7 +104,7 @@ def refresh_document_entities(session, document_id: int, text: str) -> list[Docu
 
     exclusions = list(session.execute(select(NerExclusion)).scalars().all())
     if exclusions:
-        author = getattr(doc, "author", None)
+        author = getattr(doc, "byline", None)
         excluded = [
             key
             for key, group in groups.items()

--- a/backend/library/search/sql_filters.py
+++ b/backend/library/search/sql_filters.py
@@ -122,7 +122,7 @@ def _author_match(name: str) -> ColumnElement[bool]:
             ),
         )
     )
-    legacy_byline = func.unaccent(func.lower(func.coalesce(WebDocument.author, ""))).ilike(
+    legacy_byline = func.unaccent(func.lower(func.coalesce(WebDocument.byline, ""))).ilike(
         func.unaccent(f"%{folded}%"),
     )
     return or_(exists(matching_link), and_(~exists(author_links), legacy_byline))

--- a/backend/library/stalker_web_documents_db_postgresql.py
+++ b/backend/library/stalker_web_documents_db_postgresql.py
@@ -32,7 +32,7 @@ class WebsitesDBPostgreSQL:
             stmt = select(
                 WebDocument.id, WebDocument.url, WebDocument.title, WebDocument.document_type,
                 WebDocument.created_at, WebDocument.document_state, WebDocument.document_state_error,
-                WebDocument.note, WebDocument.project, WebDocument.uuid, WebDocument.author,
+                WebDocument.note, WebDocument.project, WebDocument.uuid, WebDocument.byline,
                 WebDocument.obsidian_note_paths,
             )
 
@@ -102,7 +102,7 @@ class WebsitesDBPostgreSQL:
                 "note": row.note,
                 "project": row.project,
                 "uuid": row.uuid,
-                "author": row.author,
+                "byline": row.byline,
                 "obsidian_note_paths": row.obsidian_note_paths or [],
                 "chunks_missing_obsidian_notes": missing,
                 "chunks_with_obsidian_notes": with_notes,

--- a/backend/library/youtube_processing.py
+++ b/backend/library/youtube_processing.py
@@ -127,7 +127,7 @@ def process_youtube_url(
     if web_document.document_state == StalkerDocumentStatus.URL_ADDED.name and youtube_file.can_pytube:
         logger.info("Updating document metadata from YouTube")
         web_document.title = youtube_file.title
-        web_document.author = youtube_file.author
+        web_document.byline = youtube_file.author
         web_document.url = youtube_file.url
         web_document.original_id = youtube_file.video_id
         web_document.text = youtube_file.text

--- a/backend/server.py
+++ b/backend/server.py
@@ -1245,7 +1245,7 @@ def ner_exclusions_add():
         doc = WebDocument.get_by_id(session, doc_id)
         if doc is None:
             return {"status": "error", "message": "Document not found"}, 404
-        author = (doc.author or "").strip() or None
+        author = (doc.byline or "").strip() or None
         if author is None:
             return {"status": "error", "message": "Document has no author to scope the exclusion to"}, 400
 
@@ -1545,7 +1545,7 @@ def website_save():
 
     link_id = request.form.get('id')
     attrs = {}
-    for attr in ('text', 'title', 'language', 'tags', 'summary', 'source', 'author', 'note'):
+    for attr in ('text', 'title', 'language', 'tags', 'summary', 'source', 'byline', 'note'):
         value = request.form.get(attr)
         if value is not None:
             attrs[attr] = value

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -33,7 +33,7 @@ LONG_PARAGRAPH = (
 
 class _Doc:
     def __init__(self, author=None, title=None, url=None):
-        self.author = author
+        self.byline = author
         self.title = title
         self.url = url
 

--- a/backend/tests/unit/test_author_biography.py
+++ b/backend/tests/unit/test_author_biography.py
@@ -76,7 +76,7 @@ def test_first_biography_fills_empty_person_description():
     )
     session = MagicMock()
     session.execute.return_value.scalars.return_value.first.return_value = link
-    doc = SimpleNamespace(id=9245, author="Jacek Losik")
+    doc = SimpleNamespace(id=9245, byline="Jacek Losik")
     result = {"decision": "auto_applied", "proposed_description": "Polski dziennikarz."}
 
     with patch("library.person_registry.find_by_alias", return_value=person), \
@@ -99,7 +99,7 @@ def test_new_information_is_queued_without_overwriting_description():
     )
     session = MagicMock()
     session.execute.return_value.scalars.return_value.first.return_value = link
-    doc = SimpleNamespace(id=9245, author="Jacek Losik")
+    doc = SimpleNamespace(id=9245, byline="Jacek Losik")
     result = {
         "decision": "new_information",
         "proposed_description": "Dziennikarz money.pl specjalizujący się w transporcie.",

--- a/backend/tests/unit/test_author_service.py
+++ b/backend/tests/unit/test_author_service.py
@@ -69,10 +69,10 @@ class TestSetDocumentAuthors:
 
         with patch.object(auth_svc, "find_by_alias", return_value=None), \
                 patch.object(auth_svc, "get_document_authors", return_value=[]):
-            set_document_authors(session, doc, ["Michał Rogalski", "Piotr Gruszka"], source="manual")
+            set_document_authors(session, doc, ["Michał Rogalski", "Piotr Gruszka"], method="manual")
 
-        assert doc.author == "Michał Rogalski, Piotr Gruszka"
-        assert doc.author_source == "manual"
+        assert doc.byline == "Michał Rogalski, Piotr Gruszka"
+        assert doc.byline_method == "manual"
         added = [c.args[0] for c in session.add.call_args_list]
         persons = [a for a in added if isinstance(a, Person)]
         links = [a for a in added if isinstance(a, DocumentPerson)]
@@ -86,9 +86,9 @@ class TestSetDocumentAuthors:
 
         with patch.object(auth_svc, "find_by_alias", return_value=None), \
                 patch.object(auth_svc, "get_document_authors", return_value=[]):
-            set_document_authors(session, doc, ["Weronika Jaworska"], source="llm")
+            set_document_authors(session, doc, ["Weronika Jaworska"], method="llm")
 
-        assert doc.author_source == "llm"
+        assert doc.byline_method == "llm"
         links = [c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], DocumentPerson)]
         assert len(links) == 1
         assert links[0].confidence == "manual_review"
@@ -101,7 +101,7 @@ class TestSetDocumentAuthors:
 
         with patch.object(auth_svc, "find_by_alias", return_value=known), \
                 patch.object(auth_svc, "get_document_authors", return_value=[]):
-            set_document_authors(session, doc, ["Jacek Losik"], source="llm")
+            set_document_authors(session, doc, ["Jacek Losik"], method="llm")
 
         links = [c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], DocumentPerson)]
         assert len(links) == 1
@@ -117,7 +117,7 @@ class TestSetDocumentAuthors:
         with patch.object(auth_svc, "find_by_alias", return_value=None), \
                 patch.object(auth_svc, "get_document_authors", return_value=[]), \
                 patch.object(auth_svc, "_delete_person_if_orphaned") as orphan:
-            set_document_authors(session, doc, ["Nowy Autor"], source="manual")
+            set_document_authors(session, doc, ["Nowy Autor"], method="manual")
 
         session.delete.assert_called_once_with(stale)
         orphan.assert_called_once_with(session, 99)
@@ -140,7 +140,7 @@ class TestSetDocumentAuthors:
 
         with patch.object(auth_svc, "find_by_alias", return_value=known), \
                 patch.object(auth_svc, "get_document_authors", return_value=[]):
-            set_document_authors(session, doc, ["Donald Tusk"], source="llm")
+            set_document_authors(session, doc, ["Donald Tusk"], method="llm")
 
         assert mentioned_link.role == "author"
         # LLM extraction must not downgrade an existing confidence
@@ -155,10 +155,10 @@ class TestSetDocumentAuthors:
 
         with patch.object(auth_svc, "get_document_authors", return_value=[]), \
                 patch.object(auth_svc, "_delete_person_if_orphaned"):
-            set_document_authors(session, doc, [], source="manual")
+            set_document_authors(session, doc, [], method="manual")
 
-        assert doc.author is None
-        assert doc.author_source is None
+        assert doc.byline is None
+        assert doc.byline_method is None
         session.delete.assert_called_once_with(stale)
 
 

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -158,7 +158,7 @@ class TestWebDocumentColumns:
         "source", "publisher_id", "published_on", "published_on_method", "original_id", "document_length",
         "chapter_list", "document_state", "document_state_error",
         "text_raw", "transcript_job_id", "ai_summary_needed",
-        "author", "author_source", "note", "uuid", "project", "text_md",
+        "byline", "byline_method", "note", "uuid", "project", "text_md",
         "text_extracted", "transcript_needed", "reviewed_at",
         "obsidian_note_paths", "video_description", "ner_unavailable_at",
         "quality",
@@ -242,7 +242,7 @@ class TestWebDocumentColumnTypes:
         text_columns = [
             "summary", "tags", "text", "title", "text_raw",
             "text_md", "text_extracted", "chapter_list", "source",
-            "original_id", "transcript_job_id", "author", "note",
+            "original_id", "transcript_job_id", "byline", "note",
         ]
         for name in text_columns:
             col = _get_column(WebDocument, name)
@@ -519,7 +519,7 @@ class TestDict:
             "created_at", "document_type", "source", "published_on", "published_on_method", "original_id",
             "document_length", "chapter_list", "document_state",
             "document_state_error", "text_raw", "transcript_job_id",
-            "ai_summary_needed", "author", "author_source", "note", "uuid", "project",
+            "ai_summary_needed", "byline", "byline_method", "note", "uuid", "project",
             "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
             "quality",

--- a/backend/tests/unit/test_entity_service.py
+++ b/backend/tests/unit/test_entity_service.py
@@ -21,7 +21,7 @@ RAW = [
 def _session_with_exclusions(exclusions):
     session = MagicMock()
     session.execute.return_value.scalars.return_value.all.return_value = exclusions
-    session.get.return_value = MagicMock(author=None)
+    session.get.return_value = MagicMock(byline=None)
     return session
 
 
@@ -105,13 +105,13 @@ class TestRefreshDocumentEntities:
         exclusions = [NerExclusion(entity_text="Tusk", entity_type="*", scope="author",
                                    author="Good Times Bad Times")]
         session = _session_with_exclusions(exclusions)
-        session.get.return_value = MagicMock(author="Good Times Bad Times")
+        session.get.return_value = MagicMock(byline="Good Times Bad Times")
         with patch("library.entity_service.extract_entities", return_value=RAW):
             rows = refresh_document_entities(session, 42, "jakiś tekst")
         assert {r.entity_text for r in rows} == {"cieśnina Ormuz"}
 
         session2 = _session_with_exclusions(exclusions)
-        session2.get.return_value = MagicMock(author="Inny Kanał")
+        session2.get.return_value = MagicMock(byline="Inny Kanał")
         with patch("library.entity_service.extract_entities", return_value=RAW):
             rows2 = refresh_document_entities(session2, 42, "jakiś tekst")
         assert {r.entity_text for r in rows2} == {"Tusk", "cieśnina Ormuz"}

--- a/backend/tests/unit/test_flask_endpoints_orm.py
+++ b/backend/tests/unit/test_flask_endpoints_orm.py
@@ -116,7 +116,7 @@ class TestWebsiteGet:
             "original_id": None, "document_length": None, "chapter_list": None,
             "document_state": "URL_ADDED", "document_state_error": "NONE",
             "text_raw": None, "transcript_job_id": None, "ai_summary_needed": False,
-            "author": None, "note": None, "uuid": None, "project": None,
+            "byline": None, "note": None, "uuid": None, "project": None,
             "text_md": None, "transcript_needed": False,
         }
         mock_session = MagicMock()

--- a/backend/tests/unit/test_orm_crud.py
+++ b/backend/tests/unit/test_orm_crud.py
@@ -229,7 +229,7 @@ class TestCreateFlow:
         doc.text_raw = "Raw text"
         doc.transcript_job_id = "job-abc"
         doc.ai_summary_needed = True
-        doc.author = "Author Name"
+        doc.byline = "Author Name"
         doc.note = "A note"
         doc.uuid = "uuid-123"
         doc.project = "lenie"
@@ -259,7 +259,7 @@ class TestCreateFlow:
         assert d["text_raw"] == "Raw text"
         assert d["transcript_job_id"] == "job-abc"
         assert d["ai_summary_needed"] is True
-        assert d["author"] == "Author Name"
+        assert d["byline"] == "Author Name"
         assert d["note"] == "A note"
         assert d["uuid"] == "uuid-123"
         assert d["project"] == "lenie"
@@ -426,8 +426,8 @@ class TestDictCompatibility:
             "summary", "url", "language", "tags", "text", "paywall", "title",
             "created_at", "document_type", "source", "published_on", "published_on_method", "original_id",
             "document_length", "chapter_list", "document_state", "document_state_error",
-            "text_raw", "transcript_job_id", "ai_summary_needed", "author",
-            "author_source", "note", "uuid", "project", "text_md", "transcript_needed",
+            "text_raw", "transcript_job_id", "ai_summary_needed", "byline",
+            "byline_method", "note", "uuid", "project", "text_md", "transcript_needed",
             "reviewed_at", "obsidian_note_paths", "video_description",
             "quality",
         }
@@ -461,7 +461,7 @@ class TestDictCompatibility:
             text_raw="Raw",
             transcript_job_id="j1",
             ai_summary_needed=False,
-            author="Auth",
+            byline="Auth",
             note="Note",
             uuid="s3-1",
             project="lenie",

--- a/backend/tests/unit/test_repository_queries.py
+++ b/backend/tests/unit/test_repository_queries.py
@@ -78,7 +78,7 @@ class TestGetList:
         mock_row.note = "note"
         mock_row.project = "lenie"
         mock_row.uuid = "uuid-1"
-        mock_row.author = None
+        mock_row.byline = None
         mock_row.obsidian_note_paths = None
 
         list_result = MagicMock(all=MagicMock(return_value=[mock_row]))

--- a/backend/tests/unit/test_search_sql_filters.py
+++ b/backend/tests/unit/test_search_sql_filters.py
@@ -129,7 +129,7 @@ class TestAuthorAndDiscoverySourceFilters:
     def test_author_fallback_uses_byline_only_without_structured_author(self):
         sql = compiled(build_document_filters(SearchFilters(author_name="Jan Kowalski"))[0])
         assert "NOT (EXISTS" in sql
-        assert "web_documents.author" in sql
+        assert "web_documents.byline" in sql
         assert "LIKE" in sql
 
     def test_discovery_source_uses_sources_not_information_sources(self):

--- a/docs/api-type-sync-strategy.md
+++ b/docs/api-type-sync-strategy.md
@@ -72,7 +72,7 @@ class WebDocumentResponse(BaseModel):
     id: int
     url: str
     title: str | None = None
-    author: str | None = None
+    byline: str | None = None
     source: str | None = None
     language: str | None = None
     tags: str | None = None

--- a/docs/data-models-backend.md
+++ b/docs/data-models-backend.md
@@ -26,7 +26,7 @@ Primary document storage table.
 | `language` | varchar(10) | — | Detected language code |
 | `tags` | text | — | Comma-separated tags |
 | `source` | text | — | How the user discovered this content (e.g. "own", "unknow.news", "friend") — used to evaluate recommendation quality |
-| `author` | text | — | Content creator (YouTube channel name, article author) — metadata about who made the content |
+| `byline` | text | — | Content creator display cache (YouTube channel name, article author) — metadata about who made the content; structured links in `document_persons` (role=`author`) |
 | `note` | text | — | User notes |
 | `paywall` | boolean | DEFAULT false | Paywall indicator |
 | `published_on` | date | — | Publication date |

--- a/docs/search-rebuild-etap11-inwentaryzacja.md
+++ b/docs/search-rebuild-etap11-inwentaryzacja.md
@@ -157,7 +157,7 @@ obu frontendach, wtyczce i większości backendu). Zmierzyć przed właściwą s
 ## Rekomendowana kolejność sesji Etapu 11
 
 1. **11a**: `date_from`→`published_on` + `date_from_source`→`published_on_method` — **WYKONANE w tej samej sesji** (migracja `a2b3c4d5e6f7`, wdrożone na NAS; szczegóły we wpisie 2026-07-19 w [dzienniku](search-rebuild-progress.md)).
-2. **11b**: `author`→`byline` + `author_source`→`byline_method` (+ decyzja ner_exclusions).
+2. **11b**: `author`→`byline` + `author_source`→`byline_method` — **WYKONANE** (migracja `b3c4d5e6f7a8`, wdrożone na NAS; `ner_exclusions.author` zostaje bez zmian — osobna tabela z własnym kontraktem).
 3. **11c**: `project`→`collection_id` (nowa tabela `collections`, kolumna pusta = niskie ryzyko).
 4. **11d**: `source`→`discovery_source_id` (migracja danych + wtyczka Chrome + API /sources).
 5. **11e**: `websites_embeddings`→`document_embeddings` + `website_id`→`document_id`.

--- a/docs/search-rebuild-implementation-plan.md
+++ b/docs/search-rebuild-implementation-plan.md
@@ -51,8 +51,8 @@ Backend wykonuje deterministyczne zapytania SQL i pgvector. Frontend pokazuje, j
 | `sources` | `discovery_sources` | tabela słownikowa |
 | `date_from` | `published_on` | data publikacji — **zrobione fizycznie (Etap 11a, migracja `a2b3c4d5e6f7`)** |
 | `date_from_source` | `published_on_method` | manual/html/llm/import/url — **zrobione fizycznie (Etap 11a)**; dopuszczalne wartości na razie bez zmian (manual/llm) |
-| `author` | `byline` | tekst prezentacyjny; autorzy relacyjnie w `document_persons` |
-| `author_source` | `byline_method` | sposób ustalenia byline |
+| `author` | `byline` | tekst prezentacyjny; autorzy relacyjnie w `document_persons` — **zrobione fizycznie (Etap 11b, migracja `b3c4d5e6f7a8`)** |
+| `author_source` | `byline_method` | sposób ustalenia byline (manual/llm/html) — **zrobione fizycznie (Etap 11b)** |
 | `project` | `collection_id` | kolekcja tematyczna |
 | `created_at` dokumentu | `ingested_at` | data dodania do Lenie |
 | `uuid` | `public_id` | publiczny stabilny identyfikator |

--- a/docs/search-rebuild-progress.md
+++ b/docs/search-rebuild-progress.md
@@ -5,6 +5,45 @@ Nowe wpisy dopisywać NA GÓRZE.
 
 ---
 
+## 2026-07-19 — Etap 11, sesja B (rename `author`→`byline`) — UKOŃCZONA
+
+**Zakres wykonany:** drugi fizyczny rename podetapu 1: `author`→`byline`,
+`author_source`→`byline_method` — migracja Alembic `b3c4d5e6f7a8` (rename kolumn + constraintu
+`ck_web_documents_byline_method`; bez indeksu — kolumna go nie miała). Backend: ORM,
+`author_service.set_document_authors()` (parametr `source=` przemianowany na `method=` —
+usunięcie niejednoznacznego „source"; wartości manual/llm/html bez zmian), repozytorium,
+`sql_filters` (fallback byline), `article_quality`, `author_biography`, `entity_service`
+(odczyt byline dla wykluczeń o zasięgu autora), importy (dynamodb_sync, youtube_backfill_author,
+article_browser, youtube_batch_analyze, refresh_entities, email_import, youtube_processing).
+**API**: `POST /document/<id>/byline` (dawniej `.../author`), klucze JSON `byline`/`byline_method`
+w `/website_list`, `/website_get`, `/chunks`, `extract_author`; pole formularza `/website_save`
+to teraz `byline`. Klienci: `shared/types/documents.ts` (`WebDocument.byline`), React
+(`sharedInputs`, `useManageLLM`, `list`, `chunks`, initial values 5 editorów), **app2**
+(`sharedInputs.jsx`, `Links` — wbrew wcześniejszemu pomiarowi app2 MA pole author), Lambda
+`app-server-db` (dla spójności, niedeployowana). Wtyczka Chrome nie wysyła author — bez zmian.
+**NIE ruszone** (świadomie): `document_persons.role='author'`, `ner_exclusions.author` i jej
+API, `information_sources`, klucz `author` w promptach/odpowiedziach LLM
+(`article_extractor`/`chunk_llm_analysis`), `author_persons` w API, atrybut `stalker_youtube_file.author`
+(metadane pytubefix).
+
+**Testy uruchomione:** `tests/unit/` **1830 passed** (przed i po); ruff czysty; Vitest 11 passed;
+`npm run build` czysty (React i app2). Migracja na NAS: upgrade → psql (kolumny+constraint
+przemianowane, 538 dokumentów z byline) → downgrade → upgrade → head `b3c4d5e6f7a8`. Deploy
+backend+frontend+app2 na NAS od razu po migracji. E2E (tymczasowy klucz serwisowy, usunięty):
+`/website_list` zwraca `byline` (realne dane), `POST /document/8614/byline` set→clear z pełnym
+przywróceniem stanu (łącznie z usunięciem osieroconego rekordu `persons`), `/search` z filtrem
+`author_name` (ścieżka fallbacku byline w SQL) zwraca 1 wynik.
+
+**Otwarte ryzyka:** wartość `html` w `byline_method` jest zapisywana przez sync/refresh, ale
+CHECK constraint (przemianowany 1:1) dopuszcza manual/llm/html już od PR #247+ — bez zmian
+semantyki. Reszta ryzyk jak w sesji A (rozjazd init SQL vs Alembic).
+
+**PR/merge:** PR #305, branch `feat/search-etap-11b-byline`.
+
+**Następny krok:** Etap 11, sesja C — `project`→`collection_id` (nowa tabela `collections`,
+kolumna w 100% pusta = niskie ryzyko danych) albo od razu 11d (`source`→`discovery_source_id`,
+większa: migracja danych name→id + API `/sources` + wtyczka Chrome).
+
 ## 2026-07-19 — Etap 11, sesja A (inwentaryzacja + rename `date_from`→`published_on`) — UKOŃCZONA
 
 **Zakres wykonany:** (1) Pełna inwentaryzacja wszystkich rename'ów Etapu 11 w

--- a/infra/aws/serverless/lambdas/app-server-db/lambda_function.py
+++ b/infra/aws/serverless/lambdas/app-server-db/lambda_function.py
@@ -298,8 +298,8 @@ def lambda_handler(event, _):
         if 'source' in parsed_dict.keys():
             web_document.source = parsed_dict['source'][0]
 
-        if 'author' in parsed_dict.keys():
-            web_document.author = parsed_dict['author'][0]
+        if 'byline' in parsed_dict.keys():
+            web_document.byline = parsed_dict['byline'][0]
 
         if 'note' in parsed_dict.keys():
             web_document.note = parsed_dict['note'][0]

--- a/shared/types/documents.ts
+++ b/shared/types/documents.ts
@@ -1,6 +1,6 @@
 export interface WebDocument {
   id: string;
-  author: string;
+  byline: string;
   source: string;
   language: string;
   url: string;
@@ -22,7 +22,7 @@ export interface WebDocument {
 
 export const emptyDocument: WebDocument = {
   id: "",
-  author: "",
+  byline: "",
   source: "",
   language: "",
   url: "",

--- a/web_interface_app2/src/Common/sharedInputs.jsx
+++ b/web_interface_app2/src/Common/sharedInputs.jsx
@@ -13,11 +13,11 @@ const SharedInputs = ({
     <>
       <Input
         disabled={isLoading}
-        value={formik.values.author}
+        value={formik.values.byline}
         label={"Author"}
         onChange={formik.handleChange}
-        id={"author"}
-        name={"author"}
+        id={"byline"}
+        name={"byline"}
         type={"text"}
       />
       <div className="flexBox">

--- a/web_interface_app2/src/pages/Documents/Links/index.tsx
+++ b/web_interface_app2/src/pages/Documents/Links/index.tsx
@@ -24,7 +24,7 @@ const LenieLink = () => {
     const formik = useFormik({
         initialValues: {
             id: "",
-            author: "",
+            byline: "",
             source: "",
             language: "",
             url: "",

--- a/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
@@ -135,9 +135,9 @@ const AuthorExtractButton = ({
         return;
       }
       const res = await axios.post(`${apiUrl}/analysis_run/${runs[0].id}/extract_author`, {}, { headers });
-      if (res.data.author) {
-        formik.setFieldValue("author", res.data.author);
-        setStatus(`Ustawiono autora: ${res.data.author}`);
+      if (res.data.byline) {
+        formik.setFieldValue("byline", res.data.byline);
+        setStatus(`Ustawiono autora: ${res.data.byline}`);
       } else {
         setStatus("Nie udało się rozpoznać autora.");
       }
@@ -190,11 +190,11 @@ const SharedInputs = ({
         <div className="flex-grow">
           <Input
             disabled={isLoading}
-            value={formik.values.author}
+            value={formik.values.byline}
             label={"Author"}
             onChange={formik.handleChange}
-            id={"author"}
-            name={"author"}
+            id={"byline"}
+            name={"byline"}
             type={"text"}
           />
         </div>

--- a/web_interface_react/src/modules/shared/hooks/useManageLLM.ts
+++ b/web_interface_react/src/modules/shared/hooks/useManageLLM.ts
@@ -160,7 +160,7 @@ export const useManageLLM = ({ formik, selectedDocumentType, selectedDocumentSta
           document_type: website.document_type,
           document_state: website.document_state,
           chapter_list: website.chapter_list,
-          author: website.author,
+          byline: website.byline,
           note: website.note,
         },
         {
@@ -216,7 +216,7 @@ export const useManageLLM = ({ formik, selectedDocumentType, selectedDocumentSta
           document_type: website.document_type,
           document_state: "READY_FOR_EMBEDDING",
           chapter_list: website.chapter_list,
-          author: website.author,
+          byline: website.byline,
           note: website.note,
         },
         {

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -666,10 +666,10 @@ const Chunks = () => {
       setVideoId(data.document?.original_id ?? "");
       setDocType(data.document?.document_type ?? "");
       setDocUrl(data.document?.url ?? "");
-      setDocAuthor(data.document?.author ?? "");
-      setDocAuthorSource(data.document?.author_source ?? null);
+      setDocAuthor(data.document?.byline ?? "");
+      setDocAuthorSource(data.document?.byline_method ?? null);
       setAuthorPersons(data.document?.author_persons ?? []);
-      setAuthorInput(data.document?.author ?? "");
+      setAuthorInput(data.document?.byline ?? "");
       setDocPublishedOn(data.document?.published_on ?? null);
       setDocPublishedOnMethod(data.document?.published_on_method ?? null);
       setDateInput(data.document?.published_on ?? "");
@@ -715,8 +715,8 @@ const Chunks = () => {
         if (data.document_type) setDocType(data.document_type);
         if (data.title) setDocTitle(data.title);
         if (data.url) setDocUrl(data.url);
-        if (data.author) { setDocAuthor(data.author); setAuthorInput(data.author); }
-        if (data.author_source) setDocAuthorSource(data.author_source);
+        if (data.byline) { setDocAuthor(data.byline); setAuthorInput(data.byline); }
+        if (data.byline_method) setDocAuthorSource(data.byline_method);
         if (data.published_on) { setDocPublishedOn(data.published_on); setDateInput(data.published_on); }
         if (data.quality) setDocQuality(data.quality);
       } catch { /* analysis can still be configured manually */ }
@@ -1356,11 +1356,11 @@ const Chunks = () => {
 
   // Detect the article author (byline) from one specific chunk. Unlike speaker
   // detection, no position limit — a byline can appear at either the start or
-  // the end of an article. Saves directly to doc.author (backend commits it).
-  const applyAuthorResponse = (data: { author: string; author_source?: string; author_persons?: AuthorPerson[] }) => {
-    setDocAuthor(data.author);
-    setAuthorInput(data.author);
-    setDocAuthorSource(data.author_source ?? "llm");
+  // the end of an article. Saves directly to doc.byline (backend commits it).
+  const applyAuthorResponse = (data: { byline: string; byline_method?: string; author_persons?: AuthorPerson[] }) => {
+    setDocAuthor(data.byline);
+    setAuthorInput(data.byline);
+    setDocAuthorSource(data.byline_method ?? "llm");
     setAuthorPersons(data.author_persons ?? []);
   };
 
@@ -1373,9 +1373,9 @@ const Chunks = () => {
         body: JSON.stringify({ chunk_ids: [chunkId] }),
       });
       const data = await r.json();
-      if (data.status === "success" && data.author) {
+      if (data.status === "success" && data.byline) {
         applyAuthorResponse(data);
-        setInfo(`Ustawiono autora: ${data.author}`);
+        setInfo(`Ustawiono autora: ${data.byline}`);
       }
       else if (data.status === "success") setError("Nie udało się rozpoznać autora w tym chunku");
       else setError("Błąd wykrywania autora: " + (data.message ?? ""));
@@ -1433,13 +1433,13 @@ const Chunks = () => {
     if (!id || !authorInput.trim()) return;
     setSavingAuthor(true);
     try {
-      const r = await fetch(`${apiUrl}/document/${id}/author`, {
-        method: "POST", headers, body: JSON.stringify({ author: authorInput }),
+      const r = await fetch(`${apiUrl}/document/${id}/byline`, {
+        method: "POST", headers, body: JSON.stringify({ byline: authorInput }),
       });
       const data = await r.json();
       if (data.status === "success") {
-        applyAuthorResponse({ ...data, author_source: data.author_source ?? "manual" });
-        setInfo(`Ustawiono autora: ${data.author}`);
+        applyAuthorResponse({ ...data, byline_method: data.byline_method ?? "manual" });
+        setInfo(`Ustawiono autora: ${data.byline}`);
       } else setError("Błąd zapisu autora: " + (data.message ?? ""));
     } catch { setError("Błąd połączenia przy zapisie autora"); }
     finally { setSavingAuthor(false); }
@@ -1456,9 +1456,9 @@ const Chunks = () => {
         method: "POST", headers, body: JSON.stringify({ context_text: contextText }),
       });
       const data = await r.json();
-      if (data.status === "success" && data.author) {
+      if (data.status === "success" && data.byline) {
         applyAuthorResponse(data);
-        setInfo(`Ustawiono autora: ${data.author}. Linię autora możesz teraz oznaczyć × i usunąć.`);
+        setInfo(`Ustawiono autora: ${data.byline}. Linię autora możesz teraz oznaczyć × i usunąć.`);
       } else if (data.status === "success") setError("Nie udało się rozpoznać autora w tym kontekście");
       else setError("Błąd wykrywania autora: " + (data.message ?? ""));
     } catch { setError("Błąd połączenia przy wykrywaniu autora"); }

--- a/web_interface_react/src/modules/shared/pages/email.tsx
+++ b/web_interface_react/src/modules/shared/pages/email.tsx
@@ -20,7 +20,7 @@ const Email = () => {
   const formik: any = useFormik({
     initialValues: {
       id: "",
-      author: "",
+      byline: "",
       source: "",
       language: "",
       url: "",

--- a/web_interface_react/src/modules/shared/pages/link.tsx
+++ b/web_interface_react/src/modules/shared/pages/link.tsx
@@ -19,7 +19,7 @@ const Link = () => {
   const formik: any = useFormik({
     initialValues: {
       id: "",
-      author: "",
+      byline: "",
       source: "",
       language: "",
       url: "",

--- a/web_interface_react/src/modules/shared/pages/list.tsx
+++ b/web_interface_react/src/modules/shared/pages/list.tsx
@@ -192,8 +192,8 @@ const List = () => {
             <div className={"flexBox"}>
               {item.id}&nbsp;&nbsp;|&nbsp;&nbsp;
               {item.title} &nbsp;
-              {item.author && (
-                <span style={{ color: "#6c757d", fontStyle: "italic" }}>({item.author}) </span>
+              {item.byline && (
+                <span style={{ color: "#6c757d", fontStyle: "italic" }}>({item.byline}) </span>
               )}
               <a
                 href={item.url}

--- a/web_interface_react/src/modules/shared/pages/movie.tsx
+++ b/web_interface_react/src/modules/shared/pages/movie.tsx
@@ -20,7 +20,7 @@ const Movie = () => {
   const formik: any = useFormik({
     initialValues: {
       id: "",
-      author: "",
+      byline: "",
       source: "",
       language: "",
       url: "",

--- a/web_interface_react/src/modules/shared/pages/webpage.tsx
+++ b/web_interface_react/src/modules/shared/pages/webpage.tsx
@@ -20,7 +20,7 @@ const Webpage = () => {
   const formik: any = useFormik({
     initialValues: {
       id: "",
-      author: "",
+      byline: "",
       source: "",
       language: "",
       url: "",

--- a/web_interface_react/src/modules/shared/pages/youtube.tsx
+++ b/web_interface_react/src/modules/shared/pages/youtube.tsx
@@ -20,7 +20,7 @@ const Youtube = () => {
   const formik: any = useFormik({
     initialValues: {
       id: "",
-      author: "",
+      byline: "",
       source: "",
       language: "",
       url: "",


### PR DESCRIPTION
## Zakres

Drugi fizyczny rename podetapu 1 Etapu 11 (plan: docs/search-rebuild-implementation-plan.md, sekcja 3/7; inwentaryzacja: docs/search-rebuild-etap11-inwentaryzacja.md).

- Migracja Alembic `b3c4d5e6f7a8` (rename kolumn + CHECK `ck_web_documents_byline_method`); cykl upgrade→downgrade→upgrade przetestowany na bazie NAS, head potwierdzony
- Backend: ORM, `author_service` (parametr `source=` → `method=` — mniej niejednoznacznych „source"), repozytorium, `sql_filters` (fallback byline), quality/biography/entity_service, importy
- **API**: `POST /document/<id>/byline` (dawniej `.../author`), klucze JSON `byline`/`byline_method` w `/website_list`, `/website_get`, `/chunks`, `extract_author`; pole `/website_save` = `byline`
- Klienci: `shared/types` (`WebDocument.byline`), React (sharedInputs, useManageLLM, list, chunks + initial values 5 editorów), app2, Lambda app-server-db (spójność, niedeployowana); wtyczka Chrome nie wysyła author — bez zmian
- **Świadomie NIE ruszone**: `document_persons.role='author'`, `ner_exclusions.author` + jej API, `information_sources`, klucz `author` w kontraktach LLM, `author_persons` w odpowiedziach

## Testy
- `tests/unit/`: 1830 passed (przed i po); ruff czysty; Vitest 11 passed; build React i app2 czyste
- Wdrożone na NAS (backend+frontend+app2) bezpośrednio po migracji; E2E: `/website_list` zwraca `byline` na realnych danych, set/clear `POST /document/8614/byline` z pełnym przywróceniem stanu (łącznie z osieroconym rekordem persons), `/search` z filtrem `author_name` → 1 wynik

🤖 Generated with [Claude Code](https://claude.com/claude-code)