### PR TITLE
Fix regressions from search schema renames

### DIFF
--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -714,7 +714,7 @@ def _get_documents(session, limit: int = 50, since: Optional[str] = None,
     stmt = (
         select(Document.id)
         .where(Document.document_type == "webpage")
-        .order_by(Document.created_at.desc())
+        .order_by(Document.ingested_at.desc())
         .limit(limit)
     )
     if portal:
@@ -724,9 +724,9 @@ def _get_documents(session, limit: int = 50, since: Optional[str] = None,
         stmt = stmt.where(Document.processing_status == state)
     if since:
         since_date = datetime.strptime(since, "%Y-%m-%d")
-        # Dokumenty bez created_at przechodzą filtr (jak w starym filtrowaniu w Pythonie)
-        stmt = stmt.where(or_(Document.created_at.is_(None),
-                              Document.created_at >= since_date))
+        # Dokumenty bez ingested_at przechodzą filtr (jak w starym filtrowaniu w Pythonie)
+        stmt = stmt.where(or_(Document.ingested_at.is_(None),
+                              Document.ingested_at >= since_date))
     if not_reviewed:
         stmt = stmt.where(Document.reviewed_at.is_(None))
     if no_obsidian:

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -174,6 +174,13 @@ class DiscoverySource(Base):
         name = (name or "").strip()
         if not name:
             return None
+        # A SELECT does not find pending instances before an explicit flush
+        # when autoflush is disabled. Reuse one already staged in this unit of
+        # work so two documents with the same new source cannot enqueue
+        # duplicate rows and violate discovery_sources.name at commit time.
+        for pending in session.new:
+            if isinstance(pending, cls) and pending.name == name:
+                return pending
         existing = session.execute(
             select(cls).where(cls.name == name)
         ).scalar_one_or_none()

--- a/backend/scripts/notion_changelog.py
+++ b/backend/scripts/notion_changelog.py
@@ -29,9 +29,9 @@ from library.config_loader import load_config
 def get_recent_documents(conn, limit: int) -> list[dict]:
     """Fetch the most recently added documents from the database."""
     sql = """
-        SELECT id, url, title, document_type, created_at
+        SELECT id, url, title, document_type, ingested_at
         FROM public.documents
-        ORDER BY created_at DESC
+        ORDER BY ingested_at DESC
         LIMIT %s
     """
     with conn.cursor() as cur:
@@ -69,8 +69,8 @@ def build_notion_blocks(documents: list[dict]) -> list[dict]:
         title = doc.get("title") or "(no title)"
         url = doc.get("url") or ""
         created = ""
-        if doc.get("created_at"):
-            created = doc["created_at"].strftime("%Y-%m-%d") if isinstance(doc["created_at"], datetime) else str(doc["created_at"])
+        if doc.get("ingested_at"):
+            created = doc["ingested_at"].strftime("%Y-%m-%d") if isinstance(doc["ingested_at"], datetime) else str(doc["ingested_at"])
 
         url_cell = _rich_text_link(url, url) if url else _rich_text("")
 
@@ -159,7 +159,7 @@ def main():
 
     print(f"\nFetched {len(documents)} document(s):\n")
     for doc in documents:
-        created = doc.get("created_at", "")
+        created = doc.get("ingested_at", "")
         print(f"  [{doc.get('document_type', '?')}] {doc.get('title', '(no title)')} -- {doc.get('url', '')} ({created})")
 
     if args.dry_run:

--- a/backend/tests/unit/test_flask_endpoints_sources_crud.py
+++ b/backend/tests/unit/test_flask_endpoints_sources_crud.py
@@ -151,6 +151,16 @@ class TestDiscoverySourceEnsure:
         assert row.name == "nowe-zrodlo"
         session.add.assert_called_once_with(row)
 
+    def test_reuses_pending_row_before_flush(self):
+        from library.db.models import DiscoverySource
+        pending = DiscoverySource(name="nowe-zrodlo")
+        session = MagicMock()
+        session.new = [pending]
+
+        assert DiscoverySource.ensure(session, "nowe-zrodlo") is pending
+        session.execute.assert_not_called()
+        session.add.assert_not_called()
+
     def test_empty_name_returns_none(self):
         from library.db.models import DiscoverySource
         session = MagicMock()

--- a/slack_bot/client.py
+++ b/slack_bot/client.py
@@ -144,8 +144,8 @@ def cmd_check(base_url: str, api_key: str, url: str, **_kwargs) -> None:
         doc = websites[0]
         ok(f"Found in database (ID: {doc.get('id', '?')})")
         info(f"  Type:    {doc.get('document_type', '?')}")
-        info(f"  Status:  {doc.get('document_state', '?')}")
-        info(f"  Added:   {doc.get('created_at', '?')}")
+        info(f"  Status:  {doc.get('processing_status', '?')}")
+        info(f"  Added:   {doc.get('ingested_at', '?')}")
     else:
         info("Not found in database.")
 
@@ -159,8 +159,8 @@ def cmd_info(base_url: str, api_key: str, document_id: int, **_kwargs) -> None:
     ok(f"Document #{document_id}")
     info(f"  Title:   {data.get('title', '?')}")
     info(f"  Type:    {data.get('document_type', '?')}")
-    info(f"  Status:  {data.get('document_state', '?')}")
-    info(f"  Added:   {data.get('created_at', '?')}")
+    info(f"  Status:  {data.get('processing_status', '?')}")
+    info(f"  Added:   {data.get('ingested_at', '?')}")
     url_val = data.get("url", "")
     if url_val:
         info(f"  URL:     {url_val}")

--- a/slack_bot/src/commands.py
+++ b/slack_bot/src/commands.py
@@ -116,8 +116,8 @@ def _handle_check(ack: Callable, respond: Callable, client: LenieApiClient, comm
             respond(
                 text=f"Found in database (ID: {result['id']}). "
                 f"Type: {result['document_type']}. "
-                f"Status: {result['document_state']}. "
-                f"Added: {result['created_at']}."
+                f"Status: {result['processing_status']}. "
+                f"Added: {result['ingested_at']}."
             )
         else:
             respond(text="Not found in database.")
@@ -151,8 +151,8 @@ def _handle_info(ack: Callable, respond: Callable, client: LenieApiClient, comma
             text=f"Document #{document_id}\n"
             f"Title: {data['title']}\n"
             f"Type: {data['document_type']}\n"
-            f"Status: {data['document_state']}\n"
-            f"Added: {data['created_at']}"
+            f"Status: {data['processing_status']}\n"
+            f"Added: {data['ingested_at']}"
         )
     except ApiConnectionError:
         respond(text="Backend unreachable (connection timeout). Check if lenie-ai-server is running.")

--- a/slack_bot/src/dm_handler.py
+++ b/slack_bot/src/dm_handler.py
@@ -130,8 +130,8 @@ def handle_check(say: Callable, client: LenieApiClient, args_str: str) -> None:
             say(
                 text=f"Found in database (ID: {result['id']}). "
                 f"Type: {result['document_type']}. "
-                f"Status: {result['document_state']}. "
-                f"Added: {result['created_at']}."
+                f"Status: {result['processing_status']}. "
+                f"Added: {result['ingested_at']}."
             )
         else:
             say(text="Not found in database.")
@@ -164,8 +164,8 @@ def handle_info(say: Callable, client: LenieApiClient, args_str: str) -> None:
             text=f"Document #{document_id}\n"
             f"Title: {data['title']}\n"
             f"Type: {data['document_type']}\n"
-            f"Status: {data['document_state']}\n"
-            f"Added: {data['created_at']}"
+            f"Status: {data['processing_status']}\n"
+            f"Added: {data['ingested_at']}"
         )
     except ApiConnectionError:
         say(text="Backend unreachable (connection timeout). Check if lenie-ai-server is running.")

--- a/slack_bot/tests/unit/test_commands.py
+++ b/slack_bot/tests/unit/test_commands.py
@@ -423,8 +423,8 @@ class TestHandleCheck:
             "id": 123,
             "url": "https://example.com/article",
             "document_type": "webpage",
-            "document_state": "URL_ADDED",
-            "created_at": "2026-01-15 10:30:45",
+            "processing_status": "URL_ADDED",
+            "ingested_at": "2026-01-15 10:30:45",
         }
         ack, respond = _make_ack_respond()
         command = {"text": "https://example.com/article"}
@@ -531,7 +531,7 @@ class TestHandleCheck:
     def test_missing_keys_in_response(self):
         """5.12: KeyError handling — missing keys in check_url response."""
         client = _make_mock_client()
-        client.check_url.return_value = {"id": 123}  # missing document_type, document_state, created_at
+        client.check_url.return_value = {"id": 123}  # missing document_type, processing_status, ingested_at
         ack, respond = _make_ack_respond()
         command = {"text": "https://example.com"}
 
@@ -553,8 +553,8 @@ class TestHandleInfo:
             "id": 123,
             "title": "Article Title",
             "document_type": "webpage",
-            "document_state": "URL_ADDED",
-            "created_at": "2026-01-15 10:30:45",
+            "processing_status": "URL_ADDED",
+            "ingested_at": "2026-01-15 10:30:45",
         }
         ack, respond = _make_ack_respond()
         command = {"text": "123"}
@@ -653,7 +653,7 @@ class TestHandleInfo:
         client = _make_mock_client()
         client.get_document.return_value = {
             "id": 1, "title": "T", "document_type": "link",
-            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+            "processing_status": "URL_ADDED", "ingested_at": "2026-01-01",
         }
         call_order = []
         ack = MagicMock(side_effect=lambda: call_order.append("ack"))

--- a/slack_bot/tests/unit/test_dm_handler.py
+++ b/slack_bot/tests/unit/test_dm_handler.py
@@ -327,8 +327,8 @@ class TestDmHandleCheck:
             "id": 123,
             "url": "https://example.com/article",
             "document_type": "webpage",
-            "document_state": "URL_ADDED",
-            "created_at": "2026-01-15 10:30:45",
+            "processing_status": "URL_ADDED",
+            "ingested_at": "2026-01-15 10:30:45",
         }
         say = _make_say()
 
@@ -444,8 +444,8 @@ class TestDmHandleInfo:
             "id": 123,
             "title": "Article Title",
             "document_type": "webpage",
-            "document_state": "URL_ADDED",
-            "created_at": "2026-01-15 10:30:45",
+            "processing_status": "URL_ADDED",
+            "ingested_at": "2026-01-15 10:30:45",
         }
         say = _make_say()
 
@@ -835,7 +835,7 @@ class TestDmCommandParsing:
         client = _make_mock_client()
         client.get_document.return_value = {
             "id": 123, "title": "T", "document_type": "link",
-            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+            "processing_status": "URL_ADDED", "ingested_at": "2026-01-01",
         }
         handler_fn, _ = self._get_handler(client)
         event = _make_dm_event("info 123")
@@ -1062,7 +1062,7 @@ class TestDmIntentParsing:
         client = _make_mock_client()
         client.get_document.return_value = {
             "id": 42, "title": "T", "document_type": "link",
-            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+            "processing_status": "URL_ADDED", "ingested_at": "2026-01-01",
         }
         mock_parse.return_value = ParsedIntent(
             command="info", args={"id": 42}, confidence=0.92

--- a/slack_bot/tests/unit/test_mention_handler.py
+++ b/slack_bot/tests/unit/test_mention_handler.py
@@ -153,7 +153,7 @@ class TestMentionCommandRouting:
         client = _make_mock_client()
         client.get_document.return_value = {
             "id": 123, "title": "T", "document_type": "link",
-            "document_state": "URL_ADDED", "created_at": "2026-01-01",
+            "processing_status": "URL_ADDED", "ingested_at": "2026-01-01",
         }
         handler_fn, _ = _get_handler(client)
         event = _make_mention_event("<@U123ABC> info 123")


### PR DESCRIPTION
## Summary
- replace stale document created_at/status keys in article tooling and Slack clients
- make discovery-source get-or-create reuse pending rows before flush
- update Notion changelog SQL and regression tests

## Verification
- backend: 1882 passed
- slack bot: 287 passed
- git diff --check