### PR TITLE
Add LLM cost dashboard and document attribution

### DIFF
--- a/backend/alembic/versions/c0d1e2f3a4b5_add_llm_usage_document_context.py
+++ b/backend/alembic/versions/c0d1e2f3a4b5_add_llm_usage_document_context.py
@@ -1,0 +1,25 @@
+"""add document and analysis job context to LLM usage
+
+Revision ID: c0d1e2f3a4b5
+Revises: b9c0d1e2f3a4
+"""
+from alembic import op
+
+revision = "c0d1e2f3a4b5"
+down_revision = "b9c0d1e2f3a4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE llm_usage_logs ADD COLUMN document_id INTEGER REFERENCES documents(id) ON DELETE SET NULL")
+    op.execute("ALTER TABLE llm_usage_logs ADD COLUMN analysis_job_id VARCHAR(32) REFERENCES document_analysis_jobs(id) ON DELETE SET NULL")
+    op.execute("CREATE INDEX idx_llm_usage_logs_document_called ON llm_usage_logs(document_id, called_at)")
+    op.execute("CREATE INDEX idx_llm_usage_logs_analysis_job ON llm_usage_logs(analysis_job_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_llm_usage_logs_analysis_job")
+    op.execute("DROP INDEX IF EXISTS idx_llm_usage_logs_document_called")
+    op.execute("ALTER TABLE llm_usage_logs DROP COLUMN analysis_job_id")
+    op.execute("ALTER TABLE llm_usage_logs DROP COLUMN document_id")

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -159,16 +159,18 @@ def _analysis_worker() -> None:
 
         work = get_session()
         try:
+            from library.llm_usage.context import llm_usage_context
             service = DocumentAnalysisService(work)
-            run = service.create_run(
-                doc_id=doc_id,
-                model=params["model"], chunk_size=params["chunk_size"],
-                no_synthesis=params["no_synthesis"],
-                progress_fn=lambda msg: _update_analysis_job(job_id, progress=msg),
-                mode=params["mode"], split_only=params["split_only"],
-                preclean=params["preclean"], reclean=params["reclean"],
-                scope_chapter=params.get("scope_chapter"),
-            )
+            with llm_usage_context(document_id=doc_id, analysis_job_id=job_id):
+                run = service.create_run(
+                    doc_id=doc_id,
+                    model=params["model"], chunk_size=params["chunk_size"],
+                    no_synthesis=params["no_synthesis"],
+                    progress_fn=lambda msg: _update_analysis_job(job_id, progress=msg),
+                    mode=params["mode"], split_only=params["split_only"],
+                    preclean=params["preclean"], reclean=params["reclean"],
+                    scope_chapter=params.get("scope_chapter"),
+                )
             ad_count = sum(1 for chunk in run.chunks if chunk.type == "REKLAMA")
             _update_analysis_job(
                 job_id, status="done", run_id=run.id,

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -1676,6 +1676,12 @@ class LlmUsageLog(Base):
     search_interpretation_log_id: Mapped[int | None] = mapped_column(
         ForeignKey("search_interpretation_logs.id", ondelete="SET NULL"),
     )
+    document_id: Mapped[int | None] = mapped_column(
+        ForeignKey("documents.id", ondelete="SET NULL"),
+    )
+    analysis_job_id: Mapped[str | None] = mapped_column(
+        String(32), ForeignKey("document_analysis_jobs.id", ondelete="SET NULL"),
+    )
     operation: Mapped[str] = mapped_column(String(50), nullable=False)
     provider: Mapped[str] = mapped_column(String(50), nullable=False)
     model: Mapped[str] = mapped_column(String(100), nullable=False)
@@ -1721,6 +1727,8 @@ class LlmUsageLog(Base):
         Index("idx_llm_usage_logs_called", "called_at"),
         Index("idx_llm_usage_logs_operation_called", "operation", "called_at"),
         Index("idx_llm_usage_logs_provider_model_called", "provider", "model", "called_at"),
+        Index("idx_llm_usage_logs_document_called", "document_id", "called_at"),
+        Index("idx_llm_usage_logs_analysis_job", "analysis_job_id"),
         Index(
             "idx_llm_usage_logs_interpretation",
             "search_interpretation_log_id",

--- a/backend/library/llm_cost_routes.py
+++ b/backend/library/llm_cost_routes.py
@@ -1,0 +1,90 @@
+"""HTTP reporting API for LLM usage costs."""
+
+from datetime import date, datetime, time, timedelta
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func, select
+
+from library.db.engine import get_scoped_session
+from library.db.models import DocumentAnalysisJob, LlmUsageLog
+
+bp = Blueprint("llm_costs", __name__)
+
+
+def _date_arg(name: str, default: date) -> date:
+    value = request.args.get(name)
+    if not value:
+        return default
+    return date.fromisoformat(value)
+
+
+def _money(value):
+    return str(value) if value is not None else None
+
+
+@bp.get("/llm_costs")
+def llm_costs():
+    today = date.today()
+    try:
+        date_from = _date_arg("from", today.replace(day=1))
+        date_to = _date_arg("to", today)
+        if date_to < date_from:
+            raise ValueError("to must not be earlier than from")
+    except ValueError as exc:
+        return jsonify({"status": "error", "message": str(exc)}), 400
+
+    document_id = request.args.get("document_id", type=int)
+    start = datetime.combine(date_from, time.min)
+    end = datetime.combine(date_to + timedelta(days=1), time.min)
+    filters = [LlmUsageLog.called_at >= start, LlmUsageLog.called_at < end]
+    if document_id is not None:
+        filters.append(LlmUsageLog.document_id == document_id)
+
+    session = get_scoped_session()
+    totals = session.execute(
+        select(
+            LlmUsageLog.cost_currency,
+            func.count().label("calls"),
+            func.coalesce(func.sum(LlmUsageLog.total_tokens), 0).label("tokens"),
+            func.sum(LlmUsageLog.cost_amount).label("cost"),
+            func.count().filter(LlmUsageLog.cost_status == "unknown").label("unknown_calls"),
+        ).where(*filters).group_by(LlmUsageLog.cost_currency)
+    ).all()
+    day = func.date(LlmUsageLog.called_at).label("day")
+    daily = session.execute(
+        select(day, LlmUsageLog.cost_currency, func.count().label("calls"),
+               func.coalesce(func.sum(LlmUsageLog.total_tokens), 0).label("tokens"),
+               func.sum(LlmUsageLog.cost_amount).label("cost"))
+        .where(*filters).group_by(day, LlmUsageLog.cost_currency).order_by(day)
+    ).all()
+    operations = session.execute(
+        select(LlmUsageLog.operation, LlmUsageLog.model, LlmUsageLog.cost_currency,
+               func.count().label("calls"), func.coalesce(func.sum(LlmUsageLog.total_tokens), 0).label("tokens"),
+               func.sum(LlmUsageLog.cost_amount).label("cost"))
+        .where(*filters).group_by(LlmUsageLog.operation, LlmUsageLog.model, LlmUsageLog.cost_currency)
+        .order_by(func.sum(LlmUsageLog.cost_amount).desc().nullslast())
+    ).all()
+    jobs = session.execute(
+        select(LlmUsageLog.analysis_job_id, DocumentAnalysisJob.run_id, LlmUsageLog.cost_currency,
+               func.min(LlmUsageLog.called_at).label("started_at"), func.count().label("calls"),
+               func.coalesce(func.sum(LlmUsageLog.total_tokens), 0).label("tokens"),
+               func.sum(LlmUsageLog.cost_amount).label("cost"))
+        .outerjoin(DocumentAnalysisJob, LlmUsageLog.analysis_job_id == DocumentAnalysisJob.id)
+        .where(*filters, LlmUsageLog.analysis_job_id.isnot(None))
+        .group_by(LlmUsageLog.analysis_job_id, DocumentAnalysisJob.run_id, LlmUsageLog.cost_currency)
+        .order_by(func.min(LlmUsageLog.called_at).desc())
+    ).all()
+
+    return jsonify({
+        "status": "success", "from": date_from.isoformat(), "to": date_to.isoformat(),
+        "document_id": document_id,
+        "totals": [{"currency": r.cost_currency, "calls": r.calls, "tokens": r.tokens,
+                    "cost": _money(r.cost), "unknown_calls": r.unknown_calls} for r in totals],
+        "daily": [{"day": str(r.day), "currency": r.cost_currency, "calls": r.calls,
+                   "tokens": r.tokens, "cost": _money(r.cost)} for r in daily],
+        "operations": [{"operation": r.operation, "model": r.model, "currency": r.cost_currency,
+                        "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost)} for r in operations],
+        "analyses": [{"job_id": r.analysis_job_id, "run_id": r.run_id, "currency": r.cost_currency,
+                      "started_at": r.started_at.isoformat() if r.started_at else None,
+                      "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost)} for r in jobs],
+    })

--- a/backend/library/llm_usage/context.py
+++ b/backend/library/llm_usage/context.py
@@ -1,0 +1,22 @@
+"""Request-independent context attached to LLM usage rows."""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_document_id: ContextVar[int | None] = ContextVar("llm_document_id", default=None)
+_analysis_job_id: ContextVar[str | None] = ContextVar("llm_analysis_job_id", default=None)
+
+
+def current_usage_context() -> tuple[int | None, str | None]:
+    return _document_id.get(), _analysis_job_id.get()
+
+
+@contextmanager
+def llm_usage_context(*, document_id: int | None = None, analysis_job_id: str | None = None):
+    document_token = _document_id.set(document_id)
+    job_token = _analysis_job_id.set(analysis_job_id)
+    try:
+        yield
+    finally:
+        _analysis_job_id.reset(job_token)
+        _document_id.reset(document_token)

--- a/backend/library/llm_usage/recorder.py
+++ b/backend/library/llm_usage/recorder.py
@@ -124,6 +124,8 @@ def record_llm_usage(
     endpoint: str | None = None,
     request_id: str | None = None,
     search_interpretation_log_id: int | None = None,
+    document_id: int | None = None,
+    analysis_job_id: str | None = None,
     credits_used: Decimal | None = None,
     reported_cost: Decimal | None = None,
     reported_cost_currency: str | None = None,
@@ -158,9 +160,15 @@ def record_llm_usage(
         pricing = _active_pricing(session, provider, model)
         cost = _resolve_cost(pricing, reported, reported_cost_currency, prompt, completion)
 
+        if document_id is None and analysis_job_id is None:
+            from library.llm_usage.context import current_usage_context
+            document_id, analysis_job_id = current_usage_context()
+
         log = LlmUsageLog(
             request_id=request_id,
             search_interpretation_log_id=search_interpretation_log_id,
+            document_id=document_id,
+            analysis_job_id=analysis_job_id,
             operation=operation,
             provider=provider,
             model=model,

--- a/backend/server.py
+++ b/backend/server.py
@@ -16,6 +16,7 @@ from library.models.stalker_document_status_error import StalkerDocumentStatusEr
 from library.api_key_routes import bp as api_key_bp
 from library.auth import resolve_api_key
 from library.chunk_review_routes import bp as chunk_review_bp, start_analysis_worker
+from library.llm_cost_routes import bp as llm_cost_bp
 from library.reader_routes import bp as reader_bp
 from library.search_routes import bp as search_bp
 from library.youtube_processing import process_youtube_url
@@ -85,6 +86,7 @@ logging.info("Flask - enabling CORS for all routes")
 CORS(app)  # This will enable CORS for all routes
 
 app.register_blueprint(chunk_review_bp)
+app.register_blueprint(llm_cost_bp)
 app.register_blueprint(reader_bp)
 app.register_blueprint(api_key_bp)
 app.register_blueprint(search_bp)

--- a/backend/tests/unit/test_llm_usage_recorder.py
+++ b/backend/tests/unit/test_llm_usage_recorder.py
@@ -16,6 +16,7 @@ pytest.importorskip("sqlalchemy")
 from library.db.models import LlmPricing, LlmUsageLog  # noqa: E402
 from library.llm_usage.pricing import CostStatus, PricingError  # noqa: E402
 from library.llm_usage.recorder import record_llm_usage  # noqa: E402
+from library.llm_usage.context import llm_usage_context  # noqa: E402
 
 BIELIK_PRICING = dict(
     pricing_version="cloudferro-bielik-2026-07-18",
@@ -59,6 +60,21 @@ def bielik_factory(**kwargs) -> FakeSessionFactory:
 
 
 class TestEstimatedCost:
+    def test_document_analysis_context_is_attached_to_usage_row(self):
+        factory = bielik_factory()
+        with llm_usage_context(document_id=9258, analysis_job_id="a" * 32):
+            record_llm_usage(
+                operation="chunk_analysis",
+                provider="cloudferro",
+                model="Bielik-11B-v3.0-Instruct",
+                prompt_tokens=100,
+                completion_tokens=25,
+                session_factory=factory,
+            )
+
+        assert factory.added[0].document_id == 9258
+        assert factory.added[0].analysis_job_id == "a" * 32
+
     def test_per_token_pricing_writes_estimated_cost(self):
         factory = bielik_factory()
         record = record_llm_usage(

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -17,6 +17,7 @@ import Persons from "./modules/shared/pages/persons";
 import PersonsReview from "./modules/shared/pages/personsReview";
 import Sources from "./modules/shared/pages/sources";
 import InformationSources from "./modules/shared/pages/informationSources";
+import LlmCosts from "./modules/shared/pages/llmCosts";
 import { AuthorizationContext } from "./modules/shared/context/authorizationContext";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -55,6 +56,7 @@ function App() {
                   <Route path="/persons-review" element={<PersonsReview />} />
                   <Route path="/sources" element={<Sources />} />
                   <Route path="/information-sources" element={<InformationSources />} />
+                  <Route path="/llm-costs" element={<LlmCosts />} />
                   <Route path="/search" element={<Search />} />
                   <Route path="/upload-file" element={<UploadFile />} />
                   <Route path="*" element={<p>404</p>} />

--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -115,6 +115,12 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
           Information Sources
         </NavLink>
         <NavLink
+          to="/llm-costs"
+          className={({ isActive }) => isActive ? classes.activeLink : classes.link}
+        >
+          LLM Costs
+        </NavLink>
+        <NavLink
           to="/upload-file"
           className={({ isActive }) =>
             isActive ? classes.activeLink : classes.link

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -2096,6 +2096,7 @@ const Chunks = () => {
           <NavLink to="/list" style={{ fontSize: "0.85em", color: "#0369a1" }}>← Lista dokumentów</NavLink>
         )}
         <NavLink to={`/read/${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>📖 Czytaj</NavLink>
+        <NavLink to={`/llm-costs?document_id=${id}`} style={{ fontSize: "0.85em", color: "#0369a1" }}>💰 Koszty LLM</NavLink>
         {docUrl && (
           <a href={docUrl} target="_blank" rel="noopener noreferrer"
             title="Otwórz oryginalny artykuł — porównaj, czy tekst nie jest obcięty"

--- a/web_interface_react/src/modules/shared/pages/llmCosts.tsx
+++ b/web_interface_react/src/modules/shared/pages/llmCosts.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import axios from "axios";
+import { NavLink, useSearchParams } from "react-router-dom";
+import { AuthorizationContext } from "../context/authorizationContext";
+
+type CostRow = { currency: string | null; calls: number; tokens: number; cost: string | null; unknown_calls?: number };
+type OperationRow = CostRow & { operation: string; model: string };
+type DailyRow = CostRow & { day: string };
+type AnalysisRow = CostRow & { job_id: string; run_id: number | null; started_at: string | null };
+type Report = { totals: CostRow[]; daily: DailyRow[]; operations: OperationRow[]; analyses: AnalysisRow[] };
+
+const iso = (d: Date) => d.toISOString().slice(0, 10);
+const money = (value: string | null, currency: string | null) => value == null ? "—" : `${Number(value).toFixed(6)} ${currency ?? "?"}`;
+
+const LlmCosts = () => {
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const [params, setParams] = useSearchParams();
+  const now = new Date();
+  const [from, setFrom] = React.useState(params.get("from") ?? iso(new Date(now.getFullYear(), now.getMonth(), 1)));
+  const [to, setTo] = React.useState(params.get("to") ?? iso(now));
+  const [documentId, setDocumentId] = React.useState(params.get("document_id") ?? "");
+  const [report, setReport] = React.useState<Report | null>(null);
+  const [error, setError] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    setLoading(true); setError("");
+    try {
+      const query: Record<string, string> = { from, to };
+      if (documentId.trim()) query.document_id = documentId.trim();
+      setParams(query);
+      const response = await axios.get(`${apiUrl}/llm_costs`, { params: query, headers: { "x-api-key": apiKey ?? "" } });
+      setReport(response.data);
+    } catch (e: any) { setError(e.response?.data?.message ?? "Nie udało się pobrać kosztów LLM"); }
+    finally { setLoading(false); }
+  }, [apiUrl, apiKey, from, to, documentId, setParams]);
+
+  React.useEffect(() => { void load(); }, []); // initial report only
+
+  const tableStyle: React.CSSProperties = { width: "100%", borderCollapse: "collapse", marginTop: 10 };
+  const th: React.CSSProperties = { textAlign: "left", padding: "7px 8px", borderBottom: "1px solid #cbd5e1" };
+  const td: React.CSSProperties = { padding: "7px 8px", borderBottom: "1px solid #e2e8f0" };
+
+  return <div>
+    <h2>Koszty LLM</h2>
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "end", padding: 14, background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
+      <label>Od<br/><input type="date" value={from} onChange={e => setFrom(e.target.value)} /></label>
+      <label>Do<br/><input type="date" value={to} onChange={e => setTo(e.target.value)} /></label>
+      <label>Dokument ID (opcjonalnie)<br/><input type="number" min="1" value={documentId} onChange={e => setDocumentId(e.target.value)} placeholder="np. 9258" /></label>
+      <button className="button" onClick={load} disabled={loading}>{loading ? "Ładuję…" : "Pokaż"}</button>
+      {documentId && <NavLink to={`/chunks/${documentId}`}>Otwórz dokument #{documentId}</NavLink>}
+    </div>
+    {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
+    {report && <>
+      <h3>Podsumowanie</h3>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>{report.totals.map((r, i) =>
+        <div key={`${r.currency}-${i}`} style={{ padding: 12, minWidth: 190, border: "1px solid #cbd5e1", borderRadius: 8 }}>
+          <strong style={{ fontSize: "1.3em" }}>{money(r.cost, r.currency)}</strong><br/>{r.calls} wywołań · {r.tokens.toLocaleString("pl")} tokenów
+          {!!r.unknown_calls && <div style={{ color: "#b45309" }}>{r.unknown_calls} bez wyceny</div>}
+        </div>)}</div>
+      {!report.totals.length && <p>Brak wywołań w wybranym okresie.</p>}
+      <h3>Koszt dzienny</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Dzień</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th></tr></thead><tbody>
+        {report.daily.map((r, i) => <tr key={`${r.day}-${r.currency}-${i}`}><td style={td}>{r.day}</td><td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td></tr>)}
+      </tbody></table>
+      <h3>Modele i operacje</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Operacja</th><th style={th}>Model</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th></tr></thead><tbody>
+        {report.operations.map((r, i) => <tr key={`${r.operation}-${r.model}-${r.currency}-${i}`}><td style={td}>{r.operation}</td><td style={td}>{r.model}</td><td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td></tr>)}
+      </tbody></table>
+      {documentId && <><h3>Analizy dokumentu</h3><p style={{ color: "#64748b" }}>Powiązanie obejmuje wywołania wykonane po wdrożeniu tej funkcji.</p>
+        <table style={tableStyle}><thead><tr><th style={th}>Data</th><th style={th}>Job / run</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th></tr></thead><tbody>
+          {report.analyses.map((r, i) => <tr key={`${r.job_id}-${r.currency}-${i}`}><td style={td}>{r.started_at?.replace("T", " ").slice(0, 19)}</td><td style={td}>{r.job_id.slice(0, 8)} / {r.run_id ?? "—"}</td><td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td></tr>)}
+        </tbody></table></>}
+    </>}
+  </div>;
+};
+
+export default LlmCosts;


### PR DESCRIPTION
## Summary
- add /llm-costs report with date range and optional document filter
- attribute new chunk-analysis LLM calls to document and persistent analysis job
- add React dashboard, navigation entry, and per-document link from chunk review
- add Alembic migration for attribution columns and indexes

Historical rows remain available globally but cannot be attributed retroactively.

## Verification
- backend: 1883 passed
- frontend build: passed
- frontend: 11 passed