### PR TITLE
Show LLM costs per document by default

### DIFF
--- a/backend/library/llm_cost_routes.py
+++ b/backend/library/llm_cost_routes.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, request
 from sqlalchemy import func, select
 
 from library.db.engine import get_scoped_session
-from library.db.models import DocumentAnalysisJob, LlmUsageLog
+from library.db.models import Document, DocumentAnalysisJob, LlmUsageLog
 
 bp = Blueprint("llm_costs", __name__)
 
@@ -64,6 +64,21 @@ def llm_costs():
         .where(*filters).group_by(LlmUsageLog.operation, LlmUsageLog.model, LlmUsageLog.cost_currency)
         .order_by(func.sum(LlmUsageLog.cost_amount).desc().nullslast())
     ).all()
+    documents = session.execute(
+        select(
+            LlmUsageLog.document_id,
+            Document.title,
+            LlmUsageLog.cost_currency,
+            func.count().label("calls"),
+            func.coalesce(func.sum(LlmUsageLog.total_tokens), 0).label("tokens"),
+            func.sum(LlmUsageLog.cost_amount).label("cost"),
+            func.count().filter(LlmUsageLog.cost_status == "unknown").label("unknown_calls"),
+        )
+        .outerjoin(Document, LlmUsageLog.document_id == Document.id)
+        .where(*filters)
+        .group_by(LlmUsageLog.document_id, Document.title, LlmUsageLog.cost_currency)
+        .order_by(func.sum(LlmUsageLog.cost_amount).desc().nullslast(), LlmUsageLog.document_id)
+    ).all()
     jobs = session.execute(
         select(LlmUsageLog.analysis_job_id, DocumentAnalysisJob.run_id, LlmUsageLog.cost_currency,
                func.min(LlmUsageLog.called_at).label("started_at"), func.count().label("calls"),
@@ -84,6 +99,9 @@ def llm_costs():
                    "tokens": r.tokens, "cost": _money(r.cost)} for r in daily],
         "operations": [{"operation": r.operation, "model": r.model, "currency": r.cost_currency,
                         "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost)} for r in operations],
+        "documents": [{"document_id": r.document_id, "title": r.title, "currency": r.cost_currency,
+                       "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost),
+                       "unknown_calls": r.unknown_calls} for r in documents],
         "analyses": [{"job_id": r.analysis_job_id, "run_id": r.run_id, "currency": r.cost_currency,
                       "started_at": r.started_at.isoformat() if r.started_at else None,
                       "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost)} for r in jobs],

--- a/web_interface_react/src/modules/shared/pages/llmCosts.tsx
+++ b/web_interface_react/src/modules/shared/pages/llmCosts.tsx
@@ -7,7 +7,8 @@ type CostRow = { currency: string | null; calls: number; tokens: number; cost: s
 type OperationRow = CostRow & { operation: string; model: string };
 type DailyRow = CostRow & { day: string };
 type AnalysisRow = CostRow & { job_id: string; run_id: number | null; started_at: string | null };
-type Report = { totals: CostRow[]; daily: DailyRow[]; operations: OperationRow[]; analyses: AnalysisRow[] };
+type DocumentRow = CostRow & { document_id: number | null; title: string | null };
+type Report = { totals: CostRow[]; documents: DocumentRow[]; daily: DailyRow[]; operations: OperationRow[]; analyses: AnalysisRow[] };
 
 const iso = (d: Date) => d.toISOString().slice(0, 10);
 const money = (value: string | null, currency: string | null) => value == null ? "—" : `${Number(value).toFixed(6)} ${currency ?? "?"}`;
@@ -59,6 +60,16 @@ const LlmCosts = () => {
           {!!r.unknown_calls && <div style={{ color: "#b45309" }}>{r.unknown_calls} bez wyceny</div>}
         </div>)}</div>
       {!report.totals.length && <p>Brak wywołań w wybranym okresie.</p>}
+      <h3>Koszt per dokument</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Dokument</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th><th style={th}>Wycena</th></tr></thead><tbody>
+        {report.documents.map((r, i) => <tr key={`${r.document_id ?? "none"}-${r.currency}-${i}`}>
+          <td style={td}>{r.document_id != null
+            ? <NavLink to={`/chunks/${r.document_id}`}>#{r.document_id} — {r.title || "bez tytułu"}</NavLink>
+            : <span style={{ color: "#64748b" }}>Nieprzypisane (starsze lub globalne wywołania)</span>}</td>
+          <td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td>
+          <td style={td}>{r.unknown_calls ? <span style={{ color: "#b45309" }}>{r.unknown_calls} bez ceny</span> : "pełna"}</td>
+        </tr>)}
+      </tbody></table>
       <h3>Koszt dzienny</h3>
       <table style={tableStyle}><thead><tr><th style={th}>Dzień</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th></tr></thead><tbody>
         {report.daily.map((r, i) => <tr key={`${r.day}-${r.currency}-${i}`}><td style={td}>{r.day}</td><td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td></tr>)}


### PR DESCRIPTION
## Summary
- aggregate LLM usage by document in the reporting API
- make per-document costs the primary dashboard table
- keep historical/global calls visible as an unassigned bucket
- retain operation breakdown as secondary detail

## Verification
- backend: 1883 passed
- frontend build: passed
- frontend: 11 passed