### PR TITLE
feat: complete document LLM cost audit

### DIFF
--- a/backend/alembic/versions/d1e2f3a4b5c6_add_llm_usage_analysis_run.py
+++ b/backend/alembic/versions/d1e2f3a4b5c6_add_llm_usage_analysis_run.py
@@ -1,0 +1,27 @@
+"""Add direct analysis-run attribution to LLM usage.
+
+Revision ID: d1e2f3a4b5c6
+Revises: c0d1e2f3a4b5
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d1e2f3a4b5c6"
+down_revision = "c0d1e2f3a4b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("llm_usage_logs", sa.Column("analysis_run_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_llm_usage_logs_analysis_run", "llm_usage_logs", "document_analysis_runs",
+        ["analysis_run_id"], ["id"], ondelete="SET NULL",
+    )
+    op.create_index("idx_llm_usage_logs_analysis_run", "llm_usage_logs", ["analysis_run_id"])
+
+
+def downgrade():
+    op.drop_index("idx_llm_usage_logs_analysis_run", table_name="llm_usage_logs")
+    op.drop_constraint("fk_llm_usage_logs_analysis_run", "llm_usage_logs", type_="foreignkey")
+    op.drop_column("llm_usage_logs", "analysis_run_id")

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -243,7 +243,10 @@ def process_article_content(doc_id: int, cache_base_dir: str,
     print("  Process: converting HTML to markdown...")
     if not skip_llm:
         print("  Process: running LLM extraction (CloudFerro primary, ARK Labs fallback)...")
-    markdown_text, article = extract_article(doc, doc_cache_dir, verbose=True, skip_llm=skip_llm)
+    markdown_text, article = extract_article(
+        doc, doc_cache_dir, verbose=True, skip_llm=skip_llm,
+        operation="dynamodb_import_extraction",
+    )
 
     if not markdown_text:
         print("  Process: markdown conversion failed")

--- a/backend/library/ai.py
+++ b/backend/library/ai.py
@@ -79,7 +79,9 @@ def _record_usage(**kwargs):
 
 def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: int = 4096, top_p: float = 0.9,
            *, system_prompt: str | None = None, response_format: dict | None = None,
-           operation: str = "ai_ask", search_interpretation_log_id: int | None = None) -> AiResponse:
+           operation: str = "ai_ask", search_interpretation_log_id: int | None = None,
+           arklabs_stateful: bool = False, document_id: int | None = None,
+           analysis_job_id: str | None = None, analysis_run_id: int | None = None) -> AiResponse:
 
     if model in OPENAI_MODELS:
         provider = "openai"
@@ -128,7 +130,8 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
             from library.api.arklabs.arklabs_completion import arklabs_get_completion
 
             return arklabs_get_completion(query, model=actual_model, temperature=temperature,
-                                          max_tokens=max_token_count, system_prompt=system_prompt)
+                                          max_tokens=max_token_count, system_prompt=system_prompt,
+                                          stateful=arklabs_stateful)
 
     elif model in GOOGLE_MODELS:
         provider = "google-vertexai"
@@ -161,6 +164,7 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
             error_code=type(exc).__name__,
             latency_ms=int((time.monotonic() - started) * 1000),
             search_interpretation_log_id=search_interpretation_log_id,
+            document_id=document_id, analysis_job_id=analysis_job_id, analysis_run_id=analysis_run_id,
         )
         raise
 
@@ -176,5 +180,6 @@ def ai_ask(query: str, model: str, temperature: float = 0.7, max_token_count: in
         request_id=getattr(ai_response, "id", None),
         latency_ms=latency_ms,
         search_interpretation_log_id=search_interpretation_log_id,
+        document_id=document_id, analysis_job_id=analysis_job_id, analysis_run_id=analysis_run_id,
     )
     return ai_response

--- a/backend/library/ai_intent_parser.py
+++ b/backend/library/ai_intent_parser.py
@@ -64,7 +64,8 @@ def parse_intent(text: str, model: str | None = None) -> dict:
 
     try:
         from library.ai import ai_ask
-        ai_response = ai_ask(prompt, model=model, temperature=0.1, max_token_count=256)
+        ai_response = ai_ask(prompt, model=model, temperature=0.1, max_token_count=256,
+                             operation="intent_parsing")
         raw_response = ai_response.response_text
         if not raw_response:
             logger.warning("Empty LLM response for intent parsing")

--- a/backend/library/article_extractor.py
+++ b/backend/library/article_extractor.py
@@ -384,7 +384,8 @@ def _parse_llm_json_response(response_text: str) -> dict | None:
 
 
 def extract_article_markers_with_llm(markdown_text: str, url: str = "",
-                                     model: str = "speakleash/Bielik-11B-v3.0-Instruct") -> dict | None:
+                                     model: str = "speakleash/Bielik-11B-v3.0-Instruct",
+                                     operation: str = "article_extraction") -> dict | None:
     """Wyślij markdown do ARK Labs (Bielik) i pobierz markery granic artykułu.
 
     Tryb stateful/stateless kontrolowany przez zmienną ARK_LABS_STATEFUL (domyślnie 0=stateless).
@@ -395,7 +396,7 @@ def extract_article_markers_with_llm(markdown_text: str, url: str = "",
         dict z polami: title, author, date, article_first_sentence, article_last_sentence, tags
         lub None w przypadku błędu
     """
-    from library.api.arklabs.arklabs_completion import arklabs_get_completion
+    from library.ai import ai_ask
 
     use_stateful = os.environ.get("ARK_LABS_STATEFUL", "0") == "1"
 
@@ -412,13 +413,15 @@ def extract_article_markers_with_llm(markdown_text: str, url: str = "",
     prompt = EXTRACTION_USER_PROMPT_TEMPLATE.format(markdown_text=cleaned)
 
     try:
-        response = arklabs_get_completion(
-            prompt=prompt,
-            model=model,
-            max_tokens=800,
+        gateway_model = f"arklabs/{model.removeprefix('speakleash/')}"
+        response = ai_ask(
+            query=prompt,
+            model=gateway_model,
+            max_token_count=800,
             temperature=0.1,
             system_prompt=EXTRACTION_SYSTEM_PROMPT,
-            stateful=use_stateful,
+            operation=operation,
+            arklabs_stateful=use_stateful,
         )
 
         logger.info(f"LLM extraction tokens: prompt={response.prompt_tokens}, "
@@ -431,13 +434,14 @@ def extract_article_markers_with_llm(markdown_text: str, url: str = "",
         return None
 
 
-def _extract_markers_via_cloudferro(markdown_text: str, url: str = "") -> dict | None:
+def _extract_markers_via_cloudferro(markdown_text: str, url: str = "",
+                                    operation: str = "article_extraction") -> dict | None:
     """Wyślij markdown do CloudFerro Sherlock (Bielik) i pobierz markery granic artykułu.
 
     Używane jako fallback gdy ARK Labs jest niedostępny (timeout, 429).
     Returns: dict markerów lub None w przypadku błędu.
     """
-    from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
+    from library.ai import ai_ask
 
     portal = _detect_portal(url)
     trimmed = _trim_markdown_navigation(markdown_text)
@@ -449,12 +453,13 @@ def _extract_markers_via_cloudferro(markdown_text: str, url: str = "") -> dict |
     prompt = EXTRACTION_USER_PROMPT_TEMPLATE.format(markdown_text=cleaned)
 
     try:
-        response = sherlock_get_completion(
-            prompt=prompt,
+        response = ai_ask(
+            query=prompt,
             model=CLOUDFERRO_FALLBACK_MODEL,
-            max_tokens=800,
+            max_token_count=800,
             temperature=0.1,
             system_prompt=EXTRACTION_SYSTEM_PROMPT,
+            operation=operation,
         )
 
         logger.info(f"CloudFerro extraction tokens: prompt={response.prompt_tokens}, "
@@ -651,7 +656,8 @@ def _escape_for_regex(line: str) -> str:
 def process_article_with_llm_fallback(markdown_text: str, document_id: int,
                                        cache_dir: str, url: str,
                                        model: str = "speakleash/Bielik-11B-v3.0-Instruct",
-                                       arklabs_first: bool = False) -> str | None:
+                                       arklabs_first: bool = False,
+                                       operation: str = "article_extraction") -> str | None:
     """Główna funkcja fallback: ekstrakcja artykułu przez LLM + generowanie regex draft.
 
     arklabs_first=True: ARK Labs primary (taniej, stateful $0.01/1M input),
@@ -669,19 +675,19 @@ def process_article_with_llm_fallback(markdown_text: str, document_id: int,
         fallback_name = "CloudFerro"
 
         def _primary(text, url):
-            return extract_article_markers_with_llm(text, url=url, model=model)
+            return extract_article_markers_with_llm(text, url=url, model=model, operation=operation)
 
         def _fallback(text, url):
-            return _extract_markers_via_cloudferro(text, url=url)
+            return _extract_markers_via_cloudferro(text, url=url, operation=operation)
     else:
         primary_name = "CloudFerro"
         fallback_name = "ARK Labs"
 
         def _primary(text, url):
-            return _extract_markers_via_cloudferro(text, url=url)
+            return _extract_markers_via_cloudferro(text, url=url, operation=operation)
 
         def _fallback(text, url):
-            return extract_article_markers_with_llm(text, url=url, model=model)
+            return extract_article_markers_with_llm(text, url=url, model=model, operation=operation)
 
     markers = None
     for attempt in range(2):

--- a/backend/library/article_pipeline.py
+++ b/backend/library/article_pipeline.py
@@ -11,6 +11,8 @@ markdown całej strony (wejście dla ekstrakcji LLM i porównania boundaries).
 import logging
 import os
 
+from library.llm_usage.context import llm_usage_context
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,7 +49,8 @@ def ensure_raw_markdown(doc, cache_dir: str, verbose: bool = False) -> str | Non
 
 
 def extract_article(doc, cache_dir: str, verbose: bool = False, skip_llm: bool = False,
-                    arklabs_first: bool = False) -> tuple[str | None, str | None]:
+                    arklabs_first: bool = False,
+                    operation: str = "article_extraction") -> tuple[str | None, str | None]:
     """Surowy markdown + ekstrakcja artykułu przez LLM (CloudFerro/ARK Labs fallback).
 
     Zwraca (raw_markdown, extracted_article):
@@ -64,11 +67,13 @@ def extract_article(doc, cache_dir: str, verbose: bool = False, skip_llm: bool =
     if skip_llm:
         return markdown_text, None
 
-    article = process_article_with_llm_fallback(
-        markdown_text=markdown_text,
-        document_id=doc.id,
-        cache_dir=cache_dir,
-        url=doc.url,
-        arklabs_first=arklabs_first,
-    )
+    with llm_usage_context(document_id=doc.id):
+        article = process_article_with_llm_fallback(
+            markdown_text=markdown_text,
+            document_id=doc.id,
+            cache_dir=cache_dir,
+            url=doc.url,
+            arklabs_first=arklabs_first,
+            operation=operation,
+        )
     return markdown_text, article

--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -331,7 +331,7 @@ Zwróć TYLKO obiekt JSON bez dodatkowego tekstu:
 --- KONIEC PUBLIKACJI ---
 Uwzględnij tę listę przy ocenie pola "zrodla", nawet jeśli została technicznie wydzielona poza tekst główny."""
     try:
-        raw, _ = call_model(prompt, model, RUBRIC_MAX_TOKENS)
+        raw, _ = call_model(prompt, model, RUBRIC_MAX_TOKENS, operation="document_quality")
         match = re.search(r"\{.*\}", raw, re.DOTALL)
         if not match:
             return None

--- a/backend/library/article_tagging.py
+++ b/backend/library/article_tagging.py
@@ -39,7 +39,8 @@ def tag_article_with_llm(text: str, title: str) -> list[str]:
         f"TYTUŁ: {title}\n\nTREŚĆ:\n{text[:3000]}"
     )
     try:
-        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=100)
+        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=100,
+                          operation="thematic_tagging")
         raw = response.response_text.strip().lower()
         found = [t.strip() for t in raw.split(",") if t.strip() in THEMATIC_TAGS]
         return found
@@ -60,7 +61,8 @@ def extract_countries_with_llm(text: str, title: str) -> list[str]:
         f"TYTUŁ: {title}\n\nTREŚĆ:\n{text[:3000]}"
     )
     try:
-        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150)
+        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150,
+                          operation="country_tagging")
         raw = response.response_text.strip().lower()
         if not raw:
             return []
@@ -129,7 +131,8 @@ def confirm_places_with_llm(text: str, title: str, candidate_names: list[str]) -
         f"TYTUŁ: {title}\n\nFRAGMENTY:\n{context[:6000]}"
     )
     try:
-        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150)
+        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150,
+                          operation="place_relevance")
         raw = response.response_text.strip()
         if not raw:
             return []
@@ -171,7 +174,8 @@ def confirm_person_with_llm(text: str, title: str, mention: str, candidates: lis
         f"TYTUŁ: {title}\n\nFRAGMENTY:\n{context[:3000]}"
     )
     try:
-        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=20)
+        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=20,
+                          operation="place_candidate_selection")
         raw = response.response_text.strip().upper()
         valid = {c["qid"] for c in candidates}
         for token in re.findall(r"Q\d+", raw):
@@ -210,7 +214,8 @@ def extract_countries_hybrid(text: str, title: str) -> list[str]:
         f"TYTUŁ: {title}\n\nTREŚĆ:\n{text[:3000]}"
     )
     try:
-        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150)
+        response = ai_ask(prompt, model=_tagging_model(), temperature=0.0, max_token_count=150,
+                          operation="infrastructure_relevance")
         raw = response.response_text.strip()
         if not raw:
             return []

--- a/backend/library/author_biography.py
+++ b/backend/library/author_biography.py
@@ -82,7 +82,7 @@ Nie dopowiadaj faktów. Zwróć wyłącznie JSON:
 Osoba: {person.canonical_name}
 Notka źródłowa:
 {excerpt}"""
-        raw, _ = call_model(prompt, model, max_tokens=350)
+        raw, _ = call_model(prompt, model, max_tokens=350, operation="author_biography_extract")
         result = _json_object(raw)
         description = str(result.get("description") or "").strip()
         if not description:
@@ -100,7 +100,7 @@ Osoba: {person.canonical_name}
 Obecny opis: {person.description}
 Nowa notka źródłowa:
 {excerpt}"""
-    raw, _ = call_model(prompt, model, max_tokens=600)
+    raw, _ = call_model(prompt, model, max_tokens=600, operation="author_biography_merge")
     result = _json_object(raw)
     allowed = {"no_new_information", "new_information", "conflicting_information"}
     if result.get("decision") not in allowed:

--- a/backend/library/chunk_llm_analysis.py
+++ b/backend/library/chunk_llm_analysis.py
@@ -86,7 +86,7 @@ Gdy nic nie trzeba wykluczyć, zwróć [].
 --- PONUMEROWANE LINIE ---
 {numbered}
 --- KONIEC ---"""
-        raw, _ = call_model(prompt, model, PRECLEAN_MAX_TOKENS)
+        raw, _ = call_model(prompt, model, PRECLEAN_MAX_TOKENS, operation="article_preclean")
         for decision in _parse_cleanup_ranges(raw, batch_end - batch_start):
             for local_idx in range(decision["start_line"] - 1, decision["end_line"]):
                 labels[batch_start + local_idx] = (decision["type"], decision["reason"])
@@ -119,7 +119,7 @@ Fragment transkrypcji:
 {intro_text}"""
 
     logger.info("extract_speaker_info: len=%d", len(intro_text))
-    response_text, _ = call_model(prompt, model, max_tokens=300)
+    response_text, _ = call_model(prompt, model, max_tokens=300, operation="speaker_extraction")
     try:
         match = re.search(r'\[.*\]', response_text, re.DOTALL)
         if match:
@@ -157,7 +157,7 @@ Fragment artykułu:
 {text}"""
 
     logger.info("extract_author_info: len=%d", len(text))
-    response_text, _ = call_model(prompt, model, max_tokens=200)
+    response_text, _ = call_model(prompt, model, max_tokens=200, operation="author_extraction")
     try:
         match = re.search(r'\{.*\}', response_text, re.DOTALL)
         if match:
@@ -195,7 +195,7 @@ Fragment artykułu:
 {text}"""
 
     logger.info("extract_publication_date_info: len=%d", len(text))
-    response_text, _ = call_model(prompt, model, max_tokens=100)
+    response_text, _ = call_model(prompt, model, max_tokens=100, operation="publication_date_extraction")
     try:
         match = re.search(r'\{.*\}', response_text, re.DOTALL)
         if match:
@@ -242,16 +242,12 @@ def remove_speech_fillers(text: str) -> str:
     return text.strip()
 
 
-def call_model(prompt: str, model: str, max_tokens: int) -> tuple[str, int]:
-    """Call the appropriate LLM backend and return (response_text, token_count)."""
-    if model.startswith(_ARKLABS_PREFIX):
-        from library.api.arklabs.arklabs_completion import arklabs_get_completion
-        actual = f"speakleash/{model.removeprefix(_ARKLABS_PREFIX)}"
-        result = arklabs_get_completion(prompt, model=actual, max_tokens=max_tokens, temperature=0.2)
-    else:
-        from library.api.cloudferro.sherlock.sherlock import sherlock_get_completion
-        result = sherlock_get_completion(prompt, model=model, max_tokens=max_tokens, temperature=0.2)
-    tokens = getattr(result, "prompt_tokens", 0) or 0
+def call_model(prompt: str, model: str, max_tokens: int, *, operation: str = "document_analysis") -> tuple[str, int]:
+    """Call the audited LLM gateway and return (response_text, token_count)."""
+    from library.ai import ai_ask
+
+    result = ai_ask(prompt, model=model, max_token_count=max_tokens, temperature=0.2, operation=operation)
+    tokens = getattr(result, "total_tokens", 0) or 0
     return result.response_text, tokens
 
 
@@ -296,7 +292,7 @@ def rewrite_chunk_text(text: str, model: str, position: int = 1, total: int = 1,
     best = ""
     for attempt in range(1, 3):
         logger.info("rewrite chunk %d/%d, attempt %d, len=%d", position, total, attempt, len(text))
-        response_text, tokens = call_model(prompt, model, REWRITE_MAX_TOKENS)
+        response_text, tokens = call_model(prompt, model, REWRITE_MAX_TOKENS, operation="chunk_rewrite")
         logger.info("rewrite done: %d chars, %d tokens", len(response_text), tokens)
         if len(response_text) > len(best):
             best = response_text
@@ -332,7 +328,7 @@ Skup się na głównych tezach i wnioskach. Używaj imion rozmówców (nie pisz 
 --- KONIEC ---"""
 
     logger.info("summarize chunk, len=%d, speakers=%d", len(corrected_text), len(speakers or []))
-    response_text, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    response_text, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS, operation="chunk_summary")
     logger.info("summarize done: %d tokens", tokens)
     return response_text.strip()
 
@@ -377,7 +373,7 @@ Jeśli REKLAMA: nie dodawaj nic więcej.
 --- KONIEC ---"""
 
     logger.info("semantic analysis, len=%d, speakers=%d", len(corrected_text), len(speakers or []))
-    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS, operation="chunk_semantic_analysis")
     logger.info("semantic done: %d tokens", tokens)
 
     section_type, topic, summary_text = parse_rewritten_chunk(raw)
@@ -422,7 +418,7 @@ Jeśli ZRODLA, REKLAMA lub SZUM: nie dodawaj nic więcej.
 --- KONIEC ---"""
 
     logger.info("article analysis chunk %d/%d, len=%d", position, total, len(original_text))
-    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS)
+    raw, tokens = call_model(prompt, model, SUMMARY_MAX_TOKENS, operation="article_chunk_analysis")
     logger.info("article analysis done: %d tokens", tokens)
 
     section_type, topic, summary_text = parse_rewritten_chunk(raw)

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1904,7 +1904,9 @@ def compute_document_quality(doc_id: int):
     ]
     try:
         from library.article_quality import compute_quality
-        doc.quality = compute_quality(doc, sections, model=run.model)
+        from library.llm_usage.context import llm_usage_context
+        with llm_usage_context(document_id=doc_id, analysis_run_id=run.id):
+            doc.quality = compute_quality(doc, sections, model=run.model)
     except Exception:
         logger.exception("quality computation failed for document %d", doc_id)
         return jsonify({"status": "error", "message": "Quality computation failed"}), 500
@@ -2439,11 +2441,15 @@ def reanalyze_chunk(chunk_id: int):
                 .where(DocumentChunk.run_id == chunk.run_id)
             ) or 1
             from library.chunk_llm_analysis import analyze_article_chunk
-            result = analyze_article_chunk(text_to_analyze, model,
-                                           position=chunk.position, total=total)
+            from library.llm_usage.context import llm_usage_context
+            with llm_usage_context(document_id=run.document_id, analysis_run_id=run.id):
+                result = analyze_article_chunk(text_to_analyze, model,
+                                               position=chunk.position, total=total)
         elif mode == "semantic" and chunk.corrected_text and chunk.corrected_text.strip():
             from library.chunk_llm_analysis import analyze_chunk_semantic
-            result = analyze_chunk_semantic(chunk.corrected_text, model, speakers=speakers)
+            from library.llm_usage.context import llm_usage_context
+            with llm_usage_context(document_id=run.document_id, analysis_run_id=run.id):
+                result = analyze_chunk_semantic(chunk.corrected_text, model, speakers=speakers)
         else:
             text_to_analyze = chunk.original_text or ""
             if not text_to_analyze.strip():
@@ -2454,8 +2460,10 @@ def reanalyze_chunk(chunk_id: int):
                 .order_by(DocumentChunk.position)
             ).all()
             from library.chunk_llm_analysis import analyze_chunk
-            result = analyze_chunk(text_to_analyze, model, position=chunk.position,
-                                   total=len(all_chunks), speakers=speakers)
+            from library.llm_usage.context import llm_usage_context
+            with llm_usage_context(document_id=run.document_id, analysis_run_id=run.id):
+                result = analyze_chunk(text_to_analyze, model, position=chunk.position,
+                                       total=len(all_chunks), speakers=speakers)
     except Exception:
         logger.exception("LLM call failed for chunk %d (mode=%s)", chunk_id, mode)
         return jsonify({"status": "error", "message": "LLM call failed"}), 500

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -1682,6 +1682,9 @@ class LlmUsageLog(Base):
     analysis_job_id: Mapped[str | None] = mapped_column(
         String(32), ForeignKey("document_analysis_jobs.id", ondelete="SET NULL"),
     )
+    analysis_run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_analysis_runs.id", ondelete="SET NULL"),
+    )
     operation: Mapped[str] = mapped_column(String(50), nullable=False)
     provider: Mapped[str] = mapped_column(String(50), nullable=False)
     model: Mapped[str] = mapped_column(String(100), nullable=False)
@@ -1729,6 +1732,7 @@ class LlmUsageLog(Base):
         Index("idx_llm_usage_logs_provider_model_called", "provider", "model", "called_at"),
         Index("idx_llm_usage_logs_document_called", "document_id", "called_at"),
         Index("idx_llm_usage_logs_analysis_job", "analysis_job_id"),
+        Index("idx_llm_usage_logs_analysis_run", "analysis_run_id"),
         Index(
             "idx_llm_usage_logs_interpretation",
             "search_interpretation_log_id",

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -211,7 +211,7 @@ def _merge_topics(sections: list[dict], model: str, mode: str = "transcript") ->
         f"Fragmenty:\n{chunk_list}"
     )
     try:
-        response_text, _ = call_model(prompt, model, max_tokens=600)
+        response_text, _ = call_model(prompt, model, max_tokens=600, operation="topic_grouping")
         match = re.search(r'\[.*\]', response_text, re.DOTALL)
         if match:
             groups = json.loads(match.group())
@@ -256,7 +256,7 @@ def _synthesize(sections: list[dict], title: str, model: str, mode: str = "trans
         f"--- STRESZCZENIA SEKCJI ---\n{summaries}\n--- KONIEC ---"
     )
     try:
-        response_text, _ = call_model(prompt, model, SYNTHESIS_MAX_TOKENS)
+        response_text, _ = call_model(prompt, model, SYNTHESIS_MAX_TOKENS, operation="document_synthesis")
         return response_text.strip()
     except Exception:
         logger.exception("synthesis LLM call failed")

--- a/backend/library/information_provenance.py
+++ b/backend/library/information_provenance.py
@@ -127,7 +127,7 @@ Tekst:
 {text}"""
     # 1200 tokenów nie starczało na artykuły z długą listą źródeł — odpowiedź
     # była ucinana w połowie obiektu JSON.
-    raw, _ = call_model(prompt, model, max_tokens=2400)
+    raw, _ = call_model(prompt, model, max_tokens=2400, operation="information_provenance")
     candidates = _json_array(raw)
     result = []
     for item in candidates:

--- a/backend/library/llm_cost_routes.py
+++ b/backend/library/llm_cost_routes.py
@@ -89,6 +89,11 @@ def llm_costs():
         .group_by(LlmUsageLog.analysis_job_id, DocumentAnalysisJob.run_id, LlmUsageLog.cost_currency)
         .order_by(func.min(LlmUsageLog.called_at).desc())
     ).all()
+    calls = []
+    if document_id is not None:
+        calls = session.scalars(
+            select(LlmUsageLog).where(*filters).order_by(LlmUsageLog.called_at.desc()).limit(1000)
+        ).all()
 
     return jsonify({
         "status": "success", "from": date_from.isoformat(), "to": date_to.isoformat(),
@@ -105,4 +110,12 @@ def llm_costs():
         "analyses": [{"job_id": r.analysis_job_id, "run_id": r.run_id, "currency": r.cost_currency,
                       "started_at": r.started_at.isoformat() if r.started_at else None,
                       "calls": r.calls, "tokens": r.tokens, "cost": _money(r.cost)} for r in jobs],
+        "calls": [{
+            "id": r.id, "document_id": r.document_id, "job_id": r.analysis_job_id,
+            "run_id": r.analysis_run_id, "called_at": r.called_at.isoformat(),
+            "operation": r.operation, "provider": r.provider, "model": r.model,
+            "prompt_tokens": r.prompt_tokens, "completion_tokens": r.completion_tokens,
+            "tokens": r.total_tokens, "cost": _money(r.cost_amount), "currency": r.cost_currency,
+            "cost_status": r.cost_status, "success": r.success, "error_code": r.error_code,
+        } for r in calls],
     })

--- a/backend/library/llm_usage/context.py
+++ b/backend/library/llm_usage/context.py
@@ -5,18 +5,22 @@ from contextvars import ContextVar
 
 _document_id: ContextVar[int | None] = ContextVar("llm_document_id", default=None)
 _analysis_job_id: ContextVar[str | None] = ContextVar("llm_analysis_job_id", default=None)
+_analysis_run_id: ContextVar[int | None] = ContextVar("llm_analysis_run_id", default=None)
 
 
-def current_usage_context() -> tuple[int | None, str | None]:
-    return _document_id.get(), _analysis_job_id.get()
+def current_usage_context() -> tuple[int | None, str | None, int | None]:
+    return _document_id.get(), _analysis_job_id.get(), _analysis_run_id.get()
 
 
 @contextmanager
-def llm_usage_context(*, document_id: int | None = None, analysis_job_id: str | None = None):
+def llm_usage_context(*, document_id: int | None = None, analysis_job_id: str | None = None,
+                      analysis_run_id: int | None = None):
     document_token = _document_id.set(document_id)
     job_token = _analysis_job_id.set(analysis_job_id)
+    run_token = _analysis_run_id.set(analysis_run_id)
     try:
         yield
     finally:
+        _analysis_run_id.reset(run_token)
         _analysis_job_id.reset(job_token)
         _document_id.reset(document_token)

--- a/backend/library/llm_usage/recorder.py
+++ b/backend/library/llm_usage/recorder.py
@@ -126,6 +126,7 @@ def record_llm_usage(
     search_interpretation_log_id: int | None = None,
     document_id: int | None = None,
     analysis_job_id: str | None = None,
+    analysis_run_id: int | None = None,
     credits_used: Decimal | None = None,
     reported_cost: Decimal | None = None,
     reported_cost_currency: str | None = None,
@@ -160,15 +161,18 @@ def record_llm_usage(
         pricing = _active_pricing(session, provider, model)
         cost = _resolve_cost(pricing, reported, reported_cost_currency, prompt, completion)
 
-        if document_id is None and analysis_job_id is None:
-            from library.llm_usage.context import current_usage_context
-            document_id, analysis_job_id = current_usage_context()
+        from library.llm_usage.context import current_usage_context
+        context_document_id, context_job_id, context_run_id = current_usage_context()
+        document_id = document_id if document_id is not None else context_document_id
+        analysis_job_id = analysis_job_id if analysis_job_id is not None else context_job_id
+        analysis_run_id = analysis_run_id if analysis_run_id is not None else context_run_id
 
         log = LlmUsageLog(
             request_id=request_id,
             search_interpretation_log_id=search_interpretation_log_id,
             document_id=document_id,
             analysis_job_id=analysis_job_id,
+            analysis_run_id=analysis_run_id,
             operation=operation,
             provider=provider,
             model=model,

--- a/backend/library/time_periods.py
+++ b/backend/library/time_periods.py
@@ -98,11 +98,12 @@ def normalize_period(candidate: dict) -> dict | None:
     }
 
 
-def classify_fragment(fragment: str, model: str) -> tuple[list[dict], dict]:
+def classify_fragment(fragment: str, model: str, *, document_id: int | None = None) -> tuple[list[dict], dict]:
     """Make one LLM call and retain valid, de-duplicated periods (main period first)."""
     response = ai_ask(
         _time_period_prompt(fragment), model=model, temperature=0.1, max_token_count=800,
         operation="time_period_classification",
+        document_id=document_id,
     )
     candidates, invalid_json = _parse_periods_response(response.response_text)
     periods: list[dict] = []
@@ -134,7 +135,9 @@ def extract_document_periods(session, doc, model: str | None = None, *, chapter_
     periods: list[dict] = []
     chapter_reports: list[dict] = []
     for chapter in _chapters_for_document(doc, chapter_position):
-        extracted, report = classify_fragment(chapter["text"][:MAX_FRAGMENT_CHARS], selected_model)
+        extracted, report = classify_fragment(
+            chapter["text"][:MAX_FRAGMENT_CHARS], selected_model, document_id=getattr(doc, "id", None),
+        )
         for position, period in enumerate(extracted):
             periods.append({
                 "chapter_position": chapter["position"],

--- a/backend/library/timeline_events.py
+++ b/backend/library/timeline_events.py
@@ -336,11 +336,13 @@ FRAGMENT:
 """
 
 
-def extract_fragment_events(fragment: str, chapter_position: int | None, model: str) -> tuple[list[dict], dict]:
+def extract_fragment_events(fragment: str, chapter_position: int | None, model: str,
+                            *, document_id: int | None = None) -> tuple[list[dict], dict]:
     """Make one LLM call and retain only grounded events with normalizable dates."""
     response = ai_ask(
         _timeline_prompt(fragment), model=model, temperature=0.1, max_token_count=4000,
         operation="timeline_event_extraction",
+        document_id=document_id,
     )
     events: list[dict] = []
     rejected_quote = rejected_date = 0
@@ -403,7 +405,9 @@ def extract_document_events(session, doc, model: str | None = None, *, chapter_p
         chapter_events: list[dict] = []
         fragment_reports: list[dict] = []
         for fragment in split_timeline_fragments(chapter["text"]):
-            extracted, report = extract_fragment_events(fragment, chapter["position"], selected_model)
+            extracted, report = extract_fragment_events(
+                fragment, chapter["position"], selected_model, document_id=getattr(doc, "id", None),
+            )
             chapter_events.extend(extracted)
             fragment_reports.append(report)
         events.extend(chapter_events)

--- a/backend/library/tones.py
+++ b/backend/library/tones.py
@@ -117,11 +117,12 @@ def normalize_tone(candidate: dict) -> dict | None:
     }
 
 
-def classify_fragment(fragment: str, model: str) -> tuple[dict | None, dict]:
+def classify_fragment(fragment: str, model: str, *, document_id: int | None = None) -> tuple[dict | None, dict]:
     """Make one LLM call and return the validated tone (or None) with a report."""
     response = ai_ask(
         _tone_prompt(fragment), model=model, temperature=0.1, max_token_count=500,
         operation="tone_classification",
+        document_id=document_id,
     )
     candidate = parse_tone_response(response.response_text)
     tone = normalize_tone(candidate) if candidate is not None else None
@@ -139,7 +140,9 @@ def extract_document_tones(session, doc, model: str | None = None, *, chapter_po
     tones: list[dict] = []
     chapter_reports: list[dict] = []
     for chapter in _chapters_for_document(doc, chapter_position):
-        tone, report = classify_fragment(chapter["text"][:MAX_FRAGMENT_CHARS], selected_model)
+        tone, report = classify_fragment(
+            chapter["text"][:MAX_FRAGMENT_CHARS], selected_model, document_id=getattr(doc, "id", None),
+        )
         if tone is not None:
             tones.append({"chapter_position": chapter["position"], **tone})
         chapter_reports.append({

--- a/backend/server.py
+++ b/backend/server.py
@@ -485,8 +485,10 @@ def website_entities_refresh():
     if rows:
         try:
             from library.place_verification import verify_document_places
+            from library.llm_usage.context import llm_usage_context
 
-            summary = verify_document_places(session, doc, text)
+            with llm_usage_context(document_id=doc_id):
+                summary = verify_document_places(session, doc, text)
             session.commit()
             place_tags = summary["tagged"]
         except Exception:
@@ -495,8 +497,10 @@ def website_entities_refresh():
 
         try:
             from library.person_registry import resolve_document_persons
+            from library.llm_usage.context import llm_usage_context
 
-            p_summary = resolve_document_persons(session, doc, text)
+            with llm_usage_context(document_id=doc_id):
+                p_summary = resolve_document_persons(session, doc, text)
             session.commit()
             persons_linked = len(p_summary["linked"])
         except Exception:

--- a/backend/tests/unit/test_article_tagging.py
+++ b/backend/tests/unit/test_article_tagging.py
@@ -12,7 +12,7 @@ from library import article_tagging
 
 def _fake_ai(response_text, calls=None):
     """Zwraca podróbkę ai_ask, opcjonalnie rejestrującą wywołania w `calls`."""
-    def fake(prompt, model, temperature=0.7, max_token_count=4096, top_p=0.9):
+    def fake(prompt, model, temperature=0.7, max_token_count=4096, top_p=0.9, **kwargs):
         if calls is not None:
             calls.append({"prompt": prompt, "model": model})
         return SimpleNamespace(response_text=response_text)

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -135,7 +135,7 @@ class TestSzumType:
     def test_article_chunk_szum_has_no_summary(self, monkeypatch):
         monkeypatch.setattr(
             llm, "call_model",
-            lambda prompt, model, max_tokens: ("### SZUM: menu i stopka strony\ncokolwiek", 10),
+            lambda prompt, model, max_tokens, **kwargs: ("### SZUM: menu i stopka strony\ncokolwiek", 10),
         )
         result = llm.analyze_article_chunk("Wróć na POLSKA ŚWIAT...", "m")
         assert result["type"] == "SZUM"
@@ -146,7 +146,7 @@ class TestSzumType:
     def test_article_chunk_temat_strips_streszczenie_prefix(self, monkeypatch):
         monkeypatch.setattr(
             llm, "call_model",
-            lambda prompt, model, max_tokens: ("### TEMAT: konflikt USA-Iran\nStreszczenie: Analiza sytuacji.", 10),
+            lambda prompt, model, max_tokens, **kwargs: ("### TEMAT: konflikt USA-Iran\nStreszczenie: Analiza sytuacji.", 10),
         )
         result = llm.analyze_article_chunk("Treść merytoryczna.", "m")
         assert result["type"] == "TEMAT"

--- a/backend/tests/unit/test_llm_gateway_enforcement.py
+++ b/backend/tests/unit/test_llm_gateway_enforcement.py
@@ -1,0 +1,43 @@
+"""Architectural guard: business code must not bypass auditable LLM calls."""
+
+import ast
+from pathlib import Path
+
+
+BACKEND = Path(__file__).resolve().parents[2]
+ALLOWED = {
+    Path("library/ai.py"),
+    Path("library/api/arklabs/arklabs_completion.py"),
+    Path("library/api/cloudferro/sherlock/sherlock.py"),
+}
+LOW_LEVEL_FUNCTIONS = {"arklabs_get_completion", "sherlock_get_completion"}
+
+
+def test_business_code_does_not_call_low_level_llm_clients():
+    violations = []
+    paths = [*BACKEND.joinpath("library").rglob("*.py"), *BACKEND.joinpath("imports").rglob("*.py")]
+    paths += list(BACKEND.glob("*.py"))
+    for path in paths:
+        relative = path.relative_to(BACKEND)
+        if relative in ALLOWED or "tests" in relative.parts or "test_code" in relative.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in LOW_LEVEL_FUNCTIONS:
+                    violations.append(f"{relative}:{node.lineno} calls {node.func.id}")
+    assert violations == [], "LLM calls bypass central ai_ask audit:\n" + "\n".join(violations)
+
+
+def test_business_ai_calls_name_their_operational_moment():
+    violations = []
+    for path in BACKEND.joinpath("library").rglob("*.py"):
+        relative = path.relative_to(BACKEND)
+        if relative == Path("library/ai.py"):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "ai_ask":
+                if not any(keyword.arg == "operation" for keyword in node.keywords):
+                    violations.append(f"{relative}:{node.lineno} has no operation")
+    assert violations == [], "Audited LLM calls without an operational moment:\n" + "\n".join(violations)

--- a/backend/tests/unit/test_llm_usage_recorder.py
+++ b/backend/tests/unit/test_llm_usage_recorder.py
@@ -62,7 +62,7 @@ def bielik_factory(**kwargs) -> FakeSessionFactory:
 class TestEstimatedCost:
     def test_document_analysis_context_is_attached_to_usage_row(self):
         factory = bielik_factory()
-        with llm_usage_context(document_id=9258, analysis_job_id="a" * 32):
+        with llm_usage_context(document_id=9258, analysis_job_id="a" * 32, analysis_run_id=123):
             record_llm_usage(
                 operation="chunk_analysis",
                 provider="cloudferro",
@@ -74,6 +74,19 @@ class TestEstimatedCost:
 
         assert factory.added[0].document_id == 9258
         assert factory.added[0].analysis_job_id == "a" * 32
+        assert factory.added[0].analysis_run_id == 123
+
+    def test_explicit_document_keeps_job_and_run_from_context(self):
+        factory = bielik_factory()
+        with llm_usage_context(document_id=1, analysis_job_id="b" * 32, analysis_run_id=456):
+            record_llm_usage(
+                operation="tone_classification", provider="cloudferro",
+                model="Bielik-11B-v3.0-Instruct", document_id=2,
+                session_factory=factory,
+            )
+        assert factory.added[0].document_id == 2
+        assert factory.added[0].analysis_job_id == "b" * 32
+        assert factory.added[0].analysis_run_id == 456
 
     def test_per_token_pricing_writes_estimated_cost(self):
         factory = bielik_factory()

--- a/web_interface_react/src/modules/shared/pages/llmCosts.tsx
+++ b/web_interface_react/src/modules/shared/pages/llmCosts.tsx
@@ -8,7 +8,10 @@ type OperationRow = CostRow & { operation: string; model: string };
 type DailyRow = CostRow & { day: string };
 type AnalysisRow = CostRow & { job_id: string; run_id: number | null; started_at: string | null };
 type DocumentRow = CostRow & { document_id: number | null; title: string | null };
-type Report = { totals: CostRow[]; documents: DocumentRow[]; daily: DailyRow[]; operations: OperationRow[]; analyses: AnalysisRow[] };
+type CallRow = { id: number; document_id: number | null; job_id: string | null; run_id: number | null; called_at: string;
+  operation: string; provider: string; model: string; prompt_tokens: number | null; completion_tokens: number | null;
+  tokens: number | null; cost: string | null; currency: string | null; cost_status: string; success: boolean; error_code: string | null };
+type Report = { totals: CostRow[]; documents: DocumentRow[]; daily: DailyRow[]; operations: OperationRow[]; analyses: AnalysisRow[]; calls: CallRow[] };
 
 const iso = (d: Date) => d.toISOString().slice(0, 10);
 const money = (value: string | null, currency: string | null) => value == null ? "—" : `${Number(value).toFixed(6)} ${currency ?? "?"}`;
@@ -81,7 +84,20 @@ const LlmCosts = () => {
       {documentId && <><h3>Analizy dokumentu</h3><p style={{ color: "#64748b" }}>Powiązanie obejmuje wywołania wykonane po wdrożeniu tej funkcji.</p>
         <table style={tableStyle}><thead><tr><th style={th}>Data</th><th style={th}>Job / run</th><th style={th}>Koszt</th><th style={th}>Wywołania</th><th style={th}>Tokeny</th></tr></thead><tbody>
           {report.analyses.map((r, i) => <tr key={`${r.job_id}-${r.currency}-${i}`}><td style={td}>{r.started_at?.replace("T", " ").slice(0, 19)}</td><td style={td}>{r.job_id.slice(0, 8)} / {r.run_id ?? "—"}</td><td style={td}>{money(r.cost, r.currency)}</td><td style={td}>{r.calls}</td><td style={td}>{r.tokens.toLocaleString("pl")}</td></tr>)}
-        </tbody></table></>}
+        </tbody></table>
+        <h3>Historia operacji LLM</h3>
+        <table style={tableStyle}><thead><tr><th style={th}>Moment</th><th style={th}>Operacja</th><th style={th}>Dostawca / model</th><th style={th}>Run / job</th><th style={th}>Tokeny</th><th style={th}>Koszt</th><th style={th}>Status</th></tr></thead><tbody>
+          {report.calls.map(r => <tr key={r.id}>
+            <td style={td}>{r.called_at.replace("T", " ").slice(0, 19)}</td><td style={td}>{r.operation}</td>
+            <td style={td}>{r.provider}<br/><span style={{ color: "#64748b" }}>{r.model}</span></td>
+            <td style={td}>{r.run_id != null ? `run ${r.run_id}` : "—"}{r.job_id ? <><br/><span title={r.job_id}>job {r.job_id.slice(0, 8)}</span></> : null}</td>
+            <td style={td}>{r.tokens?.toLocaleString("pl") ?? "—"}<br/><span style={{ color: "#64748b" }}>{r.prompt_tokens ?? "?"} in / {r.completion_tokens ?? "?"} out</span></td>
+            <td style={td}>{money(r.cost, r.currency)}<br/><span style={{ color: r.cost_status === "unknown" ? "#b45309" : "#64748b" }}>{r.cost_status}</span></td>
+            <td style={td}>{r.success ? "OK" : <span style={{ color: "#b91c1c" }}>Błąd: {r.error_code ?? "nieznany"}</span>}</td>
+          </tr>)}
+        </tbody></table>
+        {!report.calls.length && <p>Brak zarejestrowanych operacji LLM dla dokumentu w tym okresie.</p>}
+      </>}
     </>}
   </div>;
 };


### PR DESCRIPTION
## Zakres
- prowadzi ekstrakcję DynamoDB, analizę chunków, preclean, jakość, syntezę, autorów i provenance przez centralnie rejestrowaną bramę LLM
- przypisuje wywołania do dokumentu, joba i runu oraz zapisuje precyzyjny moment operacyjny
- pokazuje chronologiczną historię wywołań w panelu kosztów dokumentu
- dodaje migrację analysis_run_id oraz test architektoniczny blokujący omijanie bramy

## Weryfikacja
- 166 testów objętych zmianą: passed
- ruff: passed
- Alembic: pojedynczy head d1e2f3a4b5c6
- React production build: passed

Pełny legacy test dokument_analysis próbuje łączyć się z Vault/NER na NAS w konfiguracji lokalnej; nie jest to regresja tej zmiany.