### PR TITLE
Prevent duplicate documents with canonical URLs

### DIFF
--- a/backend/alembic/versions/e2f3a4b5c6d7_add_documents_canonical_url.py
+++ b/backend/alembic/versions/e2f3a4b5c6d7_add_documents_canonical_url.py
@@ -1,0 +1,80 @@
+"""Add canonical URL identity to documents.
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+"""
+from collections import defaultdict
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e2f3a4b5c6d7"
+down_revision = "d1e2f3a4b5c6"
+branch_labels = None
+depends_on = None
+
+_EXACT = {"_ga", "_gl", "dclid", "fbclid", "gclid", "gbraid", "igshid", "msclkid", "twclid", "wbraid"}
+_PREFIXES = ("utm_", "mc_", "ss_", "vero_")
+
+
+def _canonicalize(url: str) -> str:
+    value = (url or "").strip()
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return value.split("#", 1)[0]
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    try:
+        hostname = hostname.encode("idna").decode("ascii")
+    except UnicodeError:
+        pass
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None and not ((scheme == "http" and port == 80) or (scheme == "https" and port == 443)):
+        host = f"{host}:{port}"
+    if parsed.username:
+        credentials = parsed.username + (f":{parsed.password}" if parsed.password else "")
+        host = f"{credentials}@{host}"
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/") or "/"
+    items = [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+             if k.lower() not in _EXACT and not k.lower().startswith(_PREFIXES)]
+    if hostname in {"youtu.be", "www.youtu.be"}:
+        video_id = path.strip("/").split("/", 1)[0]
+        if video_id:
+            host, path, items = "www.youtube.com", "/watch", [("v", video_id)]
+    elif hostname in {"youtube.com", "www.youtube.com", "m.youtube.com"} and path == "/watch":
+        ids = [v for k, v in items if k == "v"]
+        if ids:
+            host, items = "www.youtube.com", [("v", ids[0])]
+    return urlunsplit((scheme, host, path, urlencode(sorted(items), doseq=True), ""))
+
+
+def upgrade():
+    op.add_column("documents", sa.Column("canonical_url", sa.Text(), nullable=True))
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT id, url FROM documents ORDER BY id")).fetchall()
+    collisions = defaultdict(list)
+    for document_id, url in rows:
+        canonical = _canonicalize(url)
+        connection.execute(
+            sa.text("UPDATE documents SET canonical_url = :canonical WHERE id = :id"),
+            {"canonical": canonical, "id": document_id},
+        )
+        collisions[canonical].append(document_id)
+    for canonical, ids in collisions.items():
+        if len(ids) > 1:
+            print(f"CANONICAL URL COLLISION: {canonical} -> document IDs {ids}")
+    op.alter_column("documents", "canonical_url", nullable=False)
+    op.create_index("idx_documents_canonical_url", "documents", ["canonical_url"])
+
+
+def downgrade():
+    op.drop_index("idx_documents_canonical_url", table_name="documents")
+    op.drop_column("documents", "canonical_url")

--- a/backend/database/init/03-create-table.sql
+++ b/backend/database/init/03-create-table.sql
@@ -10,6 +10,7 @@ create table documents
     id                   serial primary key,
     summary              text,
     url                  text not null,
+    canonical_url        text not null,
     language             varchar(10),
     tags                 text,
     text                 text,
@@ -41,6 +42,7 @@ CREATE INDEX IF NOT EXISTS idx_documents_document_type ON public.documents(docum
 CREATE INDEX IF NOT EXISTS idx_documents_processing_status ON public.documents(processing_status);
 CREATE INDEX IF NOT EXISTS idx_documents_ingested_at ON public.documents(ingested_at);
 CREATE INDEX IF NOT EXISTS idx_documents_url ON public.documents(url);
+CREATE INDEX IF NOT EXISTS idx_documents_canonical_url ON public.documents(canonical_url);
 CREATE INDEX IF NOT EXISTS idx_documents_collection_id ON public.documents(collection_id);
 CREATE INDEX IF NOT EXISTS idx_documents_discovery_source_id ON public.documents(discovery_source_id);
 CREATE INDEX IF NOT EXISTS idx_documents_published_on ON public.documents(published_on);

--- a/backend/email_import.py
+++ b/backend/email_import.py
@@ -22,7 +22,9 @@ import re
 import subprocess
 import sys
 import time
-from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from urllib.parse import urlparse
+
+from library.url_normalization import canonicalize_url
 
 from library.config_loader import load_config
 
@@ -129,13 +131,8 @@ def is_tracking_url(url: str) -> bool:
 
 
 def strip_utm_params(url: str) -> str:
-    """Remove UTM and other marketing query parameters from a URL."""
-    parsed = urlparse(url)
-    params = parse_qs(parsed.query, keep_blank_values=True)
-    clean_params = {k: v for k, v in params.items()
-                    if not k.startswith(("utm_", "mc_", "ss_", "vero_"))}
-    clean_query = urlencode(clean_params, doseq=True)
-    return urlunparse(parsed._replace(query=clean_query))
+    """Backward-compatible wrapper around shared URL canonicalization."""
+    return canonicalize_url(url)
 
 
 def resolve_tracking_url(url: str, timeout: int = 5) -> str:

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -219,21 +219,23 @@ def save_cache_files(doc_id: int, text_content: str | None, html_content: str | 
 
 def refresh_existing_document(session, item: dict, text_content: str | None,
                               html_content: str | None, cache_dir: str) -> int:
-    """Apply an extension-captured source revision to an existing document.
+    """Fill a missing raw HTML source on an existing document.
 
-    The previous S3 object remains untouched. The DynamoDB create event retains
-    its UUID, while this refresh event points the document at the new object.
+    Existing raw HTML is never replaced. The DynamoDB event retains its UUID,
+    while the document is pointed at that object only when its source is absent.
     Only deterministic author metadata is refreshed here; article analysis,
     chunks and embeddings are deliberately left intact.
     """
-    target_id = int(item["target_document_id"])
-    doc = session.get(Document, target_id)
+    doc = Document.get_by_url(session, item.get("url", ""))
     if doc is None:
-        raise ValueError(f"refresh target document {target_id} does not exist")
-    if doc.url != item.get("url"):
-        raise ValueError(f"refresh URL does not match document {target_id}")
+        raise ValueError("fill target document does not exist")
+    legacy_target_id = item.get("target_document_id")
+    if legacy_target_id is not None and doc.id != int(legacy_target_id):
+        raise ValueError("legacy refresh target does not match URL")
     if not html_content:
-        raise ValueError("refresh HTML is missing from S3")
+        raise ValueError("fill HTML is missing from S3")
+    if doc.text_raw:
+        raise ValueError(f"document {doc.id} already has raw HTML")
 
     new_uuid = item.get("uuid") or item.get("s3_uuid")
     if not new_uuid:
@@ -561,9 +563,9 @@ def main():
                 text_content = None
                 html_content = None
 
-                if item.get("operation", "create") == "refresh":
+                if item.get("operation", "create") in {"refresh", "fill_missing_html"}:
                     if args.dry_run:
-                        print(f"  WOULD REFRESH document id={item.get('target_document_id')}")
+                        print(f"  WOULD FILL MISSING HTML for URL={item.get('url')}")
                         refreshed += 1
                         continue
                     if args.skip_s3:

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -31,7 +31,9 @@ from sqlalchemy import (
     text as sa_text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
-from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship, validates
+
+from library.url_normalization import canonicalize_url
 
 from pgvector.sqlalchemy import Vector
 
@@ -249,6 +251,7 @@ class Document(Base):
     # Content fields (order matches DDL in 03-create-table.sql)
     summary: Mapped[str | None] = mapped_column(Text)
     url: Mapped[str] = mapped_column(Text, nullable=False)
+    canonical_url: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     language: Mapped[str | None] = mapped_column(String(10))
     tags: Mapped[str | None] = mapped_column(Text)
     text: Mapped[str | None] = mapped_column(Text)
@@ -413,10 +416,15 @@ class Document(Base):
 
     @classmethod
     def get_by_url(cls, session: Session, url: str) -> "Document | None":
-        """Return document matching the given URL, or None."""
+        """Return a document matching the canonical identity of the URL."""
         return session.scalars(
-            select(cls).where(cls.url == url)
+            select(cls).where(cls.canonical_url == canonicalize_url(url))
         ).first()
+
+    @validates("url")
+    def _set_canonical_url(self, _key: str, value: str) -> str:
+        self.canonical_url = canonicalize_url(value)
+        return value
 
     # --- Domain methods (migrated from stalker_web_document.py) ---
 
@@ -505,6 +513,7 @@ class Document(Base):
             "previous_type": self.previous_type,
             "summary": self.summary,
             "url": self.url,
+            "canonical_url": self.canonical_url,
             "language": self.language,
             "tags": self.tags,
             "text": self.text,

--- a/backend/library/document_service.py
+++ b/backend/library/document_service.py
@@ -25,6 +25,14 @@ from library.website.website_download_context import download_raw_html, webpage_
 logger = logging.getLogger(__name__)
 
 
+class ExistingDocumentError(ValueError):
+    """Raised when an URL submitted as new already belongs to a document."""
+
+    def __init__(self, document: Document):
+        super().__init__(f"Document for URL already exists: {document.id}")
+        self.document = document
+
+
 class DocumentService:
     """Stateless service for document business logic.
 
@@ -61,6 +69,10 @@ class DocumentService:
         """
         if not url or not url_type:
             raise ValueError("Missing required parameter(s): 'url' or 'type'")
+
+        existing = Document.get_by_url(self.session, url)
+        if existing is not None:
+            raise ExistingDocumentError(existing)
 
         cfg = load_config()
         bucket_name = cfg.get("AWS_S3_WEBSITE_CONTENT")
@@ -131,20 +143,15 @@ class DocumentService:
     # save_document — extracted from /website_save
     # ------------------------------------------------------------------
 
-    def refresh_document_source(self, document_id: int, url: str, html: str,
-                                text: str = "") -> Document:
-        """Store a new captured source revision and re-extract deterministic authors."""
-        try:
-            document_id = int(document_id)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Refresh requires target_document_id") from exc
-        doc = Document.get_by_id(self.session, document_id)
+    def fill_missing_source_html(self, url: str, html: str, text: str = "") -> Document:
+        """Attach captured HTML only when the existing document has no raw source."""
+        doc = Document.get_by_url(self.session, url)
         if doc is None:
-            raise ValueError("Refresh target document does not exist")
-        if doc.url != url:
-            raise ValueError("Refresh URL does not match target document")
+            raise ValueError("Document for URL does not exist")
         if doc.document_type != "webpage" or not html:
-            raise ValueError("Refresh requires a webpage with HTML")
+            raise ValueError("Filling source requires a webpage with HTML")
+        if doc.text_raw:
+            raise ValueError("Document already has raw HTML")
 
         cfg = load_config()
         bucket_name = cfg.get("AWS_S3_WEBSITE_CONTENT")
@@ -163,6 +170,14 @@ class DocumentService:
         set_document_authors(self.session, doc, extract_article_authors(html, url), method="html")
         self.session.commit()
         return doc
+
+    def refresh_document_source(self, document_id: int, url: str, html: str,
+                                text: str = "") -> Document:
+        """Backward-compatible entry point with safe fill-only semantics."""
+        doc = Document.get_by_id(self.session, int(document_id))
+        if doc is None or doc.url != url:
+            raise ValueError("Refresh target does not match URL")
+        return self.fill_missing_source_html(url=url, html=html, text=text)
 
     def save_document(
         self,

--- a/backend/library/url_normalization.py
+++ b/backend/library/url_normalization.py
@@ -1,0 +1,77 @@
+"""Stable URL canonicalization used for document identity and deduplication."""
+
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+_TRACKING_PARAMS = {
+    "_ga", "_gl", "dclid", "fbclid", "gclid", "gbraid", "igshid",
+    "msclkid", "twclid", "wbraid",
+}
+_TRACKING_PREFIXES = ("utm_", "mc_", "ss_", "vero_")
+
+
+def _is_tracking_param(name: str) -> bool:
+    lowered = name.lower()
+    return lowered in _TRACKING_PARAMS or lowered.startswith(_TRACKING_PREFIXES)
+
+
+def canonicalize_url(url: str) -> str:
+    """Return a conservative canonical identity for an absolute URL.
+
+    The original URL remains the fetch/display address. This value is only a
+    comparison key: fragments and known tracking parameters are discarded,
+    while all potentially content-selecting query parameters are preserved.
+    """
+    value = (url or "").strip()
+    if not value:
+        raise ValueError("URL cannot be empty")
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        # Keep malformed legacy values migratable and comparable. Callers that
+        # fetch URLs remain responsible for rejecting them.
+        return value.split("#", 1)[0]
+
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    try:
+        hostname = hostname.encode("idna").decode("ascii")
+    except UnicodeError:
+        pass
+
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None and not ((scheme == "http" and port == 80) or
+                                 (scheme == "https" and port == 443)):
+        host = f"{host}:{port}"
+    if parsed.username:
+        credentials = parsed.username
+        if parsed.password:
+            credentials += f":{parsed.password}"
+        host = f"{credentials}@{host}"
+
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/") or "/"
+
+    query_items = [
+        (key, value) for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not _is_tracking_param(key)
+    ]
+
+    # Known equivalent YouTube forms share one identity.
+    if hostname in {"youtu.be", "www.youtu.be"}:
+        video_id = path.strip("/").split("/", 1)[0]
+        if video_id:
+            host, path, query_items = "www.youtube.com", "/watch", [("v", video_id)]
+    elif hostname in {"youtube.com", "www.youtube.com", "m.youtube.com"} and path == "/watch":
+        video_ids = [value for key, value in query_items if key == "v"]
+        if video_ids:
+            host, query_items = "www.youtube.com", [("v", video_ids[0])]
+
+    query = urlencode(sorted(query_items), doseq=True)
+    return urlunsplit((scheme, host, path, query, ""))

--- a/backend/server.py
+++ b/backend/server.py
@@ -5,7 +5,7 @@ import logging
 from library.config_loader import load_config
 from library.db.engine import get_scoped_session
 from library.db.models import TranscriptionLog, Document
-from library.document_service import DocumentService
+from library.document_service import DocumentService, ExistingDocumentError
 from library.search_service import SearchService
 from library.document_repository import DocumentRepository
 from library.website.website_paid import website_is_paid
@@ -220,9 +220,11 @@ def url_add():
 
         session = get_scoped_session()
         service = DocumentService(session)
-        if url_data.get("operation", "create") == "refresh":
-            doc = service.refresh_document_source(
-                document_id=url_data.get("target_document_id"),
+        operation = url_data.get("operation", "create")
+        if operation not in {"create", "fill_missing_html"}:
+            raise ValueError("Invalid operation")
+        if operation == "fill_missing_html":
+            doc = service.fill_missing_source_html(
                 url=url_data.get("url", ""),
                 html=url_data.get("html", ""),
                 text=url_data.get("text", ""),
@@ -247,6 +249,14 @@ def url_add():
             'document_id': doc.id
         }, 200
 
+    except ExistingDocumentError as e:
+        doc = e.document
+        return {
+            'status': 'already_exists',
+            'message': f'Document already exists with ID: {doc.id}',
+            'document_id': doc.id,
+            'missing_raw_html': not bool(doc.text_raw),
+        }, 409
     except ValueError as e:
         logging.error("Validation error in /url_add: %s", e)
         return {'status': 'error', 'message': 'Invalid request data'}, 400

--- a/backend/tests/unit/test_document_service.py
+++ b/backend/tests/unit/test_document_service.py
@@ -10,7 +10,7 @@ import pytest
 
 pytest.importorskip("sqlalchemy")
 
-from library.document_service import DocumentService
+from library.document_service import DocumentService, ExistingDocumentError
 from library.db.models import Document
 
 
@@ -22,6 +22,7 @@ from library.db.models import Document
 def _make_session():
     """Return a mock SQLAlchemy session."""
     session = MagicMock()
+    session.scalars.return_value.first.return_value = None
     return session
 
 
@@ -65,6 +66,23 @@ class TestDocumentServiceInit:
 
 
 class TestCreateDocument:
+    @patch("library.document_service.load_config")
+    def test_duplicate_is_rejected_before_storage(self, mock_config):
+        existing = _make_doc(text_raw="<html>stored</html>")
+        session = _make_session()
+        service = DocumentService(session)
+
+        with patch.object(Document, "get_by_url", return_value=existing), \
+             patch.object(service, "_store_file") as mock_store, \
+             pytest.raises(ExistingDocumentError) as exc:
+            service.create_document(
+                url=existing.url, url_type="webpage", html="<html>new</html>",
+            )
+
+        assert exc.value.document is existing
+        mock_store.assert_not_called()
+        session.add.assert_not_called()
+
     @patch("library.document_service.load_config")
     def test_create_document_basic(self, mock_config):
         """Create a basic link document (no S3 storage)."""
@@ -428,6 +446,31 @@ class TestSplitForEmbedding:
 # ---------------------------------------------------------------------------
 # Tests: _store_file (private, but critical)
 # ---------------------------------------------------------------------------
+
+
+class TestFillMissingSourceHtml:
+    def test_rejects_document_that_already_has_raw_html(self):
+        session = _make_session()
+        existing = _make_doc(text_raw="<html>stored</html>")
+        service = DocumentService(session)
+
+        with patch.object(Document, "get_by_url", return_value=existing), \
+             pytest.raises(ValueError, match="already has raw HTML"):
+            service.fill_missing_source_html(
+                url=existing.url, html="<html>new</html>",
+            )
+
+        session.commit.assert_not_called()
+
+    def test_rejects_unknown_url(self):
+        session = _make_session()
+        service = DocumentService(session)
+
+        with patch.object(Document, "get_by_url", return_value=None), \
+             pytest.raises(ValueError, match="does not exist"):
+            service.fill_missing_source_html(
+                url="https://example.com/missing", html="<html>new</html>",
+            )
 
 
 class TestStoreFile:

--- a/backend/tests/unit/test_flask_endpoints_orm.py
+++ b/backend/tests/unit/test_flask_endpoints_orm.py
@@ -434,6 +434,28 @@ class TestWebsiteSave:
 
 
 class TestUrlAdd:
+    def test_duplicate_returns_existing_document_details(self, client):
+        from library.document_service import ExistingDocumentError
+
+        mock_session = MagicMock()
+        existing = MagicMock()
+        existing.id = 77
+        existing.text_raw = "<html>stored</html>"
+        with patch("server.get_scoped_session", return_value=mock_session), \
+             patch("server.DocumentService") as MockDS:
+            MockDS.return_value.create_document.side_effect = ExistingDocumentError(existing)
+            resp = client.post("/url_add", json={
+                "url": "https://example.com", "type": "webpage", "html": "<html>new</html>",
+            }, headers=API_HEADERS, content_type="application/json")
+
+        assert resp.status_code == 409
+        assert resp.get_json() == {
+            "status": "already_exists",
+            "message": "Document already exists with ID: 77",
+            "document_id": 77,
+            "missing_raw_html": False,
+        }
+
     def test_successful_add(self, client):
         mock_session = MagicMock()
         mock_doc = MagicMock()

--- a/backend/tests/unit/test_orm_crud.py
+++ b/backend/tests/unit/test_orm_crud.py
@@ -182,6 +182,19 @@ class TestGetByUrl:
         assert result is doc
         assert result.url == "https://example.com/path?q=hello%20world&lang=pl#section"
 
+    def test_lookup_uses_canonical_url(self):
+        session = MagicMock()
+        Document.get_by_url(session, "HTTPS://Example.com/a/?utm_source=x#part")
+
+        statement = session.scalars.call_args.args[0]
+        assert "documents.canonical_url" in str(statement)
+        assert statement.compile().params["canonical_url_1"] == "https://example.com/a"
+
+    def test_setting_url_populates_canonical_url(self):
+        doc = Document(url="https://Example.com/a/?utm_source=x#part")
+        assert doc.url == "https://Example.com/a/?utm_source=x#part"
+        assert doc.canonical_url == "https://example.com/a"
+
 
 # ===================================================================
 # Task 3: ORM Create flow
@@ -424,7 +437,7 @@ class TestDictCompatibility:
         d = doc.dict()
         expected_keys = {
             "id", "next_id", "next_type", "previous_id", "previous_type",
-            "summary", "url", "language", "tags", "text", "paywall", "title",
+            "summary", "url", "canonical_url", "language", "tags", "text", "paywall", "title",
             "ingested_at", "document_type", "source", "discovery_source_id", "published_on", "published_on_method", "original_id",
             "document_length", "chapter_list", "processing_status", "processing_error_code",
             "text_raw", "transcript_job_id", "ai_summary_needed", "byline",

--- a/backend/tests/unit/test_url_normalization.py
+++ b/backend/tests/unit/test_url_normalization.py
@@ -1,0 +1,27 @@
+import pytest
+
+from library.url_normalization import canonicalize_url
+
+
+@pytest.mark.parametrize(("raw", "expected"), [
+    (
+        " HTTPS://Example.COM:443/article/?b=2&utm_source=x&a=1#section ",
+        "https://example.com/article?a=1&b=2",
+    ),
+    ("https://example.com", "https://example.com/"),
+    ("http://example.com:80/a/", "http://example.com/a"),
+    ("legacy/path/?utm_source=x#part", "legacy/path"),
+    ("https://example.com/a?id=7&ref=home", "https://example.com/a?id=7&ref=home"),
+    ("https://youtu.be/abc123?t=20", "https://www.youtube.com/watch?v=abc123"),
+    (
+        "https://m.youtube.com/watch?feature=share&v=abc123&utm_medium=x",
+        "https://www.youtube.com/watch?v=abc123",
+    ),
+])
+def test_canonicalize_url(raw, expected):
+    assert canonicalize_url(raw) == expected
+
+
+def test_blank_url_is_rejected():
+    with pytest.raises(ValueError, match="empty"):
+        canonicalize_url("  ")

--- a/docs/api-contracts-backend.md
+++ b/docs/api-contracts-backend.md
@@ -32,8 +32,11 @@ Add a new document (URL) to the system.
     "chapter_list": ""
   }
   ```
-- **Response**: `{status, message, document_id}`
-- **Note**: In AWS serverless, replaced by `sqs-weblink-put-into` Lambda (S3 + DynamoDB + SQS flow)
+- **Success response (Flask)**: `{status: "success", message, document_id}`
+- **Duplicate response**: HTTP `409`, `{status: "already_exists", message, document_id, missing_raw_html}`. Duplicate identity is based on normalized `canonical_url`, not exact source-string equality.
+- **Fill missing source HTML**: send `operation: "fill_missing_html"` with the existing page URL and captured `html`. The backend resolves the document by canonical URL and accepts the operation only when `text_raw` is absent. It does not rerun analysis, chunking, embeddings, or LLM calls.
+- **AWS response**: `{status: "queued", message, submission_id}` because S3/DynamoDB submission precedes the PostgreSQL import.
+- **Note**: ordinary resubmission never refreshes existing content. Replacing an existing HTML source and regenerating derived data require a separate, explicit workflow.
 
 ### GET /website_list
 List documents with filters.

--- a/docs/data-models-backend.md
+++ b/docs/data-models-backend.md
@@ -4,14 +4,15 @@
 
 ## Database Schema
 
-### Table: documents (29 columns)
+### Table: documents
 
 Primary document storage table.
 
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | `id` | serial | PK | Auto-increment identifier |
-| `url` | text | NOT NULL | Source URL |
+| `url` | text | NOT NULL | Original source URL used for display and fetching |
+| `canonical_url` | text | NOT NULL | Normalized comparison key used for URL lookup and duplicate detection |
 | `document_type` | varchar(50) | NOT NULL | movie, youtube, link, webpage, text_message, text, email, social_media_post |
 | `processing_status` | varchar(50) | NOT NULL, DEFAULT 'URL_ADDED' | Processing state (15 states) |
 | `processing_error_code` | text | — | Error details when state=ERROR |
@@ -40,7 +41,9 @@ Primary document storage table.
 | `uuid` | varchar(100) | NOT NULL DEFAULT gen_random_uuid(), UNIQUE | Global document identifier (ADR-015) |
 | `collection_id` | integer | FK → collections.id | Thematic collection (ADR-017: 1:N; replaced `project` in stage 11c) |
 
-**Indexes**: document_type, processing_status, ingested_at, url, collection_id, discovery_source_id, published_on, paywall, ai_summary_needed
+**Indexes**: document_type, processing_status, ingested_at, url, canonical_url, collection_id, discovery_source_id, published_on, paywall, ai_summary_needed
+
+`canonical_url` is derived automatically whenever `Document.url` is assigned. It removes fragments and known tracking parameters, normalizes host casing/default ports/query ordering/trailing slashes, and canonicalizes common YouTube URL variants. Parameters that may identify content are retained. Historical collisions are reported by migration `e2f3a4b5c6d7`; they are not merged automatically, so the index is intentionally non-unique until those document groups are reviewed.
 
 ### Table: document_embeddings (8 columns)
 

--- a/docs/url-normalization.md
+++ b/docs/url-normalization.md
@@ -1,0 +1,38 @@
+# Document URL normalization
+
+Documents retain two URL values:
+
+- `url` is the original address used for display and fetching;
+- `canonical_url` is the stable comparison key used by `Document.get_by_url()` and duplicate detection.
+
+The shared implementation is `backend/library/url_normalization.py`. All ORM assignments to `Document.url` populate `canonical_url` automatically.
+
+## Rules
+
+Normalization is deliberately conservative:
+
+- trim surrounding whitespace;
+- lowercase the scheme and hostname and remove a trailing hostname dot;
+- encode international hostnames with IDNA;
+- remove default ports 80/443;
+- remove the `#fragment`;
+- remove known tracking parameters (`utm_*`, `fbclid`, `gclid`, `msclkid`, and related identifiers);
+- retain content-selecting query parameters and sort them deterministically;
+- normalize empty paths and trailing slashes;
+- map common YouTube watch and `youtu.be` forms to one identity.
+
+The implementation does not globally equate `http` with `https` or an apex domain with `www`, because those addresses can represent different resources.
+
+## Database migration
+
+Migration `e2f3a4b5c6d7_add_documents_canonical_url.py` adds and backfills the column. During upgrade it prints every normalized address shared by multiple historical documents as:
+
+```text
+CANONICAL URL COLLISION: <canonical-url> -> document IDs [<id>, ...]
+```
+
+The migration does not delete or merge anything and creates a non-unique index. Review each collision before introducing a unique constraint, because chunks, analyses, embeddings, notes, and review state may be attached to different records.
+
+## Submission behavior
+
+A normal submission whose canonical URL already exists returns the existing document ID and does not store or analyze another document. Captured HTML can only be attached through `fill_missing_html`, and only if the existing document has no `text_raw`. This operation does not trigger paid LLM processing.

--- a/infra/aws/serverless/lambdas/url-add/lambda_function.py
+++ b/infra/aws/serverless/lambdas/url-add/lambda_function.py
@@ -59,7 +59,7 @@ def lambda_handler(event, context):
 
     if not target_url or not url_type:
         return _error_response("Missing required parameter(s): 'url' or 'type'")
-    if operation not in {"create", "refresh"}:
+    if operation not in {"create", "refresh", "fill_missing_html"}:
         return _error_response("Invalid operation", 400)
     if operation == "refresh":
         try:
@@ -68,6 +68,8 @@ def lambda_handler(event, context):
             return _error_response("Refresh requires target_document_id", 400)
         if target_document_id <= 0 or url_type != "webpage" or not html:
             return _error_response("Refresh requires a webpage with HTML", 400)
+    if operation == "fill_missing_html" and (url_type != "webpage" or not html):
+        return _error_response("Filling source requires a webpage with HTML", 400)
 
     # Generuj unikalny identyfikator i timestamp
     uid = str(uuid.uuid4())
@@ -127,7 +129,11 @@ def lambda_handler(event, context):
 
     return {
         'statusCode': 200,
-        'body': json.dumps(f'Successfully saved document, id: {uid}'),
+        'body': json.dumps({
+            'status': 'queued',
+            'message': 'Document submission queued for import',
+            'submission_id': uid,
+        }),
         'headers': {
             'Access-Control-Allow-Origin': '*',
             'Access-Control-Allow-Credentials': True,

--- a/shared/types/documents.ts
+++ b/shared/types/documents.ts
@@ -4,6 +4,7 @@ export interface Document {
   source: string;
   language: string;
   url: string;
+  canonical_url: string;
   tags: string;
   title: string;
   summary: string;
@@ -26,6 +27,7 @@ export const emptyDocument: Document = {
   source: "",
   language: "",
   url: "",
+  canonical_url: "",
   tags: "",
   title: "",
   summary: "",

--- a/web_chrome_extension/CHANGELOG.md
+++ b/web_chrome_extension/CHANGELOG.md
@@ -4,6 +4,12 @@ Wszystkie istotne zmiany w tym projekcie będą udokumentowane w tym pliku.
 
 Format zgodny z [Keep a Changelog](https://keepachangelog.com/) i semantycznym wersjonowaniem [Semantic Versioning](https://semver.org/).
 
+## [1.0.26] - 2026-07-20
+### Zmienione
+- Ponowne dodanie URL jest rozpoznawane jako duplikat zamiast tworzyć kolejny dokument.
+- Duplikaty są wykrywane po znormalizowanym adresie (m.in. bez fragmentów i parametrów śledzących).
+- „Odśwież istniejący dokument” zastąpiono bezpieczną operacją uzupełnienia brakującego surowego HTML, bez ręcznego podawania ID.
+
 ## [1.0.25] - 2026-07-18
 ### Dodane
 - Tryb „Odśwież istniejący dokument” wysyłający aktualny, wyrenderowany HTML strony wraz z ID dokumentu Lenie.

--- a/web_chrome_extension/manifest.json
+++ b/web_chrome_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Lenie AI assistant",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Wtyczka do komunikacji z API lenie-ai.eu",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "content_security_policy": {

--- a/web_chrome_extension/popup.html
+++ b/web_chrome_extension/popup.html
@@ -100,12 +100,8 @@
 
       <div class="form-group form-check">
         <input type="checkbox" class="form-check-input" id="refreshExisting">
-        <label class="form-check-label" for="refreshExisting">Odśwież istniejący dokument</label>
-      </div>
-      <div class="form-group" id="refreshDocumentIdContainer" style="display: none;">
-        <label for="refreshDocumentId">ID dokumentu Lenie</label>
-        <input type="number" min="1" id="refreshDocumentId" class="form-control" placeholder="np. 421">
-        <small class="form-text text-muted">Zapisze nową kopię HTML i zaktualizuje wskazany dokument po synchronizacji.</small>
+        <label class="form-check-label" for="refreshExisting">Uzupełnij brakujący surowy HTML</label>
+        <small class="form-text text-muted">Operacja zostanie odrzucona, jeśli dokument dla tego URL ma już surowy HTML.</small>
       </div>
 
       <button id="sendButton" class="btn btn-primary btn-block">Wyślij</button>

--- a/web_chrome_extension/popup.js
+++ b/web_chrome_extension/popup.js
@@ -35,12 +35,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const newSourceNameInput = document.getElementById('newSourceName');
   const addSourceButton = document.getElementById('addSourceButton');
   const refreshExisting = document.getElementById('refreshExisting');
-  const refreshDocumentId = document.getElementById('refreshDocumentId');
-  const refreshDocumentIdContainer = document.getElementById('refreshDocumentIdContainer');
-
-  refreshExisting.addEventListener('change', () => {
-    refreshDocumentIdContainer.style.display = refreshExisting.checked ? 'block' : 'none';
-  });
 
   const ADD_NEW_SOURCE = '__add_new__';
   let previousSourceValue = sourceSelect.value;
@@ -267,15 +261,6 @@ document.addEventListener('DOMContentLoaded', function () {
     sendButton.disabled = true;
     sendButton.textContent = 'Wysyłam...';
 
-    const targetDocumentId = Number.parseInt(refreshDocumentId.value, 10);
-    if (refreshExisting.checked && (!Number.isInteger(targetDocumentId) || targetDocumentId <= 0)) {
-      alert('Podaj prawidłowe ID istniejącego dokumentu.');
-      sendButton.style.backgroundColor = '';
-      sendButton.disabled = false;
-      sendButton.textContent = 'Wyślij';
-      return;
-    }
-
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       const pageUrl = tabs[0]?.url || '';
       chrome.scripting.executeScript({
@@ -300,8 +285,7 @@ document.addEventListener('DOMContentLoaded', function () {
             chapter_list: chapter_list.value
           };
           if (refreshExisting.checked) {
-            data.operation = 'refresh';
-            data.target_document_id = targetDocumentId;
+            data.operation = 'fill_missing_html';
           }
 
           return fetch(serverUrl, {
@@ -313,14 +297,21 @@ document.addEventListener('DOMContentLoaded', function () {
             body: JSON.stringify(data)
           });
         })
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(`Serwer zwrócił błąd: ${response.status} - ${response.statusText}`);
+        .then(async response => {
+          const result = await response.json().catch(() => ({}));
+          if (response.status === 409 && result.status === 'already_exists') {
+            const suffix = result.missing_raw_html
+              ? ' Brakuje mu surowego HTML — możesz użyć opcji jego uzupełnienia.'
+              : '';
+            throw new Error(`Dokument jest już w bazie (ID: ${result.document_id}).${suffix}`);
           }
-          return response.json();
+          if (!response.ok) {
+            throw new Error(result.message || `Serwer zwrócił błąd: ${response.status} - ${response.statusText}`);
+          }
+          return result;
         })
-        .then(() => {
-          alert('Strona została dodana pomyślnie!');
+        .then(result => {
+          alert(result.status === 'queued' ? 'Zgłoszenie zostało przekazane do importu.' : 'Strona została dodana pomyślnie!');
           noteInput.value = '';
           setTimeout(() => window.close(), 500);
         })


### PR DESCRIPTION
## Summary
- add conservative canonical URL normalization and persist documents.canonical_url
- reject duplicate submissions before storage and limit HTML updates to missing raw sources
- update Chrome extension, AWS queue response, shared types, and documentation
- add Alembic backfill migration that reports historical collisions without merging them

## Verification
- 123 targeted backend tests passed
- TypeScript: tsc --noEmit
- popup.js syntax check
- Alembic graph has one head: e2f3a4b5c6d7
- Gitleaks and TruffleHog hooks passed

## Deployment
Run alembic upgrade head after merge and review any CANONICAL URL COLLISION messages.