### PR TITLE
article_browser: JSON flags for chunk analysis runs (fixes PowerShell heredoc breakage)

### DIFF
--- a/.claude/commands/obsidian-note.md
+++ b/.claude/commands/obsidian-note.md
@@ -39,56 +39,25 @@ Every document type can have chunk analysis runs — mode `transcript` (youtube/
 A document can have **more than one run** (a book typically has one `split_only` run over the whole text plus one `article` run per chapter). List all runs first:
 
 ```powershell
-cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
-from library.db.engine import get_session
-from library.db.models import DocumentAnalysisRun, DocumentChunk
-session = get_session()
-runs = session.query(DocumentAnalysisRun).filter_by(document_id=<ARTICLE_ID>).order_by(DocumentAnalysisRun.created_at.desc()).all()
-if not runs:
-    print('NO_RUNS')
-else:
-    for run in runs:
-        chunks = session.query(DocumentChunk).filter_by(run_id=run.id).all()
-        temat = [c for c in chunks if c.type == 'TEMAT']
-        analyzed = [c for c in temat if c.topic]
-        approved = [c for c in temat if c.status == 'approved']
-        scope = run.scope or '(caly dokument)'
-        created = run.created_at.strftime(chr(37)+\"Y-\"+chr(37)+\"m-\"+chr(37)+\"d\")
-        print(f'RUN_ID={run.id}|MODE={run.mode}|STATUS={run.status}|SCOPE={scope}|MODEL={run.model}|CREATED={created}|TEMAT={len(temat)}|ANALYZED={len(analyzed)}|APPROVED={len(approved)}')
-session.close()
-"@
+cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python imports/article_browser.py --runs --id <ARTICLE_ID>
 ```
+
+Returns JSON: `{"doc_id", "runs": [{"run_id", "mode", "status", "scope", "model", "created_at", "temat_count", "analyzed_count", "approved_count"}, ...]}`.
 
 **Interpret the result:**
-- `NO_RUNS` → proceed to **Step 1c** (fetch full text via `--dump`)
+- Empty `runs` array → proceed to **Step 1c** (fetch full text via `--dump`)
 - **One run** → auto-select it as `<RUN_ID>`, proceed straight to **Step 2a**
-- **Multiple runs** → this is typically a book (chapter runs) or a document re-analyzed several times. Show the list to the user (id, mode, scope, temat/analyzed/approved counts). A run with `ANALYZED=0` is a `split_only` run — chunks exist but have no topic/summary yet, not usable for note-writing on its own (even if `APPROVED` is non-zero — that can happen for stale/aborted runs where chunks were approved before topics were ever generated). Propose the run with the highest `ANALYZED` as the default (break ties by `APPROVED`), but let the user pick a different `RUN_ID` (e.g. a specific chapter). Once a `RUN_ID` is chosen, proceed to **Step 2a**.
+- **Multiple runs** → this is typically a book (chapter runs) or a document re-analyzed several times. Show the list to the user (id, mode, scope, temat/analyzed/approved counts). A run with `analyzed_count=0` is a `split_only` run — chunks exist but have no topic/summary yet, not usable for note-writing on its own (even if `approved_count` is non-zero — that can happen for stale/aborted runs where chunks were approved before topics were ever generated). Propose the run with the highest `analyzed_count` as the default (break ties by `approved_count`), but let the user pick a different `RUN_ID` (e.g. a specific chapter). Once a `RUN_ID` is chosen, proceed to **Step 2a**.
 
-**Fetch the chunk list for the chosen run** (used by Step 2a — also re-run this after the user picks a different `RUN_ID` from the multi-run list above):
+**Fetch chunks + topic sections for the chosen run** (used by Step 2a — also re-run this after the user picks a different `RUN_ID` from the multi-run list above):
 
 ```powershell
-cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
-from library.db.engine import get_session
-from library.db.models import DocumentAnalysisRun, DocumentChunk
-session = get_session()
-run = session.get(DocumentAnalysisRun, <RUN_ID>)
-chunks = session.query(DocumentChunk).filter_by(run_id=run.id).order_by(DocumentChunk.position).all()
-temat = [c for c in chunks if c.type == 'TEMAT']
-reklama = [c for c in chunks if c.type != 'TEMAT']  # REKLAMA + SZUM
-approved = [c for c in temat if c.status == 'approved']
-created = run.created_at.strftime(chr(37)+\"Y-\"+chr(37)+\"m-\"+chr(37)+\"d\")
-print(f'RUN_ID={run.id}|MODE={run.mode}|SCOPE={run.scope or \"(caly dokument)\"}|MODEL={run.model}|CREATED={created}')
-print(f'TEMAT={len(temat)}|REKLAMA_SZUM={len(reklama)}|APPROVED={len(approved)}')
-print('---CHUNKS---')
-for c in temat:
-    summary = (c.summary or '(brak)').replace(chr(10), ' ')[:250]
-    notes = ','.join(c.obsidian_note_paths or [])
-    print(f'pos={c.position}|status={c.status}|notes={notes}|topic={c.topic or \"(brak)\"}|summary={summary}')
-session.close()
-"@
+cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python imports/article_browser.py --chunks --run-id <RUN_ID>
 ```
 
-If `MODE=article`, `corrected_text` is expected to be `None` for every chunk — that is normal for this mode (no rewrite step), not a data quality issue. See the note in Step 2a's "Content usage rules".
+Returns JSON: `{"run_id", "mode", "status", "scope", "model", "created_at", "temat_count", "reklama_szum_count", "chunks": [{"position", "status", "topic", "summary", "obsidian_note_paths"}, ...], "topic_sections": [{"section_id", "position", "title", "temat_count", "done_count", "chunk_positions"}, ...]}`. `chunks` is already filtered to `TEMAT` only (REKLAMA/SZUM counted separately in `reklama_szum_count`). This single call backs both the flat chunk list and the section-grouped view in Step 2a — no separate section query needed.
+
+If `mode=article`, chunk text (fetched later via `--chunk-text`) has `corrected_text=None` for every chunk — that is normal for this mode (no rewrite step), not a data quality issue. See the note in Step 2a's "Content usage rules".
 
 **Step 1c — Fetch full text (only when no chunks exist):**
 
@@ -115,64 +84,17 @@ The `--dump` JSON adds one extra field to `--meta`: `text` (full article content
 
 **Use this step whenever Step 1b found a run to use** (any document type — youtube/movie transcript chunks or webpage/link/text/book article chunks). This is the primary path whenever pre-reviewed chunks exist — it skips sending the full text to the LLM.
 
-**If `TEMAT` count is large (> 30 chunks — same threshold as the `/chunks/:id` UI's `SECTION_VIEW_THRESHOLD`), use the section-grouped view below instead of the flat list.** Typical case: books with a run per chapter, or a `split_only` whole-book run. Otherwise skip straight to **"Flat chunk list"**.
+**If `temat_count` from the `--chunks` JSON (Step 1b) is large (> 30 — same threshold as the `/chunks/:id` UI's `SECTION_VIEW_THRESHOLD`), use the section-grouped view below instead of the flat list.** Typical case: books with a run per chapter, or a `split_only` whole-book run. Otherwise skip straight to **"Flat chunk list"**.
 
 #### Section-grouped view (large runs — books)
 
-Fetch section stats:
-
-```powershell
-cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
-from library.db.engine import get_session
-from library.db.models import DocumentAnalysisRun, DocumentChunk, DocumentTopicSection
-session = get_session()
-run = session.get(DocumentAnalysisRun, <RUN_ID>)
-chunks = session.query(DocumentChunk).filter_by(run_id=run.id).order_by(DocumentChunk.position).all()
-sections = session.query(DocumentTopicSection).filter_by(run_id=run.id).order_by(DocumentTopicSection.position).all()
-covered = set()
-for s in sections:
-    positions = set(s.chunk_positions or [])
-    covered |= positions
-    members = [c for c in chunks if c.position in positions and c.type == 'TEMAT']
-    done = sum(1 for c in members if c.obsidian_note_paths or c.status == 'skipped')
-    print(f'SEC_ID={s.id}|pos={s.position}|title={s.title or \"(brak tytulu)\"}|temat={len(members)}|done={done}')
-uncovered = [c for c in chunks if c.type == 'TEMAT' and c.position not in covered]
-if uncovered:
-    done = sum(1 for c in uncovered if c.obsidian_note_paths or c.status == 'skipped')
-    print(f'SEC_ID=NONE|title=(chunki bez przypisanej sekcji)|temat={len(uncovered)}|done={done}')
-session.close()
-"@
-```
-
-Topic sections don't always cover every `TEMAT` chunk (LLM synthesis is partial) — the `SEC_ID=NONE` line covers the rest, if any.
+No extra query needed — the `topic_sections` array from Step 1b's `--chunks` call already has everything: `chunk_positions` lists which chunk positions belong to each section, `temat_count`/`done_count` are precomputed. Chunks whose position doesn't appear in any section's `chunk_positions` are "uncovered" — topic sections don't always cover every `TEMAT` chunk (LLM synthesis is partial); group these under a synthetic "(chunki bez przypisanej sekcji)" entry.
 
 **Display split into two groups (same top/bottom convention as the flat list):**
-- **Sekcje ukończone** (`done == temat`) at the TOP, compact one-liners: `Rozdział N: Tytuł — ✓ wszystkie opracowane (n tematów)`
-- **Sekcje do opracowania** (`done < temat`) at the BOTTOM: `Rozdział N: Tytuł — X/Y opracowanych`
+- **Sekcje ukończone** (`done_count == temat_count`) at the TOP, compact one-liners: `Rozdział N: Tytuł — ✓ wszystkie opracowane (n tematów)`
+- **Sekcje do opracowania** (`done_count < temat_count`) at the BOTTOM: `Rozdział N: Tytuł — X/Y opracowanych`
 
-**Ask the user** which section(s) to drill into (by `SEC_ID`, or title). Then for each chosen section, fetch its chunks:
-
-```powershell
-cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
-from library.db.engine import get_session
-from library.db.models import DocumentChunk, DocumentTopicSection
-session = get_session()
-section = session.get(DocumentTopicSection, <SEC_ID>)
-positions = set(section.chunk_positions or [])
-chunks = session.query(DocumentChunk).filter(
-    DocumentChunk.run_id == <RUN_ID>,
-    DocumentChunk.position.in_(positions),
-    DocumentChunk.type == 'TEMAT',
-).order_by(DocumentChunk.position).all()
-for c in chunks:
-    summary = (c.summary or '(brak)').replace(chr(10), ' ')[:250]
-    notes = ','.join(c.obsidian_note_paths or [])
-    print(f'pos={c.position}|status={c.status}|notes={notes}|topic={c.topic or \"(brak)\"}|summary={summary}')
-session.close()
-"@
-```
-
-(For `SEC_ID=NONE`, filter `DocumentChunk.position.notin_(covered)` instead, reusing the `covered` set logic from the stats query above.)
+**Ask the user** which section(s) to drill into (by `section_id`, or title). Then filter the `chunks` array already fetched in Step 1b to `position in section.chunk_positions` (for the uncovered group, `position` not in any section's `chunk_positions`) — no new DB call.
 
 Display these per-section chunks using the same **Już w notatkach / Nieopracowane** split as the flat list below, then continue with "For each selected chunk — fetch full text".
 
@@ -213,35 +135,23 @@ Run #42 — Bielik-11B-v3.0-Instruct (2026-06-30) — 8 tematów, 3 reklamy
 **For each selected chunk — fetch full text from DB (works for both modes):**
 
 ```powershell
-cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
-from library.db.engine import get_session
-from library.db.models import DocumentChunk
-session = get_session()
-positions = [<comma_separated_positions>]
-chunks = session.query(DocumentChunk).filter(
-    DocumentChunk.run_id == <RUN_ID>,
-    DocumentChunk.position.in_(positions)
-).order_by(DocumentChunk.position).all()
-for c in chunks:
-    print(f'=== CHUNK #{c.position} — {c.topic or \"(brak tematu)\"} ===')
-    print(c.corrected_text or c.original_text or '(brak tekstu)')
-    print()
-session.close()
-"@
+cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python imports/article_browser.py --chunk-text --run-id <RUN_ID> --positions <comma_separated_positions>
 ```
+
+Returns JSON: `{"run_id", "chunks": [{"position", "topic", "status", "text"}, ...]}`. `text` already applies the mode-aware fallback: `corrected_text` if present, else `original_text`.
 
 **Content usage rules:**
 - If chunk has `summary` and `approved` status → use `summary` as the basis, enrich only if needed
-- If chunk needs detail:
-  - **mode=transcript** (youtube/movie) → use `corrected_text` (cleaned STT transcript with fillers/rewrite applied). Never send raw `original_text` to the LLM if `corrected_text` is available.
-  - **mode=article** (webpage/link/text/book) → `corrected_text` is **always `None` by design** — this mode has no rewrite step, the source markdown is already clean. Use `original_text` directly; this is expected behavior, not missing data, and should NOT be flagged as a data quality issue to the user.
+- If chunk needs detail → use the `text` field from `--chunk-text`:
+  - **mode=transcript** (youtube/movie) → this is `corrected_text` (cleaned STT transcript with fillers/rewrite applied) — never the raw `original_text`.
+  - **mode=article** (webpage/link/text/book) → this is `original_text` — `corrected_text` is **always `None` by design** for this mode (no rewrite step, source markdown is already clean). This is expected behavior, not missing data, and should NOT be flagged as a data quality issue to the user.
 - If chunk is `pending`/`needs_reanalysis` → warn user and ask if they want to proceed anyway (this is a status-based check, orthogonal to which text field is populated)
 
 **Then proceed to Step 3** (find related notes).
 
 ### Step 2b: Standard content flow (no existing chunks)
 
-**Use this step when:** the document has no chunk analysis runs at all (Step 1b returned `NO_RUNS`) — regardless of document type. Since Step 1b now checks every type, this step mainly applies to documents that were never run through `/analyze_chunks` yet.
+**Use this step when:** the document has no chunk analysis runs at all (Step 1b's `--runs` call returned an empty `runs` array) — regardless of document type. Since Step 1b now checks every type, this step mainly applies to documents that were never run through `/analyze_chunks` yet.
 
 Check `document_type` and `text_length` from `--dump`:
 
@@ -335,15 +245,15 @@ Wait for user input on what to create/update. Then create/update the Obsidian .m
 
 After creating/updating Obsidian notes, ALWAYS update the database. Two objects need updating:
 
-**A) `WebDocument` — always update:**
+**A) `Document` — always update:**
 
 ```powershell
 cd C:\Users\ziutus\git\_lenie-all\lenie-server-2025\backend; .venv/Scripts/python -c @"
 from datetime import datetime
 from library.db.engine import get_session
-from library.db.models import WebDocument
+from library.db.models import Document
 session = get_session()
-doc = WebDocument.get_by_id(session, <ARTICLE_ID>)
+doc = Document.get_by_id(session, <ARTICLE_ID>)
 paths = list(doc.obsidian_note_paths or [])
 paths.append('relative/path/to/note.md')
 doc.obsidian_note_paths = paths

--- a/backend/imports/article_browser.py
+++ b/backend/imports/article_browser.py
@@ -17,6 +17,9 @@ Usage:
     python imports/article_browser.py --list --state NEED_MANUAL_REVIEW --format short  # IDs + titles
     python imports/article_browser.py --review --not-cleaned                           # Fast flow: articles still cleanable by regexp+LLM (excludes NEED_MANUAL_REVIEW)
     python imports/article_browser.py --review --view --manual-review                 # Slow flow: dedicated pass over articles that need manual text cleanup (alias for --state NEED_MANUAL_REVIEW)
+    python imports/article_browser.py --runs --id 8805                                # JSON list of chunk analysis runs for a document (for /obsidian-note)
+    python imports/article_browser.py --chunks --run-id 42                            # JSON chunk list + topic sections for a run (for /obsidian-note)
+    python imports/article_browser.py --chunk-text --run-id 42 --positions 3,6        # JSON full text of selected chunks (for /obsidian-note)
 """
 
 import argparse
@@ -30,8 +33,12 @@ from typing import Optional
 
 from library.models.stalker_document_status import StalkerDocumentStatus
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 # Changelog:
+#   0.7.0 — --runs/--chunks/--chunk-text: JSON zapytania o DocumentAnalysisRun/DocumentChunk/
+#           DocumentTopicSection wprost z CLI (zamiast ad-hoc `python -c` heredoków wklejanych
+#           w treść slash commandu /obsidian-note — łamały się pod PowerShell przy zagnieżdżonych
+#           cudzysłowach)
 #   0.6.0 — rozpoznawanie osób (etap 4): alias/Wikidata+LLM/fuzzy → document_persons
 #           (library.person_registry; auto przy [w] i [e], confidence przy nazwiskach)
 #   0.5.1 — weryfikacja miejsc (etap 3): geokoder LocationIQ + LLM → tagi miejsce-*
@@ -61,7 +68,7 @@ from sqlalchemy.exc import InternalError as SqlInternalError
 
 from library.config_loader import load_config
 from library.db.engine import get_session
-from library.db.models import Document
+from library.db.models import Document, DocumentAnalysisRun, DocumentChunk, DocumentTopicSection
 from library.article_extractor import _detect_portal
 from library.article_pipeline import ensure_raw_markdown, extract_article
 from library.article_cleaner import clean_article_text
@@ -953,6 +960,145 @@ def cmd_dump(session, article_id: Optional[int] = None, use_md: bool = False):
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
 
+def cmd_runs(session, article_id: Optional[int] = None):
+    """Wypisz listę chunk analysis runs dla dokumentu jako JSON.
+
+    Używane jako Step 1b w slash command /obsidian-note: sprawdź czy dokument ma
+    już przeanalizowane chunki, zanim zdecydujesz o pobraniu pełnego tekstu (--dump).
+    """
+    import json
+
+    if article_id is None:
+        print(json.dumps({"error": "--runs wymaga --id <ARTICLE_ID>"}), file=sys.stderr)
+        sys.exit(1)
+
+    runs = session.query(DocumentAnalysisRun).filter_by(document_id=article_id) \
+        .order_by(DocumentAnalysisRun.created_at.desc()).all()
+
+    runs_out = []
+    for run in runs:
+        chunks = session.query(DocumentChunk).filter_by(run_id=run.id).all()
+        temat = [c for c in chunks if c.type == "TEMAT"]
+        analyzed = [c for c in temat if c.topic]
+        approved = [c for c in temat if c.status == "approved"]
+        runs_out.append({
+            "run_id": run.id,
+            "mode": run.mode,
+            "status": run.status,
+            "scope": run.scope,
+            "model": run.model,
+            "created_at": run.created_at.isoformat() if run.created_at else None,
+            "temat_count": len(temat),
+            "analyzed_count": len(analyzed),
+            "approved_count": len(approved),
+        })
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(json.dumps({"doc_id": article_id, "runs": runs_out}, ensure_ascii=False, indent=2))
+
+
+def cmd_chunks(session, run_id: Optional[int] = None):
+    """Wypisz chunki TEMAT + sekcje tematyczne dla runa jako JSON.
+
+    Używane jako Step 2a w slash command /obsidian-note: lista chunków do wyboru
+    przez użytkownika (płaska lub — dla runów-książek — grupowana po topic_sections).
+    """
+    import json
+
+    if run_id is None:
+        print(json.dumps({"error": "--chunks wymaga --run-id <RUN_ID>"}), file=sys.stderr)
+        sys.exit(1)
+
+    run = session.get(DocumentAnalysisRun, run_id)
+    if run is None:
+        print(json.dumps({"error": f"Run {run_id} nie znaleziony."}), file=sys.stderr)
+        sys.exit(1)
+
+    all_chunks = session.query(DocumentChunk).filter_by(run_id=run_id) \
+        .order_by(DocumentChunk.position).all()
+    temat = [c for c in all_chunks if c.type == "TEMAT"]
+    reklama_szum_count = len(all_chunks) - len(temat)
+
+    sections = session.query(DocumentTopicSection).filter_by(run_id=run_id) \
+        .order_by(DocumentTopicSection.position).all()
+
+    chunks_out = [{
+        "position": c.position,
+        "status": c.status,
+        "topic": c.topic,
+        "summary": c.summary,
+        "obsidian_note_paths": c.obsidian_note_paths or [],
+    } for c in temat]
+
+    sections_out = []
+    for s in sections:
+        positions = set(s.chunk_positions or [])
+        members = [c for c in temat if c.position in positions]
+        done = sum(1 for c in members if c.obsidian_note_paths or c.status == "skipped")
+        sections_out.append({
+            "section_id": s.id,
+            "position": s.position,
+            "title": s.title,
+            "temat_count": len(members),
+            "done_count": done,
+            "chunk_positions": sorted(positions),
+        })
+
+    result = {
+        "run_id": run.id,
+        "mode": run.mode,
+        "status": run.status,
+        "scope": run.scope,
+        "model": run.model,
+        "created_at": run.created_at.isoformat() if run.created_at else None,
+        "temat_count": len(temat),
+        "reklama_szum_count": reklama_szum_count,
+        "chunks": chunks_out,
+        "topic_sections": sections_out,
+    }
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+def cmd_chunk_text(session, run_id: Optional[int] = None, positions: Optional[str] = None):
+    """Wypisz pełny tekst wybranych chunków (TEMAT) jako JSON.
+
+    Używane jako Step 2a w slash command /obsidian-note: treść chunków wybranych
+    przez użytkownika do opracowania w notatce. Zwraca corrected_text jeśli
+    dostępny (mode=transcript), inaczej original_text (mode=article —
+    corrected_text jest zawsze None, tak jest zaprojektowane, nie jest to błąd).
+    """
+    import json
+
+    if run_id is None or not positions:
+        print(json.dumps({"error": "--chunk-text wymaga --run-id <RUN_ID> --positions 1,3,5"}),
+              file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        position_list = [int(p.strip()) for p in positions.split(",") if p.strip()]
+    except ValueError:
+        print(json.dumps({"error": "--positions musi być listą liczb oddzielonych przecinkami"}),
+              file=sys.stderr)
+        sys.exit(1)
+
+    chunks = session.query(DocumentChunk).filter(
+        DocumentChunk.run_id == run_id,
+        DocumentChunk.position.in_(position_list),
+    ).order_by(DocumentChunk.position).all()
+
+    chunks_out = [{
+        "position": c.position,
+        "topic": c.topic,
+        "status": c.status,
+        "text": c.corrected_text or c.original_text or "",
+    } for c in chunks]
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    print(json.dumps({"run_id": run_id, "chunks": chunks_out}, ensure_ascii=False, indent=2))
+
+
 def cmd_show(session, article_id: Optional[int] = None, check_urls: bool = False):
     """Wyświetl artykuł (metadane + treść) i zakończ — tryb nieinteraktywny."""
     if article_id is None:
@@ -1299,11 +1445,16 @@ def main():
     group.add_argument("--dump", action="store_true", help="Wypisz artykuł jako JSON — pole text (czysta treść)")
     group.add_argument("--dump-md", action="store_true", help="Wypisz artykuł jako JSON — pole text_md (markdown z formatowaniem)")
     group.add_argument("--notes", action="store_true", help="Pokaż zapisane notatki do przetworzenia")
+    group.add_argument("--runs", action="store_true", help="JSON: lista chunk analysis runs dla dokumentu (wymaga --id)")
+    group.add_argument("--chunks", action="store_true", help="JSON: chunki TEMAT + topic sections dla runa (wymaga --run-id)")
+    group.add_argument("--chunk-text", action="store_true", help="JSON: pełny tekst wybranych chunków (wymaga --run-id --positions)")
 
     parser.add_argument("--since", default=None, help="Data od (YYYY-MM-DD)")
     parser.add_argument("--portal", default=None, help="Filtruj po portalu (np. onet.pl)")
     parser.add_argument("--state", default=None, help="Filtruj po stanie (np. MD_SIMPLIFIED)")
     parser.add_argument("--id", type=int, default=None, help="Zacznij od konkretnego ID")
+    parser.add_argument("--run-id", type=int, default=None, help="ID analysis run (dla --chunks / --chunk-text)")
+    parser.add_argument("--positions", default=None, help="Pozycje chunków oddzielone przecinkami (dla --chunk-text), np. 1,3,5")
     parser.add_argument("--view", action="store_true", help="Automatycznie pokaż treść przy --review")
     parser.add_argument("--check-urls", action="store_true", help="Sprawdź dostępność obrazków i linków")
     parser.add_argument("--limit", type=int, default=50, help="Maks. artykułów (domyślnie 50)")
@@ -1334,6 +1485,12 @@ def main():
             cmd_dump(session, article_id=args.id, use_md=False)
         elif args.dump_md:
             cmd_dump(session, article_id=args.id, use_md=True)
+        elif args.runs:
+            cmd_runs(session, article_id=args.id)
+        elif args.chunks:
+            cmd_chunks(session, run_id=args.run_id)
+        elif args.chunk_text:
+            cmd_chunk_text(session, run_id=args.run_id, positions=args.positions)
         elif args.show:
             cmd_show(session, article_id=args.id, check_urls=args.check_urls)
         elif args.list:


### PR DESCRIPTION
## Summary
- Add `--runs`, `--chunks`, `--chunk-text` JSON flags to `article_browser.py`, mirroring the existing `--meta`/`--dump` convention
- Replace the `/obsidian-note` skill's ad-hoc `python -c` heredoc snippets (which broke under PowerShell due to nested escaped quotes) with calls to these flags
- Fix a latent bug in the skill's Step 6 DB-update snippet referencing a nonexistent `WebDocument` class (should be `Document`)

## Test plan
- [x] `--runs --id 9260` / `--chunks --run-id 125` / `--chunk-text --run-id 125 --positions 1` manually verified against the NAS DB
- [x] Full `/obsidian-note 9249` workflow run end-to-end with the new flags — no PowerShell quoting errors, notes created and DB updated correctly
- [x] `PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/test_article_browser_utils.py -q` — 9 passed