### PR TITLE
feat: add document stats dashboard (/stats)

### DIFF
--- a/backend/library/stats_routes.py
+++ b/backend/library/stats_routes.py
@@ -1,0 +1,88 @@
+"""HTTP reporting API for document counts: by type, by processing state, by
+discovery source, and recent daily ingestion volume — the /stats dashboard."""
+
+from datetime import date, datetime, time, timedelta
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func, select
+
+from library.db.engine import get_scoped_session
+from library.db.models import Document, DiscoverySource
+
+bp = Blueprint("stats", __name__)
+
+DEFAULT_DAYS = 30
+MAX_DAYS = 365
+RECENT_LIMIT = 20
+
+
+@bp.get("/stats")
+def stats():
+    days = request.args.get("days", DEFAULT_DAYS, type=int)
+    if days is None or days < 1 or days > MAX_DAYS:
+        return jsonify({"status": "error", "message": f"days must be between 1 and {MAX_DAYS}"}), 400
+
+    session = get_scoped_session()
+
+    total = session.execute(select(func.count(Document.id))).scalar_one()
+
+    by_type = session.execute(
+        select(Document.document_type, func.count().label("count"))
+        .group_by(Document.document_type)
+        .order_by(func.count().desc())
+    ).all()
+
+    by_state = session.execute(
+        select(Document.processing_status, func.count().label("count"))
+        .group_by(Document.processing_status)
+        .order_by(func.count().desc())
+    ).all()
+
+    source_name = func.coalesce(DiscoverySource.name, "(brak)").label("name")
+    by_source = session.execute(
+        select(source_name, func.count().label("count"))
+        .select_from(Document)
+        .outerjoin(DiscoverySource, Document.discovery_source_id == DiscoverySource.id)
+        .group_by(source_name)
+        .order_by(func.count().desc())
+    ).all()
+
+    today = date.today()
+    date_from = today - timedelta(days=days - 1)
+    start = datetime.combine(date_from, time.min)
+    day = func.date(Document.ingested_at).label("day")
+    daily_rows = session.execute(
+        select(day, func.count().label("count"))
+        .where(Document.ingested_at >= start)
+        .group_by(day)
+        .order_by(day)
+    ).all()
+    counts_by_day = {str(r.day): r.count for r in daily_rows}
+    daily = [
+        {"day": (date_from + timedelta(days=i)).isoformat(),
+         "count": counts_by_day.get((date_from + timedelta(days=i)).isoformat(), 0)}
+        for i in range(days)
+    ]
+
+    recent_rows = session.execute(
+        select(Document.id, Document.title, Document.document_type, Document.processing_status,
+               source_name, Document.ingested_at)
+        .select_from(Document)
+        .outerjoin(DiscoverySource, Document.discovery_source_id == DiscoverySource.id)
+        .order_by(Document.ingested_at.desc())
+        .limit(RECENT_LIMIT)
+    ).all()
+
+    return jsonify({
+        "status": "success",
+        "total": total,
+        "by_type": [{"document_type": r.document_type, "count": r.count} for r in by_type],
+        "by_state": [{"processing_status": r.processing_status, "count": r.count} for r in by_state],
+        "by_source": [{"name": r.name, "count": r.count} for r in by_source],
+        "daily": daily,
+        "recent": [{
+            "id": r.id, "title": r.title, "document_type": r.document_type,
+            "processing_status": r.processing_status, "source": r.name,
+            "ingested_at": r.ingested_at.isoformat() if r.ingested_at else None,
+        } for r in recent_rows],
+    }), 200

--- a/backend/server.py
+++ b/backend/server.py
@@ -19,6 +19,7 @@ from library.chunk_review_routes import bp as chunk_review_bp, start_analysis_wo
 from library.llm_cost_routes import bp as llm_cost_bp
 from library.reader_routes import bp as reader_bp
 from library.search_routes import bp as search_bp
+from library.stats_routes import bp as stats_bp
 from library.youtube_processing import process_youtube_url
 
 logging.basicConfig(level=logging.INFO)
@@ -90,6 +91,7 @@ app.register_blueprint(llm_cost_bp)
 app.register_blueprint(reader_bp)
 app.register_blueprint(api_key_bp)
 app.register_blueprint(search_bp)
+app.register_blueprint(stats_bp)
 start_analysis_worker()
 
 

--- a/backend/tests/unit/test_stats_routes.py
+++ b/backend/tests/unit/test_stats_routes.py
@@ -1,0 +1,103 @@
+"""Unit tests for GET /stats (document counts by type/state/source + recent daily ingestion)."""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("flask")
+
+API_HEADERS = {"x-api-key": "test-api-key"}
+
+
+@pytest.fixture()
+def client():
+    """Flask test client with auth bypassed (same pattern as test_flask_endpoints_document_states)."""
+    import server
+    server.app.config["TESTING"] = True
+    with patch.object(server, "check_auth_header"):
+        with server.app.test_client() as c:
+            yield c
+
+
+def _row(**kwargs):
+    row = MagicMock()
+    for key, value in kwargs.items():
+        setattr(row, key, value)
+    return row
+
+
+def _session_with(total, by_type, by_state, by_source, daily, recent):
+    """Build a MagicMock session whose session.execute() calls, in the order
+    issued by stats_routes.stats(), return the given result sets."""
+    session = MagicMock()
+    total_result = MagicMock(scalar_one=MagicMock(return_value=total))
+    by_type_result = MagicMock(all=MagicMock(return_value=by_type))
+    by_state_result = MagicMock(all=MagicMock(return_value=by_state))
+    by_source_result = MagicMock(all=MagicMock(return_value=by_source))
+    daily_result = MagicMock(all=MagicMock(return_value=daily))
+    recent_result = MagicMock(all=MagicMock(return_value=recent))
+    session.execute.side_effect = [
+        total_result, by_type_result, by_state_result, by_source_result, daily_result, recent_result,
+    ]
+    return session
+
+
+class TestStats:
+    def test_returns_expected_shape(self, client):
+        session = _session_with(
+            total=3,
+            by_type=[_row(document_type="webpage", count=2), _row(document_type="link", count=1)],
+            by_state=[_row(processing_status="EMBEDDING_EXIST", count=3)],
+            by_source=[_row(name="own", count=3)],
+            daily=[],
+            recent=[_row(id=1, title="T", document_type="webpage", processing_status="EMBEDDING_EXIST",
+                          name="own", ingested_at=None)],
+        )
+        with patch("library.stats_routes.get_scoped_session", return_value=session):
+            resp = client.get("/stats", headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "success"
+        assert data["total"] == 3
+        assert data["by_type"] == [{"document_type": "webpage", "count": 2}, {"document_type": "link", "count": 1}]
+        assert data["by_state"] == [{"processing_status": "EMBEDDING_EXIST", "count": 3}]
+        assert data["by_source"] == [{"name": "own", "count": 3}]
+        assert len(data["daily"]) == 30  # default window
+        assert data["recent"] == [{
+            "id": 1, "title": "T", "document_type": "webpage", "processing_status": "EMBEDDING_EXIST",
+            "source": "own", "ingested_at": None,
+        }]
+
+    def test_days_param_zero_fills_and_orders(self, client):
+        today = date.today()
+        session = _session_with(total=0, by_type=[], by_state=[], by_source=[],
+                                 daily=[_row(day=str(today), count=2)], recent=[])
+        with patch("library.stats_routes.get_scoped_session", return_value=session):
+            resp = client.get("/stats?days=3", headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        expected_days = [(today - timedelta(days=i)).isoformat() for i in (2, 1, 0)]
+        assert [d["day"] for d in data["daily"]] == expected_days
+        assert data["daily"][-1]["count"] == 2
+        assert data["daily"][0]["count"] == 0
+
+    def test_days_zero_returns_400(self, client):
+        resp = client.get("/stats?days=0", headers=API_HEADERS)
+        assert resp.status_code == 400
+
+    def test_days_over_max_returns_400(self, client):
+        resp = client.get("/stats?days=9999", headers=API_HEADERS)
+        assert resp.status_code == 400
+
+
+class TestStatsAuth:
+    def test_missing_api_key_returns_401(self):
+        import server
+        server.app.config["TESTING"] = True
+        with server.app.test_client() as c:
+            resp = c.get("/stats")
+            assert resp.status_code == 401

--- a/web_interface_react/src/App.tsx
+++ b/web_interface_react/src/App.tsx
@@ -18,6 +18,7 @@ import PersonsReview from "./modules/shared/pages/personsReview";
 import Sources from "./modules/shared/pages/sources";
 import InformationSources from "./modules/shared/pages/informationSources";
 import LlmCosts from "./modules/shared/pages/llmCosts";
+import Stats from "./modules/shared/pages/stats";
 import { AuthorizationContext } from "./modules/shared/context/authorizationContext";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -57,6 +58,7 @@ function App() {
                   <Route path="/sources" element={<Sources />} />
                   <Route path="/information-sources" element={<InformationSources />} />
                   <Route path="/llm-costs" element={<LlmCosts />} />
+                  <Route path="/stats" element={<Stats />} />
                   <Route path="/search" element={<Search />} />
                   <Route path="/upload-file" element={<UploadFile />} />
                   <Route path="*" element={<p>404</p>} />

--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -17,6 +17,9 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
         <span>v{lenie_version}</span>
       </div>
       <div className={classes.linksContent}>
+        <NavLink to="/stats" className={({ isActive }) => isActive ? classes.activeLink : classes.link}>
+          Statystyki
+        </NavLink>
         <NavLink to="/list" className={({ isActive }) => isActive ? classes.activeLink : classes.link}>
           Links List
         </NavLink>

--- a/web_interface_react/src/modules/shared/pages/stats.tsx
+++ b/web_interface_react/src/modules/shared/pages/stats.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import axios from "axios";
+import { NavLink } from "react-router-dom";
+import { AuthorizationContext } from "../context/authorizationContext";
+
+type TypeRow = { document_type: string; count: number };
+type StateRow = { processing_status: string; count: number };
+type SourceRow = { name: string; count: number };
+type DailyRow = { day: string; count: number };
+type RecentRow = {
+  id: number; title: string | null; document_type: string; processing_status: string;
+  source: string; ingested_at: string | null;
+};
+type StatsReport = {
+  total: number; by_type: TypeRow[]; by_state: StateRow[]; by_source: SourceRow[];
+  daily: DailyRow[]; recent: RecentRow[];
+};
+
+const DAYS = 30;
+
+const Stats = () => {
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const [report, setReport] = React.useState<StatsReport | null>(null);
+  const [error, setError] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    setLoading(true); setError("");
+    try {
+      const response = await axios.get(`${apiUrl}/stats`, { params: { days: DAYS }, headers: { "x-api-key": apiKey ?? "" } });
+      setReport(response.data);
+    } catch (e: any) { setError(e.response?.data?.message ?? "Nie udało się pobrać statystyk"); }
+    finally { setLoading(false); }
+  }, [apiUrl, apiKey]);
+
+  React.useEffect(() => { void load(); }, [load]);
+
+  const tableStyle: React.CSSProperties = { width: "100%", borderCollapse: "collapse", marginTop: 10 };
+  const th: React.CSSProperties = { textAlign: "left", padding: "7px 8px", borderBottom: "1px solid #cbd5e1" };
+  const td: React.CSSProperties = { padding: "7px 8px", borderBottom: "1px solid #e2e8f0" };
+
+  const maxDaily = report ? Math.max(1, ...report.daily.map(d => d.count)) : 1;
+
+  return <div>
+    <h2>Statystyki dokumentów</h2>
+    {loading && <p>Ładuję…</p>}
+    {error && <p style={{ color: "#b91c1c" }}>{error}</p>}
+    {report && <>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ padding: 12, minWidth: 190, border: "1px solid #cbd5e1", borderRadius: 8 }}>
+          <strong style={{ fontSize: "1.3em" }}>{report.total.toLocaleString("pl")}</strong><br/>wszystkich dokumentów
+        </div>
+        {report.by_type.map(r => <div key={r.document_type} style={{ padding: 12, minWidth: 190, border: "1px solid #cbd5e1", borderRadius: 8 }}>
+          <strong style={{ fontSize: "1.3em" }}>{r.count.toLocaleString("pl")}</strong><br/>{r.document_type}
+        </div>)}
+      </div>
+
+      <h3>Ostatnie {DAYS} dni</h3>
+      <div style={{ display: "flex", alignItems: "flex-end", gap: 2, height: 120, padding: "8px 4px", background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8 }}>
+        {report.daily.map((d, i) => <div key={d.day} title={`${d.day}: ${d.count}`}
+          style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", alignItems: "center" }}>
+          <div style={{ width: "100%", background: "#2563eb", borderRadius: 2, height: `${(d.count / maxDaily) * 90}px`, minHeight: d.count ? 2 : 0 }} />
+          {i % 5 === 0 && <span style={{ fontSize: 10, color: "#64748b", marginTop: 4, writingMode: "vertical-rl" }}>{d.day.slice(5)}</span>}
+        </div>)}
+      </div>
+
+      <h3>Wg stanu przetwarzania</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Stan</th><th style={th}>Liczba</th></tr></thead><tbody>
+        {report.by_state.map(r => <tr key={r.processing_status}><td style={td}>{r.processing_status}</td><td style={td}>{r.count}</td></tr>)}
+      </tbody></table>
+
+      <h3>Wg źródła</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Źródło</th><th style={th}>Liczba</th></tr></thead><tbody>
+        {report.by_source.map(r => <tr key={r.name}><td style={td}>{r.name}</td><td style={td}>{r.count}</td></tr>)}
+      </tbody></table>
+
+      <h3>Ostatnio dodane</h3>
+      <table style={tableStyle}><thead><tr><th style={th}>Dodano</th><th style={th}>Tytuł</th><th style={th}>Typ</th><th style={th}>Stan</th><th style={th}>Źródło</th></tr></thead><tbody>
+        {report.recent.map(r => <tr key={r.id}>
+          <td style={td}>{r.ingested_at?.replace("T", " ").slice(0, 19) ?? "—"}</td>
+          <td style={td}><NavLink to={`/chunks/${r.id}`}>#{r.id} — {r.title || "bez tytułu"}</NavLink></td>
+          <td style={td}>{r.document_type}</td><td style={td}>{r.processing_status}</td><td style={td}>{r.source}</td>
+        </tr>)}
+      </tbody></table>
+      {!report.recent.length && <p>Brak dokumentów.</p>}
+    </>}
+  </div>;
+};
+
+export default Stats;


### PR DESCRIPTION
## Summary
- New `GET /stats` endpoint aggregating document counts by type, processing state, discovery source, plus daily ingestion counts (default 30 days) and the 20 most recent documents.
- New `/stats` React page (linked at the top of the sidebar) showing these as summary cards, tables, and a simple CSS bar chart — no new frontend dependency.

## Test plan
- [x] `cd backend && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/test_stats_routes.py -q` — 5 passed
- [x] `cd web_interface_react && npm run build` — tsc + vite build clean
- [x] Deployed to NAS (`./infra/docker/nas-deploy.sh backend frontend`); called `GET /stats` on http://192.168.200.7:5055 with a temporary service key (deleted immediately after) — verified against real data (9210 documents, correct type/state/source breakdown, daily counts, recent list)
- [ ] Manual check of http://192.168.200.7:3000/stats in browser (pending — needs a logged-in user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)