### PR TITLE
fix: move Statystyki nav link to bottom of sidebar

### DIFF
--- a/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
+++ b/web_interface_react/src/modules/shared/components/Layout/Layout.tsx
@@ -17,9 +17,6 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
         <span>v{lenie_version}</span>
       </div>
       <div className={classes.linksContent}>
-        <NavLink to="/stats" className={({ isActive }) => isActive ? classes.activeLink : classes.link}>
-          Statystyki
-        </NavLink>
         <NavLink to="/list" className={({ isActive }) => isActive ? classes.activeLink : classes.link}>
           Links List
         </NavLink>
@@ -130,6 +127,14 @@ const SideNavigation = ({ isMenuOpen, toggleMenu }: SideNavigationProps) => {
           }
         >
           Upload File (Alfa)
+        </NavLink>
+        <NavLink
+          to="/stats"
+          className={({ isActive }) =>
+            isActive ? classes.activeLink : classes.link
+          }
+        >
+          Statystyki
         </NavLink>
         <NavLink
           to="/connect"


### PR DESCRIPTION
## Summary
- Moves the "Statystyki" sidebar link (added in #322) from the top of the nav to the bottom, next to Settings — stats aren't the primary workflow entry point.

## Test plan
- [x] `npm run build` — tsc + vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)