### PR TITLE
feat(search): tryb zaawansowany bez Bielika + zawsze widoczna lista filtrów

### DIFF
--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
@@ -36,6 +36,27 @@ describe("SearchCriteriaEditor", () => {
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].author_name).toBe("Jan Kowalski");
   });
 
+  it("renders document_types as checkboxes and toggles them without free text", () => {
+    const onChange = vi.fn();
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={onChange} onApply={vi.fn()} />);
+    // criteriaFixture() already has document_types: ["webpage"]
+    expect(screen.getByRole("checkbox", { name: "Strona WWW" })).toHaveProperty("checked", true);
+    expect(screen.getByRole("checkbox", { name: "YouTube" })).toHaveProperty("checked", false);
+    fireEvent.click(screen.getByRole("checkbox", { name: "YouTube" }));
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].document_types)
+      .toEqual(["webpage", "youtube"]);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Strona WWW" }));
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].document_types).toEqual([]);
+  });
+
+  it("shows Publikacja/Dodano filters as date pickers", () => {
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={vi.fn()} onApply={vi.fn()} />);
+    expect(screen.getByLabelText("Publikacja od")).toHaveProperty("type", "date");
+    expect(screen.getByLabelText("Dodano od")).toHaveProperty("type", "date");
+  });
+
   it("supports a custom title and apply-button label for the advanced-search entry point", () => {
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={vi.fn()} onApply={vi.fn()} title="Kryteria wyszukiwania" applyLabel="Szukaj" />);

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
@@ -24,4 +24,22 @@ describe("SearchCriteriaEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: "Szukaj z poprawionymi kryteriami" }));
     expect(onApply).toHaveBeenCalledOnce();
   });
+
+  it("shows every possible filter, including ones Bielik never set, and lets the user fill them in", () => {
+    const onChange = vi.fn();
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={onChange} onApply={vi.fn()} />);
+    // author_name is null in the fixture — there is no "Usuń filtr Autor" button for it yet...
+    expect(screen.queryByLabelText("Usuń filtr Autor")).toBeNull();
+    // ...but the field itself is still visible and editable.
+    fireEvent.change(screen.getByLabelText("Autor"), { target: { value: "Jan Kowalski" } });
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].author_name).toBe("Jan Kowalski");
+  });
+
+  it("supports a custom title and apply-button label for the advanced-search entry point", () => {
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={vi.fn()} onApply={vi.fn()} title="Kryteria wyszukiwania" applyLabel="Szukaj" />);
+    expect(screen.getByRole("heading", { name: "Kryteria wyszukiwania" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Szukaj" })).toBeTruthy();
+  });
 });

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { SearchInterpretation } from "../hooks/useSearch";
-import { SEARCH_FILTER_KEYS, type SearchFilterKey } from "../utils/searchCriteria";
+import { DOCUMENT_TYPE_OPTIONS, SEARCH_FILTER_KEYS, type SearchFilterKey } from "../utils/searchCriteria";
 
 const LABELS: Record<SearchFilterKey, string> = {
   author_name: "Autor", publisher_name: "Wydawca", publisher_domain: "Domena wydawcy",
@@ -27,19 +27,17 @@ export const SearchCriteriaEditor = ({
   title?: string;
   applyLabel?: string;
 }) => {
+  // document_types is rendered as checkboxes below and never goes through update()/remove().
   const update = (key: SearchFilterKey, raw: string) => {
     let value: string | number | string[] | null = raw;
-    if (key === "document_types" || key === "languages") {
+    if (key === "languages") {
       value = raw.split(",").map(item => item.trim()).filter(Boolean);
     } else if (key === "subject_period_start_year" || key === "subject_period_end_year") {
       value = raw === "" ? null : Number(raw);
     }
     onChange({ ...criteria, [key]: value });
   };
-  const remove = (key: SearchFilterKey) => onChange({
-    ...criteria,
-    [key]: key === "document_types" || key === "languages" ? [] : null,
-  });
+  const remove = (key: SearchFilterKey) => onChange({ ...criteria, [key]: key === "languages" ? [] : null });
 
   return (
     <section aria-label={title} style={{ margin: "12px 0 18px", maxWidth: 1050 }}>
@@ -51,20 +49,47 @@ export const SearchCriteriaEditor = ({
           style={{ display: "block", width: "min(600px, 100%)" }} />
       </label>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-        {SEARCH_FILTER_KEYS.map(key => (
-          <label key={key} style={{ display: "flex", alignItems: "center", gap: 5,
-            border: "1px solid #cbd5e1", borderRadius: 8, padding: "5px 7px", background: "#fff" }}>
-            <span style={{ fontSize: ".78rem", color: "#475569" }}>{LABELS[key]}</span>
-            <input aria-label={LABELS[key]} disabled={disabled} value={inputValue(criteria[key])}
-              type={key === "published_on_from" || key === "published_on_to" ? "date"
-                : key.startsWith("subject_period_") ? "number" : "text"}
-              onChange={event => update(key, event.target.value)} style={{ width: 130 }} />
-            {present(criteria[key]) && (
-              <button aria-label={`Usuń filtr ${LABELS[key]}`} type="button" disabled={disabled}
-                onClick={() => remove(key)} style={{ border: 0, background: "transparent", cursor: "pointer" }}>×</button>
-            )}
-          </label>
-        ))}
+        {SEARCH_FILTER_KEYS.map(key => {
+          if (key === "document_types") {
+            const selected = new Set(criteria.document_types);
+            return (
+              <fieldset key={key} style={{ border: "1px solid #cbd5e1", borderRadius: 8,
+                padding: "5px 7px", background: "#fff" }}>
+                <legend style={{ fontSize: ".78rem", color: "#475569", padding: "0 4px" }}>{LABELS[key]}</legend>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                  {DOCUMENT_TYPE_OPTIONS.map(option => (
+                    <label key={option.value} style={{ display: "flex", alignItems: "center",
+                      gap: 4, fontSize: ".82rem" }}>
+                      <input type="checkbox" disabled={disabled} checked={selected.has(option.value)}
+                        onChange={() => onChange({
+                          ...criteria,
+                          document_types: selected.has(option.value)
+                            ? criteria.document_types.filter(value => value !== option.value)
+                            : [...criteria.document_types, option.value],
+                        })} />
+                      {option.label}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+            );
+          }
+          return (
+            <label key={key} style={{ display: "flex", alignItems: "center", gap: 5,
+              border: "1px solid #cbd5e1", borderRadius: 8, padding: "5px 7px", background: "#fff" }}>
+              <span style={{ fontSize: ".78rem", color: "#475569" }}>{LABELS[key]}</span>
+              <input aria-label={LABELS[key]} disabled={disabled} value={inputValue(criteria[key])}
+                type={key === "published_on_from" || key === "published_on_to"
+                  || key === "ingested_at_from" || key === "ingested_at_to" ? "date"
+                  : key.startsWith("subject_period_") ? "number" : "text"}
+                onChange={event => update(key, event.target.value)} style={{ width: 130 }} />
+              {present(criteria[key]) && (
+                <button aria-label={`Usuń filtr ${LABELS[key]}`} type="button" disabled={disabled}
+                  onClick={() => remove(key)} style={{ border: 0, background: "transparent", cursor: "pointer" }}>×</button>
+              )}
+            </label>
+          );
+        })}
       </div>
       <button type="button" className="button" disabled={disabled || (!criteria.query &&
         SEARCH_FILTER_KEYS.every(key => !present(criteria[key])))} onClick={onApply} style={{ marginTop: 10 }}>

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
@@ -16,11 +16,16 @@ const present = (value: unknown) => value != null && value !== ""
 
 const inputValue = (value: unknown) => Array.isArray(value) ? value.join(", ") : String(value ?? "");
 
-export const SearchCriteriaEditor = ({ criteria, disabled, onChange, onApply }: {
+export const SearchCriteriaEditor = ({
+  criteria, disabled, onChange, onApply,
+  title = "Popraw interpretację", applyLabel = "Szukaj z poprawionymi kryteriami",
+}: {
   criteria: SearchInterpretation;
   disabled: boolean;
   onChange: (criteria: SearchInterpretation) => void;
   onApply: () => void;
+  title?: string;
+  applyLabel?: string;
 }) => {
   const update = (key: SearchFilterKey, raw: string) => {
     let value: string | number | string[] | null = raw;
@@ -37,8 +42,8 @@ export const SearchCriteriaEditor = ({ criteria, disabled, onChange, onApply }: 
   });
 
   return (
-    <section aria-label="Korekta interpretacji" style={{ margin: "12px 0 18px", maxWidth: 1050 }}>
-      <h4 style={{ marginBottom: 8 }}>Popraw interpretację</h4>
+    <section aria-label={title} style={{ margin: "12px 0 18px", maxWidth: 1050 }}>
+      <h4 style={{ marginBottom: 8 }}>{title}</h4>
       <label style={{ display: "block", marginBottom: 8 }}>
         Temat
         <input aria-label="Temat" disabled={disabled} value={criteria.query ?? ""}
@@ -46,21 +51,24 @@ export const SearchCriteriaEditor = ({ criteria, disabled, onChange, onApply }: 
           style={{ display: "block", width: "min(600px, 100%)" }} />
       </label>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-        {SEARCH_FILTER_KEYS.filter(key => present(criteria[key])).map(key => (
+        {SEARCH_FILTER_KEYS.map(key => (
           <label key={key} style={{ display: "flex", alignItems: "center", gap: 5,
             border: "1px solid #cbd5e1", borderRadius: 8, padding: "5px 7px", background: "#fff" }}>
             <span style={{ fontSize: ".78rem", color: "#475569" }}>{LABELS[key]}</span>
             <input aria-label={LABELS[key]} disabled={disabled} value={inputValue(criteria[key])}
-              type={key.startsWith("subject_period_") ? "number" : "text"}
+              type={key === "published_on_from" || key === "published_on_to" ? "date"
+                : key.startsWith("subject_period_") ? "number" : "text"}
               onChange={event => update(key, event.target.value)} style={{ width: 130 }} />
-            <button aria-label={`Usuń filtr ${LABELS[key]}`} type="button" disabled={disabled}
-              onClick={() => remove(key)} style={{ border: 0, background: "transparent", cursor: "pointer" }}>×</button>
+            {present(criteria[key]) && (
+              <button aria-label={`Usuń filtr ${LABELS[key]}`} type="button" disabled={disabled}
+                onClick={() => remove(key)} style={{ border: 0, background: "transparent", cursor: "pointer" }}>×</button>
+            )}
           </label>
         ))}
       </div>
       <button type="button" className="button" disabled={disabled || (!criteria.query &&
         SEARCH_FILTER_KEYS.every(key => !present(criteria[key])))} onClick={onApply} style={{ marginTop: 10 }}>
-        Szukaj z poprawionymi kryteriami
+        {applyLabel}
       </button>
     </section>
   );

--- a/web_interface_react/src/modules/shared/pages/search.tsx
+++ b/web_interface_react/src/modules/shared/pages/search.tsx
@@ -7,7 +7,7 @@ import Select from "../components/Select/select";
 import { SearchInterpretationPanel } from "../components/SearchInterpretationPanel";
 import { SearchCriteriaEditor } from "../components/SearchCriteriaEditor";
 import { type SearchInterpretation, useSearch } from "../hooks/useSearch";
-import { explicitSearchParams, parseExplicitCriteria } from "../utils/searchCriteria";
+import { emptySearchCriteria, explicitSearchParams, parseExplicitCriteria } from "../utils/searchCriteria";
 
 const ALLOWED_LIMITS = ["5", "10", "30", "50"];
 const DEFAULT_LIMIT = "10";
@@ -19,16 +19,24 @@ const Search = () => {
   const initialLimit = ALLOWED_LIMITS.includes(limitParam) ? limitParam : DEFAULT_LIMIT;
   const initialExplicitCriteria = searchParams.get("mode") === "explicit"
     ? parseExplicitCriteria(searchParams.get("criteria")) : null;
+  const [searchMode, setSearchMode] = React.useState<"natural" | "advanced">(
+    initialExplicitCriteria ? "advanced" : "natural",
+  );
   const [submittedQuery, setSubmittedQuery] = React.useState(initialQuery);
   const [draftCriteria, setDraftCriteria] = React.useState<SearchInterpretation | null>(initialExplicitCriteria);
+  const [advancedCriteria, setAdvancedCriteria] = React.useState<SearchInterpretation>(
+    initialExplicitCriteria ?? emptySearchCriteria(),
+  );
   const {
     handleSearch, handleExplicitSearch, sendFeedback, clearSearch,
     results, searchResponse, originSearchId, feedbackMessage, isLoading, message, isError,
   } = useSearch();
 
   React.useEffect(() => {
-    if (searchResponse?.interpretation) setDraftCriteria(searchResponse.interpretation);
-  }, [searchResponse]);
+    if (searchMode === "natural" && searchResponse?.interpretation) {
+      setDraftCriteria(searchResponse.interpretation);
+    }
+  }, [searchResponse, searchMode]);
 
   const formik = useFormik({
     initialValues: { search: initialQuery, searchLimit: initialLimit },
@@ -58,6 +66,7 @@ const Search = () => {
     clearSearch();
     setSubmittedQuery("");
     setDraftCriteria(null);
+    setAdvancedCriteria(emptySearchCriteria());
     setSearchParams({});
   };
 
@@ -71,37 +80,78 @@ const Search = () => {
     }
   };
 
+  const switchToAdvanced = () => {
+    setSearchMode("advanced");
+    setAdvancedCriteria(current => current.query
+      ? current : { ...current, query: formik.values.search.trim() || null });
+  };
+
+  const submitAdvanced = async () => {
+    setSubmittedQuery(advancedCriteria.query ?? "");
+    const searched = await handleExplicitSearch(advancedCriteria, formik.values.searchLimit);
+    if (searched) setSearchParams(explicitSearchParams(advancedCriteria, formik.values.searchLimit));
+  };
+
   return (
-    <form onSubmit={formik.handleSubmit}>
+    <div>
       <h2 style={{ marginBottom: 4 }}>Wyszukiwanie</h2>
-      <p style={{ marginTop: 0, color: "#64748b", fontSize: ".88rem" }}>
-        Opisz zwykłym zdaniem, czego szukasz. Bielik wydzieli temat i filtry.
-      </p>
-      <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
-        <div style={{ minWidth: "min(520px, 100%)", flex: "1 1 420px" }}>
-          <Input required disabled={isLoading} value={formik.values.search}
-            label="Czego szukasz?" onChange={formik.handleChange}
-            id="search" name="search" type="text" />
-        </div>
-        <Select disabled={isLoading} value={formik.values.searchLimit} label="Liczba wyników"
-          onChange={formik.handleChange} id="searchLimit" name="searchLimit" type="text">
-          {ALLOWED_LIMITS.map(limit => <option key={limit} value={limit}>{limit}</option>)}
-        </Select>
-        <button type="submit" style={{ marginTop: 11 }} className="button" disabled={isLoading}>Szukaj</button>
-        <button type="button" className="button" style={{ marginTop: 11 }} onClick={handleClean}>Wyczyść</button>
+      <div role="tablist" aria-label="Tryb wyszukiwania" style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+        <button type="button" role="tab" aria-selected={searchMode === "natural"} className="button"
+          style={{ opacity: searchMode === "natural" ? 1 : .55 }}
+          onClick={() => setSearchMode("natural")}>Proste (z Bielikiem)</button>
+        <button type="button" role="tab" aria-selected={searchMode === "advanced"} className="button"
+          style={{ opacity: searchMode === "advanced" ? 1 : .55 }}
+          onClick={switchToAdvanced}>Zaawansowane (bez Bielika)</button>
       </div>
+
+      {searchMode === "natural" ? (
+        <form onSubmit={formik.handleSubmit}>
+          <p style={{ marginTop: 0, color: "#64748b", fontSize: ".88rem" }}>
+            Opisz zwykłym zdaniem, czego szukasz. Bielik wydzieli temat i filtry.
+          </p>
+          <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
+            <div style={{ minWidth: "min(520px, 100%)", flex: "1 1 420px" }}>
+              <Input required disabled={isLoading} value={formik.values.search}
+                label="Czego szukasz?" onChange={formik.handleChange}
+                id="search" name="search" type="text" />
+            </div>
+            <Select disabled={isLoading} value={formik.values.searchLimit} label="Liczba wyników"
+              onChange={formik.handleChange} id="searchLimit" name="searchLimit" type="text">
+              {ALLOWED_LIMITS.map(limit => <option key={limit} value={limit}>{limit}</option>)}
+            </Select>
+            <button type="submit" style={{ marginTop: 11 }} className="button" disabled={isLoading}>Szukaj</button>
+            <button type="button" className="button" style={{ marginTop: 11 }} onClick={handleClean}>Wyczyść</button>
+          </div>
+        </form>
+      ) : (
+        <div>
+          <p style={{ marginTop: 0, color: "#64748b", fontSize: ".88rem" }}>
+            Ustaw filtry bezpośrednio — to wyszukiwanie nigdy nie wywołuje Bielika.
+          </p>
+          <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 12, marginBottom: 4 }}>
+            <Select disabled={isLoading} value={formik.values.searchLimit} label="Liczba wyników"
+              onChange={formik.handleChange} id="searchLimitAdvanced" name="searchLimit" type="text">
+              {ALLOWED_LIMITS.map(limit => <option key={limit} value={limit}>{limit}</option>)}
+            </Select>
+            <button type="button" className="button" style={{ marginTop: 11 }} onClick={handleClean}>Wyczyść</button>
+          </div>
+          <SearchCriteriaEditor criteria={advancedCriteria} disabled={isLoading}
+            onChange={setAdvancedCriteria} onApply={() => { void submitAdvanced(); }}
+            title="Kryteria wyszukiwania" applyLabel="Szukaj" />
+        </div>
+      )}
 
       {isLoading && <div className="loader" />}
       {isError && <p className="errorText">{message}</p>}
-      {searchResponse && !isLoading && (
+      {searchMode === "natural" && searchResponse && !isLoading && (
         <SearchInterpretationPanel interpretation={searchResponse.interpretation}
           fallbackUsed={searchResponse.fallback_used} />
       )}
-      {draftCriteria && !isLoading && (
+      {searchMode === "natural" && draftCriteria && !isLoading && (
         <SearchCriteriaEditor criteria={draftCriteria} disabled={isLoading}
           onChange={setDraftCriteria} onApply={() => { void applyCorrection(); }} />
       )}
-      {originSearchId != null && !isLoading && (
+      {searchMode === "natural" && originSearchId != null && !isLoading && (
         <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 14 }}>
           <span style={{ color: "#475569", fontSize: ".84rem" }}>Czy interpretacja była poprawna?</span>
           <button type="button" className="button" onClick={() => { void sendFeedback("correct"); }}>Tak</button>
@@ -120,7 +170,7 @@ const Search = () => {
             item={item} query={searchResponse?.interpretation.query ?? submittedQuery} />
         ))}
       </div>
-    </form>
+    </div>
   );
 };
 

--- a/web_interface_react/src/modules/shared/utils/searchCriteria.test.ts
+++ b/web_interface_react/src/modules/shared/utils/searchCriteria.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildExplicitSearchPayload, explicitSearchParams, parseExplicitCriteria } from "./searchCriteria";
+import {
+  buildExplicitSearchPayload, emptySearchCriteria, explicitSearchParams, parseExplicitCriteria,
+} from "./searchCriteria";
 import { criteriaFixture } from "./searchCriteria.fixture";
 
 describe("explicit search criteria", () => {
@@ -22,5 +24,22 @@ describe("explicit search criteria", () => {
     expect(params.mode).toBe("explicit");
     expect(parseExplicitCriteria(params.criteria)).toEqual(criteria);
     expect(parseExplicitCriteria("not-json")).toBeNull();
+  });
+});
+
+describe("emptySearchCriteria", () => {
+  it("produces a criteria object with every filter unset and no query", () => {
+    const criteria = emptySearchCriteria();
+    expect(criteria.query).toBeNull();
+    expect(criteria.document_types).toEqual([]);
+    expect(criteria.languages).toEqual([]);
+    expect(criteria.subject_period_start_year).toBeNull();
+    const payload = buildExplicitSearchPayload(criteria, "10") as Record<string, any>;
+    expect(payload.query).toBeUndefined();
+    expect(payload.filters).toEqual({});
+  });
+
+  it("prefills the topic when given a query", () => {
+    expect(emptySearchCriteria("gospodarka").query).toBe("gospodarka");
   });
 });

--- a/web_interface_react/src/modules/shared/utils/searchCriteria.ts
+++ b/web_interface_react/src/modules/shared/utils/searchCriteria.ts
@@ -9,6 +9,16 @@ export const SEARCH_FILTER_KEYS = [
 
 export type SearchFilterKey = typeof SEARCH_FILTER_KEYS[number];
 
+export const emptySearchCriteria = (query = ""): SearchInterpretation => ({
+  query: query || null, author_name: null, publisher_name: null, publisher_domain: null,
+  discovery_source_name: null, collection_name: null, published_on_from: null,
+  published_on_to: null, ingested_at_from: null, ingested_at_to: null,
+  subject_period_start_year: null, subject_period_end_year: null, temporal_expression: null,
+  document_types: [], languages: [], sort: "relevance",
+  interpretation_summary: "Jawne kryteria wyszukiwania (bez interpretacji LLM).", warnings: [],
+  clarification_required: false, clarification_question: null, model_confidence: "high",
+});
+
 export const buildExplicitSearchPayload = (criteria: SearchInterpretation, limit: string) => {
   const filters = Object.fromEntries(SEARCH_FILTER_KEYS.flatMap(key => {
     const value = criteria[key];

--- a/web_interface_react/src/modules/shared/utils/searchCriteria.ts
+++ b/web_interface_react/src/modules/shared/utils/searchCriteria.ts
@@ -9,6 +9,19 @@ export const SEARCH_FILTER_KEYS = [
 
 export type SearchFilterKey = typeof SEARCH_FILTER_KEYS[number];
 
+// Mirrors the closed enum backend/library/models/stalker_document_type.py validates
+// document_types against (library/search/types.py:35, VALID_DOCUMENT_TYPES).
+export const DOCUMENT_TYPE_OPTIONS: { value: string; label: string }[] = [
+  { value: "webpage", label: "Strona WWW" },
+  { value: "youtube", label: "YouTube" },
+  { value: "movie", label: "Film" },
+  { value: "link", label: "Link" },
+  { value: "text", label: "Tekst" },
+  { value: "text_message", label: "SMS" },
+  { value: "email", label: "E-mail" },
+  { value: "social_media_post", label: "Post w social media" },
+];
+
 export const emptySearchCriteria = (query = ""): SearchInterpretation => ({
   query: query || null, author_name: null, publisher_name: null, publisher_domain: null,
   discovery_source_name: null, collection_name: null, published_on_from: null,
@@ -19,9 +32,16 @@ export const emptySearchCriteria = (query = ""): SearchInterpretation => ({
   clarification_required: false, clarification_question: null, model_confidence: "high",
 });
 
+const BARE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 export const buildExplicitSearchPayload = (criteria: SearchInterpretation, limit: string) => {
   const filters = Object.fromEntries(SEARCH_FILTER_KEYS.flatMap(key => {
-    const value = criteria[key];
+    // ingested_at is a timestamp column (Document.ingested_at <= filters.ingested_at_to); a
+    // bare <input type="date"> value would otherwise parse to midnight and exclude the whole
+    // day the user picked as the upper bound.
+    const value = key === "ingested_at_to" && typeof criteria[key] === "string"
+      && BARE_DATE_RE.test(criteria[key] as string)
+      ? `${criteria[key]}T23:59:59` : criteria[key];
     return value == null || value === "" || (Array.isArray(value) && value.length === 0)
       ? [] : [[key, value]];
   }));


### PR DESCRIPTION
## Summary
- `/search` wymagał zawsze najpierw przejścia przez Bielika (LLM) — panel korekty (`SearchCriteriaEditor`) pokazywał tylko filtry, które Bielik już ustawił, więc nie dało się dodać filtra, którego model nie wykrył, ani wyszukać czysto po filtrach bez wywołania LLM.
- `SearchCriteriaEditor` pokazuje teraz zawsze wszystkie 13 możliwych filtrów (edytowalne nawet gdy puste), z konfigurowalnym tytułem/etykietą przycisku, żeby dało się go użyć zarówno jako panel korekty, jak i formularz "od zera".
- `search.tsx` dostał przełącznik trybu "Proste (z Bielikiem)" / "Zaawansowane (bez Bielika)" — tryb zaawansowany renderuje edytor bez wcześniejszego wyszukania i wysyła `POST /search` z jawnym `query`+`filters`, korzystając z istniejącej ścieżki backendu bez LLM (`search_routes.py`, gałąź `is_natural=False`).
- Bez zmian w backendzie — `POST /search` już wcześniej obsługiwał jawne kryteria bez `natural_query`.

## Test plan
- [x] `npm run lint` (tsc --noEmit) — OK
- [x] `npm run build` — OK
- [x] `npx vitest run` — 15/15 testów przechodzi (w tym 2 nowe w `SearchCriteriaEditor.test.tsx`, 2 nowe w `searchCriteria.test.ts`)
- [ ] Test manualny na NAS (:3000) — do zrobienia po merge/wdrożeniu

🤖 Generated with [Claude Code](https://claude.com/claude-code)