### PR TITLE
feat(search): tabela languages + prawdziwy multi-select w filtrze języków

### DIFF
--- a/backend/alembic/versions/f3a4b5c6d7e8_create_languages_lookup_table.py
+++ b/backend/alembic/versions/f3a4b5c6d7e8_create_languages_lookup_table.py
@@ -1,0 +1,78 @@
+"""Create languages lookup table, normalize documents.language.
+
+documents.language accumulated 15 distinct raw values across 9210 rows on
+NAS (2026-07-20): case/region variants of the same language
+(pl/pl-PL/pl-pl, en/en-US/en-us), 829 empty-string rows and 28 NULL rows.
+This migration folds every value to a bare lowercase code (the part before
+a '-', if any) and treats an empty string the same as NULL — a document
+either has a known language or it doesn't. Folding is lossy by design:
+'pl-PL' and 'pl' become indistinguishable ('pl'), which is the point.
+
+documents.language stays a free TEXT column, NOT an FK to languages.id:
+language detection (library/text_detect_language.py) and every import path
+that writes it (email_import.py, dynamodb_sync.py, imports/*) keep working
+unchanged, and a language nobody has catalogued yet still writes fine.
+`languages` is a curated "known good" reference list backing the /search
+languages filter picker (GET /languages), not a hard constraint — the
+backend's SearchFilters.languages validation (library/search/types.py)
+stays a permissive 2-3 letter regex, unchanged by this migration.
+
+Revision ID: f3a4b5c6d7e8
+Revises: e2f3a4b5c6d7
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f3a4b5c6d7e8"
+down_revision = "e2f3a4b5c6d7"
+branch_labels = None
+depends_on = None
+
+# Names for languages actually observed in production on 2026-07-20. A code
+# that shows up later without an entry here just falls back to itself as
+# the display name (see the INSERT below) rather than blocking the
+# migration — there is no need to pre-populate hypothetical languages.
+_KNOWN_NAMES_PL = {
+    "pl": "polski", "en": "angielski", "de": "niemiecki", "es": "hiszpański",
+    "it": "włoski", "nl": "niderlandzki", "sk": "słowacki", "lt": "litewski",
+    "gd": "szkocki gaelicki",
+}
+
+
+def _normalize_language(value: str | None) -> str | None:
+    value = (value or "").strip().lower()
+    return value.split("-", 1)[0] or None
+
+
+def upgrade():
+    op.execute("""
+        CREATE TABLE languages (
+            id SERIAL PRIMARY KEY,
+            code TEXT NOT NULL UNIQUE,
+            name_pl TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT id, language FROM documents ORDER BY id")).fetchall()
+    seen_codes = set()
+    for document_id, raw in rows:
+        code = _normalize_language(raw)
+        if code != raw:
+            connection.execute(
+                sa.text("UPDATE documents SET language = :code WHERE id = :id"),
+                {"code": code, "id": document_id},
+            )
+        if code:
+            seen_codes.add(code)
+
+    for code in sorted(seen_codes):
+        connection.execute(
+            sa.text("INSERT INTO languages (code, name_pl) VALUES (:code, :name)"),
+            {"code": code, "name": _KNOWN_NAMES_PL.get(code, code)},
+        )
+
+
+def downgrade():
+    op.execute("DROP TABLE languages")

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -209,6 +209,29 @@ class Collection(Base):
     )
 
 
+class Language(Base):
+    """Known language lookup backing the /search languages filter picker.
+
+    documents.language stays free text (String(10), not FK'd to this
+    table) — language detection and every import path that writes it keep
+    working unchanged; this is a curated "known good" reference list, not
+    a hard constraint. Seeded by migration f3a4b5c6d7e8 from the distinct
+    codes observed in production after folding case/region variants.
+    """
+
+    __tablename__ = "languages"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    code: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    name_pl: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    def __repr__(self) -> str:
+        return f"Language(id={self.id!r}, code={self.code!r})"
+
+
 class Publisher(Base):
     """Portal which published a document (not its discovery/information source)."""
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1214,11 +1214,14 @@ def sources_delete(source_id: int):
 
 @app.route('/languages', methods=['GET'])
 def languages_list():
-    """Known languages lookup with per-language document counts, most used first.
+    """Languages currently used by at least one document, most used first.
 
-    documents.language is free text, not FK'd to this table (see Language
-    model docstring) — this backs the /search languages filter picker with
-    a curated, counted list rather than letting the UI guess valid codes."""
+    documents.language is free text, not FK'd to the languages table (see
+    Language model docstring) — this backs the /search languages filter
+    picker. An inner join against actual usage on purpose: a language that
+    no document has (any more) would otherwise show up as a checkbox that
+    always returns zero results — the languages table is a superset of
+    codes ever seen, not a set of "selectable" values."""
     from sqlalchemy import func as sa_func, select as sa_select
     from library.db.models import Language
 
@@ -1229,9 +1232,8 @@ def languages_list():
         .group_by(Document.language)
         .subquery()
     )
-    doc_count = sa_func.coalesce(counts.c.cnt, 0)
-    query = sa_select(Language, doc_count).outerjoin(counts, counts.c.code == Language.code)
-    rows = session.execute(query.order_by(doc_count.desc(), Language.code)).all()
+    query = sa_select(Language, counts.c.cnt).join(counts, counts.c.code == Language.code)
+    rows = session.execute(query.order_by(counts.c.cnt.desc(), Language.code)).all()
     return {"status": "success", "languages": [
         {"code": row.code, "name_pl": row.name_pl, "count": count} for row, count in rows
     ]}, 200

--- a/backend/server.py
+++ b/backend/server.py
@@ -1212,6 +1212,31 @@ def sources_delete(source_id: int):
     return jsonify({"status": "success", "deleted_id": source_id}), 200
 
 
+@app.route('/languages', methods=['GET'])
+def languages_list():
+    """Known languages lookup with per-language document counts, most used first.
+
+    documents.language is free text, not FK'd to this table (see Language
+    model docstring) — this backs the /search languages filter picker with
+    a curated, counted list rather than letting the UI guess valid codes."""
+    from sqlalchemy import func as sa_func, select as sa_select
+    from library.db.models import Language
+
+    session = get_scoped_session()
+    counts = (
+        sa_select(Document.language.label("code"), sa_func.count().label("cnt"))
+        .where(Document.language.isnot(None))
+        .group_by(Document.language)
+        .subquery()
+    )
+    doc_count = sa_func.coalesce(counts.c.cnt, 0)
+    query = sa_select(Language, doc_count).outerjoin(counts, counts.c.code == Language.code)
+    rows = session.execute(query.order_by(doc_count.desc(), Language.code)).all()
+    return {"status": "success", "languages": [
+        {"code": row.code, "name_pl": row.name_pl, "count": count} for row, count in rows
+    ]}, 200
+
+
 def _exclusion_dict(row):
     return {
         "id": row.id, "entity_text": row.entity_text, "entity_type": row.entity_type,

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -19,6 +19,7 @@ from library.db.models import (  # noqa: E402
     DocumentStatusErrorType,
     DocumentType,
     EmbeddingModel,
+    Language,
     Document,
     DocumentEmbedding,
     LinkDocument,
@@ -145,6 +146,27 @@ class TestEmbeddingModel:
     def test_repr(self):
         obj = EmbeddingModel(id=1, name="text-embedding-ada-002")
         assert repr(obj) == "EmbeddingModel(id=1, name='text-embedding-ada-002')"
+
+
+class TestLanguage:
+    def test_tablename(self):
+        assert Language.__tablename__ == "languages"
+
+    def test_inherits_base(self):
+        assert issubclass(Language, Base)
+
+    def test_columns(self):
+        cols = _column_names(Language)
+        assert cols == {"id", "code", "name_pl", "created_at"}
+
+    def test_instantiation(self):
+        obj = Language(code="pl", name_pl="polski")
+        assert obj.code == "pl"
+        assert obj.name_pl == "polski"
+
+    def test_repr(self):
+        obj = Language(id=1, code="pl")
+        assert repr(obj) == "Language(id=1, code='pl')"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_flask_endpoints_languages.py
+++ b/backend/tests/unit/test_flask_endpoints_languages.py
@@ -43,10 +43,13 @@ class TestLanguagesList:
             {"code": "en", "name_pl": "angielski", "count": 164},
         ]
 
-    def test_language_with_no_documents_yet_has_zero_count(self, client):
+    def test_only_languages_currently_used_by_a_document_are_returned(self, client):
+        # An inner join, on purpose: a language nobody's document has (any more) — e.g. one
+        # seeded by the migration but since edited away on its one document — must not appear
+        # as a checkbox that always returns zero results.
         session = MagicMock()
-        session.execute.return_value.all.return_value = [(_row("lt", "litewski"), 0)]
+        session.execute.return_value.all.return_value = [(_row("pl", "polski"), 8183)]
         with patch("server.get_scoped_session", return_value=session):
             resp = client.get("/languages", headers=API_HEADERS)
 
-        assert resp.get_json()["languages"] == [{"code": "lt", "name_pl": "litewski", "count": 0}]
+        assert resp.get_json()["languages"] == [{"code": "pl", "name_pl": "polski", "count": 8183}]

--- a/backend/tests/unit/test_flask_endpoints_languages.py
+++ b/backend/tests/unit/test_flask_endpoints_languages.py
@@ -1,0 +1,52 @@
+"""Unit tests for the GET /languages endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("flask")
+
+API_HEADERS = {"x-api-key": "test-api-key"}
+
+
+@pytest.fixture()
+def client():
+    """Flask test client with auth bypassed (same pattern as test_flask_endpoints_orm)."""
+    import server
+    server.app.config["TESTING"] = True
+    with patch.object(server, "check_auth_header"):
+        with server.app.test_client() as c:
+            yield c
+
+
+def _row(code="pl", name_pl="polski"):
+    row = MagicMock()
+    row.code = code
+    row.name_pl = name_pl
+    return row
+
+
+class TestLanguagesList:
+    def test_returns_languages_with_document_counts(self, client):
+        session = MagicMock()
+        session.execute.return_value.all.return_value = [
+            (_row("pl", "polski"), 8181),
+            (_row("en", "angielski"), 164),
+        ]
+        with patch("server.get_scoped_session", return_value=session):
+            resp = client.get("/languages", headers=API_HEADERS)
+
+        assert resp.status_code == 200
+        assert resp.get_json()["languages"] == [
+            {"code": "pl", "name_pl": "polski", "count": 8181},
+            {"code": "en", "name_pl": "angielski", "count": 164},
+        ]
+
+    def test_language_with_no_documents_yet_has_zero_count(self, client):
+        session = MagicMock()
+        session.execute.return_value.all.return_value = [(_row("lt", "litewski"), 0)]
+        with patch("server.get_scoped_session", return_value=session):
+            resp = client.get("/languages", headers=API_HEADERS)
+
+        assert resp.get_json()["languages"] == [{"code": "lt", "name_pl": "litewski", "count": 0}]

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
@@ -1,34 +1,47 @@
+import axios from "axios";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SearchCriteriaEditor } from "./SearchCriteriaEditor";
 import { criteriaFixture } from "../utils/searchCriteria.fixture";
 
+vi.mock("axios");
+const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
+
 describe("SearchCriteriaEditor", () => {
-  it("edits topic and filter chips", () => {
+  beforeEach(() => {
+    // Default: GET /languages returns nothing, so the languages field stays the free-text
+    // fallback in tests that don't care about the picker — matches an empty/unreachable backend.
+    mockedGet.mockReset().mockResolvedValue({ data: { languages: [] } });
+  });
+
+  it("edits topic and filter chips", async () => {
     const onChange = vi.fn();
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={onChange} onApply={vi.fn()} />);
+    await screen.findByLabelText("Temat"); // let the GET /languages effect settle first
     fireEvent.change(screen.getByLabelText("Temat"), { target: { value: "energia" } });
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].query).toBe("energia");
     fireEvent.change(screen.getByLabelText("Okres od"), { target: { value: "2010" } });
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].subject_period_start_year).toBe(2010);
   });
 
-  it("removes a filter and applies corrected criteria", () => {
+  it("removes a filter and applies corrected criteria", async () => {
     const onChange = vi.fn();
     const onApply = vi.fn();
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={onChange} onApply={onApply} />);
+    await screen.findByLabelText("Temat");
     fireEvent.click(screen.getByLabelText("Usuń filtr Wydawca"));
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].publisher_name).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Szukaj z poprawionymi kryteriami" }));
     expect(onApply).toHaveBeenCalledOnce();
   });
 
-  it("shows every possible filter, including ones Bielik never set, and lets the user fill them in", () => {
+  it("shows every possible filter, including ones Bielik never set, and lets the user fill them in", async () => {
     const onChange = vi.fn();
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={onChange} onApply={vi.fn()} />);
+    await screen.findByLabelText("Temat");
     // author_name is null in the fixture — there is no "Usuń filtr Autor" button for it yet...
     expect(screen.queryByLabelText("Usuń filtr Autor")).toBeNull();
     // ...but the field itself is still visible and editable.
@@ -36,10 +49,11 @@ describe("SearchCriteriaEditor", () => {
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].author_name).toBe("Jan Kowalski");
   });
 
-  it("renders document_types as checkboxes and toggles them without free text", () => {
+  it("renders document_types as checkboxes and toggles them without free text", async () => {
     const onChange = vi.fn();
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={onChange} onApply={vi.fn()} />);
+    await screen.findByLabelText("Temat");
     // criteriaFixture() already has document_types: ["webpage"]
     expect(screen.getByRole("checkbox", { name: "Strona WWW" })).toHaveProperty("checked", true);
     expect(screen.getByRole("checkbox", { name: "YouTube" })).toHaveProperty("checked", false);
@@ -50,16 +64,40 @@ describe("SearchCriteriaEditor", () => {
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].document_types).toEqual([]);
   });
 
-  it("shows Publikacja/Dodano filters as date pickers", () => {
+  it("renders languages as checkboxes once GET /languages resolves, replacing the free-text field", async () => {
+    mockedGet.mockResolvedValue({ data: { languages: [
+      { code: "pl", name_pl: "polski", count: 8182 },
+      { code: "en", name_pl: "angielski", count: 164 },
+    ] } });
+    const onChange = vi.fn();
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={onChange} onApply={vi.fn()} />);
+    // criteriaFixture() already has languages: ["pl"]
+    expect(await screen.findByRole("checkbox", { name: "polski (pl)" })).toHaveProperty("checked", true);
+    expect(screen.queryByLabelText("Języki")).toBeNull();
+    fireEvent.click(screen.getByRole("checkbox", { name: "angielski (en)" }));
+    expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].languages).toEqual(["pl", "en"]);
+  });
+
+  it("keeps languages as a free-text field when GET /languages has nothing to offer", async () => {
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={vi.fn()} onApply={vi.fn()} />);
+    await screen.findByLabelText("Temat");
+    expect(screen.getByLabelText("Języki")).toHaveProperty("value", "pl");
+  });
+
+  it("shows Publikacja/Dodano filters as date pickers", async () => {
+    render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
+      onChange={vi.fn()} onApply={vi.fn()} />);
+    await screen.findByLabelText("Temat");
     expect(screen.getByLabelText("Publikacja od")).toHaveProperty("type", "date");
     expect(screen.getByLabelText("Dodano od")).toHaveProperty("type", "date");
   });
 
-  it("supports a custom title and apply-button label for the advanced-search entry point", () => {
+  it("supports a custom title and apply-button label for the advanced-search entry point", async () => {
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={vi.fn()} onApply={vi.fn()} title="Kryteria wyszukiwania" applyLabel="Szukaj" />);
+    await screen.findByLabelText("Temat");
     expect(screen.getByRole("heading", { name: "Kryteria wyszukiwania" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Szukaj" })).toBeTruthy();
   });

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.test.tsx
@@ -73,9 +73,9 @@ describe("SearchCriteriaEditor", () => {
     render(<SearchCriteriaEditor criteria={criteriaFixture()} disabled={false}
       onChange={onChange} onApply={vi.fn()} />);
     // criteriaFixture() already has languages: ["pl"]
-    expect(await screen.findByRole("checkbox", { name: "polski (pl)" })).toHaveProperty("checked", true);
+    expect(await screen.findByRole("checkbox", { name: "polski (pl) · 8182" })).toHaveProperty("checked", true);
     expect(screen.queryByLabelText("Języki")).toBeNull();
-    fireEvent.click(screen.getByRole("checkbox", { name: "angielski (en)" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "angielski (en) · 164" }));
     expect(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0].languages).toEqual(["pl", "en"]);
   });
 

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
@@ -105,7 +105,7 @@ export const SearchCriteriaEditor = ({
             return (
               <CheckboxGroup key={key} label={LABELS[key]} disabled={disabled}
                 options={languageOptions.map(option => ({
-                  value: option.code, label: `${option.name_pl} (${option.code})`,
+                  value: option.code, label: `${option.name_pl} (${option.code}) · ${option.count}`,
                 }))}
                 selected={new Set(criteria.languages)}
                 onToggle={value => toggleArrayValue("languages", value)} />

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import axios from "axios";
 import type { SearchInterpretation } from "../hooks/useSearch";
+import { AuthorizationContext } from "../context/authorizationContext";
 import { DOCUMENT_TYPE_OPTIONS, SEARCH_FILTER_KEYS, type SearchFilterKey } from "../utils/searchCriteria";
 
 const LABELS: Record<SearchFilterKey, string> = {
@@ -16,6 +18,27 @@ const present = (value: unknown) => value != null && value !== ""
 
 const inputValue = (value: unknown) => Array.isArray(value) ? value.join(", ") : String(value ?? "");
 
+const CheckboxGroup = ({ label, options, selected, disabled, onToggle }: {
+  label: string;
+  options: { value: string; label: string }[];
+  selected: Set<string>;
+  disabled: boolean;
+  onToggle: (value: string) => void;
+}) => (
+  <fieldset style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "5px 7px", background: "#fff" }}>
+    <legend style={{ fontSize: ".78rem", color: "#475569", padding: "0 4px" }}>{label}</legend>
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+      {options.map(option => (
+        <label key={option.value} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: ".82rem" }}>
+          <input type="checkbox" disabled={disabled} checked={selected.has(option.value)}
+            onChange={() => onToggle(option.value)} />
+          {option.label}
+        </label>
+      ))}
+    </div>
+  </fieldset>
+);
+
 export const SearchCriteriaEditor = ({
   criteria, disabled, onChange, onApply,
   title = "Popraw interpretację", applyLabel = "Szukaj z poprawionymi kryteriami",
@@ -27,7 +50,22 @@ export const SearchCriteriaEditor = ({
   title?: string;
   applyLabel?: string;
 }) => {
-  // document_types is rendered as checkboxes below and never goes through update()/remove().
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const [languageOptions, setLanguageOptions] = React.useState<
+    { code: string; name_pl: string; count: number }[]
+  >([]);
+
+  React.useEffect(() => {
+    axios.get(`${apiUrl}/languages`, { headers: { "x-api-key": `${apiKey}` } })
+      .then(response => setLanguageOptions(response.data.languages ?? []))
+      .catch(() => undefined);
+  }, [apiUrl, apiKey]);
+
+  // document_types is always checkboxes; languages is checkboxes once GET /languages has
+  // answered, and falls back to the comma-separated text field below otherwise (so typing a
+  // code the picker doesn't know about yet still works — the backend filter itself stays a
+  // permissive regex, not an enum, see library/search/types.py). Neither goes through
+  // update()/remove() when rendered as checkboxes.
   const update = (key: SearchFilterKey, raw: string) => {
     let value: string | number | string[] | null = raw;
     if (key === "languages") {
@@ -38,6 +76,12 @@ export const SearchCriteriaEditor = ({
     onChange({ ...criteria, [key]: value });
   };
   const remove = (key: SearchFilterKey) => onChange({ ...criteria, [key]: key === "languages" ? [] : null });
+  const toggleArrayValue = (key: "document_types" | "languages", value: string) => onChange({
+    ...criteria,
+    [key]: criteria[key].includes(value)
+      ? criteria[key].filter(v => v !== value)
+      : [...criteria[key], value],
+  });
 
   return (
     <section aria-label={title} style={{ margin: "12px 0 18px", maxWidth: 1050 }}>
@@ -51,27 +95,20 @@ export const SearchCriteriaEditor = ({
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
         {SEARCH_FILTER_KEYS.map(key => {
           if (key === "document_types") {
-            const selected = new Set(criteria.document_types);
             return (
-              <fieldset key={key} style={{ border: "1px solid #cbd5e1", borderRadius: 8,
-                padding: "5px 7px", background: "#fff" }}>
-                <legend style={{ fontSize: ".78rem", color: "#475569", padding: "0 4px" }}>{LABELS[key]}</legend>
-                <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-                  {DOCUMENT_TYPE_OPTIONS.map(option => (
-                    <label key={option.value} style={{ display: "flex", alignItems: "center",
-                      gap: 4, fontSize: ".82rem" }}>
-                      <input type="checkbox" disabled={disabled} checked={selected.has(option.value)}
-                        onChange={() => onChange({
-                          ...criteria,
-                          document_types: selected.has(option.value)
-                            ? criteria.document_types.filter(value => value !== option.value)
-                            : [...criteria.document_types, option.value],
-                        })} />
-                      {option.label}
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
+              <CheckboxGroup key={key} label={LABELS[key]} disabled={disabled}
+                options={DOCUMENT_TYPE_OPTIONS} selected={new Set(criteria.document_types)}
+                onToggle={value => toggleArrayValue("document_types", value)} />
+            );
+          }
+          if (key === "languages" && languageOptions.length > 0) {
+            return (
+              <CheckboxGroup key={key} label={LABELS[key]} disabled={disabled}
+                options={languageOptions.map(option => ({
+                  value: option.code, label: `${option.name_pl} (${option.code})`,
+                }))}
+                selected={new Set(criteria.languages)}
+                onToggle={value => toggleArrayValue("languages", value)} />
             );
           }
           return (


### PR DESCRIPTION
Kontynuacja **#325** — to PR zostało automatycznie zamknięte przez GitHub, gdy branch bazowy `feat/search-advanced-mode` (#324) został skasowany po squash-merge. Branch `feat/languages-lookup-table` przebazowany na aktualny `main`, treść bez zmian względem #325.

## Summary
- `documents.language` miało 15 różnych surowych wartości na 9210 dokumentach (NAS, 2026-07-20): warianty wielkości liter/regionu tego samego języka (`pl`/`pl-PL`/`pl-pl`, `en`/`en-US`/`en-us`) plus 829 pustych stringów i 28 `NULL`.
- **Migracja `f3a4b5c6d7e8`**: tworzy `languages` (code, name_pl), normalizuje `documents.language` do surowego, małoliterowego kodu (pusty string traktowany jak `NULL`), zasila tabelę wynikowymi odrębnymi kodami. `documents.language` zostaje wolnym tekstem, NIE FK.
- **`GET /languages`**: znane języki z liczbą dokumentów per język, INNER JOIN (tylko języki faktycznie używane — druga poprawka po tym, jak złapaliśmy `sk` wiszące z licznikiem 0 po edycji dokumentu).
- **`SearchCriteriaEditor`** renderuje `languages` jako checkboxy z licznikiem w etykiecie, z fallbackiem do pola tekstowego.

Zastosowane i zweryfikowane na bazie NAS (9 → 3 realnych języków po dalszych ręcznych korektach błędnie wykrytych języków, patrz historia rozmowy).

## Test plan
- [x] `npm run lint` / `npm run build` / `npx vitest run` — 19/19
- [x] `pytest tests/unit/` — zielono (pre-istniejące failury niezwiązane)
- [x] `alembic upgrade head` wykonane na NAS, zweryfikowane SQL-em i przez `POST /search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)