### PR TITLE
feat(db): add document_images table

### DIFF
--- a/backend/alembic/versions/c8d9eafb0c1d_create_document_images.py
+++ b/backend/alembic/versions/c8d9eafb0c1d_create_document_images.py
@@ -1,0 +1,44 @@
+"""create document_images
+
+Revision ID: c8d9eafb0c1d
+Revises: a4b5c6d7e8f9
+Create Date: 2026-07-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d9eafb0c1d"
+down_revision: Union[str, None] = "a4b5c6d7e8f9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the same table may already have been created by the Docker
+    # init script 34-create-document-images.sql on a fresh database.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS document_images (
+            id               SERIAL PRIMARY KEY,
+            document_id      INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+            chunk_id         INTEGER REFERENCES document_chunks(id) ON DELETE SET NULL,
+            position         SMALLINT,
+            url              TEXT NOT NULL,
+            alt_text         TEXT,
+            caption_text     TEXT,
+            caption_category VARCHAR(30),
+            is_stock_photo   BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at       TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_document_images_document_id ON document_images(document_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS document_images")

--- a/backend/database/CLAUDE.md
+++ b/backend/database/CLAUDE.md
@@ -40,7 +40,8 @@ database/
     ├── 31-add-tags-to-user-document-notes.sql
     ├── 31-create-cited-publications.sql
     ├── 32-create-document-analysis-jobs.sql
-    └── 33-create-collections.sql                 # collections lookup + FK on documents.collection_id (stage 11c)
+    ├── 33-create-collections.sql                 # collections lookup + FK on documents.collection_id (stage 11c)
+    └── 34-create-document-images.sql             # document_images (images extracted from article text, url/caption preserved)
 ```
 
 ## How Init Scripts Are Used
@@ -278,6 +279,25 @@ in Python (LLM output with stripped diacritics is canonicalized, e.g. "srednia" 
 | `created_at` | `timestamp` | Row creation timestamp |
 
 **Index:** `(document_id, chapter_position)`.
+
+### Table: `public.document_images`
+
+Images extracted out of a document's article text (`library/article_cleaner.py`). `clean_article_text()` replaces inline `![alt](url)` markdown images with `[imgN]` markers in `text_md` — the URL used to be discarded on cleanup. This table preserves it (plus the adjacent caption/credit line, when present) so `article_quality.py` can score photo sourcing without the image markup needing to stay inline in the text shown to readers/LLM. Replace-per-document semantics (like `document_entities`): each re-clean of a document replaces its full row set. Not yet populated by any pipeline step — table + model only so far.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `serial PK` | Auto-incrementing primary key |
+| `document_id` | `integer NOT NULL` | FK to `documents.id` (CASCADE delete) |
+| `chunk_id` | `integer` | FK to `document_chunks.id` (`SET NULL` on delete) |
+| `position` | `smallint` | 0-based position of the `[imgN]` marker in the cleaned text |
+| `url` | `text NOT NULL` | Image URL |
+| `alt_text` | `text` | Alt text from `![alt](url)` |
+| `caption_text` | `text` | Adjacent caption/credit line, if any |
+| `caption_category` | `varchar(30)` | `image_marker` / `image_description` / `image_credit` (`lenie_markdown.photo_caption_candidates`) |
+| `is_stock_photo` | `boolean NOT NULL DEFAULT false` | Stock/agency source detected at extraction (shutterstock, getty, istock, ...) |
+| `created_at` | `timestamp` | Row creation timestamp |
+
+**Index:** `document_id`.
 
 ### Table: `public.infra_geometries`
 

--- a/backend/database/init/34-create-document-images.sql
+++ b/backend/database/init/34-create-document-images.sql
@@ -1,0 +1,23 @@
+-- Images extracted out of a document's article text (library/article_cleaner.py).
+-- clean_article_text() replaces inline ![alt](url) markdown images with [imgN]
+-- markers in text_md -- the URL used to be discarded. This table keeps the
+-- image (and its adjacent caption/credit line, when present) so
+-- article_quality.py can score photo sourcing without needing the image
+-- markup to still live inline in the text. Replace-per-document semantics
+-- (like document_entities): each re-clean of a document replaces its full
+-- row set.
+
+CREATE TABLE IF NOT EXISTS public.document_images (
+    id               SERIAL PRIMARY KEY,
+    document_id      INTEGER NOT NULL REFERENCES public.documents(id) ON DELETE CASCADE,
+    chunk_id         INTEGER REFERENCES public.document_chunks(id) ON DELETE SET NULL,
+    position         SMALLINT,
+    url              TEXT NOT NULL,
+    alt_text         TEXT,
+    caption_text     TEXT,
+    caption_category VARCHAR(30),
+    is_stock_photo   BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_images_document_id ON public.document_images(document_id);

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -1010,6 +1010,45 @@ class DocumentReference(Base):
         )
 
 
+class DocumentImage(Base):
+    """Image extracted out of a document's article text (library/article_cleaner.py).
+
+    ``clean_article_text()`` replaces inline ``![alt](url)`` markdown images
+    with ``[imgN]`` markers in ``text_md`` — the URL used to be discarded.
+    This table keeps the image (and its adjacent caption/credit line, when
+    present) so article_quality.py can score photo sourcing without needing
+    the image markup to still live inline in the text. Replace-per-document
+    semantics (like document_entities): each re-clean of a document replaces
+    its full row set.
+    """
+
+    __tablename__ = "document_images"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    document_id: Mapped[int] = mapped_column(
+        ForeignKey("documents.id", ondelete="CASCADE"), nullable=False,
+    )
+    chunk_id: Mapped[int | None] = mapped_column(
+        ForeignKey("document_chunks.id", ondelete="SET NULL"),
+    )
+    # 0-based position of the [imgN] marker in the cleaned text
+    position: Mapped[int | None] = mapped_column(SmallInteger)
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    alt_text: Mapped[str | None] = mapped_column(Text)
+    caption_text: Mapped[str | None] = mapped_column(Text)
+    # image_marker | image_description | image_credit (lenie_markdown.photo_caption_candidates)
+    caption_category: Mapped[str | None] = mapped_column(String(30))
+    is_stock_photo: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=sa_text("false"))
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(),
+    )
+
+    document: Mapped["Document"] = relationship(foreign_keys=[document_id])
+
+    def __repr__(self) -> str:
+        return f"DocumentImage(id={self.id!r}, document_id={self.document_id!r}, url={self.url!r})"
+
+
 class CitedPublication(Base):
     """A canonical scholarly work cited by one or more documents."""
 


### PR DESCRIPTION
## Summary
- New `document_images` table (ORM model `DocumentImage` + Alembic migration + docker init script) to preserve image `url`/`alt`/`caption` per document — today `article_cleaner.py` replaces `![alt](url)` with `[imgN]` markers in `text_md` and discards the URL entirely.
- Replace-per-document semantics (like `document_entities`); `chunk_id` SET NULL, `document_id` CASCADE.
- No pipeline writes to it yet — this PR is schema-only, follow-up wires `clean_article_text()` output into it and moves `article_quality.py`'s photo-sourcing heuristics off inline text regex.

## Test plan
- [x] `ruff check` clean
- [x] `pytest tests/unit/` — 1897 passed, the 9 failures pre-exist on `main` (canonical_url/PR #328 + Vault-dependent dynamodb_sync tests), unrelated to this change
- [x] `alembic upgrade head` applied and verified on NAS Postgres (`a4b5c6d7e8f9 → c8d9eafb0c1d`), `\d document_images` confirms columns/FKs/index

🤖 Generated with [Claude Code](https://claude.com/claude-code)