### PR TITLE
feat(quality): score photo sourcing from document_images when available

### DIFF
--- a/backend/library/article_quality.py
+++ b/backend/library/article_quality.py
@@ -346,11 +346,42 @@ Uwzględnij tę listę przy ocenie pola "zrodla", nawet jeśli została technicz
         return None
 
 
-def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -> dict:
+def _photo_source_evidence_from_db(session, document_id: int) -> list[dict] | None:
+    """Ewidencja pochodzenia zdjęć z document_images (zasilana przez
+    library.document_images.replace_document_images przy każdym czyszczeniu
+    tekstu), gdy dla dokumentu jest już dostępna.
+
+    Zwraca None — nie [] — gdy nie ma jeszcze żadnych wierszy, żeby wywołujący
+    mógł spaść na skan full_text (dokumenty sprzed tej tabeli albo bez
+    ponownego czyszczenia od jej wdrożenia). [] oznacza: sprawdzone, brak
+    kategoryzowanych podpisów — to już wiarygodna odpowiedź, nie fallback."""
+    from sqlalchemy import select
+
+    from library.db.models import DocumentImage
+
+    rows = session.scalars(
+        select(DocumentImage).where(DocumentImage.document_id == document_id)
+    ).all()
+    if not rows:
+        return None
+    return [
+        {"text": row.caption_text or "", "category": row.caption_category}
+        for row in rows
+        if row.caption_category in PHOTO_SOURCE_PENALTY_WEIGHTS
+    ]
+
+
+def compute_quality(
+    doc, chunk_sections: list[dict], model: str | None = None, session=None,
+) -> dict:
     """Policz ocenę staranności dokumentu na podstawie chunków z analizy.
 
     chunk_sections: [{"type": "TEMAT|REKLAMA|SZUM", "original": "tekst"}, ...]
     model: model LLM do rubryki; None = tylko kary deterministyczne.
+    session: gdy podana, ewidencja pochodzenia zdjęć jest czytana z
+        document_images zamiast skanowana regexem po full_text (patrz
+        _photo_source_evidence_from_db) — spada na skan tekstu, gdy
+        dokument nie ma jeszcze żadnych wierszy w tej tabeli.
 
     Wynik: {"score": 0-100, "penalties": {...}, "signals": {...},
             "llm_rubric": {...}|None, "model": ..., "computed_at": ISO}
@@ -374,11 +405,17 @@ def compute_quality(doc, chunk_sections: list[dict], model: str | None = None) -
     from library.cited_publications import extract_cited_publications
     cited_publications = extract_cited_publications(full_text)
     press_bibliography = extract_press_bibliography(full_text)
-    caption_evidence = photo_caption_candidates(full_text, getattr(doc, "url", None))
-    photo_source_evidence = [
-        item for item in caption_evidence
-        if item["category"] in PHOTO_SOURCE_PENALTY_WEIGHTS
-    ]
+
+    photo_source_evidence = None
+    document_id = getattr(doc, "id", None)
+    if session is not None and document_id is not None:
+        photo_source_evidence = _photo_source_evidence_from_db(session, document_id)
+    if photo_source_evidence is None:
+        caption_evidence = photo_caption_candidates(full_text, getattr(doc, "url", None))
+        photo_source_evidence = [
+            item for item in caption_evidence
+            if item["category"] in PHOTO_SOURCE_PENALTY_WEIGHTS
+        ]
     captions = len(photo_source_evidence)
     photo_source_penalty_details = Counter()
     for item in photo_source_evidence:

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1909,7 +1909,7 @@ def compute_document_quality(doc_id: int):
         from library.article_quality import compute_quality
         from library.llm_usage.context import llm_usage_context
         with llm_usage_context(document_id=doc_id, analysis_run_id=run.id):
-            doc.quality = compute_quality(doc, sections, model=run.model)
+            doc.quality = compute_quality(doc, sections, model=run.model, session=session)
     except Exception:
         logger.exception("quality computation failed for document %d", doc_id)
         return jsonify({"status": "error", "message": "Quality computation failed"}), 500

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -648,7 +648,7 @@ class DocumentAnalysisService:
                 try:
                     from library.article_quality import compute_quality
 
-                    doc.quality = compute_quality(doc, sections, model=model)
+                    doc.quality = compute_quality(doc, sections, model=model, session=self.session)
                     log(f"quality: {doc.quality['score']}/100 "
                         f"(penalties: {doc.quality['penalties'] or '-'})")
                 except Exception:

--- a/backend/tests/unit/test_article_quality.py
+++ b/backend/tests/unit/test_article_quality.py
@@ -4,6 +4,9 @@ deterministic quality ("staranność") scoring.
 Pure-function tests, no DB/LLM/network (compute_quality tested with model=None).
 """
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from library.article_quality import (
     compute_quality,
     count_photo_captions,
@@ -32,10 +35,18 @@ LONG_PARAGRAPH = (
 
 
 class _Doc:
-    def __init__(self, author=None, title=None, url=None):
+    def __init__(self, author=None, title=None, url=None, id=None):
         self.byline = author
         self.title = title
         self.url = url
+        self.id = id
+
+
+def _fake_session(rows):
+    """MagicMock session whose scalars(select(...)).all() returns the given rows."""
+    session = MagicMock()
+    session.scalars.return_value.all.return_value = rows
+    return session
 
 
 class TestPhotoCaptionDetection:
@@ -309,6 +320,54 @@ class TestComputeQuality:
 
         assert "photo_sources" not in q["penalties"]
         assert q["signals"]["photo_captions"] == 0
+
+    def test_session_provided_but_no_document_images_rows_falls_back_to_text_scan(self):
+        session = _fake_session([])
+        secs = self._sections() + [{"type": "TEMAT", "original": "Fot. X / shutterstock"}]
+        doc = _Doc(author="A", title="T", id=9265)
+        q = compute_quality(doc, secs, model=None, session=session)
+
+        assert q["penalties"]["photo_sources"] == 3
+        assert q["signals"]["photo_caption_categories"] == {"stock": 1}
+
+    def test_session_with_document_images_rows_used_instead_of_text_scan(self):
+        """document_images is authoritative once populated — even when full_text
+        contains a caption-looking line that isn't reflected there."""
+        rows = [
+            SimpleNamespace(caption_text="Fot. X / shutterstock", caption_category="stock"),
+            SimpleNamespace(caption_text=None, caption_category=None),  # no caption found for this image
+        ]
+        session = _fake_session(rows)
+        secs = self._sections() + [{"type": "TEMAT", "original": "Fot. Y / getty images"}]
+        doc = _Doc(author="A", title="T", id=9265)
+        q = compute_quality(doc, secs, model=None, session=session)
+
+        assert q["penalties"]["photo_sources"] == 3
+        assert q["signals"]["photo_captions"] == 1
+        assert q["signals"]["photo_caption_categories"] == {"stock": 1}
+        assert q["signals"]["photo_caption_lines"] == ["Fot. X / shutterstock"]
+
+    def test_session_with_document_images_rows_all_uncategorized_means_no_penalty(self):
+        """Rows exist (already checked at clean time) but none carry a caption —
+        that is a real answer, not missing data, so no text-scan fallback."""
+        rows = [SimpleNamespace(caption_text=None, caption_category=None)]
+        session = _fake_session(rows)
+        secs = self._sections() + [{"type": "TEMAT", "original": "Fot. Y / getty images"}]
+        doc = _Doc(author="A", title="T", id=9265)
+        q = compute_quality(doc, secs, model=None, session=session)
+
+        assert "photo_sources" not in q["penalties"]
+        assert q["signals"]["photo_captions"] == 0
+
+    def test_session_without_doc_id_falls_back_to_text_scan(self):
+        session = _fake_session([SimpleNamespace(caption_text="x", caption_category="stock")])
+        secs = self._sections() + [{"type": "TEMAT", "original": "Fot. Y / getty images"}]
+        doc = _Doc(author="A", title="T", id=None)
+        q = compute_quality(doc, secs, model=None, session=session)
+
+        # doc has no id -> DB path skipped entirely, session.scalars never called
+        session.scalars.assert_not_called()
+        assert q["signals"]["photo_caption_categories"] == {"stock": 1}
 
     def test_noise_share_penalty(self):
         secs = [


### PR DESCRIPTION
## Summary
- `compute_quality()` gains an optional `session=` param, wired at both real call sites (`chunk_review_routes.py`, `document_analysis_service.py`).
- When a document already has `document_images` rows, photo-sourcing penalties/signals are read from there instead of re-scanning `full_text` with `photo_caption_candidates()`.
- An empty row set is trusted as a real answer (checked at clean time, nothing found); only a genuinely empty table (no rows — legacy docs, or `session`/`doc.id` missing) falls back to the old text scan. Fully backward compatible: `session` defaults to `None`, so every existing caller/test keeps the old text-scan behavior unchanged.
- This is the prerequisite for eventually stripping caption/credit lines out of `text_md` (cleaner reader/LLM text) without losing the photo-sourcing quality signal — `document_images` is now the independent source of truth for it.

## Test plan
- [x] `ruff check` clean
- [x] `pytest tests/unit/` — 1917 passed; same 9 pre-existing failures as `main` (unrelated)
- [x] New tests in `test_article_quality.py`: DB rows override text scan, empty-but-populated rows mean no penalty (not a fallback trigger), no-rows-at-all falls back, missing `doc.id` skips the DB path entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)