### PR TITLE
feat(cleaning): usuwaj podpisy/credity zdjęć i chrome onet.pl z treści

### DIFF
--- a/backend/data/site_rules.json
+++ b/backend/data/site_rules.json
@@ -59,7 +59,16 @@
         "remove_string_regexp" : [
             "(?m)^Zapytaj o więcej Onet Czat z AI(?:\\s+\\[link\\d+\\])?\\s*$",
             "(?m)^Więcej (?:pogłębionych treści|treści premium dla Ciebie)\\s*$",
-            "(?m)^Dalszy ciąg artykułu pod materiałem wideo\\s*$"
+            "(?m)^Dalszy ciąg artykułu pod materiałem wideo\\s*$",
+            "(?m)^Więcej takich artykułów znajdziesz na stronie głównej Onetu\\s*$",
+            "(?m)^Top 5 treści Premium\\s*$",
+            "(?m)^(?:CZYTAJ TAKŻE|ZOBACZ RÓWNIEŻ)\\s*$",
+            "(?m)^Powiązane tematy:.*$",
+            "(?m)^Opracowanie: .+$",
+            "(?m)^\\*\\*PRZECZYTAJ CAŁY [^*\\n]+\\*\\*(?:\\s+\\[link\\d+\\])?\\s*$",
+            "(?m)^Dodaj w Google\\s*$",
+            "(?m)^Wróć na\\s*$",
+            "(?m)^Jesteś w strefie\\s*$"
         ]
     },
     "https://businessinsider.com.pl": {

--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -167,6 +167,9 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
     skip = {
         "Posłuchaj artykułu", "Skróć artykuł", "- x1 +", "x1", "Obserwuj",
         "Więcej pogłębionych treści", "Więcej treści premium dla Ciebie",
+        "Więcej takich artykułów znajdziesz na stronie głównej Onetu",
+        "Top 5 treści Premium", "CZYTAJ TAKŻE", "ZOBACZ RÓWNIEŻ",
+        "Dodaj w Google", "Wróć na", "Jesteś w strefie",
     }
     cleaned = []
     in_top_premium = False
@@ -209,6 +212,15 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
             continue
         # Reakcje: "[img1][img2]1,6 tys." lub "[img0][img1]385"
         if re.match(r'^(\[img\d+\])+[\d,]+(\s*tys\.)?$', stripped):
+            continue
+        # "Powiązane tematy: Karol Nawrocki Wołodymyr Zełenski ..."
+        if stripped.startswith("Powiązane tematy:"):
+            continue
+        # Byline redakcyjny: "Opracowanie: Mateusz Bałuka"
+        if re.match(r'^Opracowanie:\s+\S', stripped):
+            continue
+        # CTA rekomendacji: "**PRZECZYTAJ CAŁY TEKST** [linkN]", "**PRZECZYTAJ CAŁY WYWIAD**"
+        if re.match(r'^\*\*PRZECZYTAJ CAŁY [^*]+\*\*(?:\s+\[link\d+\])?$', stripped):
             continue
         cleaned.append(line)
     return cleaned
@@ -415,6 +427,76 @@ def _clean_lines_gazeta(lines: list[str]) -> list[str]:
     return cleaned
 
 
+# Kategorie photo_caption_candidates rozpoznane po jednoznacznym słowie-kluczu
+# agencji/licencji (nie po samej pozycji względem markera) — bezpieczne do
+# usunięcia z treści. "image_credit"/"image_description" to fallback samej
+# pozycji (linia tuż po [imgN], krótka, bez nagłówka) i bywa fałszywie
+# dopasowany do zwykłego akapitu (zob. test_standalone_image_line_preserved_
+# for_quality_and_collected) — dlatego NIE są tu usuwane hurtowo.
+_STRICT_CAPTION_CATEGORIES = {
+    "public_domain", "creative_commons", "own_or_private_archive",
+    "illustrative", "stock", "agency",
+}
+
+_IMG_MARKER_ALT_RE = re.compile(r'^\[img\d+(?::\s*([^\]]*))?\]\s*$')
+
+
+def _strip_photo_caption_lines(text: str, url: str) -> str:
+    """Usuń z treści linie-podpisy/credity zdjęć, których dane trafiły już
+    strukturalnie do document_images (_attach_image_captions) — zostawienie
+    ich w tekście artykułu jest tylko duplikacją. Marker [imgN] zostaje.
+
+    Dwa niezależne, bezpieczne sygnały:
+    1. Kategoria z jednoznacznym słowem-kluczem (_STRICT_CAPTION_CATEGORIES).
+    2. Para [linia-credit, linia dokładnie powtarzająca alt obrazka] tuż po
+       markerze — sama linia-credit rzadko ma rozpoznawalne słowo-klucz
+       (np. "Panthalassa/x / Wodne Sprawy"), ale jednoznaczne potwierdzenie
+       daje kolejna linia będąca dosłownym powtórzeniem alt-textu — realna
+       treść artykułu praktycznie nigdy nie powtarza dosłownie alt obrazka.
+    """
+    lines = text.splitlines()
+    remove_idx = {
+        item["line_index"] for item in photo_caption_candidates(text, url)
+        if item["category"] in _STRICT_CAPTION_CATEGORIES
+    }
+
+    pending_alt: str | None = None
+    pending_credit_idx: int | None = None
+    lines_left = 0
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        marker = _IMG_MARKER_ALT_RE.match(stripped)
+        if marker:
+            alt = (marker.group(1) or "").strip()
+            pending_alt = alt or None
+            pending_credit_idx = None
+            lines_left = 2 if pending_alt else 0
+            continue
+        if lines_left <= 0:
+            pending_alt = None
+            continue
+        lines_left -= 1
+        normalized = re.sub(r'\s+', ' ', stripped).casefold()
+        normalized_alt = re.sub(r'\s+', ' ', pending_alt or '').casefold()
+        if normalized == normalized_alt:
+            remove_idx.add(index)
+            if pending_credit_idx is not None:
+                remove_idx.add(pending_credit_idx)
+            pending_alt = None
+            lines_left = 0
+        elif pending_credit_idx is None and len(stripped) <= 120 and not stripped.startswith('#'):
+            pending_credit_idx = index
+        else:
+            pending_alt = None
+            lines_left = 0
+
+    if not remove_idx:
+        return text
+    return "\n".join(line for index, line in enumerate(lines) if index not in remove_idx)
+
+
 def _attach_image_captions(text: str, extracted_images: list[dict], url: str) -> None:
     """Dopisz caption_text/caption_category do extracted_images na podstawie linii
     sąsiadujących z markerem [imgN] w tekście — MUSI być wywołane zaraz po
@@ -501,6 +583,11 @@ def clean_article_text(text: str, url: str = "") -> dict:
     # 3b. Skojarz podpisy/credity z markerami, zanim dalsze czyszczenie
     # zdąży usunąć linię podpisu z tekstu.
     _attach_image_captions(text, extracted_images, url)
+
+    # 3c. Usuń z treści jednoznacznie rozpoznane linie-podpisy/credity zdjęć —
+    # dane trafiły już do extracted_images (document_images), zostawienie ich
+    # w tekście artykułu jest tylko duplikacją.
+    text = _strip_photo_caption_lines(text, url)
 
     # 4. Odetnij od footer markera portalu
     footer_line = _find_footer_line(text, portal)

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -117,6 +117,33 @@ class TestImageExtraction:
             "caption_text": "Dmytro Buiansky / shutterstock",
             "caption_category": "stock",
         }]
+        # Kategoria z jednoznacznym słowem-kluczem (stock) — usuwana z treści,
+        # dane podpisu przeżyły już wyżej w extracted_images.
+        assert "Dmytro Buiansky / shutterstock" not in result["text"]
+        assert "[img0: Zdjęcie]" in result["text"]
+
+    def test_credit_line_before_exact_alt_repeat_removed(self):
+        # Wzorzec z onet.pl/wodne-sprawy (dok. 9034): [imgN: alt] → linia-credit
+        # bez rozpoznawalnego słowa-klucza agencji → linia dosłownie powtarzająca alt.
+        text = (
+            f"{LONG_PARAGRAPH}\n\n![Panthalassa](https://example.com/foto.jpg)\n\n"
+            f"Panthalassa/x / Wodne Sprawy\n\nPanthalassa\n\n{LONG_PARAGRAPH}"
+        )
+        result = clean_article_text(text)
+        assert "[img0: Panthalassa]" in result["text"]
+        assert "Panthalassa/x / Wodne Sprawy" not in result["text"]
+        assert "\nPanthalassa\n" not in result["text"]
+        assert result["text"].count(LONG_PARAGRAPH) == 2
+
+    def test_credit_line_without_following_alt_repeat_kept(self):
+        # Bez potwierdzającej linii-alt-repeat sama krótka linia po markerze
+        # NIE jest usuwana (mogłaby być zwykłym akapitem) — tylko para jest bezpieczna.
+        text = (
+            f"{LONG_PARAGRAPH}\n\n![Panthalassa](https://example.com/foto.jpg)\n\n"
+            f"Zupełnie inna krótka linia\n\n{LONG_PARAGRAPH}"
+        )
+        result = clean_article_text(text)
+        assert "Zupełnie inna krótka linia" in result["text"]
 
     def test_image_with_empty_url_removed(self):
         text = f"Przed ![jakiś alt]() po.\n\n{LONG_PARAGRAPH}"
@@ -244,6 +271,27 @@ class TestOnetCleaning:
         result = clean_article_text(text, url="https://wiadomosci.onet.pl/swiat/jakis-artykul")
         assert "Posłuchaj artykułu" not in result["text"]
         assert LONG_PARAGRAPH in result["text"]
+
+    def test_onet_recommendation_and_channel_chrome_removed(self):
+        lines = [
+            "CZYTAJ TAKŻE",
+            "ZOBACZ RÓWNIEŻ",
+            "Top 5 treści Premium",
+            "Więcej takich artykułów znajdziesz na stronie głównej Onetu",
+            "Powiązane tematy: Karol Nawrocki Wołodymyr Zełenski Ukraina",
+            "Opracowanie: Mateusz Bałuka",
+            "**PRZECZYTAJ CAŁY WYWIAD** [link9]",
+            "Dodaj w Google",
+            "Wróć na",
+            "Jesteś w strefie",
+            "Treść artykułu onet.",
+        ]
+        assert _clean_lines_onet(lines) == ["Treść artykułu onet."]
+
+    def test_onet_opracowanie_prefix_requires_following_text(self):
+        # "Opracowanie:" bez nazwiska nie powinno paść ofiarą zbyt zachłannego regexu
+        lines = ["Opracowanie:", "Treść artykułu onet."]
+        assert _clean_lines_onet(lines) == ["Opracowanie:", "Treść artykułu onet."]
 
 
 class TestMoneyCleaning:


### PR DESCRIPTION
## Podsumowanie

- Nowa funkcja `_strip_photo_caption_lines()` w `article_cleaner.py` usuwa z treści artykułu linie-podpisy/credity zdjęć, które trafiają już strukturalnie do `document_images` (`_attach_image_captions`, PR #329-331). Bezpieczne, wąskie kryteria: kategoria z jednoznacznym słowem-kluczem agencji/stocka/licencji (`stock`/`agency`/`public_domain`/`creative_commons`/`illustrative`/`own_or_private_archive`) oraz para [linia-credit, linia dosłownie powtarzająca alt obrazka] tuż po markerze `[imgN]`. Marker zostaje. Nieujednoznacznione linie (np. zwykły akapit błędnie sklasyfikowany jako "credit" — udokumentowane w istniejącym teście) są świadomie pomijane.
- Kilka nowych stałych fraz portalowego "chrome" dla onet.pl (`CZYTAJ TAKŻE`/`ZOBACZ RÓWNIEŻ`, `Powiązane tematy:`, `Opracowanie:`, `**PRZECZYTAJ CAŁY ...**`, `Dodaj w Google`, `Wróć na`, `Jesteś w strefie`, `Top 5 treści Premium`, `Więcej takich artykułów...`) w `site_rules.json` i `_clean_lines_onet()`.
- Analiza kolejki `document_removed_lines` dla onet.pl (188 rekordów `pending`, wg [docs/agent/document-removed-lines-workflow.md](docs/agent/document-removed-lines-workflow.md)): 51 rozstrzygniętych (`rule_added`/`already_covered`/`rejected`), 137 pozostaje `pending` (opisowe podpisy zdjęć bez rozpoznawalnego słowa-klucza i tytuły rekomendacji — zbyt niejednoznaczne dla bezpiecznego blanket-regexu, wymagają dalszej analizy per-przypadek).

## Test plan

- [x] `pytest tests/unit/test_article_cleaner.py -q` — 48 passed (w tym 5 nowych testów: chrome onet.pl, strict-category strip, credit+alt-repeat pair, regresja "credit bez potwierdzenia zostaje")
- [x] `pytest tests/unit/test_article_quality.py tests/unit/test_removed_lines.py tests/unit/test_md_decode_onet.py -q` — 84 passed
- [x] `pytest tests/unit/ -q` — 1921 passed, 9 failed (niezwiązane z tą zmianą: `test_db_models.py`, `test_dynamodb_sync_auto_since.py` — pre-existing)
- [x] `ruff check backend/library/article_cleaner.py` — czysto
- [x] JSON `site_rules.json` zwalidowany
- [ ] Weryfikacja na przykładowym dokumencie po deployu na NAS (dok. 9034 i nowsze z kanału onet.pl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)