### PR TITLE
fix(cleaning): usuwaj wyciek 5-punktowego streszczenia Onet Czat z AI

### DIFF
--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -516,11 +516,46 @@ def _attach_image_captions(text: str, extracted_images: list[dict], url: str) ->
         pending_idx = None
 
 
+_BULLET_LINE_RE = re.compile(r'^[*-]\s+\S')
+
+# Box "Poniżej streszczenie artykułu: Skrót przygotowany przez Onet Czat z AI,
+# może zawierać błędy." generuje zawsze dokładnie 5 punktów (zweryfikowane na
+# żywo na kilku artykułach onet.pl). Ekstrakcja LLM czasem gubi sam nagłówek
+# boxu, ale zostawia te 5 punktów jako pozorny początek artykułu — prawdziwy
+# lead (inaczej sformułowany, czasem pogrubiony, czasem nie) idzie zaraz po
+# nich. Liczba dokładnie 5 jest tu jedynym bezpiecznym sygnałem: prawdziwe
+# artykuły otwierające się wypunktowaniem nie mają aż tak przewidywalnej
+# długości, więc inne liczby zostają nietknięte.
+_AI_SUMMARY_BULLET_COUNT = 5
+
+
+def _strip_leading_onet_ai_summary(text: str) -> str:
+    """Usuń z początku tekstu wyciek 5-punktowego streszczenia Onet Czat z AI
+    (nagłówek boxu bywa już wycięty wcześniej w ekstrakcji, punkty zostają)."""
+    lines = text.splitlines()
+    idx = 0
+    while idx < len(lines) and not lines[idx].strip():
+        idx += 1
+
+    bullet_count = 0
+    j = idx
+    while j < len(lines) and _BULLET_LINE_RE.match(lines[j].strip()):
+        bullet_count += 1
+        j += 1
+
+    if bullet_count != _AI_SUMMARY_BULLET_COUNT:
+        return text
+    return "\n".join(lines[:idx] + lines[j:])
+
+
 def clean_article_text(text: str, url: str = "") -> dict:
     """Wyczyść wyekstrahowany markdown. Zwraca dict: {text, links, images}."""
     extracted_links = []
     extracted_images = []
     portal = _detect_portal(url)
+
+    if portal == "onet":
+        text = _strip_leading_onet_ai_summary(text)
 
     # 1. Napraw wieloliniowe linki i tagi markdown
     text = links_correct(text)

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -11,6 +11,7 @@ from library.article_cleaner import (
     _clean_lines_wp,
     _detect_h2_ads,
     _is_portal_internal_link,
+    _strip_leading_onet_ai_summary,
     clean_article_text,
 )
 from library.article_extractor import _detect_portal, extract_article_by_markers
@@ -292,6 +293,57 @@ class TestOnetCleaning:
         # "Opracowanie:" bez nazwiska nie powinno paść ofiarą zbyt zachłannego regexu
         lines = ["Opracowanie:", "Treść artykułu onet."]
         assert _clean_lines_onet(lines) == ["Opracowanie:", "Treść artykułu onet."]
+
+    def test_strips_leading_five_bullet_ai_summary_leak(self):
+        # Box "Poniżej streszczenie artykułu: Skrót przygotowany przez Onet
+        # Czat z AI" generuje zawsze 5 punktów; ekstrakcja czasem gubi jego
+        # nagłówek i zostawia same punkty jako pozorny początek artykułu
+        # (zweryfikowane na żywo na onet.pl/informacje/magazynkontakt/...).
+        text = (
+            "* Punkt pierwszy streszczenia AI.\n"
+            "* Punkt drugi streszczenia AI.\n"
+            "* Punkt trzeci streszczenia AI.\n"
+            "* Punkt czwarty streszczenia AI.\n"
+            "* Punkt piąty streszczenia AI.\n\n"
+            f"**{LONG_PARAGRAPH}**"
+        )
+        result = _strip_leading_onet_ai_summary(text)
+        assert "Punkt pierwszy" not in result
+        assert "Punkt piąty" not in result
+        assert LONG_PARAGRAPH in result
+
+    def test_does_not_strip_leading_bullets_with_wrong_count(self):
+        # Tylko dokładnie 5 punktów jest bezpiecznym sygnałem (stały format
+        # boxu AI) — 4 lub 6 punktów to może być prawdziwa lista w artykule.
+        text = (
+            "* Punkt pierwszy.\n* Punkt drugi.\n* Punkt trzeci.\n* Punkt czwarty.\n\n"
+            f"{LONG_PARAGRAPH}"
+        )
+        assert _strip_leading_onet_ai_summary(text) == text
+
+    def test_does_not_strip_five_bullets_mid_article(self):
+        # Sygnał działa tylko na samym początku tekstu — pięć punktów
+        # gdzieś w środku prawdziwego artykułu (np. lista "kluczowych faktów")
+        # zostaje nietknięte.
+        text = (
+            f"{LONG_PARAGRAPH}\n\n"
+            "* Punkt pierwszy.\n* Punkt drugi.\n* Punkt trzeci.\n"
+            "* Punkt czwarty.\n* Punkt piąty.\n"
+        )
+        assert _strip_leading_onet_ai_summary(text) == text
+
+    def test_ai_summary_leak_stripped_end_to_end_via_clean_article_text(self):
+        text = (
+            "* Punkt pierwszy streszczenia AI.\n"
+            "* Punkt drugi streszczenia AI.\n"
+            "* Punkt trzeci streszczenia AI.\n"
+            "* Punkt czwarty streszczenia AI.\n"
+            "* Punkt piąty streszczenia AI.\n\n"
+            f"**{LONG_PARAGRAPH}**"
+        )
+        result = clean_article_text(text, url="https://www.onet.pl/informacje/onetwiadomosci/jakis-artykul")
+        assert "Punkt pierwszy" not in result["text"]
+        assert LONG_PARAGRAPH in result["text"]
 
 
 class TestMoneyCleaning:


### PR DESCRIPTION
## Kontekst

Odpowiedź na pytanie użytkownika: "czy przeglądamy też SZUM, mam wrażenie że jest problem z czyszczeniem początku artykułu". Wynik śledztwa: **tak, jest realny, potwierdzony problem** — box "Poniżej streszczenie artykułu: Skrót przygotowany przez Onet Czat z AI, może zawierać błędy." (zawsze dokładnie 5 punktów) czasem przecieka do treści artykułu, bo ekstrakcja LLM gubi sam nagłówek boxu, ale nie rozpoznaje samych punktów jako szumu.

Potwierdzone bezpośrednio w **już zatwierdzonych** (`status=approved`) chunkach: dok. 9202, 9203, 9209, 9210 — realny wyciek w danych produkcyjnych, nie tylko w kolejce review.

## Zmiana

`_strip_leading_onet_ai_summary()` — usuwa wiodący blok DOKŁADNIE 5 linii wypunktowania z samego początku tekstu (tylko portal onet). Liczba 5 to jedyny bezpieczny sygnał (stały format boxu, zweryfikowany na żywo na kilku artykułach) — inna liczba wypunktowań zostaje nietknięta, żeby nie ściąć prawdziwej listy w prawdziwym artykule.

## Test plan

- [x] 4 nowe testy: strip przy 5 punktach, brak strip przy 4/6 punktach, brak strip gdy 5 punktów jest w środku artykułu (nie na początku), end-to-end przez `clean_article_text()`
- [x] Zweryfikowane na rzeczywistym, zatwierdzonym chunku dok. 9202 (magazynkontakt) — 5 punktów usuniętych, prawdziwy lead (pogrubiony akapit) zachowany
- [x] `pytest tests/unit/test_article_cleaner.py -q` — 52 passed
- [x] `pytest tests/unit/ -q` — 1925 passed, 9 failed (pre-existing, niezwiązane: `test_db_models.py`, `test_dynamodb_sync_auto_since.py`)
- [x] `ruff check` — czysto

## Poza zakresem tego PR

Podczas śledztwa znalazłem też **osobny, poważniejszy problem**: dok. 7881 (`onetfilm`) ma 3 pierwsze chunki złożone WYŁĄCZNIE z menu nawigacyjnego strony głównej onet.pl (nie z artykułu) — całkowita porażka ekstrakcji LLM dla tej strony, nie wzorzec do regexowej reguły. Chunki mają status `pending` (nie dotarły jeszcze do recenzji), więc nic jeszcze nie "wyciekło" do produkcji, ale dokument prawdopodobnie wymaga ponownej ekstrakcji. Zgłaszam osobno, nie naprawiam w tym PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)