### PR TITLE
feat(chunks): loguj treść kasowanego chunka SZUM/REKLAMA do document_removed_lines

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -2074,6 +2074,11 @@ def delete_noise_chunk(chunk_id: int):
     This intentionally does not modify the source document. TEMAT chunks must
     be reclassified first, which protects substantive content from accidental
     deletion through the compact card action.
+
+    Before deleting, the chunk's full original_text is queued as a
+    DocumentRemovedLine (source=szum_chunk) — same pattern as apply_cleanup —
+    so the noise pattern survives for cleaner-rule mining instead of vanishing
+    with the row.
     """
     session = get_scoped_session()
     chunk = session.get(DocumentChunk, chunk_id)
@@ -2095,6 +2100,10 @@ def delete_noise_chunk(chunk_id: int):
         ]
 
     try:
+        _log_removed_lines(
+            session, document_id=chunk.document_id, run_id=run_id,
+            chunk_id=chunk.id, lines=[chunk.original_text], source="szum_chunk",
+        )
         session.delete(chunk)
         session.flush()
         # Two-phase shift avoids collisions with a possible unique(run, position).

--- a/backend/tests/unit/test_delete_noise_chunk.py
+++ b/backend/tests/unit/test_delete_noise_chunk.py
@@ -1,0 +1,99 @@
+"""Unit tests for DELETE /chunk/<id> (chunk_review_routes.delete_noise_chunk).
+
+Covers the szum_chunk logging added so a deleted REKLAMA/SZUM chunk's
+original_text survives as DocumentRemovedLine training data instead of
+vanishing with the row. LLM/DB access is mocked.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+flask = pytest.importorskip("flask")
+
+from library import chunk_review_routes as crr  # noqa: E402
+from library.db.models import DocumentChunk, DocumentRemovedLine  # noqa: E402
+
+
+def _make_chunk(**kw) -> DocumentChunk:
+    defaults = dict(
+        id=201, run_id=1, document_id=77, position=3, type="SZUM", topic=None,
+        original_text="Julia Lachowicz-Nowińska", corrected_text=None, summary=None,
+        seg_start=None, seg_end=None, rewrite_ratio=None, status="pending",
+        split_at_seg=None, split_first_type=None, split_second_type=None,
+        obsidian_note_paths=[],
+    )
+    defaults.update(kw)
+    return DocumentChunk(**defaults)
+
+
+class _ScalarsResult:
+    def __init__(self, items):
+        self._items = items
+
+    def all(self):
+        return self._items
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    session = MagicMock()
+    chunk = _make_chunk()
+    session.get.side_effect = lambda model, pk: chunk if model is DocumentChunk and pk == chunk.id else None
+    session.scalars.side_effect = lambda *_a, **_kw: _ScalarsResult([])
+    monkeypatch.setattr(crr, "get_scoped_session", lambda: session)
+    return session, chunk
+
+
+@pytest.fixture
+def client():
+    app = flask.Flask(__name__)
+    app.register_blueprint(crr.bp)
+    return app.test_client()
+
+
+class TestDeleteNoiseChunkLogsRemovedLine:
+    def test_deletes_chunk_and_logs_full_text_as_szum_chunk(self, client, fake_session):
+        session, chunk = fake_session
+        r = client.delete("/chunk/201")
+        assert r.get_json()["status"] == "success"
+
+        session.delete.assert_called_once_with(chunk)
+        added = [c.args[0] for c in session.add.call_args_list]
+        removed_lines = [a for a in added if isinstance(a, DocumentRemovedLine)]
+        assert len(removed_lines) == 1
+        row = removed_lines[0]
+        assert row.source == "szum_chunk"
+        assert row.document_id == chunk.document_id
+        assert row.run_id == chunk.run_id
+        assert row.chunk_id == chunk.id
+        assert row.line_text == "Julia Lachowicz-Nowińska"
+
+    def test_logging_happens_before_delete(self, client, fake_session):
+        # _log_removed_lines must run while the chunk row still exists (before
+        # session.delete), otherwise the FK it references would already be gone.
+        session, _chunk = fake_session
+        calls = []
+        session.add.side_effect = lambda *_a, **_kw: calls.append("add")
+        session.delete.side_effect = lambda *_a, **_kw: calls.append("delete")
+        client.delete("/chunk/201")
+        assert calls == ["add", "delete"]
+
+    def test_temat_chunk_cannot_be_deleted_and_nothing_logged(self, client, monkeypatch):
+        session = MagicMock()
+        chunk = _make_chunk(type="TEMAT")
+        session.get.side_effect = lambda model, pk: chunk if model is DocumentChunk and pk == chunk.id else None
+        monkeypatch.setattr(crr, "get_scoped_session", lambda: session)
+
+        r = client.delete("/chunk/201")
+        assert r.status_code == 400
+        session.delete.assert_not_called()
+        session.add.assert_not_called()
+
+    def test_missing_chunk_returns_404(self, client, monkeypatch):
+        session = MagicMock()
+        session.get.return_value = None
+        monkeypatch.setattr(crr, "get_scoped_session", lambda: session)
+        r = client.delete("/chunk/999")
+        assert r.status_code == 404


### PR DESCRIPTION
## Kontekst

Ciąg dalszy śledztwa "czy przeglądamy też SZUM": `DELETE /chunk/<id>` (przycisk 🗑 na `/chunks`) robił twardy `session.delete(chunk)` bez żadnego śladu. `document_removed_lines` ma FK (`chunk_id`/`run_id`) z `ON DELETE SET NULL` właśnie pod ten scenariusz, ale zapis do niej (source=`szum_chunk`) dotąd był tylko w `apply_cleanup` — funkcji, której (jak ustaliliśmy) nikt nigdy nie użył. Efekt: każde kliknięcie 🗑 na chunku SZUM/REKLAMA bezpowrotnie kasowało dowód na to, co dokładnie było szumem.

## Zmiana

`delete_noise_chunk()` woła `_log_removed_lines(..., chunk_id=chunk.id, lines=[chunk.original_text], source="szum_chunk")` **przed** `session.delete(chunk)` (kolejność istotna — FK musi jeszcze istnieć w momencie zapisu). Reszta zachowania endpointu bez zmian: TEMAT nadal chroniony, przesuwanie pozycji bez zmian, odpowiedź JSON bez zmian.

## Test plan

- [x] 4 nowe testy (`tests/unit/test_delete_noise_chunk.py`): log + delete przy sukcesie, kolejność add→delete, TEMAT wciąż odrzucany bez logowania, 404 dla brakującego chunka
- [x] `pytest tests/unit/test_delete_noise_chunk.py -q` — 4 passed
- [x] `pytest tests/unit/ -q` — 1929 passed, 9 failed (pre-existing, niezwiązane: `test_db_models.py`, `test_dynamodb_sync_auto_since.py`)
- [x] `ruff check` — czysto

🤖 Generated with [Claude Code](https://claude.com/claude-code)