### PR TITLE
feat(cleaning): dodaj czyszczenie interia.pl w clean_article_text()

### DIFF
--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -128,7 +128,11 @@ def _clean_lines_generic(lines: list[str], h2_ad_titles: set) -> list[str]:
 
         # Frazy portalowe wspólne
         if stripped in ("Dalszy ciąg materiału pod wideo", "REKLAMAKONIEC REKLAMY",
-                        "REKLAMA", "KONIEC REKLAMY", "Lubię to", "[ ]", "Rozwiń", "Zwiń"):
+                        "REKLAMA", "KONIEC REKLAMY", "Lubię to", "[ ]", "Rozwiń", "Zwiń",
+                        "Treść zewnętrzna"):
+            continue
+        # Etykieta audio wygenerowanego AI (ElevenLabs) — potwierdzone na onet.pl i interia.pl
+        if stripped.startswith("Audio generowane przez AI"):
             continue
 
         # Kontrolki video playera
@@ -201,8 +205,6 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
             continue
         # "Więcej w Strefie Premium [linkN]"
         if "Więcej w Strefie Premium" in stripped:
-            continue
-        if stripped.startswith("Audio generowane"):
             continue
         # Data publikacji: "17 marca 2026, 12:31"
         if re.match(r'^\d{1,2}\s+\w+\s+\d{4},?\s+\d{1,2}:\d{2}$', stripped):
@@ -342,6 +344,50 @@ def _clean_lines_wp(lines: list[str]) -> list[str]:
 def _clean_lines_ithardware(lines: list[str]) -> list[str]:
     """Usuń kontrolki osadzonego playera ITHardware bez globalnych reguł Play/ad."""
     return [line for line in lines if line.strip() not in {"Play", "ad"}]
+
+
+# Menu sekcji nagłówka strony interia.pl — ten sam blok na każdej stronie
+# serwisu, konwerter HTML->markdown skleja je bez separatorów w kolejne linie.
+_INTERIA_NAV_MENU_ITEMS = [
+    "Polska", "Świat", "Wydarzenia lokalne", "Okiem Interii", "Wojna w Ukrainie",
+    "Pogoda", "Redakcja", "Religia", "Felietoniści", "Raporty", "Baza wiedzy",
+    "Zielona Interia",
+]
+_INTERIA_NAV_MENU_RE = re.compile(
+    r'\n\s*'.join(re.escape(item) for item in _INTERIA_NAV_MENU_ITEMS)
+)
+
+# Pasek reakcji emocji pod artykułem — stały zestaw 5 etykiet w tej kolejności.
+_INTERIA_REACTIONS_RE = re.compile(
+    r'\n\s*'.join(re.escape(item) for item in ("Super", "Hahaha", "Szok", "Smutny", "Zły"))
+)
+
+
+def _strip_interia_chrome_blocks(text: str) -> str:
+    """Usuń stałe, wieloliniowe bloki chrome interia.pl (menu nawigacji
+    nagłówka, pasek reakcji) — bezpieczne jako dopasowanie całej sekwencji,
+    bo prawdziwa treść artykułu nigdy nie powtarza jej dosłownie."""
+    text = _INTERIA_NAV_MENU_RE.sub("", text)
+    text = _INTERIA_REACTIONS_RE.sub("", text)
+    return text
+
+
+def _clean_lines_interia(lines: list[str]) -> list[str]:
+    """Czyszczenie specyficzne dla interia.pl (wydarzenia/biznes/motoryzacja/...)."""
+    skip_exact = {"Udostępnij", "Odsłuchaj artykuł", "W skrócie", "Zobacz również:"}
+    cleaned = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped in skip_exact:
+            continue
+        # Względny znacznik czasu: "11 minut temu", "2 godziny temu"
+        if re.match(r'^\d+\s+(?:minut\w*|godzin\w*)\s+temu$', stripped):
+            continue
+        # "wczoraj, 22:30"
+        if re.match(r'^wczoraj,\s*\d{1,2}:\d{2}$', stripped):
+            continue
+        cleaned.append(line)
+    return cleaned
 
 
 def _clean_lines_bankier(lines: list[str]) -> list[str]:
@@ -556,6 +602,8 @@ def clean_article_text(text: str, url: str = "") -> dict:
 
     if portal == "onet":
         text = _strip_leading_onet_ai_summary(text)
+    elif portal == "interia":
+        text = _strip_interia_chrome_blocks(text)
 
     # 1. Napraw wieloliniowe linki i tagi markdown
     text = links_correct(text)
@@ -700,6 +748,8 @@ def clean_article_text(text: str, url: str = "") -> dict:
         lines = _clean_lines_gazeta(lines)
     elif portal == "bankier":
         lines = _clean_lines_bankier(lines)
+    elif portal == "interia":
+        lines = _clean_lines_interia(lines)
     elif "ithardware.pl" in url.lower():
         lines = _clean_lines_ithardware(lines)
 

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -7,11 +7,13 @@ from library.article_cleaner import (
     _clean_lines_money,
     _clean_lines_onet,
     _clean_lines_ithardware,
+    _clean_lines_interia,
     _is_adjacent_tag_links_line,
     _clean_lines_wp,
     _detect_h2_ads,
     _is_portal_internal_link,
     _strip_leading_onet_ai_summary,
+    _strip_interia_chrome_blocks,
     clean_article_text,
 )
 from library.article_extractor import _detect_portal, extract_article_by_markers
@@ -344,6 +346,65 @@ class TestOnetCleaning:
         result = clean_article_text(text, url="https://www.onet.pl/informacje/onetwiadomosci/jakis-artykul")
         assert "Punkt pierwszy" not in result["text"]
         assert LONG_PARAGRAPH in result["text"]
+
+
+class TestInteriaCleaning:
+    URL = "https://wydarzenia.interia.pl/bliski-wschod/news-jakis-artykul,nId,1"
+
+    def test_nav_menu_block_removed_but_article_kept(self):
+        text = (
+            f"{LONG_PARAGRAPH}\n\n"
+            "Polska\nŚwiat\nWydarzenia lokalne\nOkiem Interii\nWojna w Ukrainie\n"
+            "Pogoda\nRedakcja\nReligia\nFelietoniści\nRaporty\nBaza wiedzy\nZielona Interia\n\n"
+            f"{LONG_PARAGRAPH}"
+        )
+        result = _strip_interia_chrome_blocks(text)
+        assert "Okiem Interii" not in result
+        assert result.count(LONG_PARAGRAPH) == 2
+
+    def test_reactions_block_removed(self):
+        text = f"{LONG_PARAGRAPH}\n\nSuper\nHahaha\nSzok\nSmutny\nZły\n\n{LONG_PARAGRAPH}"
+        result = _strip_interia_chrome_blocks(text)
+        assert "Hahaha" not in result
+
+    def test_single_reaction_word_in_real_content_kept(self):
+        # Pojedyncze słowo z paska reakcji, poza pełną sekwencją, to może być
+        # zwykła treść — usuwamy tylko całą, dokładną sekwencję 5 etykiet.
+        text = f"{LONG_PARAGRAPH}\n\nSzok\n\n{LONG_PARAGRAPH}"
+        assert _strip_interia_chrome_blocks(text) == text
+
+    def test_interia_share_audio_and_timestamps_removed(self):
+        lines = [
+            "Udostępnij", "Odsłuchaj artykuł", "W skrócie", "Zobacz również:",
+            "11 minut temu", "2 godziny temu",
+            "wczoraj, 22:30", "Treść artykułu interia.",
+        ]
+        assert _clean_lines_interia(lines) == ["Treść artykułu interia."]
+
+    def test_interia_portal_detected_end_to_end(self):
+        text = (
+            "Polska\nŚwiat\nWydarzenia lokalne\nOkiem Interii\nWojna w Ukrainie\n"
+            "Pogoda\nRedakcja\nReligia\nFelietoniści\nRaporty\nBaza wiedzy\nZielona Interia\n\n"
+            f"{LONG_PARAGRAPH}\n\nUdostępnij\n\n11 minut temu"
+        )
+        result = clean_article_text(text, url=self.URL)
+        assert "Okiem Interii" not in result["text"]
+        assert "Udostępnij" not in result["text"]
+        assert "11 minut temu" not in result["text"]
+        assert LONG_PARAGRAPH in result["text"]
+
+    def test_audio_ai_disclaimer_removed_generically(self):
+        # Ta sama etykieta wystąpiła już na onet.pl i interia.pl — reguła
+        # generyczna, niezależna od portalu.
+        lines = [
+            "Audio generowane przez AI (ElevenLabs) i może zawierać błędy",
+            "Treść artykułu.",
+        ]
+        result = clean_article_text(
+            "\n\n".join(lines), url="https://wydarzenia.interia.pl/x,nId,1"
+        )
+        assert "ElevenLabs" not in result["text"]
+        assert "Treść artykułu." in result["text"]
 
 
 class TestMoneyCleaning:


### PR DESCRIPTION
## Kontekst

Weryfikacja procesu na dok. 8901 (`wydarzenia.interia.pl`) po ostatnich zmianach (photo captions, SZUM-chunk logging) ujawniła kolejną lukę: **interia.pl w ogóle nie miał gałęzi w `clean_article_text()`** — `article_extractor.py` rozpoznaje portal `"interia"` (markery dla pre-LLM prep), ale finalny cleaner spadał na sam generyczny cleaner. Efekt widoczny wprost w nowo zalogowanych `document_removed_lines` (dzięki #334): dwa całe chunki SZUM to w 100% menu nawigacji + pasek reakcji + karta rekomendacji — użytkownik musiał ręcznie dzielić i oznaczać to jako szum.

## Zmiana

- `_strip_interia_chrome_blocks()` — usuwa dwa stałe bloki wieloliniowe (menu sekcji nagłówka, pasek 5 reakcji) jako dokładną sekwencję — bezpieczne, bo prawdziwa treść artykułu nigdy jej nie powtarza.
- `_clean_lines_interia()` — `Udostępnij` / `Odsłuchaj artykuł` / `W skrócie` / `Zobacz również:` / względne znaczniki czasu (`11 minut temu`, `wczoraj, HH:MM`).
- `"Audio generowane przez AI (ElevenLabs)..."` przeniesione z `_clean_lines_onet` do generic — ta sama etykieta wystąpiła identycznie na 2 niezależnych portalach (onet.pl, interia.pl), więc kwalifikuje się do reguły globalnej.
- `"Treść zewnętrzna"` dopisane do generic (dotąd tylko w `_global` `site_rules.json`, innej, wcześniejszej warstwie pipeline'u — nie działało na finalnym tekście).

**Poza zakresem:** sklejony breadcrumb+tytuł+kategoria+nazwisko autora (`INTERIAWYDARZENIABLISKI WSCHÓD<tytuł>`) — jak przy analogicznym znalezisku na onet.pl, bezpieczne odfiltrowanie wymaga porównania z `documents.title`/`byline`, czyli zmiany sygnatury `clean_article_text()` (większy zakres, świadomie odłożone).

Rozstrzygnięto 10 rekordów `document_removed_lines` dla dok. 8901 przez `scripts/review_removed_lines.py` (7 `rule_added`, w tym 2 częściowe z jasną notatką co zostaje niepokryte; 3 `rejected` — treść specyficzna dla dokumentu: nazwa kategorii, tytuł rekomendacji, nazwisko autora).

## Test plan

- [x] 6 nowych testów w `TestInteriaCleaning`: blok nawigacji, blok reakcji, pojedyncze słowo z paska reakcji poza sekwencją zostaje, `Udostępnij`/audio/timestampy, end-to-end przez `clean_article_text()`, etykieta AI generycznie
- [x] Zweryfikowane na rzeczywistej treści usuniętego chunka SZUM z dok. 8901 (menu, pasek reakcji, `Udostępnij`, `11 minut temu` znikają; tytuł/kategoria/byline świadomie zostają)
- [x] `pytest tests/unit/test_article_cleaner.py -q` — 58 passed
- [x] `pytest tests/unit/ -q` — 1935 passed, 9 failed (pre-existing, niezwiązane)
- [x] `ruff check` — czysto

🤖 Generated with [Claude Code](https://claude.com/claude-code)