### PR TITLE
feat(dates): rozwiązuj względne znaczniki czasu publikacji względem ingested_at

### DIFF
--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -9,6 +9,7 @@ Wydzielone z imports/article_browser.py, aby logika była testowalna
 i reużywalna w skryptach batch.
 """
 
+import datetime
 import re
 
 from library.article_extractor import _detect_portal, _find_footer_line, _find_start_line
@@ -372,6 +373,16 @@ def _strip_interia_chrome_blocks(text: str) -> str:
     return text
 
 
+# Względne znaczniki czasu publikacji (interia.pl i najpewniej inne portale
+# korzystające z podobnych szablonów). Wspólne dla usuwania linii-szumu
+# (_clean_lines_interia) i dla resolve_relative_publication_date poniżej —
+# jedna definicja wzorców dla obu celów, tak jak photo_caption_candidates
+# jest współdzielone między czyszczeniem a oceną jakości.
+_RELATIVE_MINUTES_HOURS_AGO_RE = re.compile(r'^(\d+)\s+(minut\w*|godzin\w*)\s+temu$', re.IGNORECASE)
+_RELATIVE_YESTERDAY_RE = re.compile(r'^wczoraj,\s*(\d{1,2}):(\d{2})$', re.IGNORECASE)
+_RELATIVE_TODAY_RE = re.compile(r'^dzi[sś],\s*(\d{1,2}):(\d{2})$', re.IGNORECASE)
+
+
 def _clean_lines_interia(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla interia.pl (wydarzenia/biznes/motoryzacja/...)."""
     skip_exact = {"Udostępnij", "Odsłuchaj artykuł", "W skrócie", "Zobacz również:"}
@@ -380,14 +391,45 @@ def _clean_lines_interia(lines: list[str]) -> list[str]:
         stripped = line.strip()
         if stripped in skip_exact:
             continue
-        # Względny znacznik czasu: "11 minut temu", "2 godziny temu"
-        if re.match(r'^\d+\s+(?:minut\w*|godzin\w*)\s+temu$', stripped):
-            continue
-        # "wczoraj, 22:30"
-        if re.match(r'^wczoraj,\s*\d{1,2}:\d{2}$', stripped):
+        # Względny znacznik czasu: "11 minut temu", "2 godziny temu",
+        # "Wczoraj, 22:30", "Dziś, 09:15"
+        if (_RELATIVE_MINUTES_HOURS_AGO_RE.match(stripped)
+                or _RELATIVE_YESTERDAY_RE.match(stripped)
+                or _RELATIVE_TODAY_RE.match(stripped)):
             continue
         cleaned.append(line)
     return cleaned
+
+
+def resolve_relative_publication_date(
+    text: str, ingested_at: datetime.datetime | None,
+) -> datetime.date | None:
+    """Wykryj względny znacznik czasu publikacji (np. "Wczoraj, 12:58",
+    "3 godziny temu") w tekście i rozwiąż go na datę absolutną względem
+    ingested_at (kiedy pobraliśmy stronę — bez tego punktu odniesienia sama
+    linia nie wystarcza, bo "wczoraj" nie ma sensu bez wiadomo kiedy).
+
+    published_on jest kolumną typu date, więc precyzja co do godziny nie ma
+    znaczenia — liczy się tylko, na który dzień wypada wynik odjęcia.
+    Zwraca None, gdy ingested_at brak albo żaden wzorzec nie pasuje.
+    """
+    if ingested_at is None:
+        return None
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _RELATIVE_YESTERDAY_RE.match(stripped):
+            return (ingested_at - datetime.timedelta(days=1)).date()
+        if _RELATIVE_TODAY_RE.match(stripped):
+            return ingested_at.date()
+        m = _RELATIVE_MINUTES_HOURS_AGO_RE.match(stripped)
+        if m:
+            amount, unit = int(m.group(1)), m.group(2).lower()
+            delta = datetime.timedelta(hours=amount) if unit.startswith("godzin") \
+                else datetime.timedelta(minutes=amount)
+            return (ingested_at - delta).date()
+    return None
 
 
 def _clean_lines_bankier(lines: list[str]) -> list[str]:

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -423,6 +423,20 @@ class DocumentAnalysisService:
 
         log(f"doc={doc_id} mode={mode} field={text_field} len={len(text):,}")
 
+        # 2b. Backfill published_on from a relative-date artifact in the raw
+        # text (e.g. interia.pl's "Wczoraj, HH:MM") resolved against
+        # ingested_at — never overwrites an already-known date. getattr()
+        # throughout: fixture/fake Document doubles in tests don't define
+        # these columns, mirroring the existing doc.url lookup above.
+        if not is_transcript and getattr(doc, "published_on", None) is None:
+            from library.article_cleaner import resolve_relative_publication_date
+
+            resolved = resolve_relative_publication_date(text, getattr(doc, "ingested_at", None))
+            if resolved is not None:
+                doc.published_on = resolved
+                doc.published_on_method = "relative"
+                log(f"published_on backfilled from relative-date artifact: {resolved.isoformat()}")
+
         if reclean:
             from library.article_cleaner import clean_article_text
 

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -3,6 +3,8 @@
 Pure-function tests on synthetic markdown fixtures, no DB/LLM/network.
 """
 
+import datetime
+
 from library.article_cleaner import (
     _clean_lines_money,
     _clean_lines_onet,
@@ -15,6 +17,7 @@ from library.article_cleaner import (
     _strip_leading_onet_ai_summary,
     _strip_interia_chrome_blocks,
     clean_article_text,
+    resolve_relative_publication_date,
 )
 from library.article_extractor import _detect_portal, extract_article_by_markers
 
@@ -405,6 +408,50 @@ class TestInteriaCleaning:
         )
         assert "ElevenLabs" not in result["text"]
         assert "Treść artykułu." in result["text"]
+
+
+class TestResolveRelativePublicationDate:
+    # dok. 8865 (interia.pl): chunk SZUM zawierał dokładnie "Wczoraj, 12:58",
+    # ingested_at = 2026-04-13 07:10:45 -> published_on = 2026-04-12.
+    INGESTED_AT = datetime.datetime(2026, 4, 13, 7, 10, 45)
+
+    def test_yesterday_case_insensitive(self):
+        result = resolve_relative_publication_date("Wczoraj, 12:58", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 12)
+
+    def test_yesterday_lowercase(self):
+        result = resolve_relative_publication_date("wczoraj, 22:30", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 12)
+
+    def test_today(self):
+        result = resolve_relative_publication_date("Dziś, 06:00", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 13)
+
+    def test_hours_ago_crosses_midnight(self):
+        # 07:10 minus 10 godzin = poprzedni dzień
+        result = resolve_relative_publication_date("10 godzin temu", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 12)
+
+    def test_hours_ago_same_day(self):
+        result = resolve_relative_publication_date("2 godziny temu", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 13)
+
+    def test_minutes_ago(self):
+        result = resolve_relative_publication_date("30 minut temu", self.INGESTED_AT)
+        assert result == datetime.date(2026, 4, 13)
+
+    def test_found_among_other_lines(self):
+        text = f"{LONG_PARAGRAPH}\n\nWczoraj, 12:58\n\n{LONG_PARAGRAPH}"
+        assert resolve_relative_publication_date(text, self.INGESTED_AT) == datetime.date(2026, 4, 12)
+
+    def test_no_match_returns_none(self):
+        assert resolve_relative_publication_date(LONG_PARAGRAPH, self.INGESTED_AT) is None
+
+    def test_no_ingested_at_returns_none(self):
+        assert resolve_relative_publication_date("Wczoraj, 12:58", None) is None
+
+    def test_empty_text_returns_none(self):
+        assert resolve_relative_publication_date("", self.INGESTED_AT) is None
 
 
 class TestMoneyCleaning:

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -5,6 +5,7 @@ article mode must skip speaker/filler processing, use the markdown splitter,
 call analyze_article_chunk and persist mode/status on the run.
 """
 
+import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -287,3 +288,52 @@ class TestArticleMode:
 
         assert run.mode == "transcript"
         assert article_env["article"] == 0
+
+
+class TestPublishedOnBackfill:
+    """create_run() step 2b: backfill published_on from a relative-date
+    artifact (e.g. interia.pl's "Wczoraj, HH:MM") resolved against
+    ingested_at — dok. 8865, zob. resolve_relative_publication_date."""
+
+    INGESTED_AT = datetime.datetime(2026, 4, 13, 7, 10, 45)
+
+    def test_backfills_from_relative_date_artifact(self, session, article_env, monkeypatch):
+        doc = FakeDoc()
+        doc.text_md = "Wczoraj, 12:58\n\n" + ARTICLE_TEXT
+        doc.ingested_at = self.INGESTED_AT
+        doc.published_on = None
+        doc.published_on_method = None
+        monkeypatch.setattr(das.Document, "get_by_id", staticmethod(lambda _s, _id: doc))
+
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=42, model="test-model", mode="article", chunk_size=300)
+
+        assert doc.published_on == datetime.date(2026, 4, 12)
+        assert doc.published_on_method == "relative"
+
+    def test_does_not_overwrite_existing_published_on(self, session, article_env, monkeypatch):
+        doc = FakeDoc()
+        doc.text_md = "Wczoraj, 12:58\n\n" + ARTICLE_TEXT
+        doc.ingested_at = self.INGESTED_AT
+        doc.published_on = datetime.date(2026, 1, 1)
+        doc.published_on_method = "manual"
+        monkeypatch.setattr(das.Document, "get_by_id", staticmethod(lambda _s, _id: doc))
+
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=42, model="test-model", mode="article", chunk_size=300)
+
+        assert doc.published_on == datetime.date(2026, 1, 1)
+        assert doc.published_on_method == "manual"
+
+    def test_no_artifact_leaves_published_on_none(self, session, article_env, monkeypatch):
+        doc = FakeDoc()
+        doc.ingested_at = self.INGESTED_AT
+        doc.published_on = None
+        doc.published_on_method = None
+        monkeypatch.setattr(das.Document, "get_by_id", staticmethod(lambda _s, _id: doc))
+
+        service = DocumentAnalysisService(session)
+        service.create_run(doc_id=42, model="test-model", mode="article", chunk_size=300)
+
+        assert doc.published_on is None
+        assert doc.published_on_method is None


### PR DESCRIPTION
## Kontekst

Pytanie użytkownika po wyczyszczeniu dok. 8865 (`wydarzenia.interia.pl`): czy da się ustalić datę publikacji z chunka #1 oznaczonego SZUM, który zawierał wyłącznie `Wczoraj, 12:58`?

**Tak, ale nie przez istniejący mechanizm LLM.** `POST /analysis_run/<id>/extract_publication_date` → `extract_publication_date_info()` wysyła do LLM tylko fragment tekstu, bez informacji "jaki dziś jest dzień" — model nie ma jak rozwiązać względnej daty. Mamy jednak `documents.ingested_at` (kiedy pobraliśmy stronę) — to prosta, deterministyczna arytmetyka dat, bez LLM: `Wczoraj, 12:58` + `ingested_at=2026-04-13 07:10:45` → `published_on=2026-04-12`.

Ten sam wzorzec (`wczoraj, HH:MM`) już wcześniej widziałem na dok. 8901 (stąd regex w `_clean_lines_interia`, #335) — nie jest to przypadek jednostkowy.

## Zmiana

- `resolve_relative_publication_date(text, ingested_at)` w `article_cleaner.py` — rozpoznaje `Wczoraj/Dziś, HH:MM` oraz `X minut/godzin temu` (te same wzorce co `_clean_lines_interia`, wspólna definicja) i liczy datę względem `ingested_at`. Przy okazji naprawiony realny bug: regex `wczoraj` był bez `re.IGNORECASE`, więc nie łapał rzeczywistego „Wczoraj” z wielkiej litery ani w starej, ani w nowej funkcji.
- Podłączone w `DocumentAnalysisService.create_run()` (`document_analysis_service.py`, krok 2b, tylko tryb `article`) — uruchamia się automatycznie przy każdej analizie, **tylko gdy `published_on` jest jeszcze puste** (nigdy nie nadpisuje istniejącej/ręcznie wpisanej daty). Nowy `published_on_method="relative"`.

**Poza zakresem:** retroaktywny backfill dla dokumentów, które już mają ten wzorzec pochowany w usuniętych/zatwierdzonych chunkach — osobna decyzja, czy i jak to zrobić wstecz.

## Test plan

- [x] 9 testów `resolve_relative_publication_date` (w tym dokładne wartości z dok. 8865: `Wczoraj, 12:58` + realny `ingested_at` → `2026-04-12`; wielkość liter; przejście przez północ dla `X godzin temu`; brak `ingested_at`; brak dopasowania)
- [x] 3 testy integracyjne `create_run()`: backfill z artefaktu, **nie** nadpisuje istniejącej daty, brak artefaktu zostawia `None`
- [x] `pytest tests/unit/test_article_cleaner.py tests/unit/test_document_analysis_article_mode.py -q` — 89 passed
- [x] `pytest tests/unit/ -q` — 1948 passed, 9 failed (pre-existing, niezwiązane)
- [x] `ruff check` — czysto

🤖 Generated with [Claude Code](https://claude.com/claude-code)