### PR TITLE
feat(dates): jednorazowy backfill published_on z artefaktów względnej daty

### DIFF
--- a/backend/alembic/versions/c07c2d94a19f_add_relative_to_published_on_method.py
+++ b/backend/alembic/versions/c07c2d94a19f_add_relative_to_published_on_method.py
@@ -1,0 +1,36 @@
+"""add relative to published_on_method check constraint
+
+Revision ID: c07c2d94a19f
+Revises: c8d9eafb0c1d
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c07c2d94a19f"
+down_revision: Union[str, None] = "c8d9eafb0c1d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # "relative" — published_on resolved deterministically from a relative-date
+    # artifact ("Wczoraj, HH:MM", "X minut/godzin temu") against ingested_at
+    # (library.article_cleaner.resolve_relative_publication_date), distinct
+    # from "llm" (extract_publication_date_info) and "manual" (reviewer-typed).
+    op.execute("ALTER TABLE documents DROP CONSTRAINT IF EXISTS ck_documents_published_on_method")
+    op.execute("""
+        ALTER TABLE documents ADD CONSTRAINT ck_documents_published_on_method
+        CHECK (published_on_method IS NULL OR published_on_method IN ('manual', 'llm', 'relative'))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE documents DROP CONSTRAINT IF EXISTS ck_documents_published_on_method")
+    op.execute("""
+        ALTER TABLE documents ADD CONSTRAINT ck_documents_published_on_method
+        CHECK (published_on_method IS NULL OR published_on_method IN ('manual', 'llm'))
+    """)

--- a/backend/imports/backfill_relative_publication_dates.py
+++ b/backend/imports/backfill_relative_publication_dates.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""One-off backfill: resolve documents.published_on from relative-date
+artifacts (e.g. interia.pl's "Wczoraj, HH:MM", "X minut/godzin temu")
+already sitting in the database for documents where published_on was
+never set — see library.article_cleaner.resolve_relative_publication_date.
+
+create_run() (document_analysis_service.py, step 2b) does this automatically
+for new/reanalyzed documents since #336, but documents already ingested and
+chunked before that change never got the backfill. The artifact may now live
+in one of three places depending on how far the document got in review, tried
+in order of decreasing trustworthiness:
+  1. documents.text_md/text/text_raw — untouched by chunk deletion
+     (delete_noise_chunk() never modifies the source document), preserves
+     natural reading order, so a first-match is reliably the article's own
+     byline rather than an unrelated recommendation card.
+  2. document_chunks.original_text for chunks that still exist, ordered by
+     position (earliest first) — position is still meaningful here.
+  3. document_removed_lines.line_text — position/order is NOT recoverable
+     (chunk_id/run_id go NULL on delete, no ORDER BY reflects original page
+     order). A "Zobacz również:" recommendation card embeds a DIFFERENT
+     article's timestamp next to its own title — mistaking that for this
+     document's publication date would write a wrong date. So: if ANY
+     removed_lines row for a document contains a sidebar/recommendation
+     marker, this level is skipped entirely for that document (safety over
+     coverage — better to leave published_on empty than write a wrong date).
+
+Never overwrites an existing published_on.
+
+Usage:
+    python imports/backfill_relative_publication_dates.py            # dry-run (default)
+    python imports/backfill_relative_publication_dates.py --apply    # write changes
+    python imports/backfill_relative_publication_dates.py --id 8865  # single document
+"""
+
+import argparse
+import datetime
+import logging
+
+from library.config_loader import load_config
+
+load_config()  # side effect: populates os.environ for library modules
+
+from sqlalchemy import select  # noqa: E402
+
+from library.article_cleaner import resolve_relative_publication_date  # noqa: E402
+from library.db.engine import get_session  # noqa: E402
+from library.db.models import Document, DocumentChunk, DocumentRemovedLine  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Only the 7 document_type values with a registered polymorphic subclass
+# (library/db/models.py) — some rows carry a stray/legacy type (e.g. "email")
+# that has no mapped subclass and crashes ORM polymorphic loading. Excluding
+# them here is a query-side workaround, not a fix for that underlying gap.
+_KNOWN_DOCUMENT_TYPES = (
+    "link", "youtube", "movie", "webpage", "text_message", "text", "social_media_post",
+)
+
+# A relative-date line sitting near/under one of these markers most likely
+# belongs to a DIFFERENT article referenced in a recommendation card, not to
+# this document itself.
+_SIDEBAR_MARKERS = (
+    "zobacz również", "zobacz też", "czytaj także", "czytaj również",
+    "polecane", "powiązane", "czytaj więcej", "warto przeczytać",
+)
+
+
+def _contains_sidebar_marker(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _SIDEBAR_MARKERS)
+
+
+def _resolve_for_document(session, doc: Document) -> datetime.date | None:
+    """Find the safest relative-date candidate, most trustworthy source first."""
+    for text in (doc.text_md, doc.text, doc.text_raw):
+        if text:
+            resolved = resolve_relative_publication_date(text, doc.ingested_at)
+            if resolved is not None:
+                return resolved
+
+    chunk_texts = session.scalars(
+        select(DocumentChunk.original_text)
+        .where(DocumentChunk.document_id == doc.id)
+        .order_by(DocumentChunk.position)
+    ).all()
+    for chunk_text in chunk_texts:
+        if chunk_text and not _contains_sidebar_marker(chunk_text):
+            resolved = resolve_relative_publication_date(chunk_text, doc.ingested_at)
+            if resolved is not None:
+                return resolved
+
+    removed_lines = session.scalars(
+        select(DocumentRemovedLine.line_text).where(DocumentRemovedLine.document_id == doc.id)
+    ).all()
+    if any(_contains_sidebar_marker(t) for t in removed_lines):
+        return None
+    for line_text in removed_lines:
+        resolved = resolve_relative_publication_date(line_text, doc.ingested_at)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill documents.published_on from relative-date artifacts (Wczoraj/Dziś, HH:MM; X minut/godzin temu)."
+    )
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: dry-run preview only)")
+    parser.add_argument("--id", type=int, help="Process a single document by id")
+    parser.add_argument("--limit", type=int, help="Max number of documents to process")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    session = get_session()
+    try:
+        query = select(Document).where(
+            Document.published_on.is_(None), Document.ingested_at.isnot(None),
+            Document.document_type.in_(_KNOWN_DOCUMENT_TYPES),
+        )
+        if args.id:
+            query = query.where(Document.id == args.id)
+        query = query.order_by(Document.id)
+        if args.limit:
+            query = query.limit(args.limit)
+        docs = session.scalars(query).all()
+
+        logging.info(f"Checking {len(docs)} document(s) missing published_on")
+
+        updated = 0
+        for doc in docs:
+            resolved = _resolve_for_document(session, doc)
+            if resolved is None:
+                continue
+
+            logging.info(f"doc #{doc.id} ({doc.url}): published_on -> {resolved.isoformat()}")
+            if args.apply:
+                doc.published_on = resolved
+                doc.published_on_method = "relative"
+                session.commit()
+            updated += 1
+
+        logging.info(f"Done. Resolved: {updated}, checked: {len(docs)}")
+        if not args.apply:
+            logging.info("(dry-run — no changes were saved; re-run with --apply)")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/db/models.py
+++ b/backend/library/db/models.py
@@ -331,11 +331,14 @@ class Document(Base):
     )
     publisher: Mapped["Publisher | None"] = relationship("Publisher")
     published_on: Mapped[datetime.date | None] = mapped_column(Date)
-    # How published_on was set — "manual" (reviewer typed it on /chunks) or "llm"
-    # (extract_publication_date). NULL for legacy/import-set values (unknown
-    # provenance). Lets a future pass find documents where the automatic
-    # pipeline never found a date, to build deterministic per-portal rules —
-    # the same workflow document_removed_lines already does for cleanup rules.
+    # How published_on was set — "manual" (reviewer typed it on /chunks), "llm"
+    # (extract_publication_date), or "relative" (resolve_relative_publication_date
+    # — a relative-date artifact like "Wczoraj, HH:MM" resolved deterministically
+    # against ingested_at, no LLM call). NULL for legacy/import-set values
+    # (unknown provenance). Lets a future pass find documents where the
+    # automatic pipeline never found a date, to build deterministic per-portal
+    # rules — the same workflow document_removed_lines already does for
+    # cleanup rules. ck_documents_published_on_method enforces this set.
     published_on_method: Mapped[str | None] = mapped_column(String(10))
     original_id: Mapped[str | None] = mapped_column(Text)
     document_length: Mapped[int | None] = mapped_column(Integer)


### PR DESCRIPTION
## Kontekst

Dokończenie pracy z #336: retroaktywny backfill `published_on` dla dokumentów ingestowanych przed tamtą zmianą, które nigdy nie przeszły przez `create_run()` z nowym krokiem 2b.

Po drodze wyszedł realny problem: `resolve_relative_publication_date()` próbowało zapisać `published_on_method="relative"`, ale `ck_documents_published_on_method` dopuszczał tylko `manual`/`llm` — CHECK constraint violation przy pierwszej próbie zapisu. Migracja **c07c2d94a19f** dopisuje `relative` do dozwolonych wartości.

## Bezpieczeństwo źródeł danych

Przy testowaniu dry-run znalazłem realne ryzyko: `document_removed_lines` może zawierać znacznik czasu z **INNEGO** artykułu (karta rekomendacji "Zobacz również:" pokazuje tytuł + timestamp cudzego tekstu obok). Bez zachowanej kolejności wierszy (brak `ORDER BY` odzwierciedlającego pozycję na stronie — `chunk_id`/`run_id` idą na `NULL` po usunięciu chunka) branie "pierwszego trafienia" byłoby loterią.

`imports/backfill_relative_publication_dates.py` używa trzech poziomów malejącej wiarygodności:
1. `documents.text_md/text/text_raw` — nietknięte przez usuwanie chunków (`delete_noise_chunk()` świadomie nie modyfikuje dokumentu źródłowego), naturalny porządek, ten sam mechanizm co żywy pipeline (#336).
2. Wciąż istniejące `document_chunks.original_text`, wg zachowanej `position`.
3. `document_removed_lines.line_text` — **tylko jeśli żaden** wiersz tego dokumentu nie zawiera markera karty rekomendacji ("Zobacz również:"/"Czytaj także:"/itp.) — w przeciwnym razie dokument jest świadomie pomijany. Bezpieczeństwo ponad kompletność.

## Wynik na NAS

Migracja i `--apply` już uruchomione bezpośrednio na bazie NAS (dry-run najpierw, potem zweryfikowane ręcznie kilka wyników przed zapisem). **46 z 2370** sprawdzonych dokumentów uzupełnionych — w tym dok. 8865 (pytanie, które zapoczątkowało tę pracę): `2026-04-12`, zgodnie z ręcznym wyliczeniem.

## Test plan

- [x] Migracja zastosowana na NAS (`alembic upgrade head`), zweryfikowana `ck_documents_published_on_method` teraz dopuszcza `relative`
- [x] Dry-run → ręczna weryfikacja kilku wyników (w tym potwierdzenie, że wynik dla dok. 8901 pochodzi z bezpiecznego `doc.text`, nie z zanieczyszczonego `document_removed_lines`) → `--apply`
- [x] `pytest tests/unit/ -q` — 1948 passed, 9 failed (pre-existing, niezwiązane)
- [x] `ruff check` — czysto

🤖 Generated with [Claude Code](https://claude.com/claude-code)