### PR TITLE
docs: podział planów wdrożeniowych wg etapu (NAS realny vs eksperymenty)

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,29 @@
+# Dokumentacja wdrożeniowa — mapa katalogów
+
+Ten katalog grupuje dokumenty planistyczne według **etapu/środowiska wdrożenia**, nie według tematu. Podział istnieje po to, żeby nie mylić tego, co jest realnie wdrażane, z tym, co jest nauką architektury w wolnym czasie.
+
+## Co jest realne
+
+- **[`nas/`](nas/)** — jedyny katalog opisujący coś, co faktycznie działa albo jest aktywnie wdrażane: własny QNAP NAS, dla mnie i kilku zaufanych domowników/znajomych.
+  - [`storage-and-jobs-migration-plan.md`](nas/storage-and-jobs-migration-plan.md) — centralizacja storage (MinIO/S3-compatible) i jobów.
+  - [`multi-user-household.md`](nas/multi-user-household.md) — kilku zaufanych użytkowników, bez planowania wydajności pod skalę.
+
+## Co jest eksperymentem myślowym (nauka w wolnym czasie, niski priorytet)
+
+Wszystko poniżej istnieje po jednym powodzie: **żeby decyzje podejmowane dziś w `nas/` nie zamykały tanio dostępnych dróg na przyszłość**, bez budowania tych dróg na zapas. To jest też świadomy poligon do nauki projektowania aplikacji — stąd te dokumenty są utrzymywane, mimo że nic z nich nie jest dziś wdrażane.
+
+- **[`commercial-multi-tenant-scaling-experiment.md`](commercial-multi-tenant-scaling-experiment.md)** — co by się zmieniło, gdyby Lenie miało obsługiwać wielu **niezaufanych** użytkowników (SaaS). Przekrojowy — dotyczy każdego środowiska poniżej.
+- **[`federation-experiment.md`](federation-experiment.md)** — bardzo wczesne pytanie: wymiana danych między osobnymi instancjami Lenie AI (inna oś niż liczba użytkowników w jednej instancji).
+- **[`hyperscalers/`](hyperscalers/)** — AWS / Google Cloud.
+- **[`eu_cloud/`](eu_cloud/)** — OVH / CloudFerro i inni europejscy dostawcy.
+- **[`onprem/`](onprem/)** — komercyjne wdrożenie on-premise u kogoś innego (nie to samo co własny domowy NAS).
+
+## Zasada projektowa
+
+Przy podejmowaniu decyzji w `nas/` warto zadać sobie pytanie z dokumentów eksperymentalnych, ale **nie warto** implementować ich odpowiedzi na zapas. Przykład, który już działa dobrze: `backend/library/storage.py` ma jeden interfejs `ObjectStorage` z dwiema implementacjami (`LocalStorage`, `S3Storage`) — S3-compatible pokrywa MinIO, AWS S3 i CloudFerro tym samym kodem, bez gałęzi `if aws`/`if cloudferro`. To jest właściwy poziom przygotowania: tania opcjonalność, zero przedwczesnej złożoności.
+
+Analogiczne tanie decyzje do pilnowania już dziś:
+- właściciel/inicjator rekordu (`user_id` na jobach i logach LLM) — patrz [`nas/multi-user-household.md`](nas/multi-user-household.md#3-czego-brakuje-i-warto-dodać-teraz-tanie-bez-kolejek-redis);
+- konfiguracja przez zmienne środowiskowe/Vault, nie przez zahardkodowane ścieżki NAS-a — patrz [`nas/storage-and-jobs-migration-plan.md`](nas/storage-and-jobs-migration-plan.md), Etap 6.
+
+Wszystko poza tym — Redis, Celery, PgBouncer, orkiestracja, izolacja workspace, konkretny wybór hiperskalera vs chmury europejskiej — czeka na realną potrzebę.

--- a/docs/deployment/commercial-multi-tenant-scaling-experiment.md
+++ b/docs/deployment/commercial-multi-tenant-scaling-experiment.md
@@ -1,0 +1,282 @@
+# Eksperyment myślowy: od projektu hobbystycznego do usługi komercyjnej wielu użytkowników
+
+Status: eksperyment myślowy / materiał do nauki architektury, nie plan wdrożeniowy  
+Powiązane dokumenty: [docs/deployment/README.md](README.md) (co jest realne, co jest zabawą intelektualną) · [nas/storage-and-jobs-migration-plan.md](nas/storage-and-jobs-migration-plan.md) (realny plan) · [nas/multi-user-household.md](nas/multi-user-household.md) (realny plan dla kilku zaufanych użytkowników)
+
+## 1. Po co ten dokument
+
+Lenie AI jest projektem hobbystycznym, a jednocześnie poligonem do nauki architektury systemów. Realny, wdrażany zakres to instalacja na własnym NAS dla mnie i kilku zaufanych domowników/znajomych — opisana w [nas/storage-and-jobs-migration-plan.md](nas/storage-and-jobs-migration-plan.md) i [nas/multi-user-household.md](nas/multi-user-household.md). Tylko ten zakres powinien wpływać na to, co dziś trafia do kodu.
+
+Ten dokument jest osobnym eksperymentem myślowym: co musiałoby się zmienić, gdyby Lenie miało stać się usługą komercyjną dla wielu, **niezaufanych wobec siebie** użytkowników (w odróżnieniu od zaufanych domowników z `nas/multi-user-household.md`) — hostowaną on-premise, w chmurze albo hybrydowo. Cel jest edukacyjny, nie wdrożeniowy: zrozumieć, czym architektonicznie różni się „działa u mnie na NAS-ie dla rodziny” od „działa jako produkt, który da się skalować i sprzedawać obcym ludziom”. Wnioski stąd nie powinny wymuszać zmian w bieżącym kodzie, dopóki nie pojawi się realna decyzja biznesowa o obsłudze niezaufanych, płacących użytkowników.
+
+## 2. Hobby/household vs usługa komercyjna — kluczowe różnice
+
+| Wymiar | Dziś (hobby + kilku zaufanych domowników) | Usługa komercyjna wielu niezaufanych użytkowników |
+|---|---|---|
+| Model własności danych | Wspólna biblioteka; `user_id` identyfikuje tylko *kto czyta*, nie *czyje jest to dane* | Jawny `owner_user_id`/`workspace_id` na każdym rekordzie domenowym i jobie, wymuszony w warstwie serwisów, z pełną izolacją |
+| Uwierzytelnianie i autoryzacja | Klucz API per osoba, zaufany kontekst domowy, brak haseł | Uwierzytelnianie, rotacja tokenów, autoryzacja każdego odczytu/zapisu, testy izolacji „użytkownik A nie widzi danych B” |
+| Kolejka i wykonywanie jobów | PostgreSQL + jeden worker sekwencyjny wystarcza | Priorytety, fairness, lease/heartbeat, limity per użytkownik, osobne pule CPU/IO/LLM |
+| Koszty i limity | Nieistotne albo obserwowane ręcznie | Budżety per użytkownik/workspace, rozliczanie zużycia LLM/API/storage, twarde limity i kontrolowane zatrzymanie po przekroczeniu |
+| Observability | Logi + ręczna diagnostyka w razie problemu | `request_id`/`job_id`/`user_id`/`workspace_id` w logach, metryki per tenant, alerty o kolejce i heartbeacie |
+| Bezpieczeństwo | Zaufane środowisko domowe, mała powierzchnia ataku | Rate limiting, ochrona przed SSRF i path traversal, walidacja uploadów, audyt operacji administracyjnych, szyfrowanie |
+| Dostępność i SPOF | Restart NAS-a albo kontenera jest akceptowalny | SLA, potrzeba wielu instancji API, load balancer, kontrolowane wdrożenia bez przestoju |
+| Infrastruktura | Jeden host, Docker Compose | Load balancer, connection pooling (PgBouncer), ewentualnie Redis, ewentualnie orkiestrator |
+| Koszt utrzymania platformy | Musi być bliski zeru — to nie generuje przychodu | Musi się bilansować z przychodem; każdy dodatkowy komponent to świadomy koszt operacyjny do uzasadnienia |
+| Tempo dodawania złożoności | Dodawać dopiero, gdy przeszkadza brak (YAGNI) | Dodawać wcześniej — na podstawie prognozy skali, nie tylko bieżącego bólu |
+
+Praktyczna konsekwencja: architektura hobby/household powinna pozostać najprostsza z możliwych ([nas/multi-user-household.md](nas/multi-user-household.md)), ale model danych powinien od początku umożliwiać późniejsze dopisanie właściciela bez migracji — to jedyny element stąd, który już dziś tanio kupuje opcjonalność na przyszłość.
+
+## 3. Etapy i wzorce skalowania
+
+Zakładany punkt startowy: `nas/multi-user-household.md` — jeden worker, PostgreSQL Queue, kilku zaufanych użytkowników, właściciel joba już zapisywany. Kolejne elementy poniżej należy dodawać dopiero po osiągnięciu mierzalnych progów (sekcja 3.10), a nie prewencyjnie.
+
+### 3.1. Etap B — kilku niezaufanych użytkowników, nadal PostgreSQL Queue
+
+PostgreSQL może nadal obsługiwać kolejkę przy kilku użytkownikach i umiarkowanej liczbie zadań. Można uruchomić kilka workerów pobierających rekordy przez `FOR UPDATE SKIP LOCKED`.
+
+Potrzebne rozszerzenia:
+
+- priorytet joba;
+- właściciel/workspace joba;
+- heartbeat oraz lease z terminem wygaśnięcia;
+- kontrolowane retry z backoff;
+- idempotency key;
+- limity współbieżności globalne, per typ i per użytkownik;
+- fairness, aby jeden użytkownik nie blokował całej kolejki;
+- osobne pule dla zadań CPU, IO oraz kosztownych wywołań LLM;
+- timeout i możliwość anulowania;
+- deduplikacja równoważnych zadań;
+- limit rozmiaru parametrów i rezultatów przechowywanych w JSONB.
+
+Przykładowe limity:
+
+- maksymalna liczba aktywnych jobów użytkownika;
+- maksymalny rozmiar uploadu;
+- miesięczny budżet LLM/transkrypcji;
+- liczba równoległych transkrypcji;
+- przestrzeń durable i checkpoint;
+- maksymalny czas życia joba oraz scratch.
+
+Model danych z pełnym `owner_user_id`/`workspace_id`, rolami i izolacją (`workspaces`, `organizations`, Row-Level Security) opisany jest w [nas/multi-user-household.md — sekcja o granicy household vs workspace](nas/multi-user-household.md).
+
+### 3.2. Kiedy wprowadzić Redis
+
+Redis ma sens, gdy wystąpi co najmniej kilka z poniższych problemów:
+
+- bardzo częste odpytywanie PostgreSQL o nowe joby;
+- potrzeba dostarczania postępu w czasie rzeczywistym do wielu klientów;
+- duża liczba krótkich zadań;
+- potrzeba szybkich liczników, rate limiting i rozproszonych blokad;
+- wiele instancji API wymagających współdzielonego cache;
+- presja kolejki zaczyna wpływać na zapytania biznesowe PostgreSQL;
+- potrzebne są krótkotrwałe dane, których nie warto zapisywać w bazie trwałej.
+
+Redis może pełnić różne role:
+
+- broker kolejki;
+- pub/sub dla zdarzeń postępu;
+- cache odpowiedzi;
+- rate limiter;
+- magazyn krótkotrwałych sesji lub tokenów unieważnienia;
+- rozproszone semafory limitujące kosztowne usługi.
+
+Redis nie powinien być jedynym źródłem prawdy dla historii jobów. Trwały status, parametry, wynik, koszt i audyt pozostają w PostgreSQL.
+
+### 3.3. Wybór systemu kolejki po PostgreSQL
+
+Najbardziej prawdopodobny wariant dla obecnego stosu Python:
+
+```text
+API -> PostgreSQL (rekord i historia joba)
+    -> Redis (broker)
+    -> Celery workers
+```
+
+Celery zapewnia routing do kolejek, retry, harmonogram Celery Beat, limity i skalowanie workerów. Kosztem jest większa złożoność konfiguracji, trudniejsza semantyka dokładnie-jeden-raz oraz potrzeba świadomego projektowania idempotencji.
+
+Alternatywy do oceny przed decyzją:
+
+- Dramatiq + Redis — prostszy model niż Celery, mniej funkcji;
+- RQ + Redis — bardzo prosty, dobry dla nieskomplikowanych kolejek;
+- Temporal — trwałe workflow, retry i długie procesy, ale znacznie większa złożoność operacyjna;
+- chmurowe kolejki: AWS SQS, Google Cloud Tasks albo Pub/Sub — mniej infrastruktury własnej, lecz większe związanie z dostawcą;
+- Kubernetes Jobs — dobre dla ciężkich, izolowanych zadań, ale nie zastępują same w sobie kompletnego modelu workflow.
+
+Decyzja powinna wynikać z pomiarów i charakteru zadań. Dla długich procesów wieloetapowych z oczekiwaniem na zewnętrzne zdarzenia Temporal może być lepszy niż rozbudowywanie Celery. Dla zwykłych importów i analiz Celery lub Dramatiq powinny wystarczyć.
+
+### 3.4. Podział kolejek i workerów
+
+Przy większej skali należy rozdzielić zadania według charakterystyki:
+
+```text
+queue: io          pobieranie stron, importy, storage
+queue: cpu         konwersje, lokalne modele, OCR
+queue: media       YouTube, audio, transkrypcje
+queue: llm         analizy i generowanie treści
+queue: embedding   embeddingi i operacje wektorowe
+queue: maintenance cleanup, migracje, backupy
+```
+
+Każda kolejka może mieć:
+
+- inną liczbę workerów;
+- inne limity CPU i RAM;
+- osobny timeout;
+- inną politykę retry;
+- limit zewnętrznego API;
+- osobny priorytet;
+- kontrolę maksymalnego kosztu.
+
+Ciężkie zadania nie powinny blokować krótkich operacji interaktywnych.
+
+### 3.5. Skalowanie API
+
+Po przejściu na wiele instancji API:
+
+- API musi być bezstanowe;
+- sesje nie mogą zależeć od pamięci pojedynczego procesu;
+- wszystkie instancje korzystają z tej samej bazy i kolejki;
+- pliki trafiają bezpośrednio do object storage lub przez kontrolowany streaming;
+- postęp jest dystrybuowany przez Redis pub/sub, SSE albo WebSocket gateway;
+- reverse proxy/load balancer obsługuje TLS i routing;
+- migracje bazy wykonuje jeden kontrolowany proces wdrożeniowy;
+- zadania okresowe mają pojedynczego lidera albo dedykowany scheduler.
+
+Do uploadu dużych plików warto wykorzystać krótkotrwałe presigned URLs. API autoryzuje operację i rejestruje oczekiwany obiekt, ale nie musi przesyłać wszystkich bajtów przez własny proces.
+
+### 3.6. Skalowanie PostgreSQL
+
+Kolejne kroki, dopiero gdy są potrzebne:
+
+1. indeksy wynikające z rzeczywistych zapytań;
+2. connection pooling, np. PgBouncer;
+3. limity połączeń API i workerów;
+4. oddzielenie analitycznych lub ciężkich zapytań;
+5. read replica dla odczytów, jeżeli aplikacja potrafi zaakceptować opóźnienie replikacji;
+6. partycjonowanie dużych tabel logów i zdarzeń;
+7. polityka archiwizacji jobów i logów;
+8. zarządzana baza w chmurze przy przejściu na AWS/GCP.
+
+Nie należy przenosić spójnego stanu domenowego do Redis tylko po to, aby odciążyć bazę. Najpierw trzeba zmierzyć i zoptymalizować konkretne zapytania.
+
+### 3.7. Skalowanie object storage
+
+Object storage naturalnie skaluje się lepiej niż współdzielony filesystem, ale aplikacja musi uwzględniać:
+
+- wiele równoległych uploadów i multipart upload;
+- checksumy;
+- lifecycle i retencję per prefiks;
+- limity przestrzeni per workspace;
+- wersjonowanie i soft delete;
+- audyt dostępu;
+- regionalność danych;
+- koszty transferu między workerem a storage;
+- skanowanie uploadów i walidację typów plików;
+- usuwanie osieroconych obiektów po nieudanych transakcjach.
+
+Worker i storage powinny znajdować się w tej samej sieci/lokalizacji. W chmurze należy unikać transferu między regionami.
+
+### 3.8. Limity, koszty i rozliczanie użytkowników
+
+Każdy job powinien umożliwiać przypisanie zużycia do użytkownika lub workspace:
+
+- czas CPU/GPU;
+- liczba i czas wywołań zewnętrznych API;
+- tokeny i koszt LLM;
+- koszt transkrypcji;
+- bajty durable/checkpoint;
+- transfer;
+- liczba operacji object storage;
+- czas wykonania i liczba retry.
+
+Budżet powinien być sprawdzany przed zleceniem i w trakcie długiego joba. Przekroczenie limitu nie może pozostawić niespójnego stanu; job powinien zakończyć się kontrolowanym statusem.
+
+### 3.9. Observability dla wielu użytkowników
+
+Minimalny zestaw:
+
+- ustrukturyzowane logi z `request_id`, `job_id`, `user_id` i `workspace_id`;
+- metryki długości i wieku kolejek;
+- czas wykonania i odsetek błędów per typ joba;
+- zużycie CPU, RAM i dysku scratch;
+- liczba retry oraz osieroconych jobów;
+- dostępność PostgreSQL, Redis i object storage;
+- koszt LLM/API per użytkownik oraz job;
+- alerty o braku heartbeat, rosnącej kolejce i kończącym się miejscu.
+
+Przy większej skali można użyć OpenTelemetry oraz stosu Prometheus/Grafana/Loki albo zarządzanych odpowiedników AWS/GCP. Należy unikać umieszczania treści dokumentów i sekretów w logach oraz trace'ach.
+
+### 3.10. Bezpieczeństwo wieloużytkownikowe
+
+Przed zaproszeniem drugiego **niezaufanego** użytkownika (w odróżnieniu od zaufanych domowników) wymagane są co najmniej:
+
+- poprawne uwierzytelnianie i rotacja tokenów;
+- autoryzacja każdego odczytu i zapisu;
+- izolacja danych per workspace;
+- brak bezpośredniego dostępu użytkownika do kluczy MinIO/S3/GCS;
+- krótkotrwałe presigned URLs ograniczone do konkretnego klucza i operacji;
+- rate limiting API i jobów;
+- walidacja uploadów oraz ochrona przed path traversal;
+- ochrona przed SSRF w jobach pobierających URL;
+- limity rozmiaru, czasu i liczby przekierowań;
+- szyfrowanie połączeń oraz danych trwałych;
+- audyt operacji administracyjnych;
+- testy wykazujące, że użytkownik A nie może odczytać danych użytkownika B.
+
+### 3.11. Progi przejścia między etapami
+
+Przykładowe sygnały, nie sztywne wartości:
+
+| Sygnał | Następny krok |
+|---|---|
+| Jeden worker nie nadąża, ale baza działa prawidłowo | Dodać workery PostgreSQL Queue |
+| Ciężkie joby blokują krótkie | Rozdzielić pule/kolejki |
+| Polling i claim obciążają bazę | Rozważyć Redis jako broker |
+| Potrzebny realtime dla wielu klientów | Redis pub/sub + SSE/WebSocket |
+| Retry i routing stają się rozbudowane | Celery albo Dramatiq |
+| Workflow trwa dni i ma wiele oczekiwań/kompensacji | Ocenić Temporal |
+| API ogranicza przepustowość uploadów | Presigned URLs |
+| Liczba połączeń do PostgreSQL rośnie | PgBouncer i limity puli |
+| Różne joby wymagają innych zasobów | Osobne typy workerów/kontenery |
+| Pojedynczy host jest ograniczeniem lub SPOF | Orkiestrator/chmura i wiele węzłów |
+
+### 3.12. Docelowy wariant wieloużytkownikowy
+
+Możliwa architektura po osiągnięciu większej skali:
+
+```text
+                 load balancer
+                       |
+               +-------+-------+
+               |               |
+             API 1           API N
+               |               |
+               +-------+-------+
+                       |
+            PostgreSQL + PgBouncer
+                       |
+          trwały stan, historia, audyt
+
+API -> Redis broker/pub-sub -> kolejki workerów
+                              |- IO workers
+                              |- CPU/media workers
+                              |- LLM workers
+                              `- maintenance workers
+
+wszyscy -> S3/GCS/MinIO-compatible durable storage
+```
+
+Na AWS odpowiednikami mogą być zarządzany PostgreSQL, ElastiCache Redis, ECS/EKS, S3 i ewentualnie SQS. Na Google Cloud: Cloud SQL, Memorystore, Cloud Run/GKE, GCS i ewentualnie Cloud Tasks/Pub/Sub. Warstwa domenowa nie powinna zależeć od konkretnego zestawu usług. Konkretne środowiska docelowe (hiperskalerzy, chmury europejskie, on-prem enterprise) są rozwijane osobno w [docs/deployment/hyperscalers/](hyperscalers/), [docs/deployment/eu_cloud/](eu_cloud/) i [docs/deployment/onprem/](onprem/).
+
+### 3.13. Kolejność przygotowania do obsługi niezaufanych użytkowników
+
+1. Uszczelnić autoryzację i testy izolacji (rozszerzyć własność danych z household na pełny workspace).
+2. Dodać limity oraz pomiar kosztów per użytkownik.
+3. Uogólnić PostgreSQL Queue i uruchomić kilka workerów.
+4. Rozdzielić kolejki według rodzaju obciążenia.
+5. Dodać Redis dopiero dla zidentyfikowanej roli.
+6. Wybrać Celery/Dramatiq/Temporal lub usługę chmurową na podstawie pomiarów.
+7. Skalować API i bazę po usunięciu wąskich gardeł aplikacyjnych.
+8. Wprowadzić orkiestrator dopiero, gdy pojedynczy host przestanie wystarczać.
+
+Punkt wyjścia (właściciel jobów, model household) jest już przygotowany w [nas/multi-user-household.md](nas/multi-user-household.md); reszta tej listy to praca, którą warto zrobić dopiero po realnej decyzji biznesowej. Redis, Celery i Kubernetes można dołożyć później — najdroższa byłaby migracja danych bez informacji o właścicielu, a tej już unikamy.

--- a/docs/deployment/eu_cloud/ovh-cloudferro-experiment.md
+++ b/docs/deployment/eu_cloud/ovh-cloudferro-experiment.md
@@ -1,0 +1,36 @@
+# Eksperyment myślowy: OVH / CloudFerro (chmura europejska)
+
+Status: eksperyment myślowy, niski priorytet — nauka architektury w wolnym czasie, horyzont 1+ rok  
+Powiązane: [../README.md](../README.md) · [../commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md) · [../hyperscalers/aws-gcloud-experiment.md](../hyperscalers/aws-gcloud-experiment.md)
+
+## Storage: już opisane, nie duplikować
+
+Porównanie dostawców object storage zgodnych z S3 (CloudFerro, QNAP QuObjects, myQNAPcloud Object, Backblaze B2, Wasabi i inni) jest już szczegółowo opisane w głównym planie NAS: [`../nas/storage-and-jobs-migration-plan.md`, sekcja 16](../nas/storage-and-jobs-migration-plan.md#16-dostawcy-i-implementacje-zgodne-z-s3). To zostaje tam, bo dotyczy realnej, bliskiej potrzeby (backup off-site z NAS-a), nie tylko tego eksperymentu.
+
+Ten dokument dotyczy czegoś szerszego: uruchomienia **całej aplikacji** (nie tylko storage) w chmurze europejskiej.
+
+## OVH — do rozwinięcia, gdy przyjdzie czas
+
+Dzisiejszy stan wiedzy jest płytki (celowo — priorytet niski). Do zweryfikowania, gdy temat stanie się aktualny:
+
+- OVHcloud Public Cloud (compute, zgodność z OpenStack) jako odpowiednik EC2/Compute Engine;
+- OVHcloud Managed PostgreSQL jako odpowiednik RDS/Cloud SQL;
+- OVHcloud Object Storage (S3-compatible) — już wymieniony w tabeli dostawców w głównym planie;
+- OVHcloud Managed Kubernetes;
+- lokalizacje: Francja, Polska (Warszawa), Niemcy — istotne dla rezydencji danych w UE;
+- model cenowy — czy rzeczywiście brak zaskakujących opłat za egress, tak jak deklaruje CloudFerro.
+
+## Pytanie użytkownika: hiperskaler vs chmura europejska — realna różnica praktyczna
+
+To jest właściwe pytanie do zbadania, gdy temat stanie się aktualny, nie coś, co da się dziś rzetelnie rozstrzygnąć bez researchu. Szkielet porównania:
+
+| Wymiar | Hiperskaler (AWS/GCloud) | Chmura europejska (OVH/CloudFerro) |
+|---|---|---|
+| Szerokość katalogu usług zarządzanych | Bardzo szeroka (setki usług) | Węższa — głównie compute, storage, baza, Kubernetes |
+| Dojrzałość SDK/dokumentacji/community | Bardzo wysoka | Niższa, ale S3-compatible API pozwala używać tych samych narzędzi (boto3, AWS CLI) |
+| Rezydencja danych / RODO | Regiony UE dostępne, ale firma spoza UE (CLOUD Act) | Firma i dane fizycznie w UE — silniejsza gwarancja |
+| Przewidywalność cen | Częste opłaty za egress, transfer między usługami | Deklarowany prostszy model, mniej „ukrytych” opłat (do zweryfikowania per dostawca) |
+| Vendor lock-in | Wysoki przy usługach natywnych (Lambda, DynamoDB) | Niższy, jeśli trzymać się warstwy S3-compatible + standardowy PostgreSQL/Kubernetes |
+| Wsparcie i społeczność | Ogromna (Stack Overflow, fora, kursy) | Mniejsza, ale rosnąca; wsparcie często lepiej dopasowane do klienta europejskiego |
+
+Warstwa aplikacyjna Lenie (patrz `backend/library/storage.py`) jest już zaprojektowana tak, żeby ta decyzja była odwracalna na poziomie storage — `S3ObjectStorage` obsługuje MinIO, AWS i dowolnego dostawcę S3-compatible tym samym kodem. Compute i baza danych nie mają dziś takiej abstrakcji i nie muszą jej mieć, dopóki nie pojawi się realna potrzeba wyjścia poza jeden Docker Compose.

--- a/docs/deployment/federation-experiment.md
+++ b/docs/deployment/federation-experiment.md
@@ -1,0 +1,38 @@
+# Otwarte pytanie: wymiana danych między instancjami Lenie AI
+
+Status: **bardzo wczesny eksperyment myślowy — samo pytanie, nie plan.** Zebrane, żeby nie zgubić kontekstu, gdy temat wróci.  
+Powiązane: [README.md](README.md) · [nas/multi-user-household.md](nas/multi-user-household.md) · [commercial-multi-tenant-scaling-experiment.md](commercial-multi-tenant-scaling-experiment.md) · [ADR-015](../adr/adr-015-uuid-as-global-document-identifier.md)
+
+## Pytanie
+
+Jednym z możliwych przyszłych etapów jest wymiana informacji między różnymi, osobnymi instancjami Lenie AI — np. moją drugą instalacją, albo instalacją znajomego, który też zbiera i obrabia artykuły. To jest inna oś niż wielu użytkowników w jednej instancji (`nas/multi-user-household.md`, `commercial-multi-tenant-scaling-experiment.md`) — tu chodzi o **wiele niezależnych instancji wymieniających się danymi**, nie o role wewnątrz jednej.
+
+## Czy obecny model to uwzględnia? Częściowo — jeden fundament już istnieje
+
+**[ADR-015](../adr/adr-015-uuid-as-global-document-identifier.md) (2026-03-30) został podjęty właśnie z myślą o tym scenariuszu.** Dokumenty mają dziś globalnie unikalny `uuid` zamiast lokalnego, auto-increment `id` — cytat z ADR: „Cross-instance synchronization — no way to match documents between NAS and AWS databases” był jednym z motywujących problemów. To oznacza, że **identyfikacja tego samego dokumentu na dwóch instancjach już działa** — nie trzeba by wymyślać deduplikacji od zera.
+
+Poza tym jednym elementem **nic więcej w architekturze tego nie zakłada ani nie ułatwia**:
+
+- brak protokołu synchronizacji (co, kiedy, w którą stronę);
+- brak modelu zaufania między właścicielami instancji (czy w ogóle ufam drugiej instancji, czy tylko wybranym danym z niej);
+- brak selektywnego udostępniania (chcę dzielić się np. tylko artykułami z tagiem X, nie całą biblioteką, nie notatkami osobistymi);
+- brak rozwiązywania konfliktów (ten sam dokument zmieniony/otagowany różnie na obu instancjach);
+- brak rozróżnienia „mój dokument” vs „dokument otrzymany od kogoś” (kto jest źródłem prawdy po synchronizacji?);
+- embeddingi są generowane per `EMBEDDING_MODEL` skonfigurowany lokalnie — dwie instancje mogą mieć niekompatybilne wektory, więc synchronizacja samego wyszukiwania semantycznego nie jest trywialna;
+- NER/tagi/encje są dziś przycięte do `ner_exclusions` i słowników per instancja — mogą się różnić między instancjami dla tego samego tekstu.
+
+## Szkic wymagań funkcjonalnych (do doprecyzowania, gdy temat wróci)
+
+Nie plan implementacyjny — lista pytań/wymagań do rozstrzygnięcia, zanim to się stanie projektem:
+
+1. **Kierunek:** jednostronny eksport/import (ręczny, na żądanie) czy dwustronna, ciągła synchronizacja?
+2. **Zakres:** cała biblioteka czy selektywny zestaw (tag, kolekcja, źródło)?
+3. **Tożsamość instancji:** jak instancja B rozpoznaje i autoryzuje instancję A (osobna para kluczy per-instancja, nie per-użytkownik)?
+4. **Własność po transferze:** czy zsynchronizowany dokument jest tylko-do-odczytu (jak gość read-only, patrz `nas/multi-user-household.md`), czy w pełni lokalny po przyjęciu?
+5. **Deduplikacja:** `uuid` z ADR-015 rozwiązuje „czy to ten sam dokument”, ale nie „co zrobić, gdy oba mają go z różnymi tagami/notatkami”.
+6. **Koszt:** czy synchronizacja może wyzwalać ponowne, płatne przetwarzanie (embeddingi, LLM) po stronie odbiorcy, czy transferuje też gotowe wyniki?
+7. **Transport:** bezpośrednio instancja-instancja (wymaga sieciowej widoczności, dziś utrudnione przez brak stabilnego dostępu zdalnego — patrz `project_qnap_vpn_remote_access` w pamięci projektu) czy przez pośrednika (obiekt storage, plik eksportu)?
+
+## Co NIE robić teraz
+
+Nic w kodzie. To jest jedyny dokument w `docs/deployment/`, który nie ma dziś żadnego „taniego kroku” do zrobienia — nawet model danych (poza już zrobionym ADR-015) nie jest jasny na tyle, żeby cokolwiek przygotowywać na zapas. Warto go odświeżyć, gdy pojawi się konkretny drugi właściciel instancji, z którym rzeczywiście chcę wymieniać dane.

--- a/docs/deployment/hyperscalers/aws-gcloud-experiment.md
+++ b/docs/deployment/hyperscalers/aws-gcloud-experiment.md
@@ -1,0 +1,35 @@
+# Eksperyment myślowy: AWS / Google Cloud
+
+Status: eksperyment myślowy, niski priorytet — nauka architektury w wolnym czasie, horyzont 1+ rok  
+Powiązane: [../README.md](../README.md) · [../commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md) · [../nas/storage-and-jobs-migration-plan.md](../nas/storage-and-jobs-migration-plan.md)
+
+## Uwaga: to nie jest to samo co `docs/aws-roadmap.md`
+
+Repozytorium ma już `docs/aws-roadmap.md`, ale opisuje on **inną, wcześniejszą architekturę** — serwerlessową (Lambda + API Gateway + DynamoDB + SQS), sprzed przejścia na NAS jako główne środowisko. Ten dokument pyta o coś innego: co by było, gdyby **dzisiejszy** kształt aplikacji (Docker Compose: Flask API + PostgreSQL + MinIO + workery) uruchomić na AWS albo GCloud zamiast na NAS-ie. To dwa różne pytania architektoniczne, nie kontynuacja tego samego planu.
+
+## Kiedy to w ogóle ma sens rozważać
+
+Dopiero po spełnieniu kryteriów „gotowości chmurowej” z głównego planu NAS (Etap 6: konfiguracja przez sekrety, brak zahardkodowanych ścieżek QNAP, test kontraktowy adapterów storage) — patrz [../nas/storage-and-jobs-migration-plan.md](../nas/storage-and-jobs-migration-plan.md).
+
+## Co porównać, gdy przyjdzie czas (szkielet, nie research)
+
+| Warstwa | Dzisiaj na NAS | AWS | Google Cloud |
+|---|---|---|---|
+| Compute (API + worker) | Docker Compose | ECS/EKS/EC2 | Cloud Run / GKE / Compute Engine |
+| Baza danych | PostgreSQL w kontenerze | RDS/Aurora PostgreSQL | Cloud SQL for PostgreSQL |
+| Object storage | MinIO | S3 (natywnie obsługiwane już dziś przez `S3Storage`) | GCS (wymaga natywnego adaptera albo endpointu interoperacyjności S3, patrz `docs/storage.md`) |
+| Sekrety | Vault na NAS | Secrets Manager / SSM Parameter Store | Secret Manager |
+| Sieć/egress | Brak kosztu transferu | Płatny egress, NAT Gateway | Płatny egress |
+| IaC | Docker Compose | CloudFormation (już częściowo istnieje, patrz `docs/aws-roadmap.md`) i/lub CDK (patrz ADR-016) | brak dziś w repo |
+| Tożsamość/dostęp | `api_keys` + Vault | IAM | Cloud IAM |
+
+## Pytania, na które warto znać odpowiedź, zanim się zdecyduje
+
+- Ile realnie kosztowałby transfer i storage przy obecnym wolumenie danych (dziś nieduży — patrz sekcja 10 głównego planu NAS o retencji i kosztach)?
+- Czy zależy mi na zarządzanej bazie (mniej operacyjnej roboty) czy na pełnej kontroli (jak dziś na NAS)?
+- Czy chcę być w jednym ekosystemie (AWS ma już częściowe IaC w repo) czy uczyć się drugiego od zera (GCloud — czystsza karta, ale podwójny koszt nauki)?
+- Czy hiperskaler daje coś, czego nie da europejska chmura (patrz [../eu_cloud/](../eu_cloud/)) — szerszy katalog usług zarządzanych, dojrzalsze SDK, więcej dokumentacji/community — kosztem wyższej ceny i mniejszej kontroli nad lokalizacją danych?
+
+## Co NIE robić teraz
+
+Nie budować kodu pod konkretnego hiperskalera na zapas. `backend/library/storage.py` już dziś obsługuje AWS S3 tym samym kodem co MinIO (`STORAGE_BACKEND=s3`) — to jedyna „inwestycja w przyszłość”, jaka ma sens przed realną decyzją o migracji.

--- a/docs/deployment/nas/multi-user-household.md
+++ b/docs/deployment/nas/multi-user-household.md
@@ -1,0 +1,106 @@
+# Plan: kilku zaufanych użytkowników na NAS (household)
+
+Status: **realny plan, wdrażany teraz** — w odróżnieniu od [../commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md), który jest czystym eksperymentem myślowym.  
+Powiązane dokumenty: [storage-and-jobs-migration-plan.md](storage-and-jobs-migration-plan.md) · [../federation-experiment.md](../federation-experiment.md)
+
+## 1. Cel i dwa poziomy zaufania
+
+Lenie na NAS ma obsługiwać nie tylko mnie, ale też inne osoby — w dwóch różnych rolach:
+
+1. **Zaufani domownicy/znajomi** — pełny dostęp do wspólnej biblioteki, jak dziś. Bez planowania wydajności pod skalę.
+2. **Goście read-only** — osoby, którym chcę udostępnić *wynik* mojej pracy (obrobione, oczyszczone z reklam artykuły + przeszukiwanie bazy wiedzy), ale które nie mają powodu przechowywać u mnie własnych danych ani niczego zmieniać.
+
+To nie jest wersja okrojona planu komercyjnego — to świadomie inny model bezpieczeństwa niż izolacja per-workspace: **wspólna biblioteka dokumentów, zróżnicowany poziom zaufania per rola, brak izolacji danych między pełnymi użytkownikami**. Rola 1 jest dokładnie tym, co dziś opisuje docstring `User` w kodzie (`backend/library/db/models.py`): „Reader identity (household trust model). (...) no passwords.” Rola 2 (read-only) jest nowym wymaganiem, opisanym w sekcji 4.
+
+Granicę, kiedy ten model przestaje wystarczać (np. gdy ktoś niezaufany chce zapisu), opisuje sekcja 6.
+
+## 2. Co już działa dzisiaj (stan kodu, nie plan)
+
+- Tabele `users` i `api_keys` (`kind='user'` niesie `user_id`, `kind='service'` — pełny dostęp bez tożsamości czytelnika) — `backend/library/auth.py`, `backend/library/db/models.py`.
+- `GET/POST /users` (`backend/library/reader_routes.py`) — lista i tworzenie użytkownika (`username`, opcjonalny `display_name`).
+- `GET/POST /api_keys`, `DELETE /api_keys/<id>` (`backend/library/api_key_routes.py`) — tworzenie/dezaktywacja kluczy; klucz `kind=user` wymaga `user_id`. Plaintext klucza (`lk_usr_...`) pokazywany jest tylko raz przy tworzeniu.
+- `GET /whoami` — sprawdzenie tożsamości bieżącego klucza.
+- CLI alternatywa: `imports/api_key_admin.py`.
+- `UserReadingProgress`, `UserDocumentNote` — postęp czytania i notatki są **per-user**, mimo że sama biblioteka dokumentów jest wspólna.
+- Rozróżnienie `kind` jest już dziś egzekwowane per-endpoint w kodzie, nie tylko w UI (`reader_routes._require_user` odrzuca klucze `service` z 403) — to jest wzorzec, na którym oprzeć rolę read-only.
+
+Wniosek: **dodanie nowej osoby (pełnej) do systemu to już dziś dwa wywołania API** (`POST /users`, `POST /api_keys`). Rola read-only wymaga dodatkowej pracy opisanej niżej.
+
+## 3. Czego brakuje i warto dodać teraz (tanie, bez kolejek/Redis)
+
+1. **`initiated_by_user_id` (opcjonalny) na jobach.** Dziś `document_analysis_jobs` i przyszła wspólna tabela jobów z Etapu 2 ([storage-and-jobs-migration-plan.md, sekcja 6](storage-and-jobs-migration-plan.md#6-kolejka-i-wykonywanie-jobów)) nie wiążą joba z osobą, która go uruchomiła. Kolumna jest tania dziś (nullable FK) i pozwala odpowiedzieć na „kto to uruchomił” bez migracji danych później.
+2. **`user_id` (opcjonalny) na `llm_usage_logs`.** Sprawdzone w kodzie: tabela nie ma dziś żadnej kolumny wiążącej wywołanie LLM z użytkownikiem — koszt nie jest przypisywalny do osoby. To jedyne miejsce, gdzie brak tej kolumny może realnie zaboleć: gdy ktoś zapyta „ile kosztowało to, co odpaliła osoba X w tym miesiącu”, bez tej kolumny trzeba by odtwarzać to z korelacji `request_id`/czasu — dodanie kolumny teraz jest tanie, doganianie później nie.
+3. **(opcjonalnie, UX)** Prosty ekran we frontendzie: lista domowników + przycisk „dodaj klucz”, zamiast ręcznego `curl`/CLI. Nie blokuje niczego — czysto kosmetyczne.
+
+Nic z tego nie wymaga Redis, Celery, priorytetów kolejki ani budżetów — to są kroki z eksperymentu komercyjnego, nie stąd.
+
+## 4. Wymagania funkcjonalne: goście read-only
+
+**Status: wyłącznie wymagania — świadomie NIE zaimplementowane.** Poniżej jest specyfikacja tego, co ma robić rola read-only, żeby dało się ją zaprojektować dobrze za pierwszym razem, a nie dopisywać uprawnienia po fakcie.
+
+### 4.1. Kontekst i motywacja
+
+Znajomi raczej nie będą chcieli trzymać własnych danych w mojej instancji, ale chcę móc udostępnić im efekt mojej pracy: artykuły oczyszczone z reklam/szumu (`text_md` po `article_cleaner.py`) i przeszukiwanie zgromadzonej bazy wiedzy (`/search`). To inny przypadek użycia niż domownik — read-only gość nie potrzebuje własnego postępu czytania per se, ale może z niego skorzystać, jeśli już istnieje (`UserReadingProgress`/`UserDocumentNote` działają identycznie dla obu ról — to tanie i osobiste, nie kosztuje nic dodatkowego).
+
+### 4.2. Co gość read-only MOŻE robić
+
+- Przeglądać dokumenty i ich oczyszczoną treść (`/document/<id>`, widok czytnika, rozdziały).
+- Korzystać z `/search` — **w tym wariantu wspomaganego LLM** (parser zapytań naturalnego języka). To jedyny koszt zewnętrzny, na który się godzę dla tej roli.
+- Przeglądać tagi, kolekcje, encje (NER), oś czasu wydarzeń — wszystko co jest odczytem już policzonych/zapisanych danych.
+- Mieć własny, prywatny postęp czytania i notatki (już działa dla `kind=user`, tanie).
+
+### 4.3. Czego gość read-only NIE MOŻE robić
+
+Zasada ogólna z prośby: **wszystko, co kosztuje realne pieniądze poza samym zapytaniem wyszukiwania wspomaganego LLM, musi być zablokowane na poziomie roli**, nie tylko ukryte w UI. Konkretnie zablokowane:
+
+- dodawanie/edycja/usuwanie dokumentów (`/url_add`, `/website_save`, `/website_delete` i pochodne);
+- wyzwalanie importów i pipeline'u (`documents_pipeline`, `dynamodb_sync`, przyszłe joby z Etapu 2);
+- wyzwalanie transkrypcji (AssemblyAI, płatne — patrz `ADR-011`, `TRANSCRIPTION_BALANCE_USD`);
+- wyzwalanie/ponowne generowanie embeddingów;
+- wyzwalanie analizy chunków, tagowania LLM, ekstrakcji encji/NER, ekstrakcji wydarzeń/okresów/tonu — wszystko, co woła `ai_ask()`/`get_embedding()` poza samym `/search`;
+- zarządzanie użytkownikami i kluczami API (`/users`, `/api_keys`);
+- wgląd w koszty/rozliczenia innych osób.
+
+### 4.4. Wymóg audytu — monitorowanie aktywności gościa
+
+Każde żądanie roli read-only musi być logowalne, żeby dało się odpowiedzieć na pytanie „co ta osoba robiła w mojej instancji”: jaki endpoint, kiedy, jaki dokument/zapytanie wyszukiwania. To wykracza poza dzisiejszy `last_used_at` na `api_keys` (nadpisywany, bez historii, patrz `library/auth.py:_touch_last_used`) — potrzebny osobny log zdarzeń per-request, przynajmniej dla tej roli. Dla pełnych domowników taki log nie jest wymagany (są zaufani z definicji), ale nic nie stoi na przeszkodzie, by ten sam mechanizm objął też ich później.
+
+### 4.5. Model uprawnień — co to oznacza dla `AuthContext`
+
+Dzisiejszy `AuthContext.kind` ma dwie wartości (`user`, `service`) i nie ma miejsca na trzeci poziom zaufania. Do rozstrzygnięcia przy projektowaniu (nie teraz): trzeci `kind` (np. `guest`) vs. pole `role`/`can_write` na `User` albo na `ApiKey` (ten drugi wariant pozwala jednej osobie mieć zarówno klucz pełny, jak i klucz do udostępnienia dalej — wygodniejsze dla „wyślij znajomemu klucz tylko do czytania”). Egzekwowanie musi być scentralizowane (jeden punkt sprawdzenia roli per endpoint, analogicznie do `_require_user`), żeby nowy endpoint nie „zapomniał” dodać blokady.
+
+## 5. Co świadomie NIE jest robione teraz
+
+Celowo pomijane, dopóki nie zajdzie realna potrzeba (patrz sekcja 6):
+
+- `workspaces`/`organizations`, role `owner`/`admin`/`member`/`viewer`;
+- Row-Level Security w PostgreSQL;
+- limity/budżety per użytkownik z twardym zatrzymaniem;
+- priorytety, fairness i osobne pule CPU/IO/LLM w kolejce;
+- rate limiting i ochrona przed nadużyciem przez niezaufanego użytkownika;
+- presigned URLs ograniczone do właściciela obiektu;
+- synchronizacja/federacja między instancjami Lenie AI (patrz [../federation-experiment.md](../federation-experiment.md) — osobny, wczesny eksperyment myślowy).
+
+Wszystko to (poza federacją) jest opisane w [../commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md) — świadomie tam, a nie tutaj.
+
+## 6. Granica: kiedy household przestaje wystarczać
+
+| Sygnał | Co to znaczy | Gdzie szukać dalej |
+|---|---|---|
+| Ktoś niezaufany (poza rodziną/znajomymi) chce dostępu z prawem zapisu | Model „wspólna biblioteka” przestaje być bezpieczny | `../commercial-multi-tenant-scaling-experiment.md`, sekcja 2 i 3.1 (workspace, izolacja) |
+| Ktoś zaczyna generować nieproporcjonalnie duże koszty LLM/transkrypcji | Potrzebne limity/budżety per użytkownik | tamże, sekcja 3.8 |
+| Kilka osób jednocześnie zajmuje jedynego workera na długo | Potrzeba więcej niż jednego workera i fairness | tamże, sekcja 3.1 |
+| Ktoś chce mieć swoją *prywatną* (nie wspólną) bibliotekę dokumentów | To już inny produkt niż „wspólna biblioteka rodzinna” | tamże, sekcja 3.1 (pełny `owner_user_id`/`workspace_id`) |
+| Chcę wymieniać dokumenty/tagi z inną instancją Lenie AI (moją drugą albo znajomego) | To osobna oś od liczby użytkowników w jednej instancji | [../federation-experiment.md](../federation-experiment.md) |
+
+Dopóki żaden z tych sygnałów się nie pojawił, sekcje 3 i 4 powyżej to całość potrzebnej specyfikacji.
+
+## 7. Checklist wdrożenia
+
+1. Migracja: `user_id` (nullable FK do `users.id`, `ON DELETE SET NULL`) na `llm_usage_logs`.
+2. Migracja: `initiated_by_user_id` (nullable FK do `users.id`) na `document_analysis_jobs` oraz uwzględnienie tego pola w projekcie wspólnej tabeli jobów (Etap 2 głównego planu).
+3. Przekazywanie `user_id` z `AuthContext` (już dostępnego w każdym żądaniu — `library/auth.py`) do miejsc tworzących joby i wywołań LLM.
+4. Opcjonalnie: prosty ekran frontendowy do zarządzania domownikami (lista + dodawanie klucza), korzystający z istniejących `/users` i `/api_keys`.
+5. *(świadomie odłożone — dopiero projektowanie, nie implementacja)* Rola read-only: trzeci poziom w `AuthContext`, centralna lista dozwolonych endpointów per rola, tabela audytu żądań dla tej roli — patrz sekcja 4.
+
+To wyczerpuje realny zakres „kilku użytkowników” — reszta jest w eksperymencie myślowym albo w osobnym otwartym pytaniu o federację.

--- a/docs/deployment/nas/storage-and-jobs-migration-plan.md
+++ b/docs/deployment/nas/storage-and-jobs-migration-plan.md
@@ -1,0 +1,581 @@
+# Plan centralizacji storage i jobów na NAS
+
+Status: propozycja do przemyślenia  
+Cel dokumentu: opisać docelową architekturę, warianty i etapy migracji bez podejmowania jeszcze ostatecznej decyzji.
+
+Zakres: instalacja na własnym NAS — projekt hobbystyczny i edukacyjny, realnie używany, docelowo także przez kilku zaufanych domowników/znajomych (patrz [multi-user-household.md](multi-user-household.md)). Ten dokument i cały katalog [docs/deployment/nas/](.) to jedyna gałąź, która faktycznie jest wdrażana. Pozostałe katalogi w [docs/deployment/](../README.md) (hyperscalers, eu_cloud, onprem) oraz [eksperyment myślowy o skali komercyjnej](../commercial-multi-tenant-scaling-experiment.md) to nauka architektury w wolnym czasie — nie mają wpływu na bieżące decyzje kodowe poza jednym: nie zamykać sobie do nich drogi bez potrzeby (patrz [docs/deployment/README.md](../README.md)).
+
+## 1. Cel
+
+Docelowo NAS ma być jedynym miejscem wykonywania procesów i przechowywania danych instalacji domowej. Komputer oraz telefon mają działać wyłącznie jako klienci interfejsu WWW.
+
+Rozwiązanie powinno jednocześnie umożliwiać późniejsze przeniesienie do AWS albo Google Cloud bez przepisywania pipeline'ów.
+
+Docelowe wymagania:
+
+- wszystkie importy, konwersje, analizy, transkrypcje i embeddingi działają w kontenerach;
+- zadania można uruchamiać i obserwować przez API oraz WWW;
+- żaden cykliczny ani ręczny proces nie zależy od komputera deweloperskiego;
+- trwałe pliki mają jedno źródło prawdy;
+- przerwany job można ponowić po restarcie kontenera lub NAS;
+- lokalna instalacja Compose nadal działa bez obowiązkowego MinIO;
+- zmiana MinIO na AWS S3 albo Google Cloud Storage nie wpływa na logikę biznesową.
+
+## 2. Docelowa topologia
+
+```text
+telefon / komputer
+        |
+        v
+   interfejs WWW
+        |
+        v
+     API na NAS
+        |
+        v
+kolejka jobów w PostgreSQL
+        |
+        v
+ worker lub grupa workerów
+      /             \
+     v               v
+object storage    scratch workera
+MinIO/S3/GCS      lokalny dla środowiska wykonania
+```
+
+API przyjmuje żądania i zapisuje joby, ale nie powinno wykonywać długich operacji we własnym procesie. Worker pobiera zadania z trwałej kolejki, raportuje postęp i zapisuje wyniki.
+
+## 3. Klasy danych
+
+Podział jest logiczny. Nie oznacza, że zawsze potrzebne są dwa trwałe systemy przechowywania.
+
+### 3.1. Durable
+
+Trwałe dane będące źródłem prawdy:
+
+- źródłowe HTML, TXT, PDF, audio i wideo;
+- końcowy markdown, jeżeli jego ponowne uzyskanie jest kosztowne;
+- rezultaty analiz potrzebne poza bazą danych;
+- eksporty i pliki użytkownika;
+- artefakty niezbędne do odtworzenia albo wznowienia procesu.
+
+Miejsce przechowywania:
+
+- NAS: MinIO;
+- AWS: S3;
+- Google Cloud: Cloud Storage;
+- lokalny Compose: lokalny katalog lub volume przez ten sam interfejs aplikacyjny.
+
+### 3.2. Checkpoint
+
+Pośrednie rezultaty, które można odtworzyć, ale byłoby to drogie lub czasochłonne:
+
+- pobrane duże pliki;
+- części długiej transkrypcji;
+- wynik kosztownej konwersji;
+- wynik zewnętrznego API lub LLM, którego nie warto ponownie wywoływać.
+
+Checkpoint może być zapisany w object storage i objęty polityką retencji.
+
+### 3.3. Scratch
+
+Pliki robocze możliwe do ponownego wygenerowania:
+
+- rozpakowane dane;
+- tymczasowe pliki konwersji;
+- części pobieranego pliku;
+- cache bibliotek;
+- krótkotrwałe pliki pośrednie pipeline'u.
+
+Scratch jest zwykłym filesystemem dostępnym dla workera. Na NAS może to być Docker volume albo bind mount; w chmurze dysk efemeryczny kontenera, poda albo maszyny.
+
+Scratch nie jest źródłem prawdy. Po zakończeniu joba powinien być usuwany, z opcjonalnym zachowaniem po błędzie przez ograniczony czas.
+
+## 4. Dlaczego nie używać object storage jako filesystemu roboczego
+
+MinIO, S3 i GCS są magazynami obiektowymi, a nie klasycznymi filesystemami:
+
+- katalogi są tylko prefiksami kluczy;
+- zmiana części pliku zwykle wymaga zapisania całego obiektu;
+- biblioteki oczekujące `Path` i `open()` wymagają lokalnej ścieżki;
+- każda operacja jest wywołaniem sieciowym;
+- wiele małych plików zwiększa opóźnienia i koszty operacji w chmurze;
+- warstwy FUSE mają odmienną semantykę i utrudniają diagnozowanie problemów.
+
+Rekomendowany cykl joba:
+
+```text
+1. Pobierz wejście z object storage.
+2. Utwórz /work/jobs/{job_id}.
+3. Wykonaj pipeline na zwykłych plikach.
+4. Wyślij durable/checkpoint do object storage.
+5. Zapisz rezultat i status w PostgreSQL.
+6. Usuń scratch albo zachowaj go czasowo po błędzie.
+```
+
+## 5. Warstwa abstrakcji storage
+
+Interfejs aplikacji powinien być neutralny wobec dostawcy:
+
+```text
+ObjectStorage
+|- LocalObjectStorage
+|- S3ObjectStorage       (AWS S3 i MinIO)
+`- GCSObjectStorage      (natywny klient Google)
+```
+
+Minimalny kontrakt:
+
+```python
+put(key, stream, metadata=None)
+get(key)
+exists(key)
+delete(key)
+list(prefix)
+stat(key)
+materialize(key, work_dir)
+```
+
+Do rozważenia:
+
+- przesyłanie strumieniowe zamiast ładowania całych obiektów do pamięci;
+- checksumy i idempotentne zapisy;
+- wersjonowanie obiektów;
+- szyfrowanie;
+- presigned URLs dla uploadu/downloadu przez przeglądarkę;
+- jednolita konwencja kluczy, np. `documents/{uuid}/source.html` oraz `jobs/{job_id}/artifacts/...`.
+
+## 6. Kolejka i wykonywanie jobów
+
+Repozytorium zawiera już wzorzec `document_analysis_jobs`:
+
+- trwałe statusy w PostgreSQL;
+- postęp i błąd;
+- odzyskiwanie po restarcie;
+- blokadę koordynatora;
+- pobieranie zadań z `FOR UPDATE SKIP LOCKED`.
+
+Pierwszy wariant nie wymaga Redis ani Celery. Mechanizm można uogólnić do wspólnej tabeli jobów i osobnego kontenera `lenie-worker`.
+
+Przykładowe typy jobów:
+
+- `dynamodb_sync`;
+- `documents_pipeline`;
+- `youtube_processing`;
+- `document_analysis`;
+- `embedding`;
+- `storage_migration`;
+- `cache_cleanup`;
+- `backup`.
+
+Minimalne pola joba:
+
+- `id`;
+- `type`;
+- `status`: `queued`, `running`, `done`, `failed`, opcjonalnie `cancel_requested`, `cancelled`;
+- `parameters` JSONB;
+- `progress` i opcjonalny procent;
+- `result` JSONB;
+- `error`;
+- `attempt` i `max_attempts`;
+- `created_at`, `started_at`, `heartbeat_at`, `finished_at`;
+- opcjonalny użytkownik inicjujący;
+- opcjonalny klucz idempotencji.
+
+## 7. API i interfejs WWW
+
+Proponowane API:
+
+- `POST /jobs` — utworzenie joba;
+- `GET /jobs` — historia i filtrowanie;
+- `GET /jobs/{id}` — status, postęp i rezultat;
+- `POST /jobs/{id}/retry` — ponowienie;
+- `POST /jobs/{id}/cancel` — żądanie anulowania;
+- opcjonalnie Server-Sent Events albo WebSocket do aktualizacji postępu.
+
+Ekran „Zadania” powinien umożliwiać:
+
+- uruchomienie importu lub pipeline'u;
+- podanie bezpiecznego zestawu parametrów;
+- obserwację kolejki i aktywnych zadań;
+- podgląd postępu oraz błędu;
+- ponowienie zadania;
+- przejście do dokumentów lub rezultatów utworzonych przez job.
+
+API musi stosować zamkniętą listę typów jobów i walidowane parametry. Nie może przyjmować dowolnej komendy shellowej.
+
+## 8. Przenośność środowisk
+
+| Środowisko | Durable storage | Scratch | Worker |
+|---|---|---|---|
+| Lokalny Compose | volume/katalog lokalny | volume kontenera | kontener |
+| NAS | MinIO | volume lub bind mount NAS | kontener na NAS |
+| AWS | S3 | ephemeral disk ECS/EKS/EC2 lub EBS | ECS/EKS/EC2 |
+| Google Cloud | GCS | ephemeral disk Cloud Run/GKE/VM lub Persistent Disk | Cloud Run Jobs/GKE/VM |
+
+Pipeline nie powinien wiedzieć, gdzie fizycznie znajduje się durable storage. Powinien otrzymać lokalnie zmaterializowane wejście i zwrócić listę artefaktów do zapisania.
+
+## 9. Etapy migracji
+
+### Etap 0 — inwentaryzacja
+
+- znaleźć wszystkie skrypty uruchamiane lokalnie i ich harmonogramy;
+- zinwentaryzować katalogi, rozmiary, formaty i retencję;
+- sklasyfikować każdy plik jako durable, checkpoint albo scratch;
+- wskazać procesy zależne od lokalnych ścieżek i poświadczeń;
+- zapisać aktualne czasy wykonania i koszty API/LLM.
+
+### Etap 1 — storage
+
+- ustalić finalny kontrakt `ObjectStorage`;
+- zachować lokalny adapter jako fallback;
+- ustalić konwencję kluczy;
+- dodać natywny adapter GCS dopiero przed realnym wdrożeniem w Google Cloud;
+- dodać raport zajętości według prefiksów i klas danych;
+- przygotować migrację z dry-run, checksumą i raportem;
+- nie usuwać źródeł przed weryfikacją migracji i backupu.
+
+### Etap 2 — ogólna kolejka jobów
+
+- dodać model oraz migrację bazy;
+- wyodrębnić worker z procesu Flask;
+- zaimplementować claim, heartbeat, retry i recovery;
+- dodać limity współbieżności według typu joba;
+- dodać podstawowe API oraz testy.
+
+### Etap 3 — pierwszy proces end-to-end
+
+Jako pierwszy przenieść jeden ograniczony proces, prawdopodobnie `dynamodb_sync`:
+
+- wydzielić logikę CLI do funkcji/usługi;
+- pozostawić CLI jako cienki wrapper;
+- uruchamiać tę samą usługę z workera;
+- materializować wejścia i synchronizować rezultaty;
+- pokazywać status w WWW;
+- sprawdzić restart w połowie wykonania i bezpieczne ponowienie.
+
+### Etap 4 — pozostałe pipeline'y
+
+- YouTube i transkrypcje;
+- pobieranie stron oraz konwersja markdown;
+- analiza chunków;
+- embeddingi;
+- naprawy i migracje danych;
+- zadania konserwacyjne oraz cleanup.
+
+Każdy proces powinien stać się idempotentny albo mieć jasno opisane zasady ponawiania.
+
+### Etap 5 — scheduler i wyłączenie lokalnych jobów
+
+- dodać harmonogram na NAS;
+- monitorować nowe joby równolegle z dotychczasowym procesem przez okres próbny;
+- usunąć zależności od lokalnych ścieżek;
+- wyłączyć Task Scheduler/cron na komputerach;
+- udokumentować procedurę awarii i ręcznego ponowienia.
+
+### Etap 6 — gotowość chmurowa
+
+- test kontraktowy adapterów object storage;
+- konfiguracja przez sekrety środowiska;
+- brak stałych adresów NAS i ścieżek QNAP w kodzie aplikacji;
+- limity CPU, RAM, czasu i równoległości jobów;
+- metryki kosztów storage, transferu, LLM i zewnętrznych API;
+- backup PostgreSQL oraz polityka retencji object storage.
+
+## 10. Retencja i koszty
+
+Metryki do zbierania:
+
+- bajty i liczba obiektów według prefiksu;
+- liczba PUT/GET/HEAD/LIST;
+- transfer wejściowy i wyjściowy;
+- rozmiar scratch przed i po jobie;
+- czas życia checkpointów;
+- koszt LLM i API przypisany do joba;
+- koszt ponowień.
+
+Proponowana polityka początkowa:
+
+- durable: bez automatycznego usuwania;
+- checkpoint: retencja zależna od typu, np. 7–30 dni;
+- scratch po sukcesie: natychmiastowe usunięcie;
+- scratch po błędzie: 1–7 dni na diagnostykę;
+- cache modeli: osobna polityka i limit rozmiaru;
+- wersjonowanie object storage: włączyć tylko świadomie, z lifecycle.
+
+Przy małej obecnej objętości koszt pojemności chmurowej będzie niski. Większe ryzyko kosztowe stanowią transfer, duża liczba małych operacji, wersjonowanie, soft delete oraz powtarzanie drogich jobów.
+
+## 11. Niezawodność i bezpieczeństwo
+
+- job zapisuje heartbeat;
+- osierocony job wraca do kolejki albo trafia do stanu wymagającego decyzji;
+- zapis rezultatu powinien być atomowy z perspektywy stanu joba;
+- upload powinien używać tymczasowego klucza lub checksumy, jeśli częściowy wynik jest ryzykiem;
+- retry ma backoff i limit prób;
+- sekrety MinIO/AWS/GCP pozostają w Vault lub mechanizmie sekretów platformy;
+- bucket nie jest publiczny;
+- dostęp przeglądarki odbywa się przez API lub krótkotrwałe presigned URLs;
+- każdy typ joba ma osobne limity parametrów, czasu i współbieżności;
+- należy regularnie testować odtworzenie PostgreSQL i object storage z backupu.
+
+## 12. Otwarte decyzje
+
+Przed implementacją wspólnej kolejki należy zdecydować:
+
+1. Czy końcowy markdown jest durable, czy możliwym do odtworzenia checkpointem?
+2. Które artefakty LLM przechowywać i jak długo?
+3. Czy scratch na NAS ma być efemerycznym volume, czy widocznym bind mountem ułatwiającym diagnostykę?
+4. Jak długo zachowywać scratch nieudanych jobów?
+5. Czy jeden worker sekwencyjny wystarczy, czy od początku potrzebne są osobne kolejki CPU/IO/LLM?
+6. Czy `document_analysis_jobs` migrować do wspólnej tabeli, czy pozostawić jako kolejkę domenową korzystającą ze wspólnego runtime'u?
+7. Czy scheduler ma być częścią workera, osobnym kontenerem, czy ma tylko okresowo tworzyć rekordy w PostgreSQL?
+8. Czy użytkownik może anulować każdy job, czy tylko wybrane typy?
+9. Jakie dane mają być dostępne przez presigned URLs?
+10. Czy wymagane jest działanie podczas niedostępności internetu, a jeśli tak, które joby mają być kolejkowane do późniejszego wykonania?
+
+## 13. Kryteria zakończenia migracji NAS
+
+Migrację można uznać za zakończoną, gdy:
+
+- wszystkie produkcyjne joby wykonują się na NAS;
+- można je uruchomić i obserwować z telefonu przez WWW;
+- wyłączenie komputera użytkownika nie zatrzymuje żadnego procesu;
+- restart API nie przerywa trwale jobów;
+- restart workera prowadzi do kontrolowanego wznowienia lub ponowienia;
+- trwałe dane znajdują się w PostgreSQL i MinIO;
+- scratch można usunąć bez utraty źródła prawdy;
+- istnieje zweryfikowany backup oraz procedura odtworzenia;
+- nie działają już lokalne harmonogramy;
+- wykorzystanie miejsca, retencja i koszty są mierzalne.
+
+## 14. Rekomendacja robocza
+
+Na obecnym etapie rekomendowany wariant do dalszej oceny to:
+
+- PostgreSQL jako trwała kolejka jobów;
+- osobny kontener `lenie-worker` na NAS;
+- MinIO jako durable storage;
+- NAS-local volume jako scratch workera;
+- `LocalObjectStorage` dla przenośnego Compose;
+- `S3ObjectStorage` dla MinIO i AWS;
+- przyszły natywny `GCSObjectStorage` dla Google Cloud;
+- migracja po jednym pipeline'ie, zaczynając od procesu o ograniczonym zakresie;
+- brak Redis/Celery do czasu, gdy pomiary wykażą taką potrzebę.
+
+Ta rekomendacja nie jest jeszcze decyzją implementacyjną.
+
+## 15. Wieloużytkownikowość
+
+Lenie ma dziś działać dla kilku zaufanych osób (rodzina/znajomi), nie tylko dla jednego użytkownika — to jest realny, wdrażany zakres, opisany osobno w [multi-user-household.md](multi-user-household.md), żeby nie rozdmuchiwać tego dokumentu. W skrócie: baza (`users`/`api_keys`) już istnieje i działa w modelu „wspólna biblioteka, zaufani domownicy” — nie trzeba Redis, Celery ani izolacji per-workspace na tym etapie.
+
+Skalowanie do usługi komercyjnej dla wielu, niezaufanych wobec siebie użytkowników (on-prem, chmura albo hybrydowo) to osobny, czysto edukacyjny eksperyment myślowy — patrz [commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md). Jedyna rzecz stamtąd wartą zrobienia już teraz, bo jest tania: nadanie opcjonalnego właściciela (`initiated_by_user_id`) rekordom jobów, żeby uniknąć kosztownej migracji danych, gdyby taka decyzja kiedyś zapadła — opisane w [multi-user-household.md](multi-user-household.md).
+
+## 16. Dostawcy i implementacje zgodne z S3
+
+Warstwa aplikacyjna nie powinna być związana z MinIO ani AWS. Dostawca ma być wybierany przez konfigurację endpointu, poświadczeń i niewielkiego zestawu opcji zgodności.
+
+Określenie „S3-compatible” zazwyczaj oznacza zgodność podstawowych operacji obiektowych, a nie wszystkich usług i rozszerzeń AWS. Przed wyborem dostawcy trzeba zweryfikować dokładnie funkcje używane przez Lenie.
+
+### 16.1. CloudFerro
+
+CloudFerro oferuje Object Storage z API zgodnym z Amazon S3. Standardowe biblioteki takie jak `boto3`, AWS CLI i narzędzia S3 mogą korzystać z niego po ustawieniu właściwego endpointu.
+
+Z oficjalnych materiałów wynika, że infrastruktura object storage CloudFerro jest oparta o Ceph, nie MinIO. Dla aplikacji nie powinno mieć to znaczenia — oba rozwiązania udostępniają API S3.
+
+Potencjalne zalety:
+
+- europejski dostawca;
+- regiony obejmujące Warszawę i Frankfurt;
+- możliwość uruchomienia compute i Kubernetes u tego samego dostawcy;
+- standardowy oraz cold object storage;
+- dane pozostające w UE;
+- możliwość użycia tych samych klientów S3 co dla MinIO i AWS.
+
+Elementy wymagające weryfikacji przed wyborem:
+
+- bieżący cennik konkretnego regionu;
+- koszty transferu, API i retrieval;
+- minimalna retencja cold storage;
+- dostępność versioning, Object Lock i presigned URLs;
+- limity liczby obiektów oraz wydajność listowania;
+- zgodność multipart upload i ETag.
+
+CloudFerro informuje, że bardzo duża liczba obiektów w jednym bucketcie może pogarszać wydajność listowania. Konwencja kluczy i podział na buckety powinny uwzględniać przewidywaną skalę.
+
+### 16.2. QNAP QuObjects
+
+QuObjects to aplikacja uruchamiana bezpośrednio na QNAP NAS, udostępniająca lokalny object storage zgodny z S3. Jest alternatywą dla uruchamiania MinIO w kontenerze.
+
+Deklarowane funkcje obejmują:
+
+- bucket i object API;
+- multipart upload;
+- CORS;
+- versioning;
+- Object Lock i immutability;
+- polityki dostępu;
+- współpracę ze standardowymi klientami S3.
+
+QNAP wymaga QTS 5.0 lub nowszego i rekomenduje co najmniej 8 GB RAM. Model TS-453Be jest urządzeniem x86, więc powinien należeć do obsługiwanej kategorii, ale dostępność QuObjects należy potwierdzić w App Center dla używanej wersji firmware i konfiguracji RAM.
+
+Porównanie z MinIO:
+
+| MinIO w kontenerze | QNAP QuObjects |
+|---|---|
+| Przenośny między NAS i innymi hostami | Związany z platformą QNAP |
+| Konfiguracja kontrolowana przez Compose | Zarządzanie z poziomu QTS |
+| Podobne środowisko developerskie i produkcyjne | Mniej własnej infrastruktury kontenerowej |
+| Osobny kontener i volume | Natywna integracja z NAS |
+| Łatwiejsze odtworzenie poza QNAP | Wbudowane funkcje QNAP, Object Lock i administracja |
+
+Przed ostatecznym wyborem MinIO albo QuObjects należy wykonać ten sam test kontraktowy i prosty benchmark na docelowym NAS. Kod aplikacji powinien obsługiwać oba przez `S3ObjectStorage`.
+
+### 16.3. QNAP myQNAPcloud Object
+
+`myQNAPcloud Object` jest publiczną usługą chmurową QNAP zgodną z S3. Nie należy jej mylić z:
+
+- QuObjects działającym lokalnie na NAS;
+- myQNAPcloud Storage przeznaczonym bardziej do plików i backupu NAS;
+- aplikacjami QNAP służącymi tylko do synchronizacji z zewnętrznymi chmurami.
+
+Usługa jest oferowana w ramach `myQNAPcloud One`, które łączy przestrzeń klasycznego storage i object storage. QNAP deklaruje brak opłat za ingress i egress oraz rozliczanie przede wszystkim zakupionej pojemności.
+
+Zgodność nie obejmuje wszystkich funkcji AWS. Oficjalna dokumentacja wymienia między innymi brak:
+
+- AWS KMS;
+- wielu klas storage;
+- `RestoreObject`;
+- S3 Select;
+- S3 Batch Operations.
+
+Dla Lenie może to być wystarczające, jeśli aplikacja ograniczy się do podstawowych operacji, multipart upload, metadata i presigned URLs. Każdą potrzebną funkcję należy jednak potwierdzić testem.
+
+### 16.4. Inni dostawcy chmurowi
+
+Lista kandydatów do późniejszego porównania:
+
+| Dostawca | Charakterystyka do oceny |
+|---|---|
+| AWS S3 | Punkt odniesienia dla API, szeroki zestaw funkcji, osobne opłaty za storage, operacje i transfer |
+| Backblaze B2 | S3-compatible hot storage, popularny dla backupów i archiwów |
+| Cloudflare R2 | S3-compatible, model bez klasycznych opłat za egress, dobre zastosowania internetowe |
+| Wasabi | S3-compatible hot storage, prostszy model cenowy, wymagane sprawdzenie retencji i zasad egress |
+| OVHcloud | Europejski object storage zgodny z S3, warianty regionalne i wielostrefowe |
+| Scaleway | Europejski S3-compatible Object Storage z kilkoma klasami danych |
+| DigitalOcean Spaces | Prosty storage S3-compatible z CDN, częściowa zgodność funkcji AWS |
+| Hetzner Object Storage | Europejski S3-compatible storage do prostych zastosowań |
+| IBM Cloud Object Storage | Rozwiązanie chmurowe i enterprise zgodne z podstawowym API S3 |
+| Oracle Cloud Object Storage | Warstwa kompatybilności S3, niepełna zgodność z rozszerzeniami AWS |
+| Google Cloud Storage | Preferowany natywny adapter GCS; opcje interoperacyjności nie powinny zastępować testów zgodności |
+
+### 16.5. Inne rozwiązania self-hosted
+
+Poza MinIO i QuObjects istnieją:
+
+- Ceph RGW — dojrzały, rozproszony storage S3, ale znacznie cięższy operacyjnie;
+- SeaweedFS — rozproszony storage z bramą S3;
+- Garage — lekki rozproszony object storage zgodny z częścią API S3;
+- inne bramy S3 dostarczane przez platformy NAS i rozwiązania enterprise.
+
+Dla pojedynczego QNAP nie ma obecnie uzasadnienia dla samodzielnego klastra Ceph. MinIO lub QuObjects są prostsze. Rozwiązania rozproszone należy ponownie ocenić dopiero przy wielu węzłach albo wymaganiu wysokiej dostępności.
+
+### 16.6. Proponowany układ hybrydowy
+
+NAS z RAID nie jest pełnym backupem. Awaria urządzenia, błąd administracyjny, kradzież, pożar lub ransomware mogą objąć wszystkie lokalne kopie.
+
+Możliwy układ:
+
+```text
+QuObjects albo MinIO na NAS
+            |
+            +-- primary storage aplikacji
+            |
+            `-- replikacja lub backup poza lokalizację
+                    |- CloudFerro
+                    |- myQNAPcloud Object
+                    |- Backblaze B2
+                    `- inny dostawca S3-compatible
+```
+
+Backup powinien mieć osobne poświadczenia i, jeśli to możliwe, immutability/Object Lock. Konto aplikacji nie powinno mieć prawa usuwania historycznych backupów.
+
+### 16.7. Konfiguracja niezależna od dostawcy
+
+Przykładowa konfiguracja:
+
+```env
+STORAGE_DRIVER=s3
+STORAGE_ENDPOINT_URL=https://endpoint.example
+STORAGE_BUCKET=lenie-storage
+STORAGE_ACCESS_KEY=...
+STORAGE_SECRET_KEY=...
+STORAGE_REGION=...
+STORAGE_ADDRESSING_STYLE=path
+```
+
+Dodatkowe opcje mogą obejmować:
+
+- wymuszenie path-style albo virtual-hosted-style;
+- konfigurację TLS i własnego CA;
+- timeouty i retry;
+- rozmiar części multipart upload;
+- maksymalną współbieżność transferów;
+- checksum algorithm;
+- server-side encryption;
+- prefix przypisany do środowiska lub workspace.
+
+W kodzie nie powinny powstawać gałęzie `if cloudferro`, `if qnap` ani `if wasabi`, o ile dostawca nie wymaga faktycznie odmiennego zachowania. Różnice protokołu należy izolować w adapterze i konfiguracji.
+
+### 16.8. Test kontraktowy S3
+
+Każdy kandydat powinien przejść automatyczny zestaw testów na osobnym bucketcie:
+
+- utworzenie i usunięcie obiektu;
+- upload/download małego i dużego pliku;
+- streaming bez ładowania całego pliku do RAM;
+- multipart upload i przerwanie niedokończonego uploadu;
+- `HEAD` i metadata;
+- `Content-Type`;
+- listowanie z prefiksem i paginacją;
+- klucze zawierające spacje oraz Unicode;
+- kopiowanie obiektu;
+- presigned GET i PUT;
+- zachowanie `ETag` oraz checksum;
+- retry po błędzie sieciowym;
+- versioning i Object Lock, jeśli będą wymagane;
+- polityka lifecycle;
+- równoległe zapisy oraz idempotencja;
+- pomiar czasu i liczby wykonanych requestów.
+
+Testy destrukcyjne muszą działać tylko na bucketcie lub prefiksie przeznaczonym do testów.
+
+### 16.9. Kryteria porównania dostawców
+
+Decyzja nie powinna opierać się wyłącznie na cenie za GB. Należy porównać:
+
+- koszt storage;
+- koszt PUT/GET/HEAD/LIST;
+- koszt i limit egress;
+- koszt retrieval oraz minimalną retencję;
+- lokalizację i jurysdykcję danych;
+- opóźnienie z miejsca działania workerów;
+- trwałość i SLA;
+- versioning, lifecycle, Object Lock i encryption;
+- presigned URLs;
+- limity liczby obiektów, rozmiaru i requestów;
+- jakość dokumentacji i wsparcia;
+- możliwość eksportu danych i koszt migracji;
+- dostępność narzędzi backupu oraz replikacji;
+- stopień rzeczywistej zgodności z używanym podzbiorem S3.
+
+### 16.10. Rekomendacja do dalszej analizy
+
+Do krótkiej listy dla instalacji Lenie należy przyjąć:
+
+1. QuObjects jako natywny primary storage na QNAP;
+2. MinIO jako przenośny primary storage zarządzany przez Compose;
+3. CloudFerro jako europejski wariant chmurowy lub off-site backup;
+4. myQNAPcloud Object jako prosty backup zintegrowany z ekosystemem QNAP;
+5. Backblaze B2 lub Cloudflare R2 jako alternatywy kosztowe.
+
+Następny krok decyzyjny to uruchomienie QuObjects na NAS, wykonanie testu kontraktowego oraz porównanie go z działającym MinIO pod względem zużycia RAM, przepustowości, obsługi, backupu i odtwarzania.

--- a/docs/deployment/onprem/enterprise-onprem-experiment.md
+++ b/docs/deployment/onprem/enterprise-onprem-experiment.md
@@ -1,0 +1,25 @@
+# Eksperyment myślowy: komercyjne wdrożenie on-premise
+
+Status: eksperyment myślowy, niski priorytet — nauka architektury w wolnym czasie, horyzont 1+ rok  
+Powiązane: [../README.md](../README.md) · [../commercial-multi-tenant-scaling-experiment.md](../commercial-multi-tenant-scaling-experiment.md)
+
+## Czym to się różni od `nas/`
+
+`../nas/` to mój własny, domowy QNAP — środowisko, które kontroluję w 100% i które faktycznie działa. Ten dokument dotyczy innego scenariusza: Lenie wdrożone **on-premise u kogoś innego** (np. w ramach hipotetycznej sprzedaży rozwiązania organizacji, która z jakiegoś powodu nie chce chmury) — serwer/rack/datacenter, którego nie kontroluję i którego operacje IT nie są moje.
+
+## Co się zmienia względem NAS-a
+
+- **Sprzęt i sieć nie są moje** — nie mogę zakładać konkretnego QNAP-a, konkretnych portów, konkretnej topologii sieciowej. Konfiguracja musi być w pełni sparametryzowana (już dziś częściowo tak jest — `STORAGE_*`/Vault, patrz `docs/storage.md`).
+- **Object storage musi być self-hosted** — MinIO działa już dziś i przenosi się bez zmian kodu. Alternatywy do rozważenia przy większej skali: Ceph RGW (dojrzały, ciężki operacyjnie), SeaweedFS, Garage (lżejsze, mniej dojrzałe) — patrz też sekcja 16.5 w [`../nas/storage-and-jobs-migration-plan.md`](../nas/storage-and-jobs-migration-plan.md).
+- **Ja nie robię już operacji** — potrzebny byłby instalator/paczka wdrożeniowa, wersjonowane wydania, dokumentacja dla cudzego zespołu IT, a nie ręczne `nas-deploy.sh` przez SSH.
+- **Model wsparcia** — kto reaguje na awarię o 2 w nocy? To pytanie nieistotne dla instalacji domowej, kluczowe dla on-prem u klienta.
+- **Sieć może być ograniczona** — firewall korporacyjny, brak dostępu do internetu (LLM przez chmurowe API może być zablokowany), potencjalnie wymóg lokalnego modelu językowego zamiast Bielik/OpenAI/Bedrock przez sieć.
+- **Zgodność i audyt** — inny poziom wymagań niż projekt hobbystyczny (logi, kto miał dostęp do czego, retencja).
+
+## Co to ma wspólnego z eksperymentem komercyjnym wielu użytkowników
+
+Ten dokument dotyczy **gdzie** aplikacja działa; [`../commercial-multi-tenant-scaling-experiment.md`](../commercial-multi-tenant-scaling-experiment.md) dotyczy **dla ilu niezaufanych osób**. On-prem u klienta korporacyjnego niemal zawsze oznacza też wielu użytkowników z izolacją — te dwa dokumenty się przecinają, ale to osobne osie: da się sobie wyobrazić on-prem dla jednej osoby (dzisiejszy NAS) i chmurę hiperskalera dla wielu niezaufanych najemców.
+
+## Co NIE robić teraz
+
+Nic. To jedyny z trzech katalogów eksperymentalnych, który nie ma dziś żadnego taniego kroku wartego zrobienia w kodzie — w przeciwieństwie do modelu właściciela danych (przydatny też dla `nas/`) czy abstrakcji storage (przydatna też dla `hyperscalers/`/`eu_cloud/`), pełne odseparowanie od konkretnego sprzętu i model wsparcia to praca, która ma sens dopiero przy realnej decyzji o sprzedaży on-prem.


### PR DESCRIPTION
## Summary
- Wydzielono dokumentację planistyczną do `docs/deployment/`, żeby oddzielić realny zakres (własny NAS, kilku zaufanych użytkowników) od nauki architektury w wolnym czasie.
- `nas/storage-and-jobs-migration-plan.md` — przeniesiony i zaktualizowany główny plan centralizacji storage i jobów.
- `nas/multi-user-household.md` — nowy realny plan dla kilku zaufanych domowników/znajomych, oparty na już istniejącym w kodzie `User`/`ApiKey`; zawiera też specyfikację (bez implementacji) roli gościa read-only z blokadą operacji kosztowych i wymogiem audytu.
- `commercial-multi-tenant-scaling-experiment.md` — eksperyment myślowy o skali komercyjnej (niezaufani użytkownicy), przenumerowany po wydzieleniu household.
- `federation-experiment.md` — nowe, wczesne pytanie o wymianę danych między instancjami Lenie AI (odwołuje się do ADR-015 jako istniejącego fundamentu).
- `hyperscalers/`, `eu_cloud/`, `onprem/` — lekkie szkielety porównania środowisk (AWS/GCloud, OVH/CloudFerro, on-prem enterprise).

Czysto dokumentacyjna zmiana — brak zmian w kodzie.

## Test plan
- [x] Sprawdzone linki wewnętrzne między dokumentami (brak odwołań do starych ścieżek `docs/nas-*.md`)
- [ ] Przegląd treści przez użytkownika

🤖 Generated with [Claude Code](https://claude.com/claude-code)