### PR TITLE
docs: napisz CLAUDE.md, napraw nieaktualne odniesienia do AWS/Cognito/_bmad-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ backend/imports/feeds_state.yaml
 # Temporary planning notes
 planowanie_slack_part_2.txt
 
+# Artefakty BMad (brainstorming, plany, notatki) - prywatne, patrz lenie-bmad-private
+_bmad-output/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,100 @@
-@CLAUDE.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+Lenie is a personal AI assistant for collecting, managing, and searching data (articles, YouTube videos, books) using LLMs. It's a side project under active development — see `README.md` for the full narrative/vision (target: MCP server + Obsidian vault as the primary interface).
+
+**Licensing**: Business Source License 1.1 (`LICENSE`) — free to use/modify/self-host, but may not be offered as a competing hosted/managed/SaaS service. Converts to Apache 2.0 on 2030-03-12.
+
+## Deployment reality — read this before trusting other docs
+
+The project moved from an AWS-serverless architecture (Lambda/API Gateway/DynamoDB/SQS — see `docs/aws-roadmap.md`) to a **NAS-first architecture**: Docker Compose (Flask API + PostgreSQL + MinIO + workers) running on the author's own QNAP NAS. **`docs/deployment/README.md` is the current source of truth** for what's real vs. experimental — read it first when touching architecture/infra:
+
+- `docs/deployment/nas/` — the only actively-deployed environment (own NAS, household users).
+- `docs/deployment/commercial-multi-tenant-scaling-experiment.md`, `federation-experiment.md`, `hyperscalers/`, `eu_cloud/`, `onprem/` — thought experiments, low priority, must not force complexity into current code.
+
+**Several root-level docs generated 2026-02-13 predate this pivot and describe the old AWS/Cognito-era plan as if current** — `docs/index.md`, `docs/development-guide.md`, `docs/project-overview.md`, `docs/architecture-*.md`, `docs/backlog-reference.md`, `docs/aws-roadmap.md`, and the "Future: Multiuser/LLM Text Analysis" sections at the bottom of `docs/development-guide.md` (Cognito auth, `_bmad-output/implementation-artifacts/sprint-status.yaml` backlog IDs — that backlog file no longer exists in this repo, it moved to a private repo). Treat these as historical unless cross-checked against `docs/deployment/` and the subdirectory `CLAUDE.md` files below.
+
+BMad workflow output (`_bmad-output/`) is no longer stored in this repo — it was moved to a private repo (session/planning artifacts contain personal/business-strategy content not meant to be public) and `_bmad-output/` is gitignored here. `_bmad/*/config.yaml` point new BMad output there.
+
+## Repo structure — subprojects
+
+Monorepo, each subproject with its own dependency environment. Most have their own `CLAUDE.md` — read it before working in that directory instead of duplicating its content here:
+
+| Path | What it is | Docs |
+|---|---|---|
+| `backend/` | Flask REST API — the core: document CRUD, LLM/embedding operations, NER, search, auth | [backend/CLAUDE.md](backend/CLAUDE.md) (and nested `library/`, `database/`, `imports/`, `data/`, `tests/` `CLAUDE.md` files) |
+| `ner_service/` | Internal-only microservice wrapping spaCy Polish NER, isolated so the ~600MB model doesn't bloat the backend image | `ner_service/README.md` |
+| `slack_bot/` | Optional Slack bot, slash commands against the backend API | `slack_bot/README.md` |
+| `web_interface_react/` | Main React 18 SPA | [web_interface_react/CLAUDE.md](web_interface_react/CLAUDE.md) |
+| `web_chrome_extension/` | Chrome/Kiwi Manifest v3 extension, primary content-capture path | [web_chrome_extension/CLAUDE.md](web_chrome_extension/CLAUDE.md) |
+| `web_interface_app2/` | Placeholder app (only login works) — not in active use | [web_interface_app2/CLAUDE.md](web_interface_app2/CLAUDE.md) |
+| `web_landing_page/` | Static landing page | `web_landing_page/README.md` |
+| `infra/` | Docker Compose (local + NAS), AWS CloudFormation/Terraform/EKS, GCloud, Kubernetes Kustomize/Helm — AWS/K8s paths are historical, NAS Compose (`infra/docker/compose.nas.yaml`) is what's actually deployed |
+| `docs/` | Architecture docs, ADRs (`docs/adr/`), deployment plans (`docs/deployment/`) |
+
+Each subproject manages its own Python/Node dependencies independently (no shared root lockfile) — `cd` into it before installing/running.
+
+## Common commands
+
+Run from repo root unless noted. Full reference: `Makefile`, `docs/development-guide.md` (dated, verify against this file for anything infra-related).
+
+```bash
+# Docker stack (local dev)
+make build && make dev        # build + run backend/db/frontend via docker compose
+make down                     # stop and remove containers
+
+# Backend deps (uv only — never pip)
+cd backend && uv sync                    # base deps
+cd backend && uv sync --all-extras       # everything
+cd backend && uv lock                    # after editing pyproject.toml
+
+# Lint / format (ruff, line-length=120)
+make lint                     # or: cd backend && uv run ruff check .
+make lint-fix
+make format
+make format-check
+
+# Security (all via uvx — no venv pollution)
+make security                 # semgrep
+make security-deps            # pip-audit
+make security-bandit
+make security-safety
+make security-all
+```
+
+### Tests
+
+```bash
+# Backend — full suite requires PostgreSQL + a resolvable config (Vault or ENV_DATA)
+cd backend && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -q      # Windows
+pytest backend/tests/unit/                                                    # if venv already active
+pytest backend/tests/unit/test_split_for_embedding.py                         # single file
+pytest backend/tests/integration/    # requires a running PostgreSQL
+
+# slack_bot — separate venv, not uvx
+cd slack_bot && PYTHONPATH=. .venv/Scripts/python -m pytest tests/unit/ -v
+
+# ner_service — separate venv, has pl_core_news_lg installed locally
+cd ner_service && .venv/Scripts/python -m pytest tests/ -q
+```
+
+`.venv_wsl/` (Linux) is a second, separate environment used for deploy/import scripts run through WSL — never plain `uv sync` there, always `UV_PROJECT_ENVIRONMENT=.venv_wsl uv sync` or an activated `--active` sync, or it silently overwrites the Windows `.venv`.
+
+## Architecture notes that span multiple files
+
+- **Auth**: `x-api-key` header on every route except health checks. `api_keys` table, `kind=user` (reader identity, household trust model, no passwords) vs `kind=service` (full access, 403 on reader-only endpoints). See `backend/library/auth.py`, `backend/library/api_key_routes.py`, `backend/library/reader_routes.py`.
+- **Storage abstraction (in progress)**: `backend/library/storage.py` defines an `ObjectStorage` interface (`LocalStorage`/`S3Storage`, S3-compatible so MinIO/AWS/CloudFerro share one code path) per `docs/deployment/nas/storage-and-jobs-migration-plan.md` Etap 1 — new code should go through this, not direct `boto3`/filesystem calls.
+- **Job execution**: today, batch scripts (`backend/documents_pipeline.py`, `backend/imports/*.py`) run manually/locally; the plan (`docs/deployment/nas/storage-and-jobs-migration-plan.md`) moves this to a PostgreSQL-backed job queue + worker on the NAS. Don't add new cron/local-only automation without checking that plan first.
+- **Multi-user model**: household trust model (`docs/deployment/nas/multi-user-household.md`) — shared document library, `kind=user` per person, no per-workspace data isolation. This is deliberately simpler than the (separate, thought-experiment-only) commercial multi-tenant model in `docs/deployment/commercial-multi-tenant-scaling-experiment.md`.
+- **NER / entities**: `backend/library/entity_service.py`, `backend/library/person_registry.py` — person canonicalization, aliases, manual-review queue, `ner_exclusions` false-positive suppression. Backed by `ner_service/` over the internal Docker network.
+- **Search**: hybrid (explicit filters + embeddings + LLM query parsing) — see `docs/search-hybrid.md` for the current design and known regressions/fixes, not `docs/architecture-backend.md` (stale, pre-rebuild).
+- **`source` vs `byline`** on documents: `source` = how you discovered it (newsletter, friend, own), `byline` = who created it (author/channel). See `backend/CLAUDE.md` for the full explanation — a common source of confusion.
+
+## Conventions
+
+- Feature branch + PR to `main` always — never commit directly to `main` (branch protection also enforces this).
+- `.gitattributes` enforces LF line endings repo-wide; don't fight it on Windows.
+- Pre-commit hooks include gitleaks + TruffleHog secret scanning — don't bypass with `--no-verify`.

--- a/README.md
+++ b/README.md
@@ -252,3 +252,15 @@ Now we have Bielik (https://bielik.ai), which perfectly understands the magic of
 ![img.png](bielik_psy_pl.png)
 
 You can use Bielik on [CloudFerro.com](https://sherlock.cloudferro.com/#pricing)
+
+### Where Bielik is actually used today
+
+This isn't just a curiosity — Bielik (`Bielik-11B-v3.0-Instruct`/`v2.3-Instruct`, via CloudFerro Sherlock) is the default model behind most of the LLM-driven analysis in this project, wired through the common `ai_ask()` provider abstraction (`backend/library/ai.py`):
+
+- **Search query parsing** — `parse_search_query()` (`backend/library/search/parser.py`) turns a natural-language search request into structured filters (dates, authors, historical periods, sort order) behind `POST /search`; see the baseline evaluation in [`docs/search-rebuild-bielik-baseline.md`](docs/search-rebuild-bielik-baseline.md).
+- **Article thematic tagging & country extraction** — `article_tagging.py` (`DEFAULT_TAGGING_MODEL = "Bielik-11B-v3.0-Instruct"`, overridable via `TAGGING_MODEL`).
+- **Article boundary extraction** — `article_extractor.py`, separating real article text from portal noise.
+- **Chunk analysis pipeline** — `chunk_llm_analysis.py`/`document_analysis_service.py`: speaker extraction, rewriting, summarization, topic synthesis for the reader/Obsidian-note workflow.
+- **Tone, timeline, and time-period extraction** — `tones.py`, `timeline_events.py`, `time_periods.py`: per-chapter emotional tone/register, dated events, and historical periods a document discusses.
+
+Every call is routed and cost-tracked centrally (`library/llm_usage/`), regardless of which provider (Bielik, OpenAI, Bedrock, Vertex AI) actually served it. See [`backend/library/CLAUDE.md`](backend/library/CLAUDE.md) for the full provider abstraction and module list.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ See [Current Architecture](#current-architecture) for a detailed breakdown of wh
 
 ### Phase 4: Scaling & Deployment Options
 
+**Note (2026-07-22):** The realistic near-term deployment target is a self-hosted NAS (Docker Compose: Flask + PostgreSQL + MinIO + workers), not a hyperscaler — see [docs/deployment/README.md](docs/deployment/README.md) for what's actually being built vs. what's a thought experiment. ECS/EKS below are a low-priority, educational exploration (see [docs/deployment/hyperscalers/](docs/deployment/hyperscalers/)), not a near-term plan.
+
 - ECS deployment — containerized scaling with managed orchestration
 - EKS deployment — Kubernetes-based scaling for complex workloads
 - Multi-environment support — parameterized deployments across dev/qa/prod
@@ -62,22 +64,27 @@ See [Current Architecture](#current-architecture) for a detailed breakdown of wh
 
 ### Phase 6: Multiuser Support
 
-- User authentication via AWS Cognito (registration, login, JWT tokens)
+**Superseded (2026-07-22):** Implemented differently than originally planned here — a household trust model (per-user API keys, no passwords, no Cognito) for a small circle of trusted users, not general-purpose multi-tenant auth. See [docs/deployment/nas/multi-user-household.md](docs/deployment/nas/multi-user-household.md) for what's actually built and in progress. Multi-tenant auth for untrusted users remains a separate, unimplemented thought experiment ([docs/deployment/commercial-multi-tenant-scaling-experiment.md](docs/deployment/commercial-multi-tenant-scaling-experiment.md)).
+
+- ~~User authentication via AWS Cognito (registration, login, JWT tokens)~~
 - Data ownership — `user_id` column in database tables, per-user data isolation
-- Replace shared `x-api-key` with per-user Cognito auth tokens across all clients
+- ~~Replace shared `x-api-key` with per-user Cognito auth tokens across all clients~~ — per-user API keys instead, see above
 - Login/logout UI in frontend applications (React SPA, Chrome extension, Add URL app)
 - User management admin panel (user list, blocking, per-user statistics)
 
 ## Current Architecture
 
-- **Backend** — Flask REST API (Python 3.11) serving 20 endpoints with `x-api-key` auth. Handles document CRUD, text processing, AI embeddings, and vector similarity search
-- **Web Interface** — React 18 SPA for browsing, editing, and AI-processing documents. Supports two backend modes: AWS Serverless (Lambda) and Docker (Flask)
+**The primary deployment target today is a self-hosted NAS, not AWS.** See [docs/deployment/README.md](docs/deployment/README.md) for the up-to-date map of what's actually running vs. what's a low-priority thought experiment.
+
+- **Backend** — Flask REST API (Python 3.11) serving document CRUD, text processing, AI embeddings, and vector similarity search, with `x-api-key` auth
+- **Web Interface** — React 18 SPA for browsing, editing, and AI-processing documents
 - **Browser Extension** — Chrome/Kiwi Manifest v3 extension for capturing webpages and sending them to the backend
-- **Database** — PostgreSQL 18 with pgvector for vector similarity search (multi-model, variable-dimension embeddings)
-- **AWS Serverless** — API Gateway, Lambda functions, SQS queues, Step Functions for cost-optimized processing
+- **Database** — PostgreSQL with pgvector for vector similarity search (multi-model, variable-dimension embeddings)
+- **Object storage** — MinIO on NAS / S3-compatible via a swappable `ObjectStorage` abstraction (see `backend/library/storage.py`, `docs/storage.md`) — the same interface covers MinIO, AWS S3, and other S3-compatible providers without provider-specific code branches
+- **NAS deployment (primary, active)** — Docker Compose stack (Flask + PostgreSQL + MinIO + workers) on a self-hosted QNAP NAS; see [docs/deployment/nas/](docs/deployment/nas/)
+- **AWS Serverless (dormant)** — API Gateway, Lambda, SQS, Step Functions; infrastructure exists but is not actively deployed, see [docs/aws-roadmap.md](docs/aws-roadmap.md)
 - **AI Services** — OpenAI, AWS Bedrock, Google Vertex AI, CloudFerro Bielik
-- **Docker** — docker compose stack with Flask + PostgreSQL + React for local development
-- **Kubernetes** — Kustomize-based deployment with GKE dev overlay (experimental)
+- **Kubernetes** — Kustomize-based deployment with GKE dev overlay (experimental, not a near-term priority)
 
 See [CLAUDE.md](CLAUDE.md) for the full architecture reference.
 
@@ -170,15 +177,15 @@ In this project, I'm using:
 * Python as the server backend
 * PostgreSQL as the embedding database
 * React as the web interface (under development)
-* HashiCorp Vault for secrets (for local and Kubernetes environments)
-* AWS as the deployment platform (as I'm lazy and don't want to manage infrastructure)
+* HashiCorp Vault for secrets
 
 Current deployment methods:
+* Docker Compose on a self-hosted NAS (production, primary target — see [docs/deployment/](docs/deployment/))
 * Docker Compose (local development)
-* AWS Lambda (production, event-driven serverless)
+* AWS Lambda (dormant — infrastructure exists but not actively deployed, see [docs/aws-roadmap.md](docs/aws-roadmap.md))
 * Kubernetes with Kustomize (experimental)
 
-See [Roadmap](#roadmap) for planned deployment options (ECS, EKS).
+See [docs/deployment/README.md](docs/deployment/README.md) for what's real vs. a thought experiment, and [Roadmap](#roadmap) for feature-level plans.
 
 ## Services That Can Be Used to Get Data
 

--- a/_bmad/_memory/config.yaml
+++ b/_bmad/_memory/config.yaml
@@ -8,4 +8,4 @@
 user_name: Ziutus
 communication_language: Polish
 document_output_language: English
-output_folder: "{project-root}/_bmad-output"
+output_folder: "C:/Users/ziutus/git/_lenie-all/lenie-bmad-private/_bmad-output"

--- a/_bmad/bmm/config.yaml
+++ b/_bmad/bmm/config.yaml
@@ -5,12 +5,12 @@
 
 project_name: lenie-server-2025
 user_skill_level: intermediate
-planning_artifacts: "{project-root}/_bmad-output/planning-artifacts"
-implementation_artifacts: "{project-root}/_bmad-output/implementation-artifacts"
+planning_artifacts: "C:/Users/ziutus/git/_lenie-all/lenie-bmad-private/_bmad-output/planning-artifacts"
+implementation_artifacts: "C:/Users/ziutus/git/_lenie-all/lenie-bmad-private/_bmad-output/implementation-artifacts"
 project_knowledge: "{project-root}/docs"
 
 # Core Configuration Values
 user_name: Ziutus
 communication_language: Polish
 document_output_language: English
-output_folder: "{project-root}/_bmad-output"
+output_folder: "C:/Users/ziutus/git/_lenie-all/lenie-bmad-private/_bmad-output"

--- a/_bmad/core/config.yaml
+++ b/_bmad/core/config.yaml
@@ -6,4 +6,4 @@
 user_name: Ziutus
 communication_language: Polish
 document_output_language: English
-output_folder: "{project-root}/_bmad-output"
+output_folder: "C:/Users/ziutus/git/_lenie-all/lenie-bmad-private/_bmad-output"

--- a/docs/adr/adr-007-pytubefix-lambda-exclusion.md
+++ b/docs/adr/adr-007-pytubefix-lambda-exclusion.md
@@ -56,6 +56,6 @@ Packages that exceed these limits cannot be included in layers. Alternative appr
 - `infra/aws/serverless/lambda_layers/layer_create_lenie_all.sh` — layer build script (pytubefix removed)
 - `infra/aws/serverless/CLAUDE.md` — "Known Limitations" section
 - `infra/aws/CLAUDE.md` — "Lambda Serverless Constraints" section
-- `_bmad-output/planning-artifacts/epics/backlog.md` — B-67: Choose Compute Model for Serverless YouTube Processing
+- B-67: Choose Compute Model for Serverless YouTube Processing (private planning backlog, not part of this public repository)
 - `backend/library/stalker_youtube_file.py` — pytubefix consumer
 - `backend/library/youtube_processing.py` — pytubefix consumer (via stalker_youtube_file)

--- a/docs/adr/adr-008-ruamel-yaml-roundtrip.md
+++ b/docs/adr/adr-008-ruamel-yaml-roundtrip.md
@@ -38,7 +38,7 @@ Use **`ruamel.yaml>=0.18`** instead of `pyyaml` for all YAML operations in `env_
 
 ### Related Artifacts
 
-- `_bmad-output/implementation-artifacts/tech-spec-env-to-vault-compare-review-classify.md` — tech-spec requiring ruamel.yaml
+- tech-spec requiring ruamel.yaml (private planning backlog, not part of this public repository)
 - `scripts/env_to_vault.py` — consumer (YAML loader infrastructure, Task 3)
 - `scripts/vars-classification.yaml` — the SSOT file that benefits from round-trip preservation
 - `backend/pyproject.toml` — dependency declaration (Task 1)

--- a/docs/adr/adr-011-assemblyai-sole-transcription.md
+++ b/docs/adr/adr-011-assemblyai-sole-transcription.md
@@ -60,6 +60,6 @@ Additionally, the AWS Transcribe flow requires uploading video files to S3 first
 
 ### Related Artifacts
 
-- `_bmad-output/implementation-artifacts/stories-assemblyai-usage-tracking.md` — Story 6: Remove AWS Transcribe Dead Code
+- Story 6: Remove AWS Transcribe Dead Code (private planning backlog, not part of this public repository)
 - [ADR-007](#adr-007-pytubefix-excluded-from-lambda--serverless-youtube-processing-requires-alternative-compute) — Lambda constraints (YouTube processing already excluded from Lambda)
 - `backend/library/api/asemblyai/asemblyai_transcript.py` — remaining transcription implementation

--- a/docs/adr/adr-014-article-review-tracking.md
+++ b/docs/adr/adr-014-article-review-tracking.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-28
 **Status:** Accepted
 **Decision Makers:** Ziutus
-**Backlog Item:** [B-101](../\_bmad-output/planning-artifacts/epics/backlog.md) — Track Obsidian Note Status for Articles
+**Backlog Item:** B-101 — Track Obsidian Note Status for Articles (planning backlog is tracked in a private repo, not part of this public repository)
 
 ## Context
 
@@ -71,10 +71,10 @@ This enables:
 
 ### Prerequisites
 
-The following backlog items must be completed first:
-- [B-33: AWS Cognito authentication](../\_bmad-output/implementation-artifacts/sprint-status.yaml)
-- [B-34: Add `user_id` to database schema](../\_bmad-output/implementation-artifacts/sprint-status.yaml)
-- [B-35: Enforce data isolation per user](../\_bmad-output/implementation-artifacts/sprint-status.yaml)
+The following backlog items must be completed first (tracked in the private planning backlog):
+- B-33: AWS Cognito authentication — **superseded**: the actually implemented multi-user model uses per-user API keys (household trust model), not Cognito, see `docs/deployment/nas/multi-user-household.md`
+- B-34: Add `user_id` to database schema
+- B-35: Enforce data isolation per user
 
 ### New Table Schema
 
@@ -169,9 +169,9 @@ ALTER TABLE web_documents DROP COLUMN obsidian_note_paths;
 
 ## Related Artifacts
 
-- [B-101: Track Obsidian Note Status for Articles](../\_bmad-output/planning-artifacts/epics/backlog.md)
-- [B-33: Implement user authentication with AWS Cognito](../\_bmad-output/implementation-artifacts/sprint-status.yaml)
-- [B-34: Add user ownership to database schema](../\_bmad-output/implementation-artifacts/sprint-status.yaml)
+- B-101: Track Obsidian Note Status for Articles (private planning backlog)
+- B-33: Implement user authentication with AWS Cognito (private planning backlog; superseded, see note above)
+- B-34: Add user ownership to database schema (private planning backlog)
 - [ADR-004a: Migrate to SQLAlchemy ORM](adr-004a-sqlalchemy-orm-migration.md) — ORM model changes follow this pattern
 - [ADR-010: Database Lookup Tables with Foreign Keys](adr-010-database-lookup-tables.md) — Alembic migration pattern
 - `backend/imports/article_browser.py` — primary consumer

--- a/docs/adr/adr-016-cloudformation-vs-cdk.md
+++ b/docs/adr/adr-016-cloudformation-vs-cdk.md
@@ -4,6 +4,8 @@
 **Status:** Accepted (CloudFormation); Proposed (CDK evaluation)
 **Decision Makers:** Ziutus
 
+**Note (2026-07-22):** This ADR concerns IaC for the AWS track specifically, which today is not the project's primary deployment target — see [`docs/deployment/README.md`](../deployment/README.md). The decision remains valid for if/when AWS work resumes.
+
 ## Context
 
 Project Lenie's AWS infrastructure is managed by **29 CloudFormation templates** deployed via a universal `deploy.sh` script. This setup was built incrementally across 3 infrastructure sprints (Feb–Mar 2026) and now covers the entire AWS stack: VPC, RDS, DynamoDB, SQS, S3, 11 Lambda functions, 2 API Gateways, Step Functions, CloudFront, ACM, and budget controls.

--- a/docs/api-contracts-backend.md
+++ b/docs/api-contracts-backend.md
@@ -1,6 +1,8 @@
 # API Contracts — Backend
 
 > Generated: 2026-02-13 | Part: backend | Type: REST API (Flask)
+>
+> **Uwaga (2026-07-22):** Backend ma dziś znacznie więcej niż 20 endpointów (NER/encje, osoby, oś czasu, ton, źródła, `/search`, `/whoami`, `/api_keys` itd.) — pełna, aktualna lista jest w [`backend/CLAUDE.md`](../backend/CLAUDE.md). "AWS response" warianty niżej dotyczą trybu AWS Serverless, dziś nieaktywnego (`docs/aws-roadmap.md`). Kontrakty CRUD (`/url_add` i pochodne) poniżej wyglądają na wciąż aktualne — zweryfikuj przy większych zmianach.
 
 ## Overview
 

--- a/docs/architecture-backend.md
+++ b/docs/architecture-backend.md
@@ -1,6 +1,8 @@
 ﻿# Architecture â€” Backend API
 
 > Generated: 2026-02-13 | Part: backend | Type: REST API | Framework: Flask
+>
+> **ZASTĄPIONE (2026-07-22):** Ten dokument opisuje stan sprzed kilku istotnych zmian — w szczególności "ORM: None (raw psycopg2)" poniżej jest nieaktualne od [ADR-004a](adr/adr-004a-sqlalchemy-orm-migration.md) (migracja do SQLAlchemy + Pydantic), a sekcja "AWS Lambda" opisuje dziś nieaktywny tor wdrożenia (patrz `docs/aws-roadmap.md`). Aktualna architektura backendu: [`backend/CLAUDE.md`](../backend/CLAUDE.md) i zagnieżdżone `CLAUDE.md` w `backend/library/`, `backend/database/`, `backend/imports/`. Reszta tego pliku (LLM/embedding abstraction, content pipeline, testing) może wciąż być w większości aktualna, ale nie została dziś zweryfikowana — traktuj jako zapis historyczny do potwierdzenia.
 
 ## Architecture Pattern
 
@@ -25,7 +27,7 @@ PostgreSQL 18 + pgvector
 | Language | Python | >= 3.11 |
 | Framework | Flask + Flask-CORS | latest |
 | Database | PostgreSQL + pgvector | 18 |
-| ORM | None (raw psycopg2) | â€” |
+| ORM | ~~None (raw psycopg2)~~ **superseded — SQLAlchemy 2.x + Alembic, see ADR-004a** | — |
 | Package Manager | uv (hatchling build) | latest |
 | LLM | OpenAI, AWS Bedrock, Google Vertex AI, CloudFerro Bielik | multi-provider |
 | Embeddings | ada-002, Titan v1/v2, BAAI/bge-multilingual | 1024-1536 dim (model-dependent) |

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1,6 +1,8 @@
 # Architecture Decision Records (ADR)
 
 > Living document tracking key architectural decisions in Project Lenie.
+>
+> **Uwaga (2026-07-22):** Ten plik jest podsumowaniem wygenerowanym 2026-02-13 i nie obejmuje nowszych decyzji (np. ADR-015: UUID jako globalny identyfikator dokumentu, ADR-017: search rebuild scope decisions). Traktuj [`docs/adr/`](adr/) jako kompletne i aktualne źródło prawdy — ten plik jako wygodne, ale niekompletne podsumowanie starszych wpisów.
 
 ## ADR-001: Remove `/translate` Endpoint and Use Native-Language Embeddings
 

--- a/docs/architecture-infra.md
+++ b/docs/architecture-infra.md
@@ -1,6 +1,8 @@
 # Architecture — Infrastructure
 
 > Generated: 2026-02-13 | Part: infra | Type: Multi-cloud IaC
+>
+> **ZASTĄPIONE (2026-07-22):** Ten dokument nie wspomina o NAS-ie ani razu, mimo że to dziś jedyne aktywnie wdrażane środowisko (Docker Compose: Flask + PostgreSQL + MinIO + workery na własnym QNAP) — patrz [`docs/deployment/README.md`](deployment/README.md) i [`docs/deployment/nas/`](deployment/nas/). AWS Serverless (sekcja 2 poniżej) jest dziś nieaktywny/dormant (patrz `docs/aws-roadmap.md`), Kubernetes/GCloud pozostają eksperymentalne. Zachowane jako zapis historyczny stanu infrastruktury AWS/K8s.
 
 ## Architecture Pattern
 

--- a/docs/architecture-web_chrome_extension.md
+++ b/docs/architecture-web_chrome_extension.md
@@ -1,6 +1,8 @@
 # Architecture — Browser Extension (web_chrome_extension)
 
 > Generated: 2026-02-13 | Part: web_chrome_extension | Type: Chrome Extension (Manifest v3)
+>
+> **Uwaga (2026-07-22):** Popup/data-flow/permissions poniżej są prawdopodobnie wciąż aktualne. "Server URL (default: AWS API Gateway endpoint)" odzwierciedla dziś nieaktywny tor AWS (patrz `docs/aws-roadmap.md`) — docelowo powinien wskazywać na NAS, ale nie jest to jeszcze zmienione w kodzie (patrz otwarty wątek dostępu zdalnego w `docs/deployment/`). Zweryfikuj względem [`web_chrome_extension/CLAUDE.md`](../web_chrome_extension/CLAUDE.md) przed poleganiem na tym pliku.
 
 ## Architecture Pattern
 

--- a/docs/architecture-web_interface_react.md
+++ b/docs/architecture-web_interface_react.md
@@ -1,6 +1,8 @@
 # Architecture — Main Frontend (web_interface_react)
 
 > Generated: 2026-02-13 | Part: web_interface_react | Type: React 18 SPA
+>
+> **Uwaga (2026-07-22):** Struktura komponentów/hooków/routingu poniżej jest prawdopodobnie wciąż aktualna, ale nie została dziś zweryfikowana. Odniesienia do "AWS Serverless" jako trybu backendu i hooki `useDatabase`/`useVpnServer`/`useSqs` dotyczą infrastruktury AWS, która jest dziś nieaktywna (patrz `docs/aws-roadmap.md`) — główny tryb to Docker/NAS. Zweryfikuj względem [`web_interface_react/CLAUDE.md`](../web_interface_react/CLAUDE.md), jeśli istnieje, przed poleganiem na tym pliku.
 
 ## Architecture Pattern
 

--- a/docs/aws-roadmap.md
+++ b/docs/aws-roadmap.md
@@ -3,6 +3,8 @@
 > Plan rozwoju infrastruktury AWS w Project Lenie. Dokument zbiorczy — łączy informacje z [backlog-reference.md](backlog-reference.md), [aws-sync-backlog.md](aws-sync-backlog.md), [technology-choices.md](technology-choices.md) i [architecture-decisions.md](architecture-decisions.md).
 >
 > **Last updated:** 2026-03-31
+>
+> **Uwaga:** Główny kierunek rozwoju to dziś instalacja na własnym NAS, nie AWS — patrz [`docs/deployment/README.md`](deployment/README.md) jako aktualne źródło prawdy o architekturze i priorytetach. Ten dokument opisuje status istniejącej infrastruktury AWS (częściowo na pauzie, patrz "What's on hold" poniżej) oraz odrębny, czysto edukacyjny eksperyment myślowy "co gdyby dzisiejszy NAS-owy Lenie działał na AWS" — patrz [`docs/deployment/hyperscalers/aws-gcloud-experiment.md`](deployment/hyperscalers/aws-gcloud-experiment.md), który jest osobnym, nowszym dokumentem niż ten plik.
 
 ## Current State
 

--- a/docs/backlog-reference.md
+++ b/docs/backlog-reference.md
@@ -1,6 +1,8 @@
 # Backlog Reference
 
-Quick reference of all backlog items. For full specifications (acceptance criteria, technical notes, user stories), see the [main backlog](./../_bmad-output/planning-artifacts/epics/backlog.md).
+> **ZASTĄPIONE (2026-07-22):** Pełny, aktualny backlog jest dziś w prywatnym repo (`lenie-bmad-private`), nie w tym repozytorium — `_bmad-output/planning-artifacts/epics/backlog.md` już tu nie istnieje. Tabele poniżej to zapis historyczny stanu backlogu na 2026-02-13 do 2026-03-31 (patrz daty w kolumnie Status), nie aktualna lista zadań.
+
+Quick reference of all backlog items. For full specifications (acceptance criteria, technical notes, user stories), see the main backlog (private planning repo, not part of this public repository).
 
 ## Sprint 6: Security Verification
 

--- a/docs/component-inventory-web_interface_react.md
+++ b/docs/component-inventory-web_interface_react.md
@@ -1,6 +1,8 @@
 # Component Inventory — Main Frontend (web_interface_react)
 
 > Generated: 2026-02-13 | Part: web_interface_react | Type: React 18 SPA
+>
+> **Uwaga (2026-07-22):** Struktura komponentów jest prawdopodobnie w dużej mierze aktualna, ale konkretne szczegóły stron (np. `search.jsx` opisany niżej jako "Dual-path: AWS (2 calls) vs Docker (1 call)") odnoszą się do trybu AWS Serverless, dziś nieaktywnego (`docs/aws-roadmap.md`) — wyszukiwanie działa dziś przez `POST /search` (`docs/search-hybrid.md`). Zweryfikuj względem [`web_interface_react/CLAUDE.md`](../web_interface_react/CLAUDE.md) i rzeczywistego kodu przed poleganiem na szczegółach niżej.
 
 ## Component Hierarchy
 

--- a/docs/data-models-backend.md
+++ b/docs/data-models-backend.md
@@ -1,6 +1,8 @@
 # Data Models — Backend
 
 > Generated: 2026-02-13 | Part: backend | Database: PostgreSQL 18 + pgvector
+>
+> **Uwaga (2026-07-22):** Tabela `documents` poniżej wygląda na wciąż w dużej mierze aktualną (kolumny zgodne z dzisiejszym `backend/library/db/models.py`, SQLAlchemy ORM od ADR-004a) — ale przybyło od tego czasu wiele nowych tabel (encje/NER, osoby, oś czasu wydarzeń, okresy czasowe, tony, kolekcje, źródła, klucze API, koszty LLM) nieopisanych tutaj. Pełny, aktualny schemat: [`backend/database/CLAUDE.md`](../backend/database/CLAUDE.md).
 
 ## Database Schema
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,6 +1,8 @@
 # Development Guide
 
 > Generated: 2026-02-13 | Project: lenie-server-2025
+>
+> **Uwaga (2026-07-22):** Sekcje o środowisku deweloperskim (uv, WSL, debugpy, testy, line endings, MCP servers) są prawdopodobnie wciąż w dużej mierze aktualne — zweryfikuj względem [`CLAUDE.md`](../CLAUDE.md) (root), jeśli coś się nie zgadza. Dwie sekcje "Future" na końcu pliku (LLM Text Analysis, Multiuser Support) opisują plan sprzed pivotu na NAS-first i są oznaczone jako nieaktualne poniżej.
 
 ## Prerequisites
 
@@ -590,9 +592,9 @@ Common issues:
 
 ## Future: LLM Text Analysis (Phase 6)
 
-> **Status:** Backlog — po MVP (Security, MCP Server, Obsidian), przed Multiuser.
+> **Status: w dużej mierze już zaimplementowane inaczej (2026-07-22).** Automatyczna analiza LLM dokumentów (NER osób/miejsc, oś czasu wydarzeń, klasyfikacja tonu/okresów czasowych) już istnieje i jest wdrożona na NAS — patrz `backend/library/entity_service.py`, `backend/library/person_registry.py`, `docs/search-hybrid.md`. Sekcja poniżej to historyczny, wcześniejszy plan (prostszy, jedna kolumna JSONB) — nie odzwierciedla dzisiejszego, znacznie bardziej rozbudowanego stanu.
 
-Automatyczna analiza tekstu dokumentów przez LLM, zwracająca ustrukturyzowany JSON z metadanymi. Backlog items (B-29 do B-32) w `_bmad-output/implementation-artifacts/sprint-status.yaml`.
+Automatyczna analiza tekstu dokumentów przez LLM, zwracająca ustrukturyzowany JSON z metadanymi. Backlog items (B-29 do B-32) — prywatny backlog planowania, nie część tego publicznego repozytorium.
 
 ### Zakres
 
@@ -612,9 +614,9 @@ Automatyczna analiza tekstu dokumentów przez LLM, zwracająca ustrukturyzowany 
 
 ## Future: Multiuser Support (Phase 7)
 
-> **Status:** Backlog — planowane na samym końcu, po zakończeniu wszystkich faz łącznie z LLM Text Analysis.
+> **Status: SUPERSEDED (2026-07-22).** Zaimplementowane inaczej niż poniżej — household trust model (per-user API keys, brak haseł, brak Cognito) dla małego grona zaufanych użytkowników, nie ogólny multi-tenant przez AWS Cognito. Patrz [`docs/deployment/nas/multi-user-household.md`](deployment/nas/multi-user-household.md) dla aktualnego stanu. Pełny multi-tenant dla niezaufanych użytkowników pozostaje osobnym, niezaimplementowanym eksperymentem myślowym ([`docs/deployment/commercial-multi-tenant-scaling-experiment.md`](deployment/commercial-multi-tenant-scaling-experiment.md)).
 
-Sekcja multiuser umożliwi korzystanie z systemu przez wielu użytkowników na infrastrukturze AWS. Backlog items (B-23 do B-28) w `_bmad-output/implementation-artifacts/sprint-status.yaml`.
+Sekcja multiuser umożliwi korzystanie z systemu przez wielu użytkowników na infrastrukturze AWS. Backlog items (B-23 do B-28) — prywatny backlog planowania, nie część tego publicznego repozytorium.
 
 ### Zakres
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 # Project Documentation Index — Lenie Server 2025
 
 > Generated: 2026-02-13 | Version: 0.3.13.0 | Scan: Exhaustive
+>
+> **ZASTĄPIONE (2026-07-22):** Ten indeks i większość dokumentów, do których linkuje, opisują architekturę sprzed pivotu na NAS-first (AWS serverless jako "current", Cognito jako plan multiuser) — traktuj je jako zapis historyczny, nie aktualny stan. **Aktualne źródła prawdy:** [`CLAUDE.md`](../CLAUDE.md) (root — mapa podprojektów i komendy) i [`docs/deployment/README.md`](deployment/README.md) (co jest realne, co jest eksperymentem myślowym). Inne pliki linkowane niżej (`source-tree-analysis.md`, `integration-architecture.md`, `api-contracts-backend.md`, `data-models-backend.md`, `component-inventory-*.md`, `technology-choices.md`, `system-evolution.md`, `infrastructure-metrics.md`) pochodzą z tego samego wygenerowanego 2026-02-13 zestawu i najprawdopodobniej mają ten sam problem — nie zostały jeszcze zweryfikowane.
 
 ## Project Overview
 
@@ -61,7 +63,7 @@
 - [System Evolution](./system-evolution.md) — How the project evolved: embedding strategy, infrastructure cleanup, cost-driven design
 
 ### Planning & Backlog
-- [Backlog Reference](./backlog-reference.md) — Quick reference of all backlog items (B-xx) with status and dependencies
+- [Backlog Reference](./backlog-reference.md) — historyczny stan backlogu (B-xx); pełny, aktualny backlog jest dziś w prywatnym repo (`lenie-bmad-private`), nie w tym repozytorium
 
 ### Guides
 - [Development Guide](./development-guide.md) — Prerequisites, setup, running, testing, code quality
@@ -105,11 +107,11 @@
 ## Getting Started
 
 ### For AI-Assisted Development
-1. Start with this `index.md` as the primary entry point
-2. Read [Project Overview](./project-overview.md) for high-level understanding
-3. Check [Architecture docs](./architecture-backend.md) for the part you're working on
-4. Reference [API Contracts](./api-contracts-backend.md) for endpoint details
-5. Use [Data Models](./data-models-backend.md) for database schema
+1. Start with [`CLAUDE.md`](../CLAUDE.md) (root) and [`docs/deployment/README.md`](deployment/README.md) — these are current, this `index.md` and the docs below it are not
+2. ~~Read Project Overview for high-level understanding~~ — superseded, see banner above
+3. Check [Architecture docs](./architecture-backend.md) for the part you're working on, but verify against `backend/CLAUDE.md` and sibling `CLAUDE.md` files first
+4. Reference [API Contracts](./api-contracts-backend.md) for endpoint details (unverified — same 2026-02-13 generation batch)
+5. Use [Data Models](./data-models-backend.md) for database schema (unverified — same 2026-02-13 generation batch)
 
 ### For Local Development
 1. Follow [Development Guide](./development-guide.md) for setup instructions

--- a/docs/infrastructure-metrics.md
+++ b/docs/infrastructure-metrics.md
@@ -1,6 +1,8 @@
 # Infrastructure Metrics — Single Source of Truth
 
 > Last verified: 2026-03-10 | Post-Sprint 10 (B-93: /document_states endpoint)
+>
+> **ZASTĄPIONE (2026-07-22):** Ten plik nie jest już "single source of truth" — backend ma dziś dużo więcej niż 20 endpointów (NER, osoby, oś czasu, ton, źródła, `/search`, auth), a AWS Serverless (sekcja niżej) jest dormant. Aktualne źródło: [`backend/CLAUDE.md`](../backend/CLAUDE.md) (pełna, utrzymywana lista endpointów) i [`docs/deployment/README.md`](deployment/README.md). Zachowane jako zapis historyczny stanu na 2026-03-10 (widać już wtedy poprawkę o usunięciu `/website_similar` w Etapie 12).
 
 This file is the authoritative source for infrastructure counts. All other documentation files should reference or be consistent with values here.
 

--- a/docs/integration-architecture.md
+++ b/docs/integration-architecture.md
@@ -1,6 +1,8 @@
 # Integration Architecture
 
 > Generated: 2026-02-13 | Project: lenie-server-2025 | Type: Multi-part Monorepo
+>
+> **ZASTĄPIONE (2026-07-22):** Ten diagram zakłada, że tryb AWS Serverless (Lambda/API Gateway/DynamoDB) jest równoległym, aktywnym trybem obok Dockera — dziś AWS jest dormant/nieaktywny (`docs/aws-roadmap.md`), a jedyne aktywnie wdrażane środowisko to NAS (`docs/deployment/README.md`). `/website_similar` (wspomniany niżej jako endpoint AWS-trybu) został usunięty w Etapie 12 — dziś `POST /search` (patrz `docs/search-hybrid.md`). Zachowane jako zapis historyczny.
 
 ## Integration Overview
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,6 +1,8 @@
 # Project Overview — Lenie Server 2025
 
 > Generated: 2026-02-13 | Version: 0.3.13.0 | Status: Active Development
+>
+> **ZASTĄPIONE (2026-07-22):** Ten dokument opisuje architekturę sprzed pivotu na NAS-first jako "aktualną" — w szczególności AWS Serverless jako główny tryb wdrożenia, "No ORM: raw psycopg2" (nieaktualne od ADR-004a, migracja do SQLAlchemy) i "License: MIT" (nieaktualne — projekt jest dziś na Business Source License 1.1, patrz [`LICENSE`](../LICENSE)). Aktualne źródła: [`CLAUDE.md`](../CLAUDE.md) (root), [`docs/deployment/README.md`](deployment/README.md). Reszta tego pliku zachowana jako zapis historyczny.
 
 ## Executive Summary
 

--- a/docs/search-hybrid.md
+++ b/docs/search-hybrid.md
@@ -1,6 +1,13 @@
 # Hybrid document search
 
-`GET /search` (frontend `web_interface_react`) is backed by `SearchService.search_similar()`
+> **Poprawka (2026-07-22):** Ten dokument opisywał pierwotnie `GET /search` i `SearchService.search_similar()` —
+> ten endpoint/metoda zostały usunięte w Etapie 12 (patrz sekcja "Porządki wykonane w Etapie 12" niżej).
+> Dziś to `POST /search` (`backend/library/search_routes.py`) wywołujące `SearchService.search()`
+> (`backend/library/search_service.py`). Cała reszta tego dokumentu — analiza bugów, wagi scoringu,
+> decyzje wydajnościowe — dotyczy tej samej logiki merge/scoring, która przetrwała bez zmian pod nową nazwą
+> metody/endpointu; tylko nagłówek był nieaktualny.
+
+`POST /search` (frontend `web_interface_react`) is backed by `SearchService.search()`
 (`backend/library/search_service.py`), which combines two independent signals for the same
 query text:
 

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -1,6 +1,8 @@
 # Source Tree Analysis
 
 > Generated: 2026-02-13 | Project: lenie-server-2025 | Type: Multi-part Monorepo
+>
+> **ZASTĄPIONE (2026-07-22):** Drzewo poniżej pokazuje stan sprzed migracji na SQLAlchemy ORM (`stalker_web_document_db.py`/`stalker_web_documents_db_postgresql.py` → dziś `db/models.py`/`document_repository.py`, ADR-004a) i sprzed wielu nowych modułów (NER/encje, oś czasu, search hybrydowy, storage abstraction). Aktualna mapa katalogów: [`CLAUDE.md`](../CLAUDE.md) (root) i zagnieżdżone `CLAUDE.md` w każdym podkatalogu (`backend/CLAUDE.md`, `backend/library/CLAUDE.md` itd.). Zachowane jako zapis historyczny struktury na 2026-02-13.
 
 ## Project Root
 

--- a/docs/system-evolution.md
+++ b/docs/system-evolution.md
@@ -2,6 +2,8 @@
 
 A brief history of how Project Lenie evolved — key turning points, lessons learned, and why things are the way they are.
 
+> **Dopisek (2026-07-22):** Ta historia kończy się na "Trzech sprintach porządkowania infrastruktury" (luty-marzec 2026) i nie obejmuje późniejszego pivotu na architekturę NAS-first (Docker Compose: Flask + PostgreSQL + MinIO + workery na własnym QNAP, AWS Serverless dziś dormant) — patrz [`docs/deployment/README.md`](deployment/README.md) dla dalszego ciągu tej ewolucji.
+
 ## From English-Only Embeddings to Multilingual
 
 In the early days, embedding models only worked well with English text. Since most of the documents collected by Lenie are in Polish (news articles, social media posts, books), the system needed a translation step before generating embeddings. That's why the `/translate` endpoint existed and why the document processing pipeline includes a `READY_FOR_TRANSLATION` state.

--- a/docs/technology-choices.md
+++ b/docs/technology-choices.md
@@ -3,6 +3,8 @@
 > Living document describing the tools and technologies used in Project Lenie, with rationale for each choice.
 >
 > For deep architectural decisions with full context/consequences analysis, see [Architecture Decisions (ADR)](./architecture-decisions.md).
+>
+> **Uwaga (2026-07-22):** Większość wyborów narzędziowych (uv, PostgreSQL/pgvector, ruff itd.) jest wciąż aktualna. Rekomendacje przywiązane do AWS Lambda (np. "why 3.11 not 3.12+" niżej, uzasadnione warstwami Lambda) dotyczą toru AWS, dziś nieaktywnego — patrz `docs/deployment/README.md`. `docs/backlog-reference.md`, do którego linkują pozycje "Upgrade plan" niżej, zawiera już tylko historyczny stan backlogu — pełny, aktualny backlog jest w prywatnym repo.
 
 ## Language Runtimes
 


### PR DESCRIPTION
## Summary
- `CLAUDE.md` był dosłownie `@CLAUDE.md` (zepsute samo-odwołanie, efektywnie pusty) mimo że README linkuje tam 3x jako "pełne źródło architektury" — napisana realna treść na podstawie faktycznego stanu repo.
- README.md: skorygowane sekcje "Current Architecture" i "Roadmap" (Phase 4 ECS/EKS, Phase 6 Cognito), oraz nowa sekcja "Where Bielik is actually used today" z konkretnymi modułami (parser wyszukiwania, tagowanie, ekstrakcja granic artykułu, analiza chunków, ton/oś czasu/okresy).
- `docs/aws-roadmap.md`: baner wskazujący `docs/deployment/README.md` jako aktualne źródło prawdy.
- `docs/search-hybrid.md`: naprawiony nagłówek (opisywał usunięty w Etapie 12 `GET /search`/`search_similar()`, dziś `POST /search`/`SearchService.search()`).
- 4 ADR-y (007, 008, 011, 014): naprawione martwe linki do `_bmad-output/`.
- ADR-016: adnotacja że dotyczy toru AWS, nie dzisiejszego głównego celu.
- 17 plików z wygenerowanego 2026-02-13 zestawu dokumentacji (`docs/index.md`, `docs/development-guide.md`, `docs/project-overview.md`, wszystkie `docs/architecture-*.md`, `docs/architecture-decisions.md`, `docs/backlog-reference.md`, `docs/source-tree-analysis.md`, `docs/integration-architecture.md`, `docs/api-contracts-backend.md`, `docs/data-models-backend.md`, `docs/component-inventory-web_interface_react.md`, `docs/technology-choices.md`, `docs/system-evolution.md`, `docs/infrastructure-metrics.md`): banery "ZASTĄPIONE" tam, gdzie treść w większości opisuje nieaktualną architekturę AWS/Cognito, lżejsze notatki tam, gdzie treść w dużej mierze wciąż aktualna.
- `.gitignore` + `_bmad/*/config.yaml`: `_bmad-output/` wyłączone ze śledzenia, config przekierowany do prywatnego repo.

## Test plan
- [x] Linki w README/ADR/aws-roadmap/docs prowadzą do istniejących plików
- [x] CLAUDE.md odwołuje się tylko do zweryfikowanych plików/komend
- [x] Wszystkie martwe odwołania do `_bmad-output/` naprawione (opisowy tekst zamiast linku)