### PR TITLE
fix: dodaj wykrywanie autora money.pl i czyszczenie biogramu autora

### DIFF
--- a/backend/library/article_cleaner.py
+++ b/backend/library/article_cleaner.py
@@ -229,8 +229,35 @@ def _clean_lines_onet(lines: list[str]) -> list[str]:
     return cleaned
 
 
+# "o autorze" widget (wp.pl/o2.pl/money.pl — jedna CMS Grupy WP): zdjęcie,
+# imię i nazwisko, akapit biogramu, e-mail autora. Reguły niżej już usuwają
+# powtórzony podpis zdjęcia (_strip_photo_caption_lines), samą linię
+# "oprac. Nazwisko" i linię e-mail — ale akapit biogramu ("Dziennikarz
+# portalu finansowego money.pl. ...") zostawały jako pozorna treść artykułu.
+# Jedyny bezpieczny sygnał: akapit bezpośrednio poprzedzający linię
+# "x@grupawp.pl o autorze" — treść artykułu nigdy nie kończy się tuż przed
+# tym markerem, więc usunięcie poprzedzającego go akapitu nie tnie realnej treści.
+_AUTHOR_EMAIL_RE = re.compile(r'^[\w.+-]+@grupawp\.pl\s*o autorze$', re.IGNORECASE)
+
+
+def _remove_author_bio_paragraph(lines: list[str]) -> list[str]:
+    drop: set[int] = set()
+    for i, line in enumerate(lines):
+        if not _AUTHOR_EMAIL_RE.match(line.strip()):
+            continue
+        j = i - 1
+        while j >= 0 and not lines[j].strip():
+            j -= 1
+        if j >= 0:
+            drop.add(j)
+    if not drop:
+        return lines
+    return [line for k, line in enumerate(lines) if k not in drop]
+
+
 def _clean_lines_money(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla money.pl."""
+    lines = _remove_author_bio_paragraph(lines)
     skip_exact = {"Skomentuj", "Notowania", "Udostępnij", "Słuchaj", "Kopiuj link"}
     skip_startswith = ("Udostępnij na ", "Źródło zdjęć:", "Źródło artykułu:",
                        "oprac.", "Dźwięk został wygenerowany")
@@ -271,6 +298,7 @@ def _clean_lines_money(lines: list[str]) -> list[str]:
 
 def _clean_lines_wp(lines: list[str]) -> list[str]:
     """Czyszczenie specyficzne dla wp.pl/o2.pl/tech.wp.pl."""
+    lines = _remove_author_bio_paragraph(lines)
     skip_exact = {"Skomentuj", "Słuchaj", "Udostępnij", "Kopiuj link",
                   "Zaloguj", "Obserwuj nas na:", "Wyłączono komentarze"}
     skip_startswith = ("Udostępnij na ", "Dźwięk został wygenerowany",

--- a/backend/library/article_metadata.py
+++ b/backend/library/article_metadata.py
@@ -8,13 +8,31 @@ from bs4 import BeautifulSoup
 
 
 def _is_wp_url(url: str) -> bool:
+    """Grupa Wirtualna Polska portals sharing the same CMS byline widget."""
     host = (urlparse(url).hostname or "").lower()
-    return host == "wp.pl" or host.endswith(".wp.pl") or host == "o2.pl" or host.endswith(".o2.pl")
+    return (
+        host == "wp.pl"
+        or host.endswith(".wp.pl")
+        or host == "o2.pl"
+        or host.endswith(".o2.pl")
+        or host == "money.pl"
+        or host.endswith(".money.pl")
+    )
 
 
 def _is_onet_url(url: str) -> bool:
     host = (urlparse(url).hostname or "").lower()
     return host == "onet.pl" or host.endswith(".onet.pl")
+
+
+# money.pl's "cauthor" value sometimes bakes in the "oprac." (opracowanie /
+# compiled by) label that is otherwise rendered as a separate <span> next to
+# the byline link, e.g. "oprac. Przemysław Ciszak" instead of just the name.
+_AUTHOR_LABEL_PREFIX_RE = re.compile(r"^\s*oprac\.?\s*:?\s*", re.IGNORECASE)
+
+
+def _strip_author_label_prefix(name: str) -> str:
+    return _AUTHOR_LABEL_PREFIX_RE.sub("", name).strip()
 
 
 def _as_types(value) -> set[str]:
@@ -101,13 +119,13 @@ def extract_article_author(html: str | None, url: str = "") -> str | None:
         except (json.JSONDecodeError, AttributeError):
             author = ""
         if author:
-            return author
+            return _strip_author_label_prefix(author)
 
     soup = BeautifulSoup(html, "html.parser")
     byline = soup.select_one("#wp-article-author-info .wp-article-author-link, .wp-article-author-link")
     if byline:
         author = byline.get_text(" ", strip=True)
         if author:
-            return author
+            return _strip_author_label_prefix(author)
 
     return None

--- a/backend/tests/unit/test_article_cleaner.py
+++ b/backend/tests/unit/test_article_cleaner.py
@@ -487,6 +487,25 @@ class TestMoneyCleaning:
             "Litera T w treści artykułu pozostaje.",
         ]
 
+    def test_money_author_bio_paragraph_removed(self):
+        lines = [
+            "Treść artykułu money.",
+            "",
+            "Dziennikarz portalu finansowego money.pl. Specjalizuje się w energetyce.",
+            "",
+            "przemyslaw.ciszak@grupawp.plo autorze",
+            "Źródło artykułu:",
+        ]
+        assert _clean_lines_money(lines) == ["Treść artykułu money.", "", ""]
+
+    def test_money_paragraph_not_removed_without_author_email_marker(self):
+        lines = [
+            "Treść artykułu money.",
+            "",
+            "Zwykły akapit, po którym nie ma widgetu o autorze.",
+        ]
+        assert _clean_lines_money(lines) == lines
+
 
 class TestWpCleaning:
     def test_wp_comments_author_and_tags_removed(self):
@@ -556,6 +575,16 @@ class TestWpCleaning:
             "Kontakt do autora: autor@grupawp.pl",
         ]
         assert _clean_lines_wp(lines) == ["Kontakt do autora: autor@grupawp.pl"]
+
+    def test_wp_author_bio_paragraph_removed(self):
+        lines = [
+            "Treść artykułu wp.",
+            "",
+            "Dziennikarz działu technologii Wirtualnej Polski.",
+            "",
+            "lukasz.maziewski@grupawp.plo autorze",
+        ]
+        assert _clean_lines_wp(lines) == ["Treść artykułu wp.", "", ""]
 
 
 class TestSafeUiArtifacts:

--- a/backend/tests/unit/test_article_metadata.py
+++ b/backend/tests/unit/test_article_metadata.py
@@ -32,6 +32,23 @@ def test_wp_rule_does_not_apply_to_other_domains():
     assert extract_article_author(html, "https://example.com/artykul") is None
 
 
+def test_money_pl_strips_oprac_label_from_cauthor():
+    html = """
+    <meta name="author" content="Grupa Wirtualna Polska">
+    <script>window.page={"cauthor":"oprac. Przemysław Ciszak"};</script>
+    """
+    assert extract_article_author(html, "https://www.money.pl/gospodarka/artykul.html") == "Przemysław Ciszak"
+
+
+def test_money_pl_visible_byline_has_no_oprac_label_to_strip():
+    html = """
+    <div class="wp-article-author"><span>oprac.&nbsp;</span>
+      <a class="wp-article-author-link">Przemysław Ciszak</a>
+    </div>
+    """
+    assert extract_article_author(html, "https://www.money.pl/gospodarka/artykul.html") == "Przemysław Ciszak"
+
+
 def test_onet_extracts_multiple_authors_from_article_json_ld():
     html = '''<script type="application/ld+json">{
       "@context": "https://schema.org", "@graph": [


### PR DESCRIPTION
## Summary
- money.pl dzieli CMS z wp.pl/o2.pl (Grupa WP), ale `extract_article_author()` obsługiwał tylko wp.pl/o2.pl — dla money.pl byline zostawał puste
- wartość `cauthor` na money.pl bywa poprzedzona etykietą "oprac." (np. "oprac. Przemysław Ciszak") — dodano usuwanie tego prefiksu
- widget "o autorze" (zdjęcie + biogram + e-mail) zostawiał akapit biogramu w wyekstrahowanej treści artykułu (money.pl i wp.pl/o2.pl) — usuwany teraz jako akapit bezpośrednio poprzedzający linię "x@grupawp.pl o autorze"

## Test plan
- [x] `pytest backend/tests/unit/test_article_cleaner.py backend/tests/unit/test_article_metadata.py -q` — 79 passed
- [ ] deploy na NAS i weryfikacja na realnym dokumencie money.pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)