### PR TITLE
fix: wyizoluj biogram autora z text_md gdy autor wykryty po podziale na chunki

### DIFF
--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -1613,6 +1613,10 @@ def extract_author(run_id: int):
     document's byline field, always overwriting any existing value — this is
     a reviewer-triggered manual action, unlike the automatic pipeline step in
     document_analysis_service.create_run() which never overwrites.
+
+    Also isolates a trailing author-biography paragraph from doc.text_md, if
+    one is found (extract_trailing_author_biography() — same mechanism as the
+    11b2 pipeline step).
     """
     session = get_scoped_session()
     run = session.get(DocumentAnalysisRun, run_id)
@@ -1667,6 +1671,22 @@ def extract_author(run_id: int):
         abort(404, f"Document {run.document_id} not found")
     from library.author_service import set_document_authors
     author_persons = set_document_authors(session, doc, author_names, method="llm")
+
+    # The byline was just discovered by this manual action, so — same as the
+    # 11b2 automatic fallback in document_analysis_service.create_run() —
+    # extract_trailing_author_biography() never got a chance to isolate the
+    # "o autorze" widget from doc.text_md before this run's chunks were split.
+    # Do it now against the stored text_md: cheap (regex, no LLM), and keeps
+    # the NEXT run/reclean from re-surfacing it as its own chunk.
+    bio_paragraph_removed = False
+    from library.author_biography import extract_trailing_author_biography, process_author_biography
+
+    stripped_md, bio = extract_trailing_author_biography(doc.text_md or "", author_names[0])
+    if bio:
+        doc.text_md = stripped_md
+        process_author_biography(session, doc, bio, run.model)
+        bio_paragraph_removed = True
+
     try:
         session.commit()
     except Exception:
@@ -1679,6 +1699,7 @@ def extract_author(run_id: int):
         "byline": doc.byline,
         "byline_method": doc.byline_method,
         "author_persons": author_persons,
+        "bio_paragraph_removed": bio_paragraph_removed,
     })
 
 

--- a/backend/library/document_analysis_service.py
+++ b/backend/library/document_analysis_service.py
@@ -644,6 +644,10 @@ class DocumentAnalysisService:
             #       single chapter excerpt is not a reliable place to look for a byline.
             if not is_transcript and scope is None and not (getattr(doc, "byline", None) or "").strip():
                 try:
+                    from library.author_biography import (
+                        extract_trailing_author_biography,
+                        process_author_biography,
+                    )
                     from library.author_service import set_document_authors
                     from library.chunk_llm_analysis import extract_author_info, head_tail_excerpt
 
@@ -651,6 +655,22 @@ class DocumentAnalysisService:
                     if author_names:
                         set_document_authors(self.session, doc, author_names, method="llm")
                         log(f"author detected: {', '.join(author_names)}")
+
+                        # The byline wasn't known yet when this run's text was split
+                        # above (11b2 runs after chunking), so extract_trailing_author_biography()
+                        # never got a chance to isolate the "o autorze" widget from
+                        # doc.text_md the way it does when the byline is already known
+                        # (see the article-mode split earlier in this function). Do it
+                        # now against the stored text_md — cheap (regex, no LLM) and
+                        # keeps the NEXT run/reclean from re-surfacing it as its own
+                        # chunk; this run's already-created chunks are unaffected.
+                        stripped_md, bio = extract_trailing_author_biography(
+                            doc.text_md or "", author_names[0]
+                        )
+                        if bio:
+                            doc.text_md = stripped_md
+                            process_author_biography(self.session, doc, bio, model)
+                            log("author biography isolated from doc.text_md for future runs")
                 except Exception:
                     logger.exception("author extraction failed, continuing without author")
 

--- a/backend/tests/unit/test_document_analysis_article_mode.py
+++ b/backend/tests/unit/test_document_analysis_article_mode.py
@@ -337,3 +337,76 @@ class TestPublishedOnBackfill:
 
         assert doc.published_on is None
         assert doc.published_on_method is None
+
+
+class TestAuthorBiographyIsolationOnLateDetection:
+    """create_run() step 11b2: when the byline is only discovered by the LLM
+    fallback (i.e. AFTER this run's text was already split — see the
+    article-mode branch earlier in create_run(), which only isolates the
+    trailing "o autorze" widget when the byline is known ahead of time),
+    extract_trailing_author_biography() gets a second chance to strip it
+    from doc.text_md so the NEXT run/reclean doesn't re-surface it as its
+    own chunk. See [[project_article_author_detection]]/doc 9270 (money.pl/
+    o2.pl bio widget)."""
+
+    BIO_TEXT = (
+        "Jan Kowalski Dziennikarz o2.pl\n\n"
+        "Zajmował się dziennikarstwem od 2010 roku, pracował w kilku redakcjach lokalnych."
+    )
+
+    def test_bio_isolated_and_persisted_when_author_discovered_late(
+        self, session, article_env, monkeypatch,
+    ):
+        doc = FakeDoc()
+        doc.byline = None
+        doc.text_md = ARTICLE_TEXT.rstrip() + "\n\n" + self.BIO_TEXT
+        monkeypatch.setattr(das.Document, "get_by_id", staticmethod(lambda _s, _id: doc))
+        monkeypatch.setattr(llm, "extract_author_info", lambda text, model: ["Jan Kowalski"])
+
+        def fake_set_authors(_session, doc, names, method):
+            doc.byline = ", ".join(names)
+            return {"linked": [], "skipped": []}
+
+        monkeypatch.setattr("library.author_service.set_document_authors", fake_set_authors)
+
+        bio_calls = []
+        monkeypatch.setattr(
+            "library.author_biography.process_author_biography",
+            lambda _session, _doc, bio, _model: bio_calls.append(bio) or {
+                "person_id": 1, "status": "auto_applied",
+            },
+        )
+
+        DocumentAnalysisService(session).create_run(
+            doc_id=42, model="test-model", mode="article", chunk_size=300,
+        )
+
+        assert doc.byline == "Jan Kowalski"
+        assert bio_calls == [self.BIO_TEXT]
+        assert "Zajmował się dziennikarstwem" not in doc.text_md
+
+    def test_no_bio_found_leaves_text_md_untouched(self, session, article_env, monkeypatch):
+        doc = FakeDoc()
+        doc.byline = None
+        doc.text_md = ARTICLE_TEXT
+        monkeypatch.setattr(das.Document, "get_by_id", staticmethod(lambda _s, _id: doc))
+        monkeypatch.setattr(llm, "extract_author_info", lambda text, model: ["Jan Kowalski"])
+
+        monkeypatch.setattr(
+            "library.author_service.set_document_authors",
+            lambda _session, doc, names, method: setattr(doc, "byline", ", ".join(names))
+            or {"linked": [], "skipped": []},
+        )
+        bio_calls = []
+        monkeypatch.setattr(
+            "library.author_biography.process_author_biography",
+            lambda *a, **kw: bio_calls.append(a) or {"person_id": 1, "status": "auto_applied"},
+        )
+
+        DocumentAnalysisService(session).create_run(
+            doc_id=42, model="test-model", mode="article", chunk_size=300,
+        )
+
+        assert doc.byline == "Jan Kowalski"
+        assert bio_calls == []
+        assert doc.text_md == ARTICLE_TEXT


### PR DESCRIPTION
## Summary
- `extract_trailing_author_biography()` (`library/author_biography.py`) już usuwał trailing-biogram autora z `article_body` przed podziałem na chunki — ale tylko gdy `doc.byline` był znany PRZED podziałem
- gdy autor jest ustalany dopiero przez fallback LLM (krok 11b2, po podziale na chunki) albo ręcznie przez `/analysis_run/<id>/extract_author` na istniejącym runie, funkcja nigdy wcześniej nie dostawała szansy zadziałać — biogram zostawał w `doc.text_md` i przy każdym kolejnym czyszczeniu/podziale wracał jako osobny chunk SZUM (zob. dok. #9270, o2.pl)
- fix: po ustaleniu autora w obu miejscach wołamy ten sam, już istniejący, bezkosztowy (regex, bez LLM) mechanizm na `doc.text_md`; jeśli znajdzie biogram — zapisuje oczyszczony tekst na przyszłość i przekazuje go do `process_author_biography()` (opis osoby w rejestrze)

## Test plan
- [x] `pytest backend/tests/unit/test_document_analysis_article_mode.py backend/tests/unit/test_author_biography.py backend/tests/unit/test_author_service.py -q` — 53 passed
- [x] `pytest backend/tests/unit/ -q` — 1954 passed (13 pre-existing, niepowiązane failury w storage.py/dynamodb_sync.py z osobnego, nieukończonego zadania)
- [x] ruff clean
- [ ] deploy na NAS i weryfikacja na dok. #9270 (autor wykryty ręcznie na istniejącym runie → biogram znika z text_md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)