### PR TITLE
Document preparation, storage and search pagination

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -36,7 +36,7 @@ backend/
 
 ## Main Application (`server.py`)
 
-Flask + Flask-CORS application exposing 23 REST API endpoints. **Version**: 0.3.14.0.
+Flask + Flask-CORS application exposing 23 REST API endpoints. **Version**: 0.3.15.5.
 
 ### API Endpoints
 

--- a/backend/imports/dynamodb_sync.py
+++ b/backend/imports/dynamodb_sync.py
@@ -44,6 +44,7 @@ from library.db.models import ImportLog, Document
 from library.document_service import DocumentService
 from library.import_log_tracker import ImportLogTracker
 from library.models.stalker_document_status import StalkerDocumentStatus
+from library.storage import LocalStorage, storage_from_config
 
 cfg = load_config()
 
@@ -199,7 +200,8 @@ def fetch_s3_content(s3_client, bucket: str, doc_uuid: str) -> tuple[str | None,
     return text_content, html_content
 
 
-def save_cache_files(doc_id: int, text_content: str | None, html_content: str | None, cache_dir: str):
+def save_cache_files(doc_id: int, text_content: str | None, html_content: str | None, cache_dir: str,
+                     storage=None):
     """Save S3 content to cache in document_prepare convention: {cache_dir}/{doc_id}/{doc_id}.ext"""
     doc_dir = os.path.join(cache_dir, str(doc_id))
     os.makedirs(doc_dir, exist_ok=True)
@@ -208,12 +210,16 @@ def save_cache_files(doc_id: int, text_content: str | None, html_content: str | 
         path = os.path.join(doc_dir, f"{doc_id}.html")
         with open(path, "w", encoding="utf-8") as f:
             f.write(html_content)
+        if storage and not isinstance(storage, LocalStorage):
+            storage.put_bytes(f"cache/markdown/{doc_id}/{doc_id}.html", html_content.encode("utf-8"), "text/html")
         print(f"  Cache: saved {path} ({len(html_content)} chars)")
 
     if text_content:
         path = os.path.join(doc_dir, f"{doc_id}.txt")
         with open(path, "w", encoding="utf-8") as f:
             f.write(text_content)
+        if storage and not isinstance(storage, LocalStorage):
+            storage.put_bytes(f"cache/markdown/{doc_id}/{doc_id}.txt", text_content.encode("utf-8"), "text/plain")
         print(f"  Cache: saved {path} ({len(text_content)} chars)")
 
 
@@ -316,6 +322,20 @@ def process_article_content(doc_id: int, cache_base_dir: str,
 
     print("  Process: LLM failed — no article markers extracted")
     return True, False
+
+
+def sync_generated_cache(doc_id: int, cache_base_dir: str, storage) -> None:
+    """Upload pipeline artifacts after local path-based processing finishes."""
+    if isinstance(storage, LocalStorage):
+        return
+    doc_dir = os.path.join(cache_base_dir, str(doc_id))
+    if not os.path.isdir(doc_dir):
+        return
+    for name in os.listdir(doc_dir):
+        path = os.path.join(doc_dir, name)
+        if os.path.isfile(path):
+            with open(path, "rb") as handle:
+                storage.put_bytes(f"cache/markdown/{doc_id}/{name}", handle.read())
 
 
 def sync_item_to_postgres(item: dict, text_content: str | None, html_content: str | None,
@@ -428,6 +448,7 @@ def main():
     # Resolve cache dir default from config
     if args.data_dir is None:
         args.data_dir = os.path.join(cfg.get("CACHE_DIR") or "tmp", "markdown")
+    cache_storage = storage_from_config(cfg)
 
     try:
         working_timezone = ZoneInfo(args.timezone)
@@ -615,7 +636,7 @@ def main():
 
                 # Save cache files after successful insert (doc_id now available)
                 if result == "added" and doc_id and (text_content or html_content):
-                    save_cache_files(doc_id, text_content, html_content, args.data_dir)
+                    save_cache_files(doc_id, text_content, html_content, args.data_dir, cache_storage)
 
                 # Convert HTML to markdown + LLM extraction (webpage only, saves to cache)
                 if result == "added" and doc_id and doc_type == "webpage" and not args.skip_s3:
@@ -629,6 +650,7 @@ def main():
                         md_converted += 1
                     if llm_ok:
                         llm_extracted += 1
+                    sync_generated_cache(doc_id, args.data_dir, cache_storage)
 
                 if result == "added":
                     added += 1

--- a/backend/imports/storage_migrate.py
+++ b/backend/imports/storage_migrate.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Copy a local file tree to configured storage and report storage usage.
+
+Examples:
+  python imports/storage_migrate.py usage
+  python imports/storage_migrate.py upload --source tmp --prefix cache --dry-run
+  python imports/storage_migrate.py upload --source data --prefix documents
+"""
+
+from __future__ import annotations
+
+import argparse
+import mimetypes
+from pathlib import Path
+
+from library.config_loader import load_config
+from library.storage import storage_from_config, usage
+
+
+def human_size(value: int) -> str:
+    size = float(value)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if size < 1024 or unit == "TiB":
+            return f"{size:.2f} {unit}"
+        size /= 1024
+    return f"{size:.2f} TiB"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate local files to local/S3/MinIO storage")
+    sub = parser.add_subparsers(dest="command", required=True)
+    usage_parser = sub.add_parser("usage", help="Count objects and bytes in configured storage")
+    usage_parser.add_argument("--prefix", default="")
+    upload = sub.add_parser("upload", help="Upload a local directory recursively")
+    upload.add_argument("--source", required=True)
+    upload.add_argument("--prefix", default="")
+    upload.add_argument("--dry-run", action="store_true")
+    upload.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    store = storage_from_config(load_config())
+    if args.command == "usage":
+        count, total = usage(store, args.prefix)
+        print(f"Objects: {count}\nBytes: {total}\nSize: {human_size(total)}")
+        return
+
+    source = Path(args.source).resolve()
+    if not source.is_dir():
+        parser.error(f"source is not a directory: {source}")
+    copied = skipped = bytes_copied = 0
+    for path in source.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source).as_posix()
+        key = "/".join(part for part in (args.prefix.strip("/"), relative) if part)
+        if not args.overwrite and store.exists(key):
+            skipped += 1
+            continue
+        size = path.stat().st_size
+        print(f"{'DRY-RUN ' if args.dry_run else ''}{path} -> {key} ({human_size(size)})")
+        if not args.dry_run:
+            store.put_bytes(key, path.read_bytes(), mimetypes.guess_type(path.name)[0])
+        copied += 1
+        bytes_copied += size
+    print(f"Copied: {copied} ({human_size(bytes_copied)}), skipped: {skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/library/article_metadata.py
+++ b/backend/library/article_metadata.py
@@ -89,6 +89,27 @@ def _extract_onet_authors(html: str) -> list[str]:
     return names
 
 
+def _article_jsonld_objects(html: str):
+    """Yield JSON-LD objects describing the page's primary article."""
+    soup = BeautifulSoup(html, "html.parser")
+    article_types = {"Article", "NewsArticle", "ReportageNewsArticle", "AnalysisNewsArticle"}
+    for script in soup.select('script[type="application/ld+json"]'):
+        try:
+            payload = json.loads(script.string or script.get_text())
+        except (json.JSONDecodeError, TypeError):
+            continue
+        roots = payload if isinstance(payload, list) else [payload]
+        for root in roots:
+            if not isinstance(root, dict):
+                continue
+            objects = root.get("@graph", [root])
+            if not isinstance(objects, list):
+                objects = [objects]
+            for obj in objects:
+                if isinstance(obj, dict) and _as_types(obj.get("@type")) & article_types:
+                    yield obj
+
+
 def extract_article_authors(html: str | None, url: str = "") -> list[str]:
     """Extract all deterministic portal byline authors from raw HTML."""
     if not html:
@@ -96,7 +117,44 @@ def extract_article_authors(html: str | None, url: str = "") -> list[str]:
     if _is_onet_url(url):
         return _extract_onet_authors(html)
     author = extract_article_author(html, url)
-    return [author] if author else []
+    if author:
+        return [author]
+    for article in _article_jsonld_objects(html):
+        names = _author_names(article.get("author"))
+        if names:
+            return names
+    soup = BeautifulSoup(html, "html.parser")
+    meta = soup.select_one('meta[name="author"], meta[property="article:author"]')
+    value = (meta.get("content") or "").strip() if meta else ""
+    return [value] if value else []
+
+
+def extract_article_publication_date(html: str | None, url: str = "") -> str | None:
+    """Return an ISO publication date from structured HTML metadata."""
+    if not html:
+        return None
+    candidates: list[str] = []
+    for article in _article_jsonld_objects(html):
+        value = article.get("datePublished")
+        if isinstance(value, str):
+            candidates.append(value)
+    soup = BeautifulSoup(html, "html.parser")
+    for selector in (
+        'meta[property="article:published_time"]',
+        'meta[name="date"]',
+        'meta[name="pubdate"]',
+        'time[datetime]',
+    ):
+        node = soup.select_one(selector)
+        if node:
+            value = node.get("content") or node.get("datetime")
+            if value:
+                candidates.append(value)
+    for value in candidates:
+        match = re.search(r"(?<!\d)(\d{4}-\d{2}-\d{2})(?!\d)", value)
+        if match:
+            return match.group(1)
+    return None
 
 
 def extract_article_author(html: str | None, url: str = "") -> str | None:

--- a/backend/library/chunk_review_routes.py
+++ b/backend/library/chunk_review_routes.py
@@ -572,8 +572,16 @@ def reclean_preview(doc_id: int):
 
     if save:
         from library.document_images import replace_document_images
+        from library.lenie_markdown import md_remove_markdown
 
-        setattr(doc, field, after)
+        # Article preparation always establishes Markdown as the canonical
+        # webpage body, including legacy rows where only text existed.
+        if doc.document_type == "webpage":
+            doc.text_md = after
+            doc.text = md_remove_markdown(after)
+            field = "text_md"
+        else:
+            setattr(doc, field, after)
         doc.document_length = len(after)
         doc.quality = None
         replace_document_images(session, doc.id, cleaned["images"])
@@ -595,6 +603,177 @@ def reclean_preview(doc_id: int):
         "before_end_preview": before[-700:],
         "start_preview": after[:400],
         "end_preview": after[-700:],
+    })
+
+
+def _document_head_tail(doc: Document) -> str:
+    from library.chunk_llm_analysis import head_tail_excerpt
+
+    return head_tail_excerpt(doc.text_md or doc.text or "")
+
+
+@bp.route("/document/<int:doc_id>/extract_author", methods=["POST"])
+def extract_document_author(doc_id: int):
+    """Extract and save a byline without requiring an analysis run."""
+    from library.article_metadata import extract_article_authors
+    from library.author_service import set_document_authors
+
+    session = get_scoped_session()
+    doc = session.get(Document, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    context_text = data.get("context_text")
+    biography_text = data.get("biography_text")
+    if context_text is not None and not isinstance(context_text, str):
+        return jsonify({"status": "error", "message": "context_text must be a string"}), 400
+    if biography_text is not None and not isinstance(biography_text, str):
+        return jsonify({"status": "error", "message": "biography_text must be a string"}), 400
+
+    names = [] if context_text else extract_article_authors(doc.text_raw, doc.url or "")
+    method = "html" if names else "llm"
+    if not names:
+        source_text = (context_text or _document_head_tail(doc)).strip()[:12000]
+        if not source_text:
+            return jsonify({"status": "error", "message": "Document has no text content"}), 400
+        try:
+            from library.chunk_llm_analysis import extract_author_info
+            from library.document_analysis_service import DEFAULT_ANALYSIS_MODEL
+
+            names = extract_author_info(source_text, DEFAULT_ANALYSIS_MODEL)
+            method = "llm"
+        except Exception:
+            logger.exception("document author extraction failed for %d", doc_id)
+            return jsonify({"status": "error", "message": "Author extraction failed"}), 500
+
+    if not names:
+        return jsonify({"status": "success", "byline": None, "byline_method": None})
+    author_persons = set_document_authors(session, doc, names, method=method)
+    biography = None
+    if biography_text and len(names) == 1:
+        from library.author_biography import process_author_biography
+        from library.document_analysis_service import DEFAULT_ANALYSIS_MODEL
+
+        biography = process_author_biography(
+            session, doc, biography_text.strip()[:12000], DEFAULT_ANALYSIS_MODEL,
+        )
+    session.commit()
+    return jsonify({
+        "status": "success", "byline": doc.byline,
+        "byline_method": doc.byline_method, "author_persons": author_persons,
+        "biography": biography,
+    })
+
+
+@bp.route("/document/<int:doc_id>/extract_publication_date", methods=["POST"])
+def extract_document_publication_date(doc_id: int):
+    """Extract and save publication date without requiring an analysis run."""
+    from library.article_metadata import extract_article_publication_date
+
+    session = get_scoped_session()
+    doc = session.get(Document, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    context_text = data.get("context_text")
+    if context_text is not None and not isinstance(context_text, str):
+        return jsonify({"status": "error", "message": "context_text must be a string"}), 400
+
+    date_str = None if context_text else extract_article_publication_date(doc.text_raw, doc.url or "")
+    method = "html" if date_str else "llm"
+    if not date_str:
+        source_text = (context_text or _document_head_tail(doc)).strip()[:12000]
+        if not source_text:
+            return jsonify({"status": "error", "message": "Document has no text content"}), 400
+        try:
+            from library.chunk_llm_analysis import extract_publication_date_info
+            from library.document_analysis_service import DEFAULT_ANALYSIS_MODEL
+
+            date_str = extract_publication_date_info(source_text, DEFAULT_ANALYSIS_MODEL)
+            method = "llm"
+        except Exception:
+            logger.exception("document publication-date extraction failed for %d", doc_id)
+            return jsonify({"status": "error", "message": "Publication date extraction failed"}), 500
+    if not date_str:
+        return jsonify({"status": "success", "published_on": None, "published_on_method": None})
+    try:
+        doc.published_on = date.fromisoformat(date_str)
+    except ValueError:
+        return jsonify({"status": "success", "published_on": None, "published_on_method": None})
+    doc.published_on_method = method
+    session.commit()
+    return jsonify({
+        "status": "success", "published_on": doc.published_on.isoformat(),
+        "published_on_method": doc.published_on_method,
+    })
+
+
+@bp.route("/document/<int:doc_id>/extract_persons", methods=["POST"])
+def extract_document_persons(doc_id: int):
+    """Add people found in a reviewer-selected excerpt to the registry.
+
+    Unlike a full entity refresh this endpoint is deliberately additive: it
+    never removes entities already stored for the document.
+    """
+    from library.db.models import DocumentEntity
+    from library.ner_client import (
+        NERExtractionError, aggregate_entities_detailed, extract_entities_strict,
+    )
+    from library.person_registry import resolve_document_persons
+
+    session = get_scoped_session()
+    doc = session.get(Document, doc_id)
+    if doc is None:
+        abort(404, f"Document {doc_id} not found")
+
+    data = request.get_json(silent=True) or {}
+    context_text = data.get("context_text")
+    if not isinstance(context_text, str) or not context_text.strip():
+        return jsonify({"status": "error", "message": "context_text must be a non-empty string"}), 400
+    context_text = context_text.strip()[:12000]
+
+    try:
+        grouped = aggregate_entities_detailed(
+            extract_entities_strict(context_text), types=("persName",),
+        )
+    except NERExtractionError:
+        logger.exception("selected person extraction failed for document %d", doc_id)
+        return jsonify({"status": "error", "message": "Person extraction service is unavailable"}), 503
+
+    found: list[str] = []
+    for (entity_type, entity_text), details in grouped.items():
+        found.append(entity_text)
+        entity = session.scalars(select(DocumentEntity).where(
+            DocumentEntity.document_id == doc_id,
+            DocumentEntity.entity_type == entity_type,
+            func.lower(DocumentEntity.entity_text) == entity_text.lower(),
+        )).first()
+        variants = list(dict.fromkeys(details.get("variants", [])))
+        if entity is None:
+            session.add(DocumentEntity(
+                document_id=doc_id, entity_type=entity_type,
+                entity_text=entity_text, mention_count=details.get("count", 1),
+                variants=variants,
+            ))
+        else:
+            entity.mention_count = max(entity.mention_count or 1, details.get("count", 1))
+            entity.variants = list(dict.fromkeys([*(entity.variants or []), *variants]))
+
+    if not found:
+        return jsonify({"status": "success", "persons_found": [], "linked": [], "skipped": []})
+
+    session.flush()
+    resolution = resolve_document_persons(session, doc, context_text)
+    session.commit()
+    return jsonify({
+        "status": "success", "persons_found": found,
+        "linked": [
+            {"mention": mention, "person": canonical, "confidence": confidence}
+            for mention, canonical, confidence in resolution["linked"]
+        ],
+        "skipped": resolution["skipped"],
     })
 
 

--- a/backend/library/document_repository.py
+++ b/backend/library/document_repository.py
@@ -59,6 +59,7 @@ class DocumentRepository:
             stmt = stmt.where(or_(
                 Document.url.ilike(pattern, escape="\\"),
                 Document.text.ilike(pattern, escape="\\"),
+                Document.text_md.ilike(pattern, escape="\\"),
                 Document.title.ilike(pattern, escape="\\"),
                 Document.summary.ilike(pattern, escape="\\"),
                 Document.chapter_list.ilike(pattern, escape="\\"),
@@ -276,7 +277,7 @@ class DocumentRepository:
                 Document.url,
                 Document.language,
                 DocumentEmbedding.text_original,
-                func.length(Document.text).label("websites_text_length"),
+                func.length(func.coalesce(func.nullif(Document.text_md, ""), Document.text)).label("websites_text_length"),
                 func.length(DocumentEmbedding.text).label("embeddings_text_length"),
                 Document.title,
                 Document.document_type,
@@ -357,7 +358,7 @@ class DocumentRepository:
             func.coalesce(Document.title, ""),
             func.coalesce(Document.tags, ""),
             func.coalesce(Document.note, ""),
-            func.coalesce(Document.text, ""),
+            func.coalesce(func.nullif(Document.text_md, ""), Document.text, ""),
         ))
         title = func.unaccent(func.coalesce(Document.title, ""))
         phrase = func.unaccent(f"%{query}%")
@@ -379,19 +380,19 @@ class DocumentRepository:
         return [
             {
                 "document_id": doc.id,
-                "text": (doc.text or "")[:1000],
+                "text": (doc.text_md or doc.text or "")[:1000],
                 # Full (untruncated) text for SearchService._merge_results() coverage
                 # scoring only -- popped before the API response is returned. A
                 # matching token past the first 1000 chars (a long article's intro
                 # is often boilerplate/AI summary, not the matched sentence) must
                 # not be scored as absent. See docs/search-hybrid.md.
-                "text_for_scoring": doc.text or "",
+                "text_for_scoring": doc.text_md or doc.text or "",
                 "similarity": 0.0,
                 "id": None,
                 "url": doc.url,
                 "language": doc.language,
-                "text_original": (doc.text or "")[:1000],
-                "websites_text_length": len(doc.text or ""),
+                "text_original": (doc.text_md or doc.text or "")[:1000],
+                "websites_text_length": len(doc.text_md or doc.text or ""),
                 "embeddings_text_length": 0,
                 "title": doc.title,
                 "document_type": doc.document_type,

--- a/backend/library/document_service.py
+++ b/backend/library/document_service.py
@@ -21,6 +21,7 @@ from library.document_repository import DocumentRepository
 from library.text_functions import split_text_for_embedding
 from library.text_transcript import chapters_text_to_list
 from library.website.website_download_context import download_raw_html, webpage_raw_parse, webpage_text_clean
+from library.storage import storage_from_config
 
 logger = logging.getLogger(__name__)
 
@@ -75,27 +76,18 @@ class DocumentService:
             raise ExistingDocumentError(existing)
 
         cfg = load_config()
-        bucket_name = cfg.get("AWS_S3_WEBSITE_CONTENT")
-        use_aws_s3 = bucket_name is not None
-
-        logger.info("Using AWS S3: %s", use_aws_s3)
+        storage = storage_from_config(cfg)
 
         doc_uuid = None
-
-        if use_aws_s3:
-            import boto3
-            s3_client = boto3.client("s3")
-        else:
-            s3_client = None
 
         if url_type == "webpage":
             uid = str(uuid.uuid4())
             doc_uuid = uid
 
             if text:
-                self._store_file(uid, "txt", text, use_aws_s3, s3_client, bucket_name)
+                self._store_file(uid, "txt", text, storage=storage)
             if html:
-                self._store_file(uid, "html", html, use_aws_s3, s3_client, bucket_name)
+                self._store_file(uid, "html", html, storage=storage)
             else:
                 logger.info("Missing HTML part!")
 
@@ -118,27 +110,29 @@ class DocumentService:
         logger.info("Successfully saved document to database with ID: %s", doc.id)
         return doc
 
-    def _store_file(self, uid: str, extension: str, content: str, use_s3: bool, s3_client, bucket_name: str | None) -> None:
-        """Store a file to S3 or local disk. Raises RuntimeError on failure."""
+    def _store_file(self, uid: str, extension: str, content: str, use_s3=None, s3_client=None,
+                    bucket_name: str | None = None, storage=None) -> None:
+        """Store a file through the configured backend. Legacy args remain for callers/tests."""
         file_name = f"{uid}.{extension}"
-
-        if use_s3:
+        if storage is None:  # compatibility for older direct callers
             try:
-                s3_client.put_object(Bucket=bucket_name, Key=file_name, Body=content)
-                logger.info("Successfully uploaded %s to %s", file_name, bucket_name)
+                if use_s3:
+                    s3_client.put_object(Bucket=bucket_name, Key=file_name, Body=content)
+                else:
+                    os.makedirs("/app/data", exist_ok=True)
+                    with open(f"/app/data/{file_name}", "w", encoding="utf-8") as handle:
+                        handle.write(content)
+                return
             except Exception as e:
-                logger.error("Failed to upload %s to %s: %s", file_name, bucket_name, e)
-                raise RuntimeError(f"Failed to upload {extension} file to storage") from e
-        else:
-            try:
-                os.makedirs("/app/data", exist_ok=True)
-                local_file_path = f"/app/data/{file_name}"
-                with open(local_file_path, "w", encoding="utf-8") as f:
-                    f.write(content)
-                logger.info("Successfully saved %s to /app/data/", file_name)
-            except Exception as e:
-                logger.error("Failed to save %s to /app/data/: %s", file_name, e)
-                raise RuntimeError(f"Failed to save {extension} file locally") from e
+                raise RuntimeError(f"Failed to upload {extension} file to storage" if use_s3 else
+                                   f"Failed to save {extension} file locally") from e
+        try:
+            storage.put_bytes(file_name, content.encode("utf-8"), f"text/{extension}; charset=utf-8")
+            logger.info("Successfully stored %s", file_name)
+        except Exception as e:
+            logger.error("Failed to store %s: %s", file_name, e)
+            raise RuntimeError(f"Failed to upload {extension} file to storage" if use_s3 else
+                               f"Failed to save {extension} file locally") from e
 
     # ------------------------------------------------------------------
     # save_document — extracted from /website_save
@@ -155,13 +149,11 @@ class DocumentService:
             raise ValueError("Document already has raw HTML")
 
         cfg = load_config()
-        bucket_name = cfg.get("AWS_S3_WEBSITE_CONTENT")
-        use_s3 = bucket_name is not None
-        s3_client = __import__("boto3").client("s3") if use_s3 else None
+        storage = storage_from_config(cfg)
         new_uuid = str(uuid.uuid4())
         if text:
-            self._store_file(new_uuid, "txt", text, use_s3, s3_client, bucket_name)
-        self._store_file(new_uuid, "html", html, use_s3, s3_client, bucket_name)
+            self._store_file(new_uuid, "txt", text, storage=storage)
+        self._store_file(new_uuid, "html", html, storage=storage)
 
         doc.uuid = new_uuid
         doc.text_raw = html
@@ -190,7 +182,12 @@ class DocumentService:
     ) -> Document:
         """Look up or create a document, apply attribute updates, and commit.
 
-        Accepted keyword attrs: text, title, language, tags, summary, source, byline, note.
+        Accepted keyword attrs: text, text_md, title, language, tags, summary,
+        source, byline, note.
+
+        For webpages ``text_md`` is the canonical editable article body.
+        ``text`` is maintained as a derived plain-text compatibility/search
+        representation so the two fields cannot silently diverge.
         Raises ValueError for invalid document_type.
         Returns the saved Document.
         """
@@ -210,7 +207,7 @@ class DocumentService:
         if processing_status is not None:
             doc.set_processing_status(processing_status)
 
-        for attr in ("text", "title", "language", "tags", "summary", "byline", "note"):
+        for attr in ("title", "language", "tags", "summary", "byline", "note"):
             value = attrs.get(attr)
             if value is not None:
                 setattr(doc, attr, value)
@@ -222,6 +219,28 @@ class DocumentService:
 
         if document_type is not None:
             doc.set_document_type(document_type)
+
+        effective_type = document_type or doc.document_type
+        submitted_text = attrs.get("text")
+        submitted_md = attrs.get("text_md")
+        if effective_type == "webpage":
+            # Legacy webpages may only have plain text. The next explicit save
+            # promotes it to the canonical Markdown field (plain text is valid
+            # Markdown), while all normal saves derive text from text_md.
+            canonical_md = submitted_md or submitted_text
+            if canonical_md is not None:
+                from library.lenie_markdown import md_remove_markdown
+
+                doc.text_md = canonical_md
+                doc.text = md_remove_markdown(canonical_md)
+                doc.document_length = len(canonical_md)
+                doc.quality = None
+        elif submitted_text is not None:
+            # Transcripts and other non-webpage documents keep plain text as
+            # their native canonical representation.
+            doc.text = submitted_text
+        if effective_type != "webpage" and submitted_md is not None:
+            doc.text_md = submitted_md
 
         doc.analyze()
 

--- a/backend/library/person_registry.py
+++ b/backend/library/person_registry.py
@@ -146,8 +146,10 @@ def resolve_document_persons(session, doc, text: str) -> dict:
     for ent in entities:
         name = ent.entity_text.strip()
 
-        # 1. Known alias/canonical name — cheapest, no network
-        person = find_by_alias(session, name)
+        # 1. Known full alias/canonical name — cheapest, no network. A bare
+        # surname is context-dependent ("Trump" may mean Donald, Donald Jr.,
+        # Ivanka, ...), so it must go through contextual disambiguation below.
+        person = find_by_alias(session, name) if len(name.split()) >= 2 else None
         if person is not None:
             if _link(session, doc.id, person, name, CONFIDENCE_ALIAS):
                 linked.append((name, person.canonical_name, CONFIDENCE_ALIAS))
@@ -170,6 +172,12 @@ def resolve_document_persons(session, doc, text: str) -> dict:
                     select(Person).where(Person.wikidata_qid == qid)
                 ).scalars().first()
                 if person is None:
+                    # A local row may predate Wikidata enrichment. Reuse the
+                    # exact full label instead of creating a duplicate row.
+                    person = find_by_alias(session, chosen["label"])
+                    if person is not None and person.wikidata_qid not in (None, qid):
+                        person = None
+                if person is None:
                     person = Person(
                         canonical_name=chosen["label"],
                         wikidata_qid=qid,
@@ -177,6 +185,11 @@ def resolve_document_persons(session, doc, text: str) -> dict:
                     )
                     session.add(person)
                     session.flush()
+                else:
+                    if person.wikidata_qid is None:
+                        person.wikidata_qid = qid
+                    if not person.description and chosen["description"]:
+                        person.description = chosen["description"]
                 _add_alias(session, person, name)
                 if _link(session, doc.id, person, name, CONFIDENCE_WIKIDATA):
                     linked.append((name, person.canonical_name, CONFIDENCE_WIKIDATA))

--- a/backend/library/search/sql_filters.py
+++ b/backend/library/search/sql_filters.py
@@ -28,6 +28,7 @@ from library.db.models import (
     Publisher,
     PublisherDomain,
     Document,
+    DocumentEmbedding,
 )
 from library.publisher_registry import normalize_publisher_domain
 from library.search.types import SearchFilters
@@ -92,6 +93,11 @@ def build_document_filters(filters: SearchFilters) -> list[ColumnElement[bool]]:
 
     if filters.languages:
         conditions.append(Document.language.in_(filters.languages))
+
+    if filters.without_embedding:
+        conditions.append(~exists(
+            select(DocumentEmbedding.id).where(DocumentEmbedding.document_id == Document.id)
+        ))
 
     if filters.subject_period_start_year is not None or filters.subject_period_end_year is not None:
         conditions.append(_subject_period_overlap(

--- a/backend/library/search/types.py
+++ b/backend/library/search/types.py
@@ -245,6 +245,7 @@ class SearchFilters:
     subject_period_end_year: int | None = None
     document_types: tuple[str, ...] = ()
     languages: tuple[str, ...] = ()
+    without_embedding: bool = False
 
     def __post_init__(self):
         set_ = object.__setattr__
@@ -261,12 +262,13 @@ class SearchFilters:
         set_(self, "subject_period_end_year", _opt_year("subject_period_end_year", self.subject_period_end_year))
         set_(self, "document_types", _document_types("document_types", self.document_types))
         set_(self, "languages", _languages("languages", self.languages))
+        set_(self, "without_embedding", _bool("without_embedding", self.without_embedding))
         _ordered("published_on_from", self.published_on_from, self.published_on_to)
         _ordered("ingested_at_from", self.ingested_at_from, self.ingested_at_to)
         _ordered("subject_period_start_year", self.subject_period_start_year, self.subject_period_end_year)
 
     def is_empty(self) -> bool:
-        return all(getattr(self, f.name) in (None, ()) for f in fields(self))
+        return all(getattr(self, f.name) in (None, (), False) for f in fields(self))
 
 
 @dataclass(frozen=True)
@@ -294,6 +296,7 @@ class ParsedSearchQuery:
     temporal_expression: str | None = None
     document_types: tuple[str, ...] = ()
     languages: tuple[str, ...] = ()
+    without_embedding: bool = False
     sort: SearchSort = SearchSort.RELEVANCE
     interpretation_summary: str = ""
     warnings: tuple[str, ...] = ()

--- a/backend/library/search_routes.py
+++ b/backend/library/search_routes.py
@@ -155,7 +155,9 @@ def execute_search():
     if parsed.clarification_required or ambiguities:
         response.update({
             "results": [],
-            "pagination": {"limit": limit, "offset": offset, "returned": 0},
+            "pagination": {
+                "limit": limit, "offset": offset, "returned": 0, "has_more": False,
+            },
             "clarification_required": True,
             "clarification_question": parsed.clarification_question,
             "ambiguities": ambiguities,
@@ -163,16 +165,20 @@ def execute_search():
         return jsonify(response), 200
 
     try:
-        results = SearchService(get_scoped_session()).search(
-            parsed.query, parsed.to_filters(), limit=limit, offset=offset, sort=sort,
+        results_with_sentinel = SearchService(get_scoped_session()).search(
+            parsed.query, parsed.to_filters(), limit=limit + 1, offset=offset, sort=sort,
         )
     except RuntimeError:
         logger.exception("Search execution failed")
         return jsonify({"status": "error", "message": "Search execution failed"}), 503
 
+    has_more = len(results_with_sentinel) > limit
+    results = results_with_sentinel[:limit]
     response.update({
         "results": results,
-        "pagination": {"limit": limit, "offset": offset, "returned": len(results)},
+        "pagination": {
+            "limit": limit, "offset": offset, "returned": len(results), "has_more": has_more,
+        },
         "clarification_required": False,
         "clarification_question": None,
         "ambiguities": [],

--- a/backend/library/storage.py
+++ b/backend/library/storage.py
@@ -1,0 +1,129 @@
+"""Storage abstraction for durable document files and processing cache.
+
+The S3 implementation works with AWS S3, MinIO and other S3-compatible stores.
+Local storage remains the zero-configuration default.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Protocol
+
+
+class ObjectStorage(Protocol):
+    def put_bytes(self, key: str, data: bytes, content_type: str | None = None) -> None: ...
+    def get_bytes(self, key: str) -> bytes: ...
+    def exists(self, key: str) -> bool: ...
+    def iter_objects(self, prefix: str = ""): ...
+
+
+def _safe_key(key: str) -> str:
+    value = key.replace("\\", "/").lstrip("/")
+    if not value or any(part in ("", ".", "..") for part in value.split("/")):
+        raise ValueError(f"Invalid storage key: {key!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class StoredObject:
+    key: str
+    size: int
+
+
+class LocalStorage:
+    def __init__(self, root: str | os.PathLike):
+        self.root = Path(root).resolve()
+
+    def _path(self, key: str) -> Path:
+        path = (self.root / _safe_key(key)).resolve()
+        if self.root not in path.parents:
+            raise ValueError(f"Storage key escapes root: {key!r}")
+        return path
+
+    def put_bytes(self, key: str, data: bytes, content_type: str | None = None) -> None:
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def get_bytes(self, key: str) -> bytes:
+        return self._path(key).read_bytes()
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).is_file()
+
+    def iter_objects(self, prefix: str = ""):
+        base = self.root / prefix if prefix else self.root
+        if not base.exists():
+            return
+        for path in base.rglob("*"):
+            if path.is_file():
+                yield StoredObject(path.relative_to(self.root).as_posix(), path.stat().st_size)
+
+
+class S3Storage:
+    def __init__(self, bucket: str, endpoint_url: str | None = None, region: str | None = None,
+                 access_key: str | None = None, secret_key: str | None = None, client=None):
+        self.bucket = bucket
+        if client is None:
+            import boto3
+            kwargs = {"endpoint_url": endpoint_url, "region_name": region}
+            if access_key:
+                kwargs["aws_access_key_id"] = access_key
+            if secret_key:
+                kwargs["aws_secret_access_key"] = secret_key
+            client = boto3.client("s3", **{k: v for k, v in kwargs.items() if v})
+        self.client = client
+
+    def put_bytes(self, key: str, data: bytes, content_type: str | None = None) -> None:
+        kwargs = {"Bucket": self.bucket, "Key": _safe_key(key), "Body": data}
+        if content_type:
+            kwargs["ContentType"] = content_type
+        self.client.put_object(**kwargs)
+
+    def get_bytes(self, key: str) -> bytes:
+        return self.client.get_object(Bucket=self.bucket, Key=_safe_key(key))["Body"].read()
+
+    def exists(self, key: str) -> bool:
+        from botocore.exceptions import ClientError
+        try:
+            self.client.head_object(Bucket=self.bucket, Key=_safe_key(key))
+            return True
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") in ("404", "NoSuchKey", "NotFound"):
+                return False
+            raise
+
+    def iter_objects(self, prefix: str = ""):
+        paginator = self.client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for item in page.get("Contents", []):
+                yield StoredObject(item["Key"], item["Size"])
+
+
+def storage_from_config(cfg, *, local_root: str = "/app/data") -> ObjectStorage:
+    """Build storage. STORAGE_BACKEND defaults to local for desktop installs."""
+    backend = (cfg.get("STORAGE_BACKEND") or "local").lower()
+    if backend == "local":
+        return LocalStorage(cfg.get("STORAGE_LOCAL_ROOT") or local_root)
+    if backend not in ("s3", "minio"):
+        raise ValueError(f"Unsupported STORAGE_BACKEND: {backend}")
+    bucket = cfg.get("STORAGE_BUCKET") or cfg.get("AWS_S3_WEBSITE_CONTENT")
+    if not bucket:
+        raise ValueError("STORAGE_BUCKET is required for S3/MinIO storage")
+    return S3Storage(
+        bucket=bucket,
+        endpoint_url=cfg.get("STORAGE_ENDPOINT_URL") or cfg.get("S3_ENDPOINT_URL"),
+        region=cfg.get("STORAGE_REGION") or cfg.get("AWS_REGION"),
+        access_key=cfg.get("STORAGE_ACCESS_KEY") or cfg.get("AWS_ACCESS_KEY_ID"),
+        secret_key=cfg.get("STORAGE_SECRET_KEY") or cfg.get("AWS_SECRET_ACCESS_KEY"),
+    )
+
+
+def usage(storage: ObjectStorage, prefix: str = "") -> tuple[int, int]:
+    count = total = 0
+    for obj in storage.iter_objects(prefix):
+        count += 1
+        total += obj.size
+    return count, total

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lenie-server"
-version = "0.3.14.0"
+version = "0.3.15.5"
 description = "Personal AI assistant for collecting, managing, and searching data using LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/server.py
+++ b/backend/server.py
@@ -28,7 +28,7 @@ cfg = load_config()
 
 secrets_backend = cfg.require("SECRETS_BACKEND", "env")
 
-APP_VERSION = "0.3.14.0"
+APP_VERSION = "0.3.15.5"
 BUILD_TIME = "2026.07.04 08:00"
 
 logging.info(f"APP VERSION={APP_VERSION} (build time:{BUILD_TIME})")
@@ -1556,7 +1556,7 @@ def website_save():
 
     link_id = request.form.get('id')
     attrs = {}
-    for attr in ('text', 'title', 'language', 'tags', 'summary', 'source', 'byline', 'note'):
+    for attr in ('text', 'text_md', 'title', 'language', 'tags', 'summary', 'source', 'byline', 'note'):
         value = request.form.get(attr)
         if value is not None:
             attrs[attr] = value

--- a/backend/tests/unit/test_article_metadata_generic.py
+++ b/backend/tests/unit/test_article_metadata_generic.py
@@ -1,0 +1,19 @@
+from library.article_metadata import extract_article_authors, extract_article_publication_date
+
+
+def test_generic_jsonld_article_metadata():
+    html = '''
+    <html><head><script type="application/ld+json">
+    {"@type":"NewsArticle","author":[{"name":"Jan Kowalski"},{"name":"Anna Nowak"}],
+     "datePublished":"2026-07-21T12:30:00+02:00"}
+    </script></head></html>
+    '''
+    assert extract_article_authors(html, "https://example.com/a") == ["Jan Kowalski", "Anna Nowak"]
+    assert extract_article_publication_date(html, "https://example.com/a") == "2026-07-21"
+
+
+def test_generic_meta_metadata_fallback():
+    html = '''<meta name="author" content="Maria Testowa">
+              <meta property="article:published_time" content="2025-03-04T08:00:00Z">'''
+    assert extract_article_authors(html, "https://example.com/a") == ["Maria Testowa"]
+    assert extract_article_publication_date(html, "https://example.com/a") == "2025-03-04"

--- a/backend/tests/unit/test_document_service.py
+++ b/backend/tests/unit/test_document_service.py
@@ -153,19 +153,19 @@ class TestCreateDocument:
             )
             assert mock_store.call_count == 1
 
+    @patch("library.document_service.storage_from_config")
     @patch("library.document_service.load_config")
-    def test_create_document_with_s3(self, mock_config):
-        """When S3 bucket configured, _store_file is called with S3 params."""
+    def test_create_document_with_s3(self, mock_config, mock_storage_from_config):
+        """Configured object storage is passed to every stored webpage part."""
         cfg = MagicMock()
-        cfg.get.return_value = "my-bucket"
         mock_config.return_value = cfg
+        storage = MagicMock()
+        mock_storage_from_config.return_value = storage
 
-        mock_boto3 = MagicMock()
         session = _make_session()
         service = DocumentService(session)
 
-        with patch.dict(sys.modules, {"boto3": mock_boto3}), \
-             patch.object(service, "_store_file") as mock_store:
+        with patch.object(service, "_store_file") as mock_store:
             service.create_document(
                 url="https://example.com",
                 url_type="webpage",
@@ -174,10 +174,8 @@ class TestCreateDocument:
             )
 
             assert mock_store.call_count == 2
-            # Verify S3 params are passed (use_s3=True, bucket="my-bucket")
             for call in mock_store.call_args_list:
-                assert call[0][3] is True  # use_s3
-                assert call[0][5] == "my-bucket"  # bucket_name
+                assert call.kwargs["storage"] is storage
 
     @patch("library.document_service.load_config")
     def test_create_document_invalid_type(self, mock_config):
@@ -199,6 +197,38 @@ class TestCreateDocument:
 
 
 class TestSaveDocument:
+    def test_webpage_markdown_is_canonical_and_plain_text_is_derived(self):
+        session = _make_session()
+        doc = _make_doc()
+        doc.document_type = "webpage"
+
+        with patch.object(Document, "get_by_id", return_value=doc):
+            service = DocumentService(session)
+            service.save_document(
+                url="https://example.com", link_id=42,
+                document_type="webpage", text="stale plain text",
+                text_md="# Heading\n\nArticle body",
+            )
+
+        assert doc.text_md == "# Heading\n\nArticle body"
+        assert doc.text == "Heading\n\nArticle body"
+        assert doc.document_length == len(doc.text_md)
+        assert doc.quality is None
+
+    def test_legacy_webpage_plain_text_is_promoted_to_markdown(self):
+        session = _make_session()
+        doc = _make_doc()
+        doc.document_type = "webpage"
+
+        with patch.object(Document, "get_by_id", return_value=doc):
+            DocumentService(session).save_document(
+                url="https://example.com", link_id=42,
+                document_type="webpage", text="Legacy article", text_md="",
+            )
+
+        assert doc.text_md == "Legacy article"
+        assert doc.text == "Legacy article"
+
     def test_save_existing_by_id(self):
         """Save updates an existing document found by ID."""
         session = _make_session()

--- a/backend/tests/unit/test_flask_endpoints_orm.py
+++ b/backend/tests/unit/test_flask_endpoints_orm.py
@@ -349,6 +349,7 @@ class TestWebsiteSave:
                     "processing_status": "URL_ADDED",
                     "document_type": "webpage",
                     "text": "new text",
+                    "text_md": "# New text",
                     "title": "New Title",
                 }, headers=API_HEADERS)
 
@@ -357,6 +358,7 @@ class TestWebsiteSave:
         assert data["status"] == "success"
         assert "42" in data["message"]
         mock_service.save_document.assert_called_once()
+        assert mock_service.save_document.call_args.kwargs["text_md"] == "# New text"
 
     def test_create_new_doc(self, client):
         mock_doc = MagicMock()

--- a/backend/tests/unit/test_person_registry.py
+++ b/backend/tests/unit/test_person_registry.py
@@ -208,6 +208,53 @@ class TestResolveDocumentPersons:
         mock_wd.assert_not_called()
         assert result["linked"] == [("Donald Tusk", "Donald Tusk", CONFIDENCE_ALIAS)]
 
+    def test_bare_surname_uses_context_instead_of_ambiguous_alias(self):
+        existing = _person(person_id=7, name="Donald Trump")
+        existing.wikidata_qid = "Q22686"
+        existing.description = "prezydent Stanów Zjednoczonych"
+        candidates = [
+            {"qid": "Q22686", "label": "Donald Trump", "description": "prezydent Stanów Zjednoczonych"},
+            {"qid": "Q3713655", "label": "Donald Trump Jr.", "description": "amerykański przedsiębiorca"},
+        ]
+        session = _session([_entity("Trump")])
+        qid_result = MagicMock()
+        qid_result.scalars.return_value.first.return_value = existing
+        link_result = MagicMock()
+        link_result.scalars.return_value.first.return_value = None
+        session.execute.side_effect = [qid_result, link_result]
+
+        with patch("library.person_registry.find_by_alias") as mock_alias, \
+                patch("library.person_registry._add_alias"), \
+                patch("library.wikidata_client.search_persons", return_value=candidates), \
+                patch("library.article_tagging.confirm_person_with_llm", return_value="Q22686") as mock_llm:
+            result = resolve_document_persons(session, _doc(title="Trump przemawia jako prezydent"), "prezydent Trump")
+
+        mock_alias.assert_not_called()
+        mock_llm.assert_called_once()
+        assert result["linked"] == [("Trump", "Donald Trump", CONFIDENCE_WIKIDATA)]
+
+    def test_wikidata_pick_enriches_existing_local_person_without_qid(self):
+        existing = _person(person_id=7, name="Donald Trump")
+        existing.wikidata_qid = None
+        existing.description = None
+        candidates = [
+            {"qid": "Q22686", "label": "Donald Trump", "description": "prezydent Stanów Zjednoczonych"},
+        ]
+        session = _session([_entity("Trump")])
+
+        with patch("library.person_registry.find_by_alias", return_value=existing) as mock_alias, \
+                patch("library.person_registry._add_alias"), \
+                patch("library.wikidata_client.search_persons", return_value=candidates), \
+                patch("library.article_tagging.confirm_person_with_llm", return_value="Q22686"):
+            result = resolve_document_persons(session, _doc(), "prezydent Trump")
+
+        mock_alias.assert_called_once_with(session, "Donald Trump")
+        assert existing.wikidata_qid == "Q22686"
+        assert existing.description == "prezydent Stanów Zjednoczonych"
+        assert result["linked"] == [("Trump", "Donald Trump", CONFIDENCE_WIKIDATA)]
+        created = [c.args[0] for c in session.add.call_args_list if isinstance(c.args[0], Person)]
+        assert created == []
+
     def test_single_word_without_wikidata_human_is_skipped(self):
         session = _session([_entity("Starlinek")])
         with patch("library.wikidata_client.search_persons", return_value=[]):

--- a/backend/tests/unit/test_search_routes.py
+++ b/backend/tests/unit/test_search_routes.py
@@ -78,12 +78,31 @@ class TestSearchEndpoint:
         body = response.get_json()
         assert body["status"] == "explicit"
         assert body["results"] == [{"document_id": 7}]
-        assert body["pagination"] == {"limit": 5, "offset": 0, "returned": 1}
+        assert body["pagination"] == {
+            "limit": 5, "offset": 0, "returned": 1, "has_more": False,
+        }
         parser.assert_not_called()
         args, kwargs = service.search.call_args
         assert args[0] is None
         assert args[1].languages == ("pl",)
         assert kwargs["sort"] is SearchSort.PUBLISHED_DESC
+        assert kwargs["limit"] == 6
+
+    def test_pagination_uses_extra_result_as_has_more_sentinel(self, client):
+        service = MagicMock()
+        service.search.return_value = [{"document_id": i} for i in range(1, 5)]
+        with patch.object(routes, "SearchService", return_value=service):
+            with patch.object(routes, "get_scoped_session", return_value=MagicMock()):
+                response = client.post("/search", json={
+                    "filters": {"languages": ["pl"]}, "limit": 3, "offset": 6,
+                })
+        body = response.get_json()
+        assert [row["document_id"] for row in body["results"]] == [1, 2, 3]
+        assert body["pagination"] == {
+            "limit": 3, "offset": 6, "returned": 3, "has_more": True,
+        }
+        assert service.search.call_args.kwargs["limit"] == 4
+        assert service.search.call_args.kwargs["offset"] == 6
 
     def test_natural_query_parses_and_executes(self, client):
         service = MagicMock()

--- a/backend/tests/unit/test_search_sql_filters.py
+++ b/backend/tests/unit/test_search_sql_filters.py
@@ -180,3 +180,9 @@ class TestCombinedFilters:
         sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
         assert "documents.collection_id" in sql
         assert "documents.document_type" in sql
+
+
+def test_without_embedding_uses_correlated_not_exists():
+    sql = compiled(build_document_filters(SearchFilters(without_embedding=True))[0])
+    assert "NOT (EXISTS" in sql
+    assert "document_embeddings.document_id = documents.id" in sql

--- a/backend/tests/unit/test_storage.py
+++ b/backend/tests/unit/test_storage.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+from library.storage import LocalStorage, S3Storage, usage
+
+
+def test_local_roundtrip_and_usage(tmp_path):
+    storage = LocalStorage(tmp_path)
+    storage.put_bytes("cache/42/42.html", b"hello")
+    assert storage.get_bytes("cache/42/42.html") == b"hello"
+    assert storage.exists("cache/42/42.html")
+    assert usage(storage, "cache") == (1, 5)
+
+
+def test_s3_uses_endpoint_agnostic_api():
+    client = MagicMock()
+    client.get_object.return_value = {"Body": MagicMock(read=lambda: b"value")}
+    storage = S3Storage("lenie", client=client)
+    storage.put_bytes("documents/a.txt", b"value", "text/plain")
+    assert storage.get_bytes("documents/a.txt") == b"value"
+    client.put_object.assert_called_once_with(
+        Bucket="lenie", Key="documents/a.txt", Body=b"value", ContentType="text/plain"
+    )
+
+
+def test_local_rejects_path_traversal(tmp_path):
+    storage = LocalStorage(tmp_path)
+    try:
+        storage.put_bytes("../outside", b"bad")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1350,7 +1350,7 @@ wheels = [
 
 [[package]]
 name = "lenie-server"
-version = "0.3.14.0"
+version = "0.3.15.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,10 @@
 # Observability Strategy — Lenie Server 2025
 
-> Last updated: 2026-02-18 | Version: 0.3.13.0
+> Last updated: 2026-07-22 | Originally written for version 0.3.13.0
 
-This document describes the project's logging, tracing, and monitoring strategy across all deployment environments (AWS, Docker/local, Kubernetes, GCloud). It serves as the standard for current observability practices and a reference for future improvements.
+This document describes the project's logging, tracing, and monitoring strategy across its deployment environments (AWS Lambda, Docker/local). It serves as the standard for current observability practices and a reference for future improvements.
+
+**Note (2026-07-22):** The Kubernetes and GCloud sections that used to be here were removed along with `infra/kubernetes/`, `infra/gcloud/`, and `infra/aws/eks/` — those deployment targets no longer exist in this repo (stale relative to the current NAS-first architecture). The AWS Lambda inventory below (Lambda function list, `rds-*`/`ec2-*` functions) predates the 2026-07-02 RDS/SQS decommission and has not been re-verified since — treat those specific tables as historical, not current.
 
 **Note:** Source file line numbers referenced in this document were verified against version 0.3.13.0 and may drift with future code changes.
 
@@ -64,20 +66,6 @@ The project has **minimal and fragmented observability**. Logging exists in most
 
 **Warning:** `DataTraceEnabled: true` on the app API Gateway logs full request/response bodies to CloudWatch. Review this setting before enabling in production environments with sensitive data.
 
-### Kubernetes Health Probes
-
-Health probes are configured consistently across both Helm and Kustomize deployments:
-
-| Probe | Path | Port | Initial Delay | Period |
-|-------|------|------|---------------|--------|
-| startupProbe | `/startup` | 5000 | 5s | 10s |
-| readinessProbe | `/readiness` | 5000 | 10s | 10s |
-| livenessProbe | `/liveness` | 5000 | 10s | 30s |
-
-Sources:
-- Helm: `infra/kubernetes/helm/lenie-ai-server/values.yaml:99-116`
-- Kustomize: `infra/kubernetes/kustomize/base/server/server_deployment.yml:44-61`
-
 ### Frontend Monitoring
 
 All frontend applications currently have **no client-side monitoring or error tracking**:
@@ -95,8 +83,6 @@ AWS RUM (Real User Monitoring) was previously integrated but was completely remo
 |-------------|---------|---------|---------|------------|
 | **AWS Lambda** | CloudWatch (JSON via CF LoggingConfig for infra Lambdas — code still uses print(); basic Python logging for app Lambdas) | X-Ray on API GW app only | CloudWatch built-in | CloudWatch alarms (none configured) |
 | **Docker/local** | stdout/stderr (Python logging) | None | `/metrics` stub (returns 500 — view returns None) | None |
-| **Kubernetes** | stdout/stderr (Python logging) | None | `/metrics` stub (returns 500), health probes (startup, readiness, liveness) | None |
-| **GCloud** | Future: Cloud Logging | Future | Future | Future |
 
 ---
 
@@ -197,35 +183,6 @@ All log entries should use JSON format with the following required fields:
 1. Add `python-json-logger` or equivalent for structured JSON output
 2. Generate and propagate request IDs via Flask middleware
 3. Add Docker Compose healthcheck using `/healthz` endpoint
-
-### Kubernetes
-
-**Current setup:**
-- **Logging**: Python `logging` module outputs to stdout/stderr — Kubernetes captures container stdout as pod logs
-- **Tracing**: None
-- **Metrics**: `/metrics` endpoint exists (stub, currently returns 500) — could be consumed by Prometheus if implemented
-- **Health probes**: Fully configured (startupProbe, readinessProbe, livenessProbe) in both Helm and Kustomize deployments
-- **Pod logs**: Accessible via `kubectl logs <pod-name>`
-
-**Gaps:**
-- No log aggregation (future: stdout → Fluentd/Fluent Bit → centralized storage)
-- No Prometheus metrics implementation (stub endpoint only)
-- No distributed tracing (future: OpenTelemetry or Jaeger)
-
-**Recommended improvements (future stories):**
-1. Implement Prometheus metrics via `prometheus_client` library
-2. Deploy Fluent Bit DaemonSet for log aggregation
-3. Add OpenTelemetry instrumentation for distributed tracing
-
-### GCloud (Future)
-
-**Planned setup:**
-- **Logging**: Cloud Logging (automatic for GKE pods writing to stdout)
-- **Tracing**: Cloud Trace
-- **Metrics**: Cloud Monitoring
-- **Integration**: Cloud Logging agent auto-collects stdout/stderr from GKE containers
-
-No GCloud deployment exists yet — this section will be updated when GCloud support is implemented.
 
 ---
 
@@ -344,7 +301,7 @@ Self-hosting eliminates the 50k units/month limit and keeps all prompt/response 
 |------|----------|--------|----------|
 | **aws-xray-sdk** | `pyproject.toml:63` (docker extra), `pyproject.toml:82` (all extra) | Dependency installed in Docker and all extras. **NOT imported or used** in any application code. | **Keep for now** — needed when X-Ray instrumentation is implemented in Lambda application code. Remove if X-Ray approach is abandoned. |
 | **Langfuse** | `pyproject.toml:32` (base dependency), `library/api/openai/openai_my.py:5` (commented import: `# from langfuse.decorators import observe`) | Dependency installed. Import and `@observe()` decorator commented out (line 5, 14). | **Activate** — chosen as LLM observability tool. See [LLM Observability](#llm-observability) section for integration plan. |
-| **Prometheus `/metrics`** | `server.py:695-697` | Endpoint exists but implementation is `pass` (returns `None`, causing Flask 500 error). `prometheus_client` library is **NOT installed**. | **Keep stub** — implement with `prometheus_client` when Kubernetes monitoring is set up. The route registration ensures the path is reserved for future use. |
+| **Prometheus `/metrics`** | `server.py:695-697` | Endpoint exists but implementation is `pass` (returns `None`, causing Flask 500 error). `prometheus_client` library is **NOT installed**. | **Keep stub** — implement with `prometheus_client` if/when container-level monitoring is set up on the NAS. The route registration ensures the path is reserved for future use. |
 
 ### Removed Tools
 
@@ -361,7 +318,6 @@ Self-hosting eliminates the 50k units/month limit and keeps all prompt/response 
 | **CloudWatch Metrics** | API Gateway app stage | Active — via StageDescription MetricsEnabled |
 | **X-Ray (API Gateway level)** | `api-gw-app.yaml:589` | Active — TracingEnabled at API Gateway stage level (not SDK-level in application code) |
 | **Lambda LoggingConfig** | `api-gw-infra.yaml` | Active — JSON format, INFO level for infrastructure Lambda functions |
-| **Kubernetes health probes** | Helm + Kustomize configs | Active — startup, readiness, liveness probes configured |
 
 ---
 
@@ -389,7 +345,7 @@ Every API request should be logged with the following information for audit and 
 
 ### Implementation Approach (Future Story)
 
-**Flask (Docker/Kubernetes):**
+**Flask (Docker):**
 - Add `@app.before_request` middleware to generate `request_id` and record start time
 - Add `@app.after_request` middleware to log the audit entry with response status and duration
 - Store `request_id` in Flask's `g` object for propagation to downstream loggers

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,67 @@
+# File storage
+
+Lenie uses one S3-compatible interface for durable document objects. Local disk is the default, so a desktop installation needs no MinIO container.
+
+## Target NAS topology
+
+In the target deployment the NAS is the only execution and persistence environment:
+
+```text
+phone / computer browser
+          |
+          v
+React UI -> API container -> PostgreSQL job queue
+                              |
+                              v
+                         worker container
+                         /             \
+                MinIO durable data   NAS work volume
+```
+
+The browser only submits and monitors work. Import, conversion, transcription, analysis and embedding processes run in worker containers on the NAS. No scheduled or manual job may depend on a developer computer.
+
+MinIO is the durable object store and backup boundary. A Docker volume or NAS bind mount is still used as a worker scratch/work directory because path-oriented conversion tools require a filesystem. This is NAS-local ephemeral state, not a dependency on a user's computer. Jobs must be restartable from PostgreSQL plus MinIO and may delete their scratch directory after completion.
+
+The existing persistent `document_analysis_jobs` queue is the implementation pattern to generalize. The target is a common jobs table/API and a dedicated `lenie-worker` container. The API process should not execute long-running jobs in a background thread.
+
+## Configuration
+
+Portable single-computer Compose fallback:
+
+```env
+STORAGE_BACKEND=local
+STORAGE_LOCAL_ROOT=/app/data
+```
+
+NAS MinIO setup:
+
+```env
+STORAGE_BACKEND=minio
+STORAGE_ENDPOINT_URL=http://lenie-minio:9000
+STORAGE_BUCKET=lenie-storage
+STORAGE_ACCESS_KEY=lenie-admin
+STORAGE_SECRET_KEY=change-me
+STORAGE_REGION=us-east-1
+```
+
+AWS S3 uses `STORAGE_BACKEND=s3`, omits `STORAGE_ENDPOINT_URL`, and can use the normal AWS credential chain. Google Cloud Storage is not S3 API compatible by default; use its interoperability/HMAC endpoint or add a native adapter later.
+
+`STORAGE_BACKEND` is explicit. The legacy `AWS_S3_WEBSITE_CONTENT` is accepted as a bucket-name fallback, but no longer selects cloud storage by itself.
+
+## Migration and accounting
+
+Run from `backend/`, with the target backend configured:
+
+```console
+python imports/storage_migrate.py upload --source data --dry-run
+python imports/storage_migrate.py upload --source data
+python imports/storage_migrate.py upload --source tmp --prefix cache
+python imports/storage_migrate.py usage
+python imports/storage_migrate.py usage --prefix cache
+```
+
+Uploads are non-destructive and skip existing keys. Verify object counts before removing sources manually. The usage command counts logical bytes; physical MinIO usage can be larger because of filesystem overhead, versioning, erasure coding or replication.
+
+## Cache boundary
+
+Source `.html/.txt` files are durable objects. Pipeline files under `CACHE_DIR` are a NAS-local worker scratch space because converters and LLM tools require paths. `dynamodb_sync.py` mirrors its cache to `cache/markdown/` in MinIO/S3 after processing. Other legacy pipelines must adopt the same materialize/process/sync lifecycle before desktop schedules can be retired.

--- a/infra/aws/CLAUDE.md
+++ b/infra/aws/CLAUDE.md
@@ -27,7 +27,7 @@ No NAT Gateway (saves ~$30/month), DynamoDB PAY_PER_REQUEST billing, budget aler
 
 ### Lambda Serverless Constraints
 
-Lambda layers have a **50 MB zipped / 250 MB unzipped** size limit. This prevents including packages with large binary dependencies (e.g., `pytubefix` with its `nodejs-wheel-binaries` ~60 MB dependency). YouTube video processing is therefore **not available** in Lambda functions — only in Docker/K8s deployments and batch scripts.
+Lambda layers have a **50 MB zipped / 250 MB unzipped** size limit. This prevents including packages with large binary dependencies (e.g., `pytubefix` with its `nodejs-wheel-binaries` ~60 MB dependency). YouTube video processing is therefore **not available** in Lambda functions — only in Docker deployments and batch scripts.
 
 VPC-attached Lambdas cannot access AWS APIs or the internet without NAT Gateway (~$30/month) or VPC Endpoints (~$7-22/month), both exceeding the $8/month budget. VPC Lambdas must use Lambda environment variables for configuration instead of SSM Parameter Store.
 
@@ -42,8 +42,6 @@ aws/
 ├── CLAUDE.md
 ├── ubuntu_aws_cli_install.sh   # WSL/Ubuntu setup script for AWS CLI and tools
 ├── cloudformation/             # CloudFormation templates and deployment scripts
-│   └── CLAUDE.md
-├── eks/                        # EKS cluster configurations (eksctl + Karpenter)
 │   └── CLAUDE.md
 ├── serverless/                 # Lambda function source code, layers, and deploy scripts
 │   └── CLAUDE.md
@@ -60,9 +58,6 @@ Primary IaC approach. Custom `deploy.sh` script manages stack lifecycle (create/
 
 ### serverless/
 Lambda function source code and Lambda layer build scripts (psycopg2, lenie_all, openai). **1 deployed Lambda function remains: `url-add`** (CF-managed; source in `lambdas/url-add/`). `sqs-weblink-put-into` and `sqs-size` were deleted 2026-07-02 with the SQS pipeline. The app-server-db/internet document-serving Lambdas (formerly non-CF-managed) were deleted 2026-07-02; their sources and sanitized config snapshots stay in the repo for restoration. Includes packaging script (`zip_to_s3.sh`). See `serverless/CLAUDE.md` for details and [docs/aws-serverless-restoration.md](../../docs/aws-serverless-restoration.md) for the restoration guide.
-
-### eks/
-EKS cluster configurations. Main cluster `lenie-ai` (K8s 1.31, spot instances, us-east-1) and a Karpenter POC cluster. Managed via `eksctl` with addons: EBS CSI Driver, Metrics Server, Stakater Reloader, AWS Load Balancer Controller. Includes automated deployment script for Karpenter setup. See `eks/CLAUDE.md` for details.
 
 ### terraform/
 Terraform configuration (AWS provider ~> 5.0) covering VPC with 4 subnets (2 public + 2 private) and an EC2 bastion host module. Exists primarily for IaC comparison purposes. See `terraform/CLAUDE.md` for details.
@@ -89,7 +84,6 @@ Jenkins target (`aws-start-jenkins`) was removed since Jenkins is not currently 
 | Lambda | 1 function: `url-add` (Chrome extension ingestion → S3 + DynamoDB). All others deleted 2026-07-02 — see [docs/aws-serverless-restoration.md](../../docs/aws-serverless-restoration.md) |
 | API Gateway | 1 REST API (app: single `/url_add` endpoint) + custom domain `api.{env}.lenie-ai.eu` (root mapping only) |
 | EC2 | None running — the orphaned `ec2-lenie` stack was deleted 2026-07-02; only the (unused) launch template stack remains |
-| EKS | Kubernetes cluster (alternative deployment target) |
 | Route53 | DNS for lenie-ai.eu domain |
 | SSM Parameter Store | Cross-stack value sharing |
 | CloudWatch | Logging, Step Function execution monitoring |

--- a/web_interface_react/CLAUDE.md
+++ b/web_interface_react/CLAUDE.md
@@ -2,7 +2,7 @@
 
 React 18 single-page application for managing documents and running AI operations (text correction, embedding, similarity search). Built with **Vite** and **TypeScript**.
 
-**App version**: 0.3.14.0 | **Package version**: 0.3.14.0
+**App version**: 0.3.15.5 | **Package version**: 0.3.15.5
 
 ## Directory Structure
 

--- a/web_interface_react/package.json
+++ b/web_interface_react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenie-ai",
-  "version": "0.3.14.0",
+  "version": "0.3.15.5",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/web_interface_react/src/modules/shared/components/ArticlePreparationPanel/articlePreparationPanel.tsx
+++ b/web_interface_react/src/modules/shared/components/ArticlePreparationPanel/articlePreparationPanel.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import axios from "axios";
+import { AuthorizationContext } from "../../context/authorizationContext";
+
+interface CleanupPreview {
+  before_length: number;
+  after_length: number;
+  removed_line_count: number;
+  removed_lines_preview: string[];
+  portal: string | null;
+  source_field: string;
+}
+
+const ArticlePreparationPanel = ({ formik }: { formik: any }) => {
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const [preview, setPreview] = React.useState<CleanupPreview | null>(null);
+  const [busy, setBusy] = React.useState<string | null>(null);
+  const [message, setMessage] = React.useState("");
+  const headers = React.useMemo(() => ({
+    "x-api-key": `${apiKey ?? ""}`,
+    "Content-Type": "application/json",
+  }), [apiKey]);
+
+  const loadPreview = React.useCallback(async () => {
+    if (!formik.values.id) return;
+    try {
+      const response = await axios.post(
+        `${apiUrl}/document/${formik.values.id}/reclean_preview`,
+        { save: false }, { headers },
+      );
+      setPreview(response.data);
+    } catch {
+      setPreview(null);
+    }
+  }, [apiUrl, formik.values.id, headers]);
+
+  React.useEffect(() => { void loadPreview(); }, [loadPreview]);
+
+  const refreshDocument = async () => {
+    const response = await axios.get(`${apiUrl}/website_get`, {
+      params: { id: formik.values.id }, headers,
+    });
+    formik.setFormikState({ values: { ...formik.values, ...response.data } });
+  };
+
+  const saveCleanup = async () => {
+    if (!window.confirm("Zapisać oczyszczony Markdown jako kanoniczną treść artykułu?")) return;
+    setBusy("cleanup"); setMessage("");
+    try {
+      const response = await axios.post(
+        `${apiUrl}/document/${formik.values.id}/reclean_preview`,
+        { save: true }, { headers },
+      );
+      await refreshDocument();
+      setPreview(response.data);
+      setMessage(`Zapisano Markdown: ${response.data.before_length} → ${response.data.after_length} znaków.`);
+    } catch { setMessage("Nie udało się zapisać oczyszczonego artykułu."); }
+    finally { setBusy(null); }
+  };
+
+  const extract = async (kind: "author" | "date") => {
+    setBusy(kind); setMessage("");
+    const endpoint = kind === "author" ? "extract_author" : "extract_publication_date";
+    try {
+      const response = await axios.post(
+        `${apiUrl}/document/${formik.values.id}/${endpoint}`, {}, { headers },
+      );
+      if (kind === "author" && response.data.byline) {
+        formik.setFieldValue("byline", response.data.byline);
+        setMessage(`Autor: ${response.data.byline} (${response.data.byline_method}).`);
+      } else if (kind === "date" && response.data.published_on) {
+        formik.setFieldValue("published_on", response.data.published_on);
+        setMessage(`Data publikacji: ${response.data.published_on} (${response.data.published_on_method}).`);
+      } else {
+        setMessage(kind === "author" ? "Nie znaleziono autora." : "Nie znaleziono daty publikacji.");
+      }
+    } catch { setMessage("Ekstrakcja metadanych nie powiodła się."); }
+    finally { setBusy(null); }
+  };
+
+  if (!formik.values.id) return null;
+  const changed = !!preview && preview.before_length !== preview.after_length;
+  return (
+    <section style={{ border: "1px solid #cbd5e1", borderRadius: 6, padding: 12, marginBottom: 14 }}>
+      <strong>Przygotowanie artykułu</strong>
+      <p style={{ margin: "6px 0", color: "#475569" }}>
+        Ten etap działa niezależnie od chunków. Kanoniczną treścią strony jest Markdown.
+      </p>
+      {preview && (
+        <div style={{ fontSize: "0.9em", marginBottom: 8 }}>
+          Źródło: <code>{preview.source_field}</code> · portal: {preview.portal ?? "nierozpoznany"} · {preview.before_length} → {preview.after_length} znaków
+          {changed ? ` · do usunięcia: ${preview.removed_line_count} linii` : " · bez zmian"}
+          {preview.removed_lines_preview.length > 0 && (
+            <details><summary>Przykładowe usuwane elementy</summary>
+              <pre style={{ whiteSpace: "pre-wrap" }}>{preview.removed_lines_preview.join("\n")}</pre>
+            </details>
+          )}
+        </div>
+      )}
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button type="button" className="button" onClick={loadPreview} disabled={!!busy}>Sprawdź czyszczenie</button>
+        <button type="button" className="button" onClick={saveCleanup} disabled={!!busy || !preview}>
+          {busy === "cleanup" ? "Czyszczę…" : "Zapisz oczyszczony Markdown"}
+        </button>
+        <button type="button" className="button" onClick={() => extract("author")} disabled={!!busy}>
+          {busy === "author" ? "Szukam…" : "Znajdź autora"}
+        </button>
+        <button type="button" className="button" onClick={() => extract("date")} disabled={!!busy}>
+          {busy === "date" ? "Szukam…" : "Znajdź datę"}
+        </button>
+      </div>
+      {formik.values.published_on && <div style={{ marginTop: 7 }}>Data publikacji: {formik.values.published_on}</div>}
+      {message && <div style={{ marginTop: 7 }}>{message}</div>}
+    </section>
+  );
+};
+
+export default ArticlePreparationPanel;

--- a/web_interface_react/src/modules/shared/components/MarkdownLineEditor/markdownLineEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/MarkdownLineEditor/markdownLineEditor.tsx
@@ -1,0 +1,204 @@
+import React from "react";
+import axios from "axios";
+import { AuthorizationContext } from "../../context/authorizationContext";
+
+type MarkKind = "author" | "date" | "sources" | "links" | "ads" | "persons";
+
+const emptyMarks = (): Record<MarkKind, Set<number>> => ({
+  author: new Set(), date: new Set(), sources: new Set(), links: new Set(), ads: new Set(), persons: new Set(),
+});
+
+const MarkdownLineEditor = ({ formik, disabled }: { formik: any; disabled: boolean }) => {
+  const { apiUrl, apiKey } = React.useContext(AuthorizationContext);
+  const value: string = formik.values.text_md || formik.values.text || "";
+  const lines: string[] = value.split("\n");
+  const [editing, setEditing] = React.useState(false);
+  const [draft, setDraft] = React.useState(value);
+  const [marks, setMarks] = React.useState<Record<MarkKind, Set<number>>>(emptyMarks);
+  const [compactLabels, setCompactLabels] = React.useState(true);
+  const [busy, setBusy] = React.useState<MarkKind | null>(null);
+  const [message, setMessage] = React.useState("");
+
+  React.useEffect(() => { if (!editing) setDraft(value); }, [value, editing]);
+
+  const changeText = (next: string) => {
+    formik.setFieldValue("text_md", next);
+    setMarks(emptyMarks());
+  };
+  const removeLine = (index: number) => changeText(lines.filter((_, i) => i !== index).join("\n"));
+  const keepFrom = (index: number) => {
+    if (index === 0 || window.confirm(`Usunąć ${index} linii przed wybraną linią?`)) changeText(lines.slice(index).join("\n"));
+  };
+  const keepThrough = (index: number) => {
+    const removed = lines.length - index - 1;
+    if (removed === 0 || window.confirm(`Usunąć ${removed} linii po wybranej linii?`)) changeText(lines.slice(0, index + 1).join("\n"));
+  };
+  // First click sets a section anchor; second click fills the entire
+  // contiguous range. A third click starts a new range for that category.
+  const toggleMark = (kind: MarkKind, index: number) => setMarks(prev => {
+    const current = prev[kind];
+    let next: Set<number>;
+    if (current.size === 0) next = new Set([index]);
+    else if (current.size === 1 && !current.has(index)) {
+      const anchor = [...current][0];
+      next = new Set(Array.from({ length: Math.abs(index - anchor) + 1 }, (_, offset) => Math.min(anchor, index) + offset));
+    } else next = new Set([index]);
+    return { ...prev, [kind]: next };
+  });
+  const selectedText = (kind: MarkKind) => [...marks[kind]].sort((a, b) => a - b).map(i => lines[i]).join("\n").trim();
+  const headers = { "x-api-key": `${apiKey ?? ""}`, "Content-Type": "application/json" };
+
+  const saveAuthorSection = async () => {
+    const text = selectedText("author");
+    if (!text) return;
+    setBusy("author"); setMessage("");
+    try {
+      const response = await axios.post(`${apiUrl}/document/${formik.values.id}/extract_author`, {
+        context_text: text, biography_text: text,
+      }, { headers });
+      if (response.data.byline) {
+        formik.setFieldValue("byline", response.data.byline);
+        setMessage(`Zapisano autora: ${response.data.byline}${response.data.biography ? " oraz notkę biograficzną" : ""}.`);
+      } else setMessage("Nie rozpoznano autora w zaznaczonej sekcji.");
+    } catch { setMessage("Nie udało się zapisać autora i biografii."); }
+    finally { setBusy(null); }
+  };
+
+  const saveDateLine = async () => {
+    const text = selectedText("date");
+    if (!text) return;
+    setBusy("date"); setMessage("");
+    try {
+      const response = await axios.post(`${apiUrl}/document/${formik.values.id}/extract_publication_date`, {
+        context_text: text,
+      }, { headers });
+      if (response.data.published_on) {
+        formik.setFieldValue("published_on", response.data.published_on);
+        setMessage(`Zapisano datę publikacji: ${response.data.published_on}.`);
+      } else setMessage("Nie rozpoznano daty w zaznaczonych liniach.");
+    } catch { setMessage("Nie udało się zapisać daty publikacji."); }
+    finally { setBusy(null); }
+  };
+
+  const savePersonsSection = async () => {
+    const text = selectedText("persons");
+    if (!text) return;
+    setBusy("persons"); setMessage("");
+    try {
+      const response = await axios.post(`${apiUrl}/document/${formik.values.id}/extract_persons`, {
+        context_text: text,
+      }, { headers });
+      const found: string[] = response.data.persons_found || [];
+      const linked = response.data.linked || [];
+      if (found.length) setMessage(`Rozpoznano: ${found.join(", ")}. Dodano ${linked.length} nowych powiązań z dokumentem.`);
+      else setMessage("Nie rozpoznano osób w zaznaczonej sekcji.");
+    } catch { setMessage("Nie udało się pobrać osób z zaznaczonej sekcji."); }
+    finally { setBusy(null); }
+  };
+
+  const markSourcesSection = () => {
+    const selected = [...marks.sources].sort((a, b) => a - b);
+    if (!selected.length) return;
+    const first = selected[0];
+    if (first > 0 && /^#{1,6}\s+źr[oó]d/i.test(lines[first - 1].trim())) {
+      setMessage("Ta sekcja ma już nagłówek Źródła.");
+      return;
+    }
+    changeText([...lines.slice(0, first), "## Źródła", ...lines.slice(first)].join("\n"));
+    setMessage("Dodano nagłówek „## Źródła”. Zapisz dokument głównym przyciskiem.");
+  };
+
+  const addSectionHeading = (kind: "sources" | "links", heading: string) => {
+    const selected = [...marks[kind]].sort((a, b) => a - b);
+    if (!selected.length) return;
+    const first = selected[0];
+    if (first > 0 && lines[first - 1].trim().toLocaleLowerCase("pl").includes(heading.toLocaleLowerCase("pl"))) {
+      setMessage(`Ta sekcja ma już nagłówek ${heading}.`); return;
+    }
+    changeText([...lines.slice(0, first), `## ${heading}`, ...lines.slice(first)].join("\n"));
+    setMessage(`Dodano nagłówek „## ${heading}”. Zapisz dokument głównym przyciskiem.`);
+  };
+
+  const deleteMarkedSections = () => {
+    const selected = new Set<number>();
+    (Object.keys(marks) as MarkKind[]).forEach(kind => marks[kind].forEach(index => selected.add(index)));
+    if (!selected.size || !window.confirm(`Usunąć ${selected.size} zaznaczonych linii ze wszystkich sekcji?`)) return;
+    changeText(lines.filter((_, index) => !selected.has(index)).join("\n"));
+    setMessage(`Usunięto ${selected.size} linii z zaznaczonych sekcji.`);
+  };
+
+  const marked = (kind: MarkKind, index: number) => marks[kind].has(index);
+  const label = (shortLabel: string, fullLabel: string) => compactLabels ? shortLabel : fullLabel;
+  return (
+    <section style={{ margin: "8px 0 14px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 7 }}>
+        <strong>Treść artykułu — recenzja linii ({lines.length})</strong>
+        <button type="button" className="button" onClick={() => { setDraft(value); setEditing(v => !v); }}>
+          {editing ? "Wróć do linii" : "Edytuj cały Markdown"}
+        </button>
+        <button type="button" className="button" onClick={() => setCompactLabels(current => !current)}>
+          {compactLabels ? "Pełne nazwy przycisków" : "Skróty przycisków"}
+        </button>
+      </div>
+      {editing ? (
+        <div>
+          <textarea value={draft} disabled={disabled} onChange={e => setDraft(e.target.value)}
+            style={{ width: "100%", minHeight: 560, boxSizing: "border-box", padding: 10, fontFamily: "monospace", lineHeight: 1.5 }} />
+          <button type="button" className="button" disabled={disabled || !draft.trim()} onClick={() => { changeText(draft); setEditing(false); }}>
+            Zastosuj edycję w formularzu
+          </button>
+        </div>
+      ) : (
+        <>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8, padding: 8, background: "#f8fafc" }}>
+            <button type="button" className="button" disabled={!marks.author.size || !!busy} onClick={saveAuthorSection}>
+              {busy === "author" ? "Analizuję…" : `Zapisz autora + biografię (${marks.author.size})`}
+            </button>
+            <button type="button" className="button" disabled={!marks.date.size || !!busy} onClick={saveDateLine}>
+              {busy === "date" ? "Analizuję…" : `Zapisz datę (${marks.date.size})`}
+            </button>
+            <button type="button" className="button" disabled={!marks.persons.size || !!busy} onClick={savePersonsSection}>
+              {busy === "persons" ? "Analizuję…" : label(`P (${marks.persons.size})`, `Dodaj osoby (${marks.persons.size})`)}
+            </button>
+            <button type="button" className="button" disabled={!marks.sources.size || !!busy} onClick={markSourcesSection}>
+              Oznacz sekcję Źródła ({marks.sources.size})
+            </button>
+            <button type="button" className="button" disabled={!marks.links.size || !!busy} onClick={() => addSectionHeading("links", "Linki")}>
+              Oznacz sekcję Linki ({marks.links.size})
+            </button>
+            <button type="button" className="button" disabled={!Object.values(marks).some(set => set.size) || !!busy} onClick={deleteMarkedSections}>
+              Usuń zaznaczone sekcje
+            </button>
+            <button type="button" onClick={() => setMarks(emptyMarks())}>{label("0", "Wyczyść zaznaczenia")}</button>
+          </div>
+          {message && <div style={{ marginBottom: 8 }}>{message}</div>}
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 5, maxHeight: "68vh", overflow: "auto" }}>
+            {lines.map((line, index) => (
+              <div key={`${index}-${line.slice(0, 30)}`} style={{
+                display: "grid", gridTemplateColumns: compactLabels ? "46px repeat(9, 34px) minmax(280px, 1fr)" : "46px repeat(9, auto) minmax(280px, 1fr)", gap: 5,
+                alignItems: "start", padding: "3px 6px", borderBottom: "1px solid #f1f5f9",
+                background: marked("persons", index) ? "#fef3c7" : marked("author", index) ? "#f3e8ff" : marked("date", index) ? "#dbeafe" : marked("sources", index) ? "#ede9fe" : marked("links", index) ? "#dcfce7" : marked("ads", index) ? "#fee2e2" : index % 2 ? "#fafafa" : "white",
+              }}>
+                <span style={{ color: "#94a3b8", textAlign: "right", paddingTop: 3 }}>{index + 1}</span>
+                <button type="button" title="Usuń linię" onClick={() => removeLine(index)}>{label("×", "Usuń")}</button>
+                <button type="button" title="Usuń wszystko przed tą linią" onClick={() => keepFrom(index)}>{label("⇤", "Początek")}</button>
+                <button type="button" title="Usuń wszystko po tej linii" onClick={() => keepThrough(index)}>{label("⇥", "Koniec")}</button>
+                <button type="button" title="Autor lub notka biograficzna" onClick={() => toggleMark("author", index)} style={{ fontWeight: marked("author", index) ? 700 : 400 }}>{label("A", "Autor/bio")}</button>
+                <button type="button" title="Data publikacji" onClick={() => toggleMark("date", index)} style={{ fontWeight: marked("date", index) ? 700 : 400 }}>{label("D", "Data")}</button>
+                <button type="button" title="Element sekcji źródeł" onClick={() => toggleMark("sources", index)} style={{ fontWeight: marked("sources", index) ? 700 : 400 }}>{label("Ź", "Źródła")}</button>
+                <button type="button" title="Pierwsze kliknięcie: początek sekcji linków; drugie: koniec" onClick={() => toggleMark("links", index)} style={{ fontWeight: marked("links", index) ? 700 : 400 }}>{label("L", "Linki")}</button>
+                <button type="button" title="Pierwsze kliknięcie: początek reklamy/szumu; drugie: koniec" onClick={() => toggleMark("ads", index)} style={{ fontWeight: marked("ads", index) ? 700 : 400 }}>{label("R", "Reklama")}</button>
+                <button type="button" title="Pierwsze kliknięcie: początek sekcji osób; drugie: koniec" onClick={() => toggleMark("persons", index)} style={{ fontWeight: marked("persons", index) ? 700 : 400 }}>{label("P", "Osoby")}</button>
+                <span style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", paddingTop: 3 }}>
+                  {line || <em style={{ color: "#cbd5e1" }}>pusta linia</em>}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default MarkdownLineEditor;

--- a/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
+++ b/web_interface_react/src/modules/shared/components/SearchCriteriaEditor.tsx
@@ -10,10 +10,10 @@ const LABELS: Record<SearchFilterKey, string> = {
   published_on_from: "Publikacja od", published_on_to: "Publikacja do",
   ingested_at_from: "Dodano od", ingested_at_to: "Dodano do",
   subject_period_start_year: "Okres od", subject_period_end_year: "Okres do",
-  document_types: "Typy", languages: "Języki",
+  document_types: "Typy", languages: "Języki", without_embedding: "Without embedding",
 };
 
-const present = (value: unknown) => value != null && value !== ""
+const present = (value: unknown) => value != null && value !== "" && value !== false
   && (!Array.isArray(value) || value.length > 0);
 
 const inputValue = (value: unknown) => Array.isArray(value) ? value.join(", ") : String(value ?? "");
@@ -75,7 +75,10 @@ export const SearchCriteriaEditor = ({
     }
     onChange({ ...criteria, [key]: value });
   };
-  const remove = (key: SearchFilterKey) => onChange({ ...criteria, [key]: key === "languages" ? [] : null });
+  const remove = (key: SearchFilterKey) => onChange({
+    ...criteria,
+    [key]: key === "languages" ? [] : key === "without_embedding" ? false : null,
+  });
   const toggleArrayValue = (key: "document_types" | "languages", value: string) => onChange({
     ...criteria,
     [key]: criteria[key].includes(value)
@@ -94,6 +97,16 @@ export const SearchCriteriaEditor = ({
       </label>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
         {SEARCH_FILTER_KEYS.map(key => {
+          if (key === "without_embedding") {
+            return (
+              <label key={key} style={{ display: "flex", alignItems: "center", gap: 5,
+                border: "1px solid #cbd5e1", borderRadius: 8, padding: "5px 7px", background: "#fff" }}>
+                <input type="checkbox" disabled={disabled} checked={Boolean(criteria.without_embedding)}
+                  onChange={event => onChange({ ...criteria, without_embedding: event.target.checked })} />
+                <span style={{ fontSize: ".82rem", color: "#475569" }}>{LABELS[key]}</span>
+              </label>
+            );
+          }
           if (key === "document_types") {
             return (
               <CheckboxGroup key={key} label={LABELS[key]} disabled={disabled}

--- a/web_interface_react/src/modules/shared/components/SharedInputs/InputsForAllExceptLink.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/InputsForAllExceptLink.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import Input from "../Input/input";
 import EntitiesPanel from "../EntitiesPanel/entitiesPanel";
+import ArticlePreparationPanel from "../ArticlePreparationPanel/articlePreparationPanel";
+import MarkdownLineEditor from "../MarkdownLineEditor/markdownLineEditor";
 
 interface InputsForAllExceptLinkProps {
   formik: any;
@@ -20,7 +22,10 @@ const InputsForAllExceptLink = ({
 }: InputsForAllExceptLinkProps) => {
   return (
     <>
-      {formik.values.text_md && (
+      {showCleanText && <ArticlePreparationPanel formik={formik} />}
+      {showCleanText ? (
+        <MarkdownLineEditor formik={formik} disabled={isLoading} />
+      ) : formik.values.text_md && (
         <details style={{ marginBottom: "8px" }}>
           <summary style={{ cursor: "pointer" }}>Website MarkDown content</summary>
           <Input
@@ -34,16 +39,10 @@ const InputsForAllExceptLink = ({
           />
         </details>
       )}
-      <Input
-        disabled={isLoading}
-        value={formik.values.text}
-        label={"Website content"}
-        onChange={formik.handleChange}
-        id={"text"}
-        name={"text"}
-        type={"text"}
-        multiline
-      />{" "}
+      {!showCleanText && (
+        <Input disabled={isLoading} value={formik.values.text} label={"Website content"}
+          onChange={formik.handleChange} id={"text"} name={"text"} type={"text"} multiline />
+      )}{" "}
         <div style={{marginTop: "10px"}}>
             {formik.values.id && (
                 <NavLink
@@ -54,21 +53,12 @@ const InputsForAllExceptLink = ({
                     Przegląd chunków →
                 </NavLink>
             )}
-            {showCleanText && (
-                <button
-                    className={"button"}
-                    style={{marginRight: "10px"}}
-                    onClick={() => handleRemoveNotNeededText(formik.values)}
-                >
-                    Clean Text
-                </button>
-            )}
         </div>
-        {formik.values.text && (
+        {(showCleanText ? (formik.values.text_md || formik.values.text) : formik.values.text) && (
             <div style={{marginTop: "10px"}}>
-                Długość: {formik.values.text.length} znaków
+                Długość: {(showCleanText ? (formik.values.text_md || formik.values.text) : formik.values.text).length} znaków
                 {" · "}
-                Słowa: {formik.values.text.trim().split(/\s+/).length}
+                Słowa: {(showCleanText ? (formik.values.text_md || formik.values.text) : formik.values.text).trim().split(/\s+/).length}
                 {formik.values.embeddings_count != null && (
                     <>
                         {" · "}
@@ -83,17 +73,19 @@ const InputsForAllExceptLink = ({
                 )}
             </div>
         )}
-        <br/>
+      <br/>
+      {!showCleanText && (
         <Input
-            disabled={isLoading}
-        value={formik.values.chapter_list}
-        label={"Chapter list:"}
-        onChange={formik.handleChange}
-        id={"chapter_list"}
-        name={"chapter_list"}
-        type={"text"}
-        multiline
-      />
+          disabled={isLoading}
+          value={formik.values.chapter_list}
+          label={"Chapter list:"}
+          onChange={formik.handleChange}
+          id={"chapter_list"}
+          name={"chapter_list"}
+          type={"text"}
+          multiline
+        />
+      )}
       <Input
         disabled={isLoading}
         value={formik.values.note}

--- a/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
+++ b/web_interface_react/src/modules/shared/components/SharedInputs/sharedInputs.tsx
@@ -110,7 +110,10 @@ const SourceSelect = ({ formik, isLoading, sources }: { formik: any; isLoading: 
 // chunk_ids — the per-chunk variant lives in chunks.tsx, where a reviewer
 // can point at one specific chunk instead). Only shown for document types
 // that go through chunk analysis; link documents have no full text to run it on.
-const AUTHOR_EXTRACT_TYPES = ["webpage", "youtube", "movie", "email"];
+// Webpages expose document-level extraction in ArticlePreparationPanel; it
+// must not depend on an analysis run. This legacy run-backed button remains
+// useful for transcripts.
+const AUTHOR_EXTRACT_TYPES = ["youtube", "movie", "email"];
 
 const AuthorExtractButton = ({
   formik, isLoading, apiUrl, apiKey,

--- a/web_interface_react/src/modules/shared/constants/variables.ts
+++ b/web_interface_react/src/modules/shared/constants/variables.ts
@@ -1,1 +1,1 @@
-export const lenie_version = "0.3.14.0";
+export const lenie_version = "0.3.15.5";

--- a/web_interface_react/src/modules/shared/hooks/useSearch.ts
+++ b/web_interface_react/src/modules/shared/hooks/useSearch.ts
@@ -19,6 +19,7 @@ export interface SearchInterpretation {
   temporal_expression: string | null;
   document_types: string[];
   languages: string[];
+  without_embedding?: boolean;
   sort: string;
   interpretation_summary: string;
   warnings: string[];
@@ -35,11 +36,18 @@ export interface SearchResponse {
   results: any[];
   clarification_required: boolean;
   clarification_question: string | null;
+  pagination?: {
+    limit: number;
+    offset: number;
+    returned: number;
+    has_more: boolean;
+  };
 }
 
-export const buildNaturalSearchPayload = (naturalQuery: string, limit: string) => ({
+export const buildNaturalSearchPayload = (naturalQuery: string, limit: string, offset = 0) => ({
   natural_query: naturalQuery.trim(),
   limit: Number(limit),
+  ...(offset ? { offset } : {}),
 });
 
 export const useSearch = () => {
@@ -52,14 +60,14 @@ export const useSearch = () => {
   const [feedbackMessage, setFeedbackMessage] = React.useState("");
   const { apiKey, apiUrl } = React.useContext(AuthorizationContext);
 
-  const handleSearch = React.useCallback(async (naturalQuery: string, limit: string) => {
+  const handleSearch = React.useCallback(async (naturalQuery: string, limit: string, offset = 0) => {
     setIsLoading(true);
     setIsError(false);
     setMessage("");
     try {
       const response = await axios.post<SearchResponse>(
         `${apiUrl}/search`,
-        buildNaturalSearchPayload(naturalQuery, limit),
+        buildNaturalSearchPayload(naturalQuery, limit, offset),
         { headers: { "Content-Type": "application/json", "x-api-key": `${apiKey}` } },
       );
       setSearchResponse(response.data);
@@ -75,14 +83,14 @@ export const useSearch = () => {
   }, [apiKey, apiUrl]);
 
   const handleExplicitSearch = React.useCallback(async (
-    criteria: SearchInterpretation, limit: string,
+    criteria: SearchInterpretation, limit: string, offset = 0,
   ) => {
     setIsLoading(true);
     setIsError(false);
     setMessage("");
     try {
       const response = await axios.post<SearchResponse>(`${apiUrl}/search`,
-        buildExplicitSearchPayload(criteria, limit), {
+        { ...buildExplicitSearchPayload(criteria, limit), ...(offset ? { offset } : {}) }, {
           headers: { "Content-Type": "application/json", "x-api-key": `${apiKey}` },
         });
       setSearchResponse(response.data);

--- a/web_interface_react/src/modules/shared/pages/chunks.tsx
+++ b/web_interface_react/src/modules/shared/pages/chunks.tsx
@@ -1593,9 +1593,10 @@ const Chunks = () => {
   const reviewReady = tematChunks.length > 0 && unapprovedTematCount === 0 && chunksToAnalyze.length === 0;
   const workflowBusy = !!jobId || reanalyzingAll || approvingAll || !!embedJobId;
   const analyzedTematCount = tematChunks.filter(c => c.summary).length;
-  // A noisy article leaves REKLAMA/SZUM chunks behind; a clean article leaves
-  // none, so once the LLM analysis produced summaries the detection step is done.
-  const noiseMarkingDone = reklamaCount > 0 || analyzedTematCount > 0 || runStatus === "reviewed";
+  const zrodlaCount = chunks.filter(c => c.type === "ZRODLA").length;
+  const adsCount = chunks.filter(c => c.type === "REKLAMA").length;
+  const noiseCount = chunks.filter(c => c.type === "SZUM").length;
+  const classificationSummary = `${tematChunks.length} TEMAT · ${zrodlaCount} ŹRÓDŁA · ${adsCount} REKLAMA · ${noiseCount} SZUM`;
   const processComplete = runStatus === "reviewed" && embeddedCount > 0 && !embedJobId;
 
   // ── User notes: match notes to chunks of the selected run ──
@@ -2318,24 +2319,19 @@ const Chunks = () => {
           <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
             {([
               {
-                label: "1. Analiza chunków",
+                label: "1. Klasyfikacja, tematy i streszczenia",
                 done: chunksToAnalyze.length === 0,
-                detail: chunksToAnalyze.length > 0 ? `${chunksToAnalyze.length} wymaga analizy` : `${tematChunks.length} treści TEMAT`,
+                detail: chunksToAnalyze.length > 0 ? `${chunksToAnalyze.length} wymaga analizy` : classificationSummary,
                 subs: [
                   {
                     label: "Podział na chunki",
                     done: chunkTotal > 0,
                     detail: chunkTotal > 0 ? `${chunkTotal} chunków` : "brak chunków",
                   },
-                  ...(runMode === "article" ? [{
-                    label: "Wykrywanie reklam i szumu",
-                    done: noiseMarkingDone,
-                    detail: reklamaCount > 0 ? `${reklamaCount} poza TEMAT` : noiseMarkingDone ? "nie wykryto" : "oczekuje",
-                  }] : []),
                   {
-                    label: "Analiza LLM (tematy i streszczenia)",
+                    label: runMode === "article" ? "Analiza LLM: klasyfikacja, tematy i streszczenia" : "Analiza LLM: tematy i streszczenia",
                     done: tematChunks.length > 0 && chunksToAnalyze.length === 0 && analyzedTematCount > 0,
-                    detail: `${analyzedTematCount}/${tematChunks.length} przeanalizowanych`,
+                    detail: chunksToAnalyze.length === 0 ? classificationSummary : `${analyzedTematCount}/${tematChunks.length} TEMAT przeanalizowanych`,
                   },
                 ],
               },

--- a/web_interface_react/src/modules/shared/pages/search.tsx
+++ b/web_interface_react/src/modules/shared/pages/search.tsx
@@ -23,6 +23,7 @@ const Search = () => {
     initialExplicitCriteria ? "advanced" : "natural",
   );
   const [submittedQuery, setSubmittedQuery] = React.useState(initialQuery);
+  const [pageOffset, setPageOffset] = React.useState(0);
   const [draftCriteria, setDraftCriteria] = React.useState<SearchInterpretation | null>(initialExplicitCriteria);
   const [advancedCriteria, setAdvancedCriteria] = React.useState<SearchInterpretation>(
     initialExplicitCriteria ?? emptySearchCriteria(),
@@ -42,6 +43,7 @@ const Search = () => {
     initialValues: { search: initialQuery, searchLimit: initialLimit },
     onSubmit: async data => {
       const query = data.search.trim();
+      setPageOffset(0);
       setSubmittedQuery(query);
       const params: Record<string, string> = { q: query };
       if (data.searchLimit !== DEFAULT_LIMIT) params.limit = data.searchLimit;
@@ -65,6 +67,7 @@ const Search = () => {
     formik.resetForm({ values: { search: "", searchLimit: DEFAULT_LIMIT } });
     clearSearch();
     setSubmittedQuery("");
+    setPageOffset(0);
     setDraftCriteria(null);
     setAdvancedCriteria(emptySearchCriteria());
     setSearchParams({});
@@ -72,6 +75,7 @@ const Search = () => {
 
   const applyCorrection = async () => {
     if (!draftCriteria) return;
+    setPageOffset(0);
     setSubmittedQuery(draftCriteria.query ?? "");
     const searched = await handleExplicitSearch(draftCriteria, formik.values.searchLimit);
     if (searched) {
@@ -87,9 +91,20 @@ const Search = () => {
   };
 
   const submitAdvanced = async () => {
+    setPageOffset(0);
     setSubmittedQuery(advancedCriteria.query ?? "");
     const searched = await handleExplicitSearch(advancedCriteria, formik.values.searchLimit);
     if (searched) setSearchParams(explicitSearchParams(advancedCriteria, formik.values.searchLimit));
+  };
+
+  const changePage = async (nextOffset: number) => {
+    const offset = Math.max(0, nextOffset);
+    const searched = searchMode === "advanced"
+      ? await handleExplicitSearch(advancedCriteria, formik.values.searchLimit, offset)
+      : draftCriteria
+        ? await handleExplicitSearch(draftCriteria, formik.values.searchLimit, offset)
+        : await handleSearch(submittedQuery, formik.values.searchLimit, offset);
+    if (searched !== false) setPageOffset(offset);
   };
 
   return (
@@ -170,6 +185,22 @@ const Search = () => {
             item={item} query={searchResponse?.interpretation.query ?? submittedQuery} />
         ))}
       </div>
+      {results && !isLoading && (pageOffset > 0 || searchResponse?.pagination?.has_more) && (
+        <nav aria-label="Stronicowanie wyników"
+          style={{ display: "flex", alignItems: "center", gap: 10, paddingBottom: 30 }}>
+          <button type="button" className="button" disabled={pageOffset === 0}
+            onClick={() => { void changePage(pageOffset - Number(formik.values.searchLimit)); }}>
+            Poprzednia
+          </button>
+          <span style={{ color: "#475569", fontSize: ".88rem" }}>
+            Strona {Math.floor(pageOffset / Number(formik.values.searchLimit)) + 1}
+          </span>
+          <button type="button" className="button" disabled={!searchResponse?.pagination?.has_more}
+            onClick={() => { void changePage(pageOffset + Number(formik.values.searchLimit)); }}>
+            Następna
+          </button>
+        </nav>
+      )}
     </div>
   );
 };

--- a/web_interface_react/src/modules/shared/pages/webpage.tsx
+++ b/web_interface_react/src/modules/shared/pages/webpage.tsx
@@ -34,6 +34,7 @@ const Webpage = () => {
       processing_error_code: "",
       chapter_list: "",
       note: "",
+      published_on: "",
       next_id: null,
       previous_id: null,
       next_type: "",
@@ -71,7 +72,7 @@ const Webpage = () => {
           </NavLink>
         )}
       </div>
-      <form onSubmit={formik.handleSubmit} style={{ maxWidth: "800px" }}>
+      <form onSubmit={formik.handleSubmit} style={{ width: "min(1600px, calc(100vw - 48px))", maxWidth: "100%" }}>
         <SharedInputs
           formik={formik}
           isLoading={isLoading}

--- a/web_interface_react/src/modules/shared/utils/searchCriteria.ts
+++ b/web_interface_react/src/modules/shared/utils/searchCriteria.ts
@@ -4,7 +4,7 @@ export const SEARCH_FILTER_KEYS = [
   "author_name", "publisher_name", "publisher_domain", "discovery_source_name",
   "collection_name", "published_on_from", "published_on_to", "ingested_at_from",
   "ingested_at_to", "subject_period_start_year", "subject_period_end_year",
-  "document_types", "languages",
+  "document_types", "languages", "without_embedding",
 ] as const;
 
 export type SearchFilterKey = typeof SEARCH_FILTER_KEYS[number];
@@ -27,7 +27,7 @@ export const emptySearchCriteria = (query = ""): SearchInterpretation => ({
   discovery_source_name: null, collection_name: null, published_on_from: null,
   published_on_to: null, ingested_at_from: null, ingested_at_to: null,
   subject_period_start_year: null, subject_period_end_year: null, temporal_expression: null,
-  document_types: [], languages: [], sort: "relevance",
+  document_types: [], languages: [], without_embedding: false, sort: "relevance",
   interpretation_summary: "Jawne kryteria wyszukiwania (bez interpretacji LLM).", warnings: [],
   clarification_required: false, clarification_question: null, model_confidence: "high",
 });
@@ -42,7 +42,7 @@ export const buildExplicitSearchPayload = (criteria: SearchInterpretation, limit
     const value = key === "ingested_at_to" && typeof criteria[key] === "string"
       && BARE_DATE_RE.test(criteria[key] as string)
       ? `${criteria[key]}T23:59:59` : criteria[key];
-    return value == null || value === "" || (Array.isArray(value) && value.length === 0)
+    return value == null || value === "" || value === false || (Array.isArray(value) && value.length === 0)
       ? [] : [[key, value]];
   }));
   return {


### PR DESCRIPTION
## Zakres
- usprawnienia strony edit i workflow chunks
- kanoniczny Markdown oraz panel przygotowania artykułu
- abstrakcja storage i narzędzie migracyjne
- paginacja /search oraz filtr Without embedding
- usunięcie nieużywanego workflow tłumaczeń

## Weryfikacja
- backend search: 195 testów
- backend edit/storage: 72 testy
- frontend: 19 testów
- frontend production build
- gitleaks i TruffleHog